### PR TITLE
ovnkube-node: Allow setting the uplink port via OVN_GATEWAY_OPTS

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -419,6 +419,8 @@ type GatewayConfig struct {
 	EgressGWInterface string `gcfg:"egw-interface"`
 	// NextHop is the gateway IP address of Interface; will be autodetected if not given
 	NextHop string `gcfg:"next-hop"`
+	// UplinkPort is the port used as the uplink on the gateway interface bridge.
+	UplinkPort string `gcfg:"uplink-port"`
 	// VLANID is the option VLAN tag to apply to gateway traffic for "shared" mode
 	VLANID uint `gcfg:"vlan-id"`
 	// NodeportEnable sets whether to provide Kubernetes NodePort service or not
@@ -1311,6 +1313,12 @@ var OVNGatewayFlags = []cli.Flag{
 			"configured in the node is used. Only useful with " +
 			"\"init-gateways\"",
 		Destination: &cliConfig.Gateway.NextHop,
+	},
+	&cli.StringFlag{
+		Name: "gateway-uplink-port",
+		Usage: "The port to be used as the uplink on the gateway interface bridge." +
+			"Used in scenarios when it cannot be auto detected.",
+		Destination: &cliConfig.Gateway.UplinkPort,
 	},
 	&cli.UintFlag{
 		Name: "gateway-vlanid",


### PR DESCRIPTION
This PR introduces an option (uplink-port) to bypass the interface which should be used from a given bridge as a gateway interface.

This is useful when we want to have two processes of ovnkube-node on the same host.