### PR TITLE
move ovnkube_node_cni_request_duration metrics to linear buckets

### DIFF
--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -15,7 +15,7 @@ var MetricCNIRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOp
 	Subsystem: MetricOvnkubeSubsystemNode,
 	Name:      "cni_request_duration_seconds",
 	Help:      "The duration of CNI server requests.",
-	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	Buckets:   prometheus.LinearBuckets(1, 0.5, 15)},
 	//labels
 	[]string{"command", "err"},
 )


### PR DESCRIPTION
The buckets defined for this metric was:
 -- prometheus.ExponentialBuckets(.1, 2, 15)
which expands to:
[0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2, 102.4, ...]

This doesn't provide accurate information for analysis because we found that most of the P99 latency falls in the range between 1.6 - 6.4, so we only see the value 1.6, 3.2, 6.4, while it would be better to see if it is for example, 2, 3, 4, or 5 seconds for the CNI request duration.

Furthermoe, our goal is to provide networking to Pods sooner tha 15s instead of pow(2, 15)!

This patch changes it to use linearBuckets instead of Exponential.

Authored-by: Han Zhou <hzhou@ovn.org>
