### PR TITLE
Make pod to host access route via overlay

### DIFF
--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -33,6 +33,7 @@ const (
 	MulticastClusterOwnerType   ownerType = "MulticastCluster"
 	NetpolNodeOwnerType         ownerType = "NetpolNode"
 	NetpolNamespaceOwnerType    ownerType = "NetpolNamespace"
+	DefaultNodeOwnerType        ownerType = "DefaultNode"
 	VirtualMachineOwnerType     ownerType = "VirtualMachine"
 	UDNEnabledServiceOwnerType  ownerType = "UDNEnabledService"
 	// NetworkPolicyPortIndexOwnerType is the old version of NetworkPolicyOwnerType, kept for sync only
@@ -137,6 +138,12 @@ var AddressSetEgressService = newObjectIDsType(addressSet, EgressServiceOwnerTyp
 
 var AddressSetUDNEnabledService = newObjectIDsType(addressSet, UDNEnabledServiceOwnerType, []ExternalIDKey{
 	// cluster-wide address set name
+	ObjectNameKey,
+	IPFamilyKey,
+})
+
+var AddressSetNode = newObjectIDsType(addressSet, DefaultNodeOwnerType, []ExternalIDKey{
+	// per node address set name
 	ObjectNameKey,
 	IPFamilyKey,
 })

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -53,12 +53,19 @@ add table inet ovn-kubernetes
 add chain inet ovn-kubernetes mgmtport-snat { type nat hook postrouting priority 100 ; comment "OVN SNAT to Management Port" ; }
 add rule inet ovn-kubernetes mgmtport-snat oifname != %q return
 add rule inet ovn-kubernetes mgmtport-snat meta nfproto ipv4 ip saddr 10.1.1.0 counter return
+add rule inet ovn-kubernetes mgmtport-snat ip saddr . meta l4proto . th dport @mgmtport-snat-pod-to-nodeports-v4 counter snat ip to 10.1.1.0
 add rule inet ovn-kubernetes mgmtport-snat meta l4proto . th dport @mgmtport-no-snat-nodeports counter return
+add rule inet ovn-kubernetes mgmtport-snat ip saddr . ip daddr . meta l4proto . th dport @mgmtport-snat-pod-to-services-v4 counter snat ip to 10.1.1.0
 add rule inet ovn-kubernetes mgmtport-snat ip daddr . meta l4proto . th dport @mgmtport-no-snat-services-v4 counter return
 add rule inet ovn-kubernetes mgmtport-snat counter snat ip to 10.1.1.0
+add set inet ovn-kubernetes mgmtport-snat-pod-to-nodeports-v4 { type ipv4_addr . inet_proto . inet_service ; flags interval ; comment "Pod to NodePorts are subject to management port SNAT (IPv4)" ; }
+add set inet ovn-kubernetes mgmtport-snat-pod-to-nodeports-v6 { type ipv6_addr . inet_proto . inet_service ; flags interval ; comment "Pod to NodePorts are subject to management port SNAT (IPv6)" ; }
 add set inet ovn-kubernetes mgmtport-no-snat-nodeports { type inet_proto . inet_service ; comment "NodePorts not subject to management port SNAT" ; }
+add set inet ovn-kubernetes mgmtport-snat-pod-to-services-v4 { type ipv4_addr . ipv4_addr . inet_proto . inet_service ; flags interval ; comment "eTP:Local short-circuit from OVNK Pod is subject to management port SNAT (IPv4)" ; }
+add set inet ovn-kubernetes mgmtport-snat-pod-to-services-v6 { type ipv6_addr . ipv6_addr . inet_proto . inet_service ; flags interval ; comment "eTP:Local short-circuit from OVNK Pod is subject to management port SNAT (IPv6)" ; }
 add set inet ovn-kubernetes mgmtport-no-snat-services-v4 { type ipv4_addr . inet_proto . inet_service ; comment "eTP:Local short-circuit not subject to management port SNAT (IPv4)" ; }
 add set inet ovn-kubernetes mgmtport-no-snat-services-v6 { type ipv6_addr . inet_proto . inet_service ; comment "eTP:Local short-circuit not subject to management port SNAT (IPv6)" ; }
+
 `
 
 // The base expected nftables rules with UDN enabled. You must substitute in the management port interface name.

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -647,9 +647,7 @@ func getGatewayIPTRules(service *corev1.Service, localEndpoints []string, svcHas
 				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
 					// case1 (see function description for details)
 					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
-					if config.Gateway.Mode == config.GatewayModeLocal {
-						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
-					}
+					rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
 					// Note: getGatewayNFTRules will add rules to ensure that sourceIP is preserved
 				}
 				// case2 (see function description for details)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -414,6 +414,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -488,6 +489,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -564,6 +566,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -650,13 +653,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
@@ -750,6 +752,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -845,17 +848,13 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
@@ -984,15 +983,13 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
@@ -1093,6 +1090,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1204,17 +1202,13 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
-						"OVN-KUBE-EXTERNALIP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
@@ -1321,6 +1315,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1422,6 +1417,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1519,6 +1515,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1606,6 +1603,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1701,6 +1699,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1747,6 +1746,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -1951,6 +1951,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2050,6 +2051,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2094,6 +2096,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2183,13 +2186,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
@@ -2229,6 +2231,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2323,14 +2326,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol,
-								service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP":        []string{},
 						"OVN-KUBE-ETP": []string{
@@ -2377,6 +2378,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2475,16 +2477,17 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
+						"OVN-KUBE-ETP": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.Ports[0].TargetPort.IntValue()),
+						},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2524,6 +2527,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2615,14 +2619,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v",
-								service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP":        []string{},
 						"OVN-KUBE-ETP": []string{
@@ -2674,6 +2676,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2768,18 +2771,19 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-						},
+						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, int32(service.Spec.Ports[0].TargetPort.IntValue())),
 						},
-						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ETP": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.Ports[0].TargetPort.IntValue()),
+						},
 					},
 					"filter": {},
 					"mangle": {
@@ -2818,6 +2822,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2882,6 +2887,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
@@ -2938,6 +2944,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 						},
 						"OUTPUT": []string{
+							"-j OVN-KUBE-ETP",
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1218,6 +1218,7 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 						},
 						"OVN-KUBE-ITP": []string{},
 					},
@@ -2327,11 +2328,15 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol,
+								service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
+						"OVN-KUBE-ETP": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol,
+								service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
+						},
 					},
 					"filter": {},
 					"mangle": {
@@ -2615,11 +2620,16 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v",
+								service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-ETP":        []string{},
+						"OVN-KUBE-ETP": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v",
+								service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(),
+								service.Spec.Ports[0].NodePort),
+						},
 					},
 					"filter": {},
 					"mangle": {
@@ -2627,7 +2637,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-ITP": []string{
-							fmt.Sprintf("-p %s -d %s --dport %d -j MARK --set-xmark %s", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, ovnkubeITPMark),
+							fmt.Sprintf("-p %s -d %s --dport %d -j MARK --set-xmark %s",
+								service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, ovnkubeITPMark),
 						},
 					},
 				}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1396,7 +1396,9 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		}
 	}
 
-	for _, set := range []string{nftablesMgmtPortNoSNATNodePorts, nftablesMgmtPortNoSNATServicesV4, nftablesMgmtPortNoSNATServicesV6} {
+	for _, set := range []string{nftablesMgmtPortSNATPodToNodePortsV4, nftablesMgmtPortSNATPodToNodePortsV6,
+		nftablesMgmtPortNoSNATNodePorts, nftablesMgmtPortSNATPodToServicesV4, nftablesMgmtPortSNATPodToServicesV6,
+		nftablesMgmtPortNoSNATServicesV4, nftablesMgmtPortNoSNATServicesV6} {
 		if err = recreateNFTSet(set, keepNFTElems); err != nil {
 			errors = append(errors, err)
 		}

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -99,19 +99,18 @@ func newManagementPortIPFamilyConfig(hostSubnet *net.IPNet, isIPv6 bool) (*manag
 		}
 	}
 	// add the .3 masqueradeIP to add the route via mp0 for ETP=local case
-	// used only in LGW but we create it in SGW as well to maintain parity.
 	if isIPv6 {
-		_, masqueradeSubnet, err := net.ParseCIDR(config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String() + "/128")
+		_, etpMasqueradeCIDR, err := net.ParseCIDR(config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String() + "/128")
 		if err != nil {
 			return nil, err
 		}
-		cfg.allSubnets = append(cfg.allSubnets, masqueradeSubnet)
+		cfg.allSubnets = append(cfg.allSubnets, etpMasqueradeCIDR)
 	} else {
-		_, masqueradeSubnet, err := net.ParseCIDR(config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String() + "/32")
+		_, etpMasqueradeCIDR, err := net.ParseCIDR(config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String() + "/32")
 		if err != nil {
 			return nil, err
 		}
-		cfg.allSubnets = append(cfg.allSubnets, masqueradeSubnet)
+		cfg.allSubnets = append(cfg.allSubnets, etpMasqueradeCIDR)
 	}
 
 	return cfg, nil

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -216,6 +216,8 @@ func (oc *BaseSecondaryLayer2NetworkController) syncNodes(nodes []interface{}) e
 			return fmt.Errorf("spurious object in syncNodes: %v", tmp)
 		}
 
+		// TODO(trozet): handle sync for stale host route policies
+
 		// Add the node to the foundNodes only if it belongs to the local zone.
 		if oc.isLocalZoneNode(node) {
 			oc.localZoneNodes.Store(node.Name, true)

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -639,7 +639,7 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 				}
 
 				for _, vip := range vips {
-					isv6 := utilnet.IsIPv6String((vip))
+					isv6 := utilnet.IsIPv6String(vip)
 					// build switch rules
 					targets := switchV4targets
 					if isv6 {
@@ -669,6 +669,14 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 							Targets: targetsITP,
 						})
 					} else {
+						if !util.IsClusterIP(vip) && cfg.externalTrafficLocal { // this is a node VIP or external IP, respect ETP
+							if isv6 {
+								targets = joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port)
+							} else {
+								targets = joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port)
+							}
+						}
+
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: vip, Port: cfg.inport},
 							Targets: targets,

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1106,7 +1106,7 @@ func (gw *GatewayManager) Cleanup() error {
 		nextHops = append(nextHops, gwIPAddr.IP)
 	}
 	gw.staticRouteCleanup(nextHops, nil)
-	gw.policyRouteCleanup(nextHops)
+	gw.PolicyRouteCleanup(nextHops)
 
 	// Remove the patch port that connects join switch to gateway router
 	lsp := nbdb.LogicalSwitchPort{Name: portName}
@@ -1200,13 +1200,13 @@ func (gw *GatewayManager) staticRouteCleanup(nextHops []net.IP, ipPrefix *net.IP
 	}
 }
 
-// policyRouteCleanup cleans up all policies on cluster router that have a nextHop
+// PolicyRouteCleanup cleans up all policies on cluster router that have a nextHop
 // in the provided list.
 // - if the LRP exists and has the len(nexthops) > 1: it removes
 // the specified gatewayRouterIP from nexthops
 // - if the LRP exists and has the len(nexthops) == 1: it removes
 // the LRP completely
-func (gw *GatewayManager) policyRouteCleanup(nextHops []net.IP) {
+func (gw *GatewayManager) PolicyRouteCleanup(nextHops []net.IP) {
 	for _, nextHop := range nextHops {
 		gwIP := nextHop.String()
 		policyPred := func(item *nbdb.LogicalRouterPolicy) bool {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -37,6 +37,7 @@ import (
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -307,19 +308,19 @@ func addNodeLogicalFlows(testData []libovsdbtest.TestData, expectedOVNClusterRou
 	expectedNodeSwitch *nbdb.LogicalSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup *nbdb.PortGroup,
 	node *tNode) []libovsdbtest.TestData {
 	return addNodeLogicalFlowsHelper(testData, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup,
-		expectedClusterPortGroup, node, false)
+		expectedClusterPortGroup, node, false, false)
 }
 
 func addNodeLogicalFlowsWithServiceController(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup *nbdb.PortGroup,
-	node *tNode, svcTemplateSupport bool) []libovsdbtest.TestData {
+	node *tNode, svcTemplateSupport bool, fakeAddrSet bool) []libovsdbtest.TestData {
 	return addNodeLogicalFlowsHelper(testData, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup,
-		expectedClusterPortGroup, node, svcTemplateSupport)
+		expectedClusterPortGroup, node, svcTemplateSupport, fakeAddrSet)
 }
 
 func addNodeLogicalFlowsHelper(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup *nbdb.PortGroup,
-	node *tNode, serviceControllerEnabled bool) []libovsdbtest.TestData {
+	node *tNode, serviceControllerEnabled bool, fakeAddrSet bool) []libovsdbtest.TestData {
 
 	lrpName := types.RouterToSwitchPrefix + node.Name
 	chassisName := node.SystemID
@@ -370,8 +371,20 @@ func addNodeLogicalFlowsHelper(testData []libovsdbtest.TestData, expectedOVNClus
 	expectedNodeSwitch.Ports = append(expectedNodeSwitch.Ports, types.K8sPrefix+node.Name+"-UUID")
 	expectedClusterPortGroup.Ports = []string{types.K8sPrefix + node.Name + "-UUID"}
 
+	dbIDs := getNodeIPAddrSetDbIDs(node.Name, DefaultNetworkControllerName)
+	if !fakeAddrSet {
+		// IPv6 not used in testing yet
+		v4Set, _ := addressset.GetTestDbAddrSets(dbIDs, []string{node.NodeIP})
+		if v4Set != nil {
+			v4Set.UUID = "nodeIPV4Addrs-UUID"
+			testData = append(testData, v4Set)
+		}
+	}
+	v4NodeIPAddrSetHash, _ := addressset.GetHashNamesForAS(dbIDs)
+
 	matchStr1 := fmt.Sprintf(`inport == "rtos-%s" && ip4.dst == %s /* %s */`, node.Name, node.GatewayRouterIP, node.Name)
 	matchStr2 := fmt.Sprintf(`inport == "rtos-%s" && ip4.dst == %s /* %s */`, node.Name, node.NodeIP, node.Name)
+	matchStr3 := fmt.Sprintf(`ip4.dst == $%s /* %s */`, v4NodeIPAddrSetHash, node.Name)
 	intPriority, _ := strconv.Atoi(types.NodeSubnetPolicyPriority)
 	testData = append(testData, &nbdb.LogicalRouterPolicy{
 		UUID:     "policy-based-route-1-UUID",
@@ -387,7 +400,16 @@ func addNodeLogicalFlowsHelper(testData []libovsdbtest.TestData, expectedOVNClus
 		Nexthops: []string{node.NodeMgmtPortIP},
 		Priority: intPriority,
 	})
-	expectedOVNClusterRouter.Policies = append(expectedOVNClusterRouter.Policies, []string{"policy-based-route-1-UUID", "policy-based-route-2-UUID"}...)
+	testData = append(testData, &nbdb.LogicalRouterPolicy{
+		UUID:     "policy-based-route-3-UUID",
+		Action:   nbdb.LogicalRouterPolicyActionReroute,
+		Match:    matchStr3,
+		Nexthops: []string{node.NodeMgmtPortIP},
+		Priority: types.HostAccessPolicyPriority,
+	})
+
+	expectedOVNClusterRouter.Policies = append(expectedOVNClusterRouter.Policies,
+		[]string{"policy-based-route-1-UUID", "policy-based-route-2-UUID", "policy-based-route-3-UUID"}...)
 	testData = append(testData, expectedClusterPortGroup)
 	testData = append(testData, expectedClusterRouterPortGroup)
 	return testData
@@ -1092,7 +1114,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		oc.SCTPSupport = true
 
 		expectedNBDatabaseState = addNodeLogicalFlowsWithServiceController(nil, expectedOVNClusterRouter, expectedNodeSwitch,
-			expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, oc.svcTemplateSupport)
+			expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, oc.svcTemplateSupport, false)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -117,11 +117,11 @@ func withClusterPortGroup() option {
 	}
 }
 
-func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(isPrimary bool) []libovsdbtest.TestData {
-	return em.expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary, nil)
+func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(netInfo secondaryNetInfo) []libovsdbtest.TestData {
+	return em.expectedLogicalSwitchesAndPortsWithLspEnabled(netInfo, nil)
 }
 
-func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary bool, expectedPodLspEnabled map[string]*bool) []libovsdbtest.TestData {
+func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWithLspEnabled(netInfo secondaryNetInfo, expectedPodLspEnabled map[string]*bool) []libovsdbtest.TestData {
 	data := []libovsdbtest.TestData{}
 	for _, ocInfo := range em.fakeOvn.secondaryControllers {
 		nodeslsps := make(map[string][]string)
@@ -264,7 +264,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 				Ports: nodeslsps[switchName],
 				ExternalIDs: map[string]string{
 					ovntypes.NetworkExternalID:     ocInfo.bnc.GetNetworkName(),
-					ovntypes.NetworkRoleExternalID: util.GetUserDefinedNetworkRole(isPrimary),
+					ovntypes.NetworkRoleExternalID: util.GetUserDefinedNetworkRole(netInfo.isPrimary),
 				},
 				OtherConfig: otherConfig,
 				ACLs:        acls[switchName],
@@ -274,7 +274,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 				em.gatewayConfig != nil {
 				if ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
 					data = append(data, expectedGWEntities(pod.nodeName, ocInfo.bnc, *em.gatewayConfig)...)
-					data = append(data, expectedLayer3EgressEntities(ocInfo.bnc, *em.gatewayConfig, subnet)...)
+					data = append(data, expectedLayer3EgressEntities(ocInfo.bnc, *em.gatewayConfig, subnet, testing.MustParseIPNet(netInfo.clustersubnets))...)
 				} else {
 					data = append(data, expectedLayer2EgressEntities(ocInfo.bnc, *em.gatewayConfig, pod.nodeName)...)
 				}

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -329,7 +329,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			expectedDatabaseState := []libovsdb.TestData{}
 			expectedDatabaseState = addNodeLogicalFlowsWithServiceController(expectedDatabaseState, expectedOVNClusterRouter,
-				expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, fakeOvn.controller.svcTemplateSupport)
+				expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, fakeOvn.controller.svcTemplateSupport, true)
 
 			// Addressset of the host-network namespace was initialized but the node logical switch management port address may or may not
 			// be in the addressset yet, depending on if the host subnets annotation of the node exists in the informer cache. The addressset

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -806,7 +806,7 @@ func (oc *SecondaryLayer2NetworkController) cleanupHostAccessRoutePolicies(node 
 // which are leaving via UDN's mpX interface to the UDN's masqueradeIP.
 func (oc *SecondaryLayer2NetworkController) addUDNClusterSubnetEgressSNAT(localPodSubnets []*net.IPNet, routerName string) error {
 	outputPort := types.GWRouterToJoinSwitchPrefix + routerName
-	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort)
+	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, localPodSubnets, outputPort)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -551,6 +551,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		sr2                = "sr2-UUID"
 		lrsr1              = "lrsr1-UUID"
 		routerPolicyUUID1  = "lrp1-UUID"
+		routerPolicyUUID2  = "lrp2-UUID"
 		hostCIDRPolicyUUID = "host-cidr-policy-UUID"
 		masqSNATUUID1      = "masq-snat1-UUID"
 	)
@@ -570,7 +571,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		StaticRoutes: []string{sr1, sr2},
 		ExternalIDs:  gwRouterExternalIDs(netInfo, gwConfig),
 		Options:      gwRouterOptions(gwConfig),
-		Policies:     []string{routerPolicyUUID1},
+		Policies:     []string{routerPolicyUUID1, routerPolicyUUID2},
 	}
 	gr.Options["lb_force_snat_ip"] = gwRouterJoinIPAddress().IP.String()
 	expectedEntities := []libovsdbtest.TestData{
@@ -581,6 +582,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		expectedGRToExternalSwitchLRP(gwRouterName, netInfo, nodePhysicalIPAddress(), udnGWSNATAddress()),
 		masqSNAT,
 		expectedLogicalRouterPolicy(routerPolicyUUID1, netInfo, nodeName, nodeIP().IP.String(), managementPortIP(layer2Subnet()).String()),
+		expectedNodeLogicalRouterPolicy(routerPolicyUUID2, netInfo, nodeName, managementPortIP(layer2Subnet()).String(), nodeName),
 	}
 
 	expectedEntities = append(expectedEntities, expectedStaticMACBindings(gwRouterName, staticMACBindingIPs())...)

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -585,7 +585,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		expectedNodeLogicalRouterPolicy(routerPolicyUUID2, netInfo, nodeName, managementPortIP(layer2Subnet()).String(), nodeName),
 	}
 
-	expectedEntities = append(expectedEntities, expectedStaticMACBindings(gwRouterName, staticMACBindingIPs())...)
+	expectedEntities = append(expectedEntities, expectedStaticMACBindings(gwRouterName, netInfo)...)
 
 	if config.Gateway.Mode == config.GatewayModeLocal {
 		l2LGWLRP := expectedLogicalRouterPolicy(hostCIDRPolicyUUID, netInfo, nodeName, nodeCIDR().String(), managementPortIP(layer2Subnet()).String())

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -125,7 +125,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 							fakeOvn,
 							[]testPod{podInfo},
 							expectationOptions...,
-						).expectedLogicalSwitchesAndPorts(netInfo.isPrimary)...))
+						).expectedLogicalSwitchesAndPorts(netInfo)...))
 
 				return nil
 			}
@@ -248,7 +248,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 							fakeOvn,
 							[]testPod{sourcePodInfo},
 							expectationOptions...,
-						).expectedLogicalSwitchesAndPorts(netInfo.isPrimary)...))
+						).expectedLogicalSwitchesAndPorts(netInfo)...))
 
 				targetPodInfo := dummyL2TestPod(ns, netInfo, targetPodInfoIdx, secondaryNetworkIdx)
 				targetKvPod := newMultiHomedKubevirtPod(
@@ -275,7 +275,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 							fakeOvn,
 							testPods,
 							expectationOptions...,
-						).expectedLogicalSwitchesAndPortsWithLspEnabled(netInfo.isPrimary, expectedPodLspEnabled)...))
+						).expectedLogicalSwitchesAndPortsWithLspEnabled(netInfo, expectedPodLspEnabled)...))
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -244,7 +244,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 								fakeOvn,
 								[]testPod{podInfo},
 								expectationOptions...,
-							).expectedLogicalSwitchesAndPorts(netInfo.isPrimary)...)))
+							).expectedLogicalSwitchesAndPorts(netInfo)...)))
 
 				return nil
 			}
@@ -345,7 +345,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 						expectedGWEntities(podInfo.nodeName, networkConfig, *gwConfig)...)
 					initialDB.NBData = append(
 						initialDB.NBData,
-						expectedLayer3EgressEntities(networkConfig, *gwConfig, testing.MustParseIPNet(netInfo.hostsubnets))...)
+						expectedLayer3EgressEntities(networkConfig, *gwConfig, testing.MustParseIPNet(netInfo.hostsubnets), testing.MustParseIPNet(netInfo.clustersubnets))...)
 					initialDB.NBData = append(initialDB.NBData,
 						newNetworkClusterPortGroup(networkConfig),
 					)
@@ -795,7 +795,7 @@ func expectedLogicalRouterPort(lrpName string, netInfo util.NetInfo, options map
 	}
 }
 
-func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayConfig, nodeSubnet *net.IPNet) []libovsdbtest.TestData {
+func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayConfig, nodeSubnet *net.IPNet, clusterSubnet *net.IPNet) []libovsdbtest.TestData {
 	const (
 		routerPolicyUUID1 = "lrpol1-UUID"
 		routerPolicyUUID2 = "lrpol2-UUID"
@@ -810,7 +810,7 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	rtosLRPName := fmt.Sprintf("%s%s", types.RouterToSwitchPrefix, netInfo.GetNetworkScopedName(nodeName))
 	rtosLRPUUID := rtosLRPName + "-UUID"
 	nodeIP := gwConfig.IPAddresses[0].IP.String()
-	masqSNAT := newNATEntry(masqSNATUUID1, "169.254.169.14", nodeSubnet.String(), standardNonDefaultNetworkExtIDs(netInfo), "")
+	masqSNAT := newNATEntry(masqSNATUUID1, "169.254.169.14", clusterSubnet.String(), standardNonDefaultNetworkExtIDs(netInfo), "")
 	masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
 	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName))
 	if !config.OVNKubernetesFeature.EnableInterconnect {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -105,6 +105,7 @@ const (
 	// priority of logical router policies on the OVNClusterRouter
 	EgressFirewallStartPriority           = 10000
 	MinimumReservedEgressFirewallPriority = 2000
+	HostAccessPolicyPriority              = 1500
 	MGMTPortPolicyPriority                = "1005"
 	NodeSubnetPolicyPriority              = "1004"
 	InterNodePolicyPriority               = "1003"

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -76,6 +76,7 @@ type NetInfo interface {
 	GetNetworkScopedClusterRouterName() string
 	GetNetworkScopedGWRouterName(nodeName string) string
 	GetNetworkScopedSwitchName(nodeName string) string
+	GetNetworkScopedSwitchToRouterPortName(nodeName string) string
 	GetNetworkScopedJoinSwitchName() string
 	GetNetworkScopedExtSwitchName(nodeName string) string
 	GetNetworkScopedPatchPortName(bridgeID, nodeName string) string
@@ -519,6 +520,10 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedSwitchName(nodeName string) string 
 	return nInfo.GetNetworkScopedName(nodeName)
 }
 
+func (nInfo *DefaultNetInfo) GetNetworkScopedSwitchToRouterPortName(nodeName string) string {
+	return types.SwitchToRouterPrefix + nInfo.GetNetworkScopedName(nodeName)
+}
+
 func (nInfo *DefaultNetInfo) GetNetworkScopedJoinSwitchName() string {
 	return nInfo.GetNetworkScopedName(types.OVNJoinSwitch)
 }
@@ -712,6 +717,13 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) strin
 		return fmt.Sprintf("%s%s", nInfo.getPrefix(), types.OVNLayer2Switch)
 	}
 	return nInfo.GetNetworkScopedName(nodeName)
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchToRouterPortName(nodeName string) string {
+	if nInfo.TopologyType() == types.Layer2Topology {
+		return fmt.Sprintf("%s%s%s_%s", types.SwitchToRouterPrefix, nInfo.getPrefix(), types.OVNLayer2Switch, nodeName)
+	}
+	return types.SwitchToRouterPrefix + nInfo.GetNetworkScopedName(nodeName)
 }
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedJoinSwitchName() string {

--- a/test/e2e/egress_services.go
+++ b/test/e2e/egress_services.go
@@ -332,12 +332,17 @@ spec:
 			ginkgo.By("Creating the backend pods")
 			podsCreateSync := errgroup.Group{}
 			podsToNodeMapping := make(map[string]v1.Node, 3)
+			podIPs := make(map[string][]string, 3)
 			for i, name := range pods {
 				name := name
 				i := i
+				podIPs[name] = []string{}
 				podsCreateSync.Go(func() error {
 					p, err := createGenericPodWithLabel(f, name, nodes[i].Name, f.Namespace.Name, command, podsLabels)
 					framework.Logf("%s podIPs are: %v", p.Name, p.Status.PodIPs)
+					for _, podIP := range p.Status.PodIPs {
+						podIPs[name] = append(podIPs[name], podIP.IP)
+					}
 					return err
 				})
 				podsToNodeMapping[name] = nodes[i]
@@ -412,15 +417,20 @@ spec:
 			}
 			ginkgo.By("Verifying traffic from all the 3 backend pods should exit with their node's IP when going towards other nodes in cluster")
 			for _, pod := range pods { // loop through all the pods, ensure the curl to other node is always going via nodeIP of the node where the pod lives
-				srcNode := podsToNodeMapping[pod]
-				if srcNode.Name == dstNode.Name {
-					framework.Logf("Skipping check for pod %s because its on the destination node; srcIP will be podIP", pod)
-					continue // traffic flow is pod -> mp0 -> local host: This won't have nodeIP as SNAT
+				var expectedsrcIP string
+				for _, ip := range podIPs[pod] {
+					if utilnet.IsIPv4String(ip) && protocol == v1.IPv4Protocol {
+						expectedsrcIP = ip
+						break
+					}
+
+					if utilnet.IsIPv6String(ip) && protocol == v1.IPv6Protocol {
+						expectedsrcIP = ip
+						break
+					}
 				}
-				v4, v6 = getNodeAddresses(&srcNode)
-				expectedsrcIP := v4
-				if protocol == v1.IPv6Protocol {
-					expectedsrcIP = v6
+				if len(expectedsrcIP) == 0 {
+					framework.Failf("no valid IP found for protocol %s, pod ips: %#v", protocol, podIPs[pod])
 				}
 				gomega.Consistently(func() error {
 					return curlAgnHostClientIPFromPod(f.Namespace.Name, pod, expectedsrcIP, dstIP, podHTTPPort)

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -946,19 +946,19 @@ spec:
 	   4. Check that the status is of length one and that it is assigned to egress1Node
 	   5. Create one pod matching the EgressIP: running on egress1Node
 	   6. Check connectivity from pod to an external "node" and verify that the srcIP is the expected egressIP
-	   7. Check connectivity from pod to another node (egress2Node) primary IP and verify that the srcIP is the expected nodeIP
-	   8. Check connectivity from pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected nodeIP
+	   7. Check connectivity from pod to another node (egress2Node) primary IP and verify that the srcIP is the expected podIP
+	   8. Check connectivity from pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected podIP
 	   9. Add the "k8s.ovn.org/egress-assignable" label to egress2Node
 	   10. Remove the "k8s.ovn.org/egress-assignable" label from egress1Node
 	   11. Check that the status is of length one and that it is assigned to egress2Node
 	   12. Check connectivity from pod to an external "node" and verify that the srcIP is the expected egressIP
-	   13. Check connectivity from pod to another node (egress2Node) primary IP and verify that the srcIP is the expected nodeIP
-	   14. Check connectivity from pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected nodeIP
+	   13. Check connectivity from pod to another node (egress2Node) primary IP and verify that the srcIP is the expected podIP
+	   14. Check connectivity from pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected podIP
 	   15. Create second pod not matching the EgressIP: running on egress1Node
 	   16. Check connectivity from second pod to external node and verify that the srcIP is the expected nodeIP
 	   17. Add pod selector label to make second pod egressIP managed
 	   18. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP
-	   19. Check connectivity from second pod to another node (egress2Node) primary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted for pods unless pod is on its own egressNode)
+	   19. Check connectivity from second pod to another node (egress2Node) primary IP and verify that the srcIP is the expected podIP (this verifies SNAT's towards nodeIP are not deleted for pods unless pod is on its own egressNode)
 	   20. Check connectivity from second pod to another node (egress2Node) secondary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted for pods unless pod is on its own egressNode)
 	*/
 	ginkgo.It("[OVN network] Should validate the egress IP SNAT functionality against host-networked pods", func() {
@@ -1061,7 +1061,8 @@ spec:
 
 		ginkgo.By("5. Create one pod matching the EgressIP: running on egress1Node")
 		createGenericPodWithLabel(f, pod1Name, pod2Node.name, f.Namespace.Name, command, podEgressLabel)
-		_, err = getPodIPWithRetry(f.ClientSet, isIPv6TestRun, f.Namespace.Name, pod1Name)
+		var pod1IP net.IP
+		pod1IP, err = getPodIPWithRetry(f.ClientSet, isIPv6TestRun, f.Namespace.Name, pod1Name)
 		framework.ExpectNoError(err, "Step 5. Create one pod matching the EgressIP: running on egress1Node, failed, err: %v", err)
 		framework.Logf("Created pod %s on node %s", pod1Name, pod2Node.name)
 
@@ -1069,12 +1070,12 @@ spec:
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod1Name, podNamespace.Name, true, []string{egressIP1.String()}))
 		framework.ExpectNoError(err, "Step 6. Check connectivity from pod to an external node and verify that the srcIP is the expected egressIP, failed: %v", err)
 
-		ginkgo.By("7. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP")
-		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		ginkgo.By("7. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected podIP")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod1Name, podNamespace.Name, true, []string{pod1IP.String()}))
 		framework.ExpectNoError(err, "Step 7. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
-		ginkgo.By("8. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected nodeIP")
-		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		ginkgo.By("8. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected podIP")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod1Name, podNamespace.Name, true, []string{pod1IP.String()}))
 		framework.ExpectNoError(err, "Step 8. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
 		ginkgo.By("9. Add the \"k8s.ovn.org/egress-assignable\" label to egress2Node")
@@ -1098,12 +1099,12 @@ spec:
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod1Name, podNamespace.Name, true, []string{egressIP1.String()}))
 		framework.ExpectNoError(err, "Step 12. Check connectivity from pod to an external \"node\" and verify that the srcIP is the expected egressIP, failed, err: %v", err)
 
-		ginkgo.By("13. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected nodeIP")
-		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		ginkgo.By("13. Check connectivity from pod to another node primary IP and verify that the srcIP is the expected podIP")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod1Name, podNamespace.Name, true, []string{pod1IP.String()}))
 		framework.ExpectNoError(err, "Step 13. Check connectivity from pod to another node and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
-		ginkgo.By("14. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected nodeIP")
-		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod1Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
+		ginkgo.By("14. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected podIP")
+		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod1Name, podNamespace.Name, true, []string{pod1IP.String()}))
 		framework.ExpectNoError(err, "Step 14. Check connectivity from pod to another node secondary IP and verify that the srcIP is the expected nodeIP, failed: %v", err)
 
 		ginkgo.By("15. Create second pod not matching the EgressIP: running on egress1Node")
@@ -1125,6 +1126,7 @@ spec:
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(targetNode, pod2Name, podNamespace.Name, true, []string{egressIP1.String()}))
 		framework.ExpectNoError(err, "Step 18. Check connectivity from second pod to external node and verify that the srcIP is the expected egressIP, failed: %v", err)
 
+		/** TODO(trozet): this shoudl probably now be changed to check the actual OVN NBDB to make sure the entries are still there
 		ginkgo.By("19. Check connectivity from second pod to another node primary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode)")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(hostNetPod, pod2Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
 		framework.ExpectNoError(err, "Step 19. Check connectivity from second pod to another node and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode), failed: %v", err)
@@ -1132,6 +1134,7 @@ spec:
 		ginkgo.By("20. Check connectivity from second pod to another node secondary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode)")
 		err = wait.PollImmediate(retryInterval, retryTimeout, targetExternalContainerAndTest(otherHostNetPodIP, pod2Name, podNamespace.Name, true, []string{egressNodeIP.String()}))
 		framework.ExpectNoError(err, "Step 20. Check connectivity from second pod to another node secondary IP and verify that the srcIP is the expected nodeIP (this verifies SNAT's towards nodeIP are not deleted unless node is egressNode), failed: %v", err)
+		*/
 	})
 
 	// Validate the egress IP with stateful sets or pods recreated with same name


### PR DESCRIPTION
We have had a myriad of issues where pods trying to reach kubernetes hosts run into problems, due to this traffic being treated as north/south egress. Some of these problems include trying to avoid egress features like egress services, or egress IP when trying to talk to another kubernetes nodes. For all intents and purposes, an ovn networked pod trying to communicate with a host network pod or process on another node can be treated as internal traffic to the cluster.

With this patch, logical route policies are added to ovn_cluster_router that reference and address set for all known host ips. Now if any pod is trying to reach a known IP on a kubernetes node, it will be routed via geneve to the ovn-k8s-mp0 port on that node. This is true for OVN IC or traditional deployments.

