### PR TITLE
Make ovnkube-node management port interface name configurable

### DIFF
--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -513,7 +513,7 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 
 	// Set information specific to ovn-k8s-mp0. This info is required for routingViaHost gateway mode traffic to an external IP
 	// destination.
-	podInfo.OvnK8sMp0PortName = types.K8sMgmtIntfName
+	podInfo.OvnK8sMp0PortName = util.GetK8sMgmtIntfName()
 	portCmd := fmt.Sprintf("ovs-vsctl get Interface %s ofport", podInfo.OvnK8sMp0PortName)
 	localOutput, localError, err := execInPod(coreclient, restconfig, ovnNamespace, podInfo.OvnKubePodName, podInfo.OvnKubeContainerName, portCmd, "")
 	if err != nil {

--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
@@ -15,7 +15,6 @@ import (
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"github.com/vishvananda/netlink"
@@ -208,9 +207,9 @@ func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
 		// No static cluster subnet is provided in config. Try to detect the hybrid overlay node subnet dynamically
 		// Add a route via the hybrid overlay port IP through the management port
 		// interface for each hybrid overlay cluster subnet
-		mgmtPortLink, err := util.GetNetLinkOps().LinkByName(types.K8sMgmtIntfName)
+		mgmtPortLink, err := util.GetNetLinkOps().LinkByName(util.GetK8sMgmtIntfName())
 		if err != nil {
-			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
+			return fmt.Errorf("failed to lookup link %s: %v", util.GetK8sMgmtIntfName(), err)
 		}
 
 		n.RLock()
@@ -303,9 +302,9 @@ func (n *NodeController) DeleteNode(node *kapi.Node) error {
 		// No static cluster subnet is provided in config. Try to detect the hybrid overlay node subnet dynamically
 		// Add a route via the hybrid overlay port IP through the management port
 		// interface for each hybrid overlay cluster subnet
-		mgmtPortLink, err := util.GetNetLinkOps().LinkByName(types.K8sMgmtIntfName)
+		mgmtPortLink, err := util.GetNetLinkOps().LinkByName(util.GetK8sMgmtIntfName())
 		if err != nil {
-			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
+			return fmt.Errorf("failed to lookup link %s: %v", util.GetK8sMgmtIntfName(), err)
 		}
 		n.RLock()
 		defer n.RUnlock()
@@ -461,9 +460,9 @@ func (n *NodeController) handleHybridOverlayMACIPChange(node *kapi.Node) error {
 			return fmt.Errorf("updated Hybrid Overlay Dristributed router IP annotation not a valid IP address %s", node.Annotations[hotypes.HybridOverlayDRIP])
 		}
 		n.drIP = newDRIP
-		mgmtPortLink, err := util.GetNetLinkOps().LinkByName(types.K8sMgmtIntfName)
+		mgmtPortLink, err := util.GetNetLinkOps().LinkByName(util.GetK8sMgmtIntfName())
 		if err != nil {
-			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
+			return fmt.Errorf("failed to lookup link %s: %v", util.GetK8sMgmtIntfName(), err)
 		}
 		err = n.createOrReplaceRoutes(mgmtPortLink, oldDRIP)
 		if err != nil {
@@ -633,9 +632,9 @@ func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
 			"IN_PORT",
 			extVXLANName, subnet.String(), hotypes.HybridOverlayVNI, n.drMAC.String(), portMACRaw))
 
-	mgmtPortLink, err := util.GetNetLinkOps().LinkByName(types.K8sMgmtIntfName)
+	mgmtPortLink, err := util.GetNetLinkOps().LinkByName(util.GetK8sMgmtIntfName())
 	if err != nil {
-		return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
+		return fmt.Errorf("failed to lookup link %s: %v", util.GetK8sMgmtIntfName(), err)
 	}
 
 	err = n.createOrReplaceRoutes(mgmtPortLink, nil)

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -189,7 +189,8 @@ var (
 
 	// OvnKubeNode holds ovnkube-node parsed config file parameters and command-line overrides
 	OvnKubeNode = OvnKubeNodeConfig{
-		Mode: types.NodeModeFull,
+		Mode:             types.NodeModeFull,
+		MgmtPortIntfName: "ovn-k8s-mp0",
 	}
 
 	ClusterManager = ClusterManagerConfig{
@@ -497,6 +498,7 @@ type OvnKubeNodeConfig struct {
 	DPResourceDeviceIdsMap map[string][]string
 	MgmtPortNetdev         string `gcfg:"mgmt-port-netdev"`
 	MgmtPortDPResourceName string `gcfg:"mgmt-port-dp-resource-name"`
+	MgmtPortIntfName       string `gcfg:"mgmt-port-netdev-intf-name"`
 }
 
 // ClusterManagerConfig holds configuration for ovnkube-cluster-manager
@@ -1478,6 +1480,12 @@ var OvnKubeNodeFlags = []cli.Flag{
 			"and used to allow host network services and pods to access k8s pod and service networks. ",
 		Value:       OvnKubeNode.MgmtPortNetdev,
 		Destination: &cliConfig.OvnKubeNode.MgmtPortNetdev,
+	},
+	&cli.StringFlag{
+		Name:        "ovnkube-node-mgmt-port-intf-name",
+		Usage:       "name of the interface to be used as the management port. Default is ovn-k8s-mp0",
+		Value:       OvnKubeNode.MgmtPortIntfName,
+		Destination: &cliConfig.OvnKubeNode.MgmtPortIntfName,
 	},
 	&cli.StringFlag{
 		Name: "ovnkube-node-mgmt-port-dp-resource-name",

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -266,7 +266,7 @@ func checkForStaleOVSInternalPorts() {
 	staleInterfaceArgs := []string{}
 	values := strings.Split(stdout, "\n\n")
 	for _, val := range values {
-		if val == ovntypes.K8sMgmtIntfName || val == ovntypes.K8sMgmtIntfName+"_0" {
+		if val == util.GetK8sMgmtIntfName() || val == util.GetK8sMgmtIntfName()+"_0" {
 			klog.Errorf("Management port %s is missing. Perhaps the host rebooted "+
 				"or SR-IOV VFs were disabled on the host.", val)
 			continue

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 	factoryMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory/mocks"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
@@ -67,7 +66,7 @@ var _ = Describe("Healthcheck tests", func() {
 			It("removes stale ports from bridge", func() {
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    genListStalePortsCmd(),
-					Output: "foo\n\nbar\n\n" + types.K8sMgmtIntfName + "\n\n",
+					Output: "foo\n\nbar\n\n" + util.GetK8sMgmtIntfName() + "\n\n",
 					Err:    nil,
 				})
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -84,7 +83,7 @@ var _ = Describe("Healthcheck tests", func() {
 			It("Does not remove any ports from bridge", func() {
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    genListStalePortsCmd(),
-					Output: types.K8sMgmtIntfName + "\n\n",
+					Output: util.GetK8sMgmtIntfName() + "\n\n",
 					Err:    nil,
 				})
 				checkForStaleOVSInternalPorts()

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -505,7 +505,7 @@ func importManagementPortAnnotation(node *kapi.Node) (string, error) {
 
 // Take care of alternative names for the netdevName by making sure we
 // use the link attribute name as well as handle the case when netdevName
-// was renamed to types.K8sMgmtIntfName
+// was renamed to util.GetK8sMgmtIntfName()
 func getManagementPortNetDev(netdevName string) (string, error) {
 	link, err := util.GetNetLinkOps().LinkByName(netdevName)
 	if err != nil {
@@ -514,7 +514,7 @@ func getManagementPortNetDev(netdevName string) (string, error) {
 		}
 		// this may not the first time invoked on the node after reboot
 		// netdev may have already been renamed to ovn-k8s-mp0.
-		link, err = util.GetNetLinkOps().LinkByName(types.K8sMgmtIntfName)
+		link, err = util.GetNetLinkOps().LinkByName(util.GetK8sMgmtIntfName())
 		if err != nil {
 			return "", fmt.Errorf("failed to get link device for %s. %v", netdevName, err)
 		}
@@ -1011,9 +1011,9 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 				if needLegacySvcRoute {
 					klog.Info("System may be upgrading, falling back to legacy K8S Service via management port")
 					// add back legacy route for service via management port
-					link, err := util.LinkSetUp(types.K8sMgmtIntfName)
+					link, err := util.LinkSetUp(util.GetK8sMgmtIntfName())
 					if err != nil {
-						return fmt.Errorf("unable to get link for %s, error: %v", types.K8sMgmtIntfName, err)
+						return fmt.Errorf("unable to get link for %s, error: %v", util.GetK8sMgmtIntfName(), err)
 					}
 					var gwIP net.IP
 					var routes []routemanager.Route
@@ -1428,9 +1428,9 @@ func configureSvcRouteViaBridge(routeManager *routemanager.Controller, bridge st
 func upgradeServiceRoute(routeManager *routemanager.Controller, bridgeName string) error {
 	klog.Info("Updating K8S Service route")
 	// Flush old routes
-	link, err := util.LinkSetUp(types.K8sMgmtIntfName)
+	link, err := util.LinkSetUp(util.GetK8sMgmtIntfName())
 	if err != nil {
-		return fmt.Errorf("unable to get link: %s, error: %v", types.K8sMgmtIntfName, err)
+		return fmt.Errorf("unable to get link: %s, error: %v", util.GetK8sMgmtIntfName(), err)
 	}
 	for _, serviceCIDR := range config.Kubernetes.ServiceCIDRs {
 		serviceCIDR := *serviceCIDR

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1033,7 +1033,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		}
 
 		fakeMgmtPortConfig := managementPortConfig{
-			ifName:    types.K8sMgmtIntfName,
+			ifName:    util.GetK8sMgmtIntfName(),
 			link:      nil,
 			routerMAC: nil,
 			ipv4:      &fakeMgmtPortIPFamilyConfig,

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1636,7 +1636,7 @@ func initSvcViaMgmPortRoutingRules(hostSubnets []*net.IPNet) error {
 		gatewayIP := util.GetNodeGatewayIfAddr(hostSubnet).IP.String()
 		for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
 			if isIPv6 == utilnet.IsIPv6CIDR(svcCIDR) {
-				if stdout, stderr, err := util.RunIP("route", "replace", "table", ovnkubeSvcViaMgmPortRT, svcCIDR.String(), "via", gatewayIP, "dev", types.K8sMgmtIntfName); err != nil {
+				if stdout, stderr, err := util.RunIP("route", "replace", "table", ovnkubeSvcViaMgmPortRT, svcCIDR.String(), "via", gatewayIP, "dev", util.GetK8sMgmtIntfName()); err != nil {
 					return fmt.Errorf("error adding routing table entry into custom routing table: %s: stdout: %s, stderr: %s, err: %v", ovnkubeSvcViaMgmPortRT, stdout, stderr, err)
 				}
 				klog.V(5).Infof("Successfully added route into custom routing table: %s", ovnkubeSvcViaMgmPortRT)
@@ -1673,11 +1673,11 @@ func initSvcViaMgmPortRoutingRules(hostSubnets []*net.IPNet) error {
 	// NOTE: v6 doesn't have rp_filter strict mode block
 	rpFilterLooseMode := "2"
 	// TODO: Convert testing framework to mock golang module utilities. Example:
-	// result, err := sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", types.K8sMgmtIntfName), rpFilterLooseMode)
-	stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.ipv4.conf.%s.rp_filter=%s", types.K8sMgmtIntfName, rpFilterLooseMode))
-	if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.rp_filter = %s", types.K8sMgmtIntfName, rpFilterLooseMode) {
+	// result, err := sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", util.GetK8sMgmtIntfName()), rpFilterLooseMode)
+	stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.ipv4.conf.%s.rp_filter=%s", util.GetK8sMgmtIntfName(), rpFilterLooseMode))
+	if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.rp_filter = %s", util.GetK8sMgmtIntfName(), rpFilterLooseMode) {
 		return fmt.Errorf("could not set the correct rp_filter value for interface %s: stdout: %v, stderr: %v, err: %v",
-			types.K8sMgmtIntfName, stdout, stderr, err)
+			util.GetK8sMgmtIntfName(), stdout, stderr, err)
 	}
 
 	return nil

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -20,7 +20,7 @@ import (
 func genOVSAddMgmtPortCmd(nodeName, repName string) string {
 	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s"+
 		" external-ids:ovn-orig-mgmt-port-rep-name=%s",
-		types.K8sMgmtIntfName+"_0", types.K8sMgmtIntfName+"_0", types.K8sPrefix+nodeName, repName)
+		util.GetK8sMgmtIntfName()+"_0", util.GetK8sMgmtIntfName()+"_0", types.K8sPrefix+nodeName, repName)
 }
 
 func mockOVSListInterfaceMgmtPortNotExistCmd(execMock *ovntest.FakeExec, mgmtPortName string) {
@@ -71,7 +71,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			}
 			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(
 				nil, fmt.Errorf("failed to get interface"))
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+			netlinkOpsMock.On("LinkByName", util.GetK8sMgmtIntfName()).Return(
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
@@ -88,12 +88,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName+"_0").Return(
+			netlinkOpsMock.On("LinkByName", util.GetK8sMgmtIntfName()+"_0").Return(
 				nil, fmt.Errorf("link not found"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
-			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName+"_0").Return(fmt.Errorf("failed to set name"))
-			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName+"_0")
+			netlinkOpsMock.On("LinkSetName", linkMock, util.GetK8sMgmtIntfName()+"_0").Return(fmt.Errorf("failed to set name"))
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, util.GetK8sMgmtIntfName()+"_0")
 
 			_, err := mgmtPortDpu.Create(nil, nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -115,14 +115,14 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName+"_0").Return(
+			netlinkOpsMock.On("LinkByName", util.GetK8sMgmtIntfName()+"_0").Return(
 				nil, fmt.Errorf("link not found"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
-			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName+"_0").Return(nil)
+			netlinkOpsMock.On("LinkSetName", linkMock, util.GetK8sMgmtIntfName()+"_0").Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
-			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName+"_0")
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, util.GetK8sMgmtIntfName()+"_0")
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
@@ -130,7 +130,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			mpcfg, err := mgmtPortDpu.Create(nil, nodeAnnotatorMock, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName + "_0"))
+			Expect(mpcfg.ifName).To(Equal(util.GetK8sMgmtIntfName() + "_0"))
 			Expect(mpcfg.link).To(Equal(linkMock))
 		})
 
@@ -158,7 +158,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			mpcfg, err := mgmtPortDpu.Create(nil, nodeAnnotatorMock, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName + "_0"))
+			Expect(mpcfg.ifName).To(Equal(util.GetK8sMgmtIntfName() + "_0"))
 			Expect(mpcfg.link).To(Equal(linkMock))
 		})
 	})
@@ -181,7 +181,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			}
 			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(
 				nil, fmt.Errorf("failed to get interface"))
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+			netlinkOpsMock.On("LinkByName", util.GetK8sMgmtIntfName()).Return(
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
@@ -209,10 +209,10 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetHardwareAddr", linkMock, expectedMgmtPortMac).Return(nil)
-			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
+			netlinkOpsMock.On("LinkSetName", linkMock, util.GetK8sMgmtIntfName()).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
-			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, util.GetK8sMgmtIntfName())
 			execMock.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
 			})
@@ -242,6 +242,14 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: "ovn-k8s-mp0", MTU: 1400, HardwareAddr: expectedMgmtPortMac})
+
+			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
+				linkMock, nil).Once()
+			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil).Once()
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -222,7 +222,7 @@ func setupManagementPortIPFamilyConfig(routeManager *routemanager.Controller, mp
 	// source protocol address to be in the Logical Switch's subnet.
 	if exists, err = util.LinkNeighExists(mpcfg.link, cfg.gwIP, mpcfg.routerMAC); err == nil && !exists {
 		warnings = append(warnings, fmt.Sprintf("missing arp entry for MAC/IP binding (%s/%s) on link %s",
-			mpcfg.routerMAC.String(), cfg.gwIP, types.K8sMgmtIntfName))
+			mpcfg.routerMAC.String(), cfg.gwIP, util.GetK8sMgmtIntfName()))
 		err = util.LinkNeighAdd(mpcfg.link, cfg.gwIP, mpcfg.routerMAC)
 	}
 	if err != nil {
@@ -230,10 +230,10 @@ func setupManagementPortIPFamilyConfig(routeManager *routemanager.Controller, mp
 	}
 
 	createForwardingRule := func(family string) error {
-		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.%s.conf.%s.forwarding=1", family, types.K8sMgmtIntfName))
-		if err != nil || stdout != fmt.Sprintf("net.%s.conf.%s.forwarding = 1", family, types.K8sMgmtIntfName) {
+		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.%s.conf.%s.forwarding=1", family, util.GetK8sMgmtIntfName()))
+		if err != nil || stdout != fmt.Sprintf("net.%s.conf.%s.forwarding = 1", family, util.GetK8sMgmtIntfName()) {
 			return fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
-				types.K8sMgmtIntfName, stdout, stderr, err)
+				util.GetK8sMgmtIntfName(), stdout, stderr, err)
 		}
 		return nil
 	}
@@ -472,7 +472,7 @@ func DelMgtPortIptRules() {
 	if err != nil {
 		return
 	}
-	rule := []string{"-o", types.K8sMgmtIntfName, "-j", iptableMgmPortChain}
+	rule := []string{"-o", util.GetK8sMgmtIntfName(), "-j", iptableMgmPortChain}
 	_ = ipt.Delete("nat", "POSTROUTING", rule...)
 	_ = ipt6.Delete("nat", "POSTROUTING", rule...)
 	_ = ipt.ClearChain("nat", iptableMgmPortChain)

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -196,10 +196,10 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	const (
 		nodeName      string = "node1"
 		mgtPortMAC    string = "00:00:00:55:66:77"
-		mgtPort       string = types.K8sMgmtIntfName
 		legacyMgtPort string = types.K8sPrefix + nodeName
 		mtu           string = "1400"
 	)
+	mgtPort := util.GetK8sMgmtIntfName()
 
 	// generic setup
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -318,9 +318,9 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 	const (
 		nodeName   string = "node1"
 		mgtPortMAC string = "0a:58:0a:01:01:02"
-		mgtPort    string = types.K8sMgmtIntfName
 		mtu        int    = 1400
 	)
+	mgtPort := util.GetK8sMgmtIntfName()
 
 	// OVS cmd setup
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -412,9 +412,9 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 	const (
 		nodeName   string = "node1"
 		mgtPortMAC string = "0a:58:0a:01:01:02"
-		mgtPort    string = types.K8sMgmtIntfName
 		mtu        int    = 1400
 	)
+	mgtPort := util.GetK8sMgmtIntfName()
 
 	// OVS cmd setup
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -501,7 +501,7 @@ var _ = Describe("Management Port Operations", func() {
 
 		t := GinkgoT()
 		origNetlinkOps := util.GetNetLinkOps()
-		mgmtPortName := types.K8sMgmtIntfName
+		mgmtPortName := util.GetK8sMgmtIntfName()
 		netlinkMockErr := fmt.Errorf("netlink mock error")
 		fakeExecErr := fmt.Errorf("face exec error")
 		hostSubnets := []*net.IPNet{}
@@ -801,7 +801,7 @@ var _ = Describe("Management Port Operations", func() {
 				// Set up a fake k8sMgmt interface
 				err := testNS.Do(func(ns.NetNS) error {
 					defer GinkgoRecover()
-					ovntest.AddLink(types.K8sMgmtIntfName)
+					ovntest.AddLink(util.GetK8sMgmtIntfName())
 					return nil
 				})
 				Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -9,9 +9,6 @@ const (
 	HybridOverlayPrefix   = "int-"
 	HybridOverlayGRSubfix = "-gr"
 
-	// K8sMgmtIntfName name to be used as an OVS internal port on the node
-	K8sMgmtIntfName = "ovn-k8s-mp0"
-
 	// PhysicalNetworkName is the name that maps to an OVS bridge that provides
 	// access to physical/external network
 	PhysicalNetworkName     = "physnet"

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -101,6 +101,18 @@ func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	return types.K8sPrefix + nodeName
 }
 
+const k8sMgmtIntfDefaultName = "ovn-k8s-mp0"
+
+// GetK8sMgmtIntfName returns name of the management ovs port interface from
+// the configuration or default one if it is missing
+func GetK8sMgmtIntfName() string {
+	// check configuration first
+	if config.OvnKubeNode.MgmtPortIntfName != "" {
+		return config.OvnKubeNode.MgmtPortIntfName
+	}
+	return k8sMgmtIntfDefaultName
+}
+
 // GetWorkerFromGatewayRouter determines a node's corresponding worker switch name from a gateway router name
 func GetWorkerFromGatewayRouter(gr string) string {
 	return strings.TrimPrefix(gr, types.GWRouterPrefix)

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
@@ -245,4 +246,32 @@ func TestGenerateId(t *testing.T) {
 	assert.Equal(t, 10, len(id))
 	matchesPattern, _ := regexp.MatchString("([a-zA-Z0-9-]*)", id)
 	assert.True(t, matchesPattern)
+}
+
+func TestGetK8sMgmtIntfName(t *testing.T) {
+	tests := []struct {
+		desc                   string
+		configMgmtPortIntfName string
+		expectedValue          string
+	}{
+		{
+			desc:                   "use config value",
+			configMgmtPortIntfName: "configValue",
+			expectedValue:          "configValue",
+		},
+		{
+			desc:                   "use const value",
+			configMgmtPortIntfName: "",
+			expectedValue:          GetK8sMgmtIntfName(),
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			config.OvnKubeNode.MgmtPortIntfName = tc.configMgmtPortIntfName
+			ret := GetK8sMgmtIntfName()
+			if tc.expectedValue != ret {
+				t.Fail()
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR adds allows the user to configure the management port interface name used by ovnkube-node to be configurable.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
It is needed in the case we want to have two  ovnkube-node processes on the same node.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Setup a Kubernetes cluster with ovn-kubernetes and set OVNKUBE_NODE_MGMT_PORT_INTF_NAME in ovnkube-node yaml to a different value than `ovn-k8s-mp0` 
