### PR TITLE
Secondary nets: implement support for nested virtualization

### DIFF
--- a/docs/features/multiple-networks/multi-homing.md
+++ b/docs/features/multiple-networks/multi-homing.md
@@ -65,6 +65,8 @@ spec:
 - `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 - `netAttachDefName` (string, required): must match `<namespace>/<net-attach-def name>`
   of the surrounding object.
+- `disablePortSecurity` (boolean, optional): enable this flag to opt-out of port
+  security, thus removing MAC / IP spoofing protection from your workloads.
 
 **NOTE**
 - the `subnets` attribute indicates both the subnet across the cluster, and per node.
@@ -110,6 +112,11 @@ spec:
 - `excludeSubnets` (string, optional): a comma separated list of CIDRs / IPs.
   These IPs will be removed from the assignable IP pool, and never handed over
   to the pods.
+- `disablePortSecurity` (boolean, optional): enable this flag to opt-out of port
+  security, thus removing MAC / IP spoofing protection from your workloads.
+- `allowL2Unknown` (boolean, optional): enable this flag to allow traffic for
+unknown destinations to be delivered to the ports attached to the secondary
+network.
 
 **NOTE**
 - when the subnets attribute is omitted, the logical switch implementing the
@@ -161,6 +168,11 @@ localnet network.
   These IPs will be removed from the assignable IP pool, and never handed over
   to the pods.
 - `vlanID` (integer, optional): assign VLAN tag. Defaults to none.
+- `disablePortSecurity` (boolean, optional): enable this flag to opt-out of port
+  security, thus removing MAC / IP spoofing protection from your workloads.
+- `allowL2Unknown` (boolean, optional): enable this flag to allow traffic for
+unknown destinations to be delivered to the ports attached to the secondary
+network.
 
 **NOTE**
 - when the subnets attribute is omitted, the logical switch implementing the

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -32,11 +32,18 @@ type NetConf struct {
 	// they are originally created - e.g. a KubeVirt VM's migration, or
 	// restart.
 	AllowPersistentIPs bool `json:"allowPersistentIPs,omitempty"`
-	// DisablePortSecurity is valid on both localnet / layer topologies.
+	// DisablePortSecurity is valid on both localnet / layer2 topologies.
 	// It allows the admin to opt out of port security, allowing nested
 	// virtualization scenarios, where traffic from multiple MAC addresses
 	// (bridged VMs) can egress over the OVN port
 	DisablePortSecurity bool `json:"disablePortSecurity,omitempty"`
+	// enableL2Unknown is valid on both localnet / layer2 topologies.
+	// This allows the logical switch ports attaching to this network to have
+	// an unknown set of Ethernet addresses. When an OVN logical switch
+	// processes a unicast Ethernet frame whose destination MAC address is not
+	// in any logical port’s addresses column, it delivers it to the port (or
+	// ports) whose addresses columns include unknown.
+	EnableL2Unknown bool `json:"enableL2Unknown,omitempty"`
 
 	// PciAddrs in case of using sriov or Auxiliry device name in case of SF
 	DeviceID string `json:"deviceID,omitempty"`

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -32,6 +32,11 @@ type NetConf struct {
 	// they are originally created - e.g. a KubeVirt VM's migration, or
 	// restart.
 	AllowPersistentIPs bool `json:"allowPersistentIPs,omitempty"`
+	// DisablePortSecurity is valid on both localnet / layer topologies.
+	// It allows the admin to opt out of port security, allowing nested
+	// virtualization scenarios, where traffic from multiple MAC addresses
+	// (bridged VMs) can egress over the OVN port
+	DisablePortSecurity bool `json:"disablePortSecurity,omitempty"`
 
 	// PciAddrs in case of using sriov or Auxiliry device name in case of SF
 	DeviceID string `json:"deviceID,omitempty"`

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -566,7 +566,9 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 	}
 
 	// CNI depends on the flows from port security, delay setting it until end
-	lsp.PortSecurity = addresses
+	if !bnc.NetInfo.DisablePortSecurity() {
+		lsp.PortSecurity = addresses
+	}
 
 	// On layer2 topology with interconnect, we need to add specific port config
 	if bnc.isLayer2Interconnect() {

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -570,8 +570,12 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		lsp.PortSecurity = append(lsp.PortSecurity, lsp.Addresses...)
 	}
 	if bnc.AllowL2Unknown() {
-		const allowUnknownAddresses = "unknown"
+		const (
+			allowUnknownAddresses = "unknown"
+			useFDB                = "force_fdb_lookup"
+		)
 		lsp.Addresses = append(lsp.Addresses, allowUnknownAddresses)
+		lsp.Options[useFDB] = "true"
 	}
 
 	// On layer2 topology with interconnect, we need to add specific port config

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -566,8 +566,12 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 	}
 
 	// CNI depends on the flows from port security, delay setting it until end
-	if !bnc.NetInfo.DisablePortSecurity() {
-		lsp.PortSecurity = addresses
+	if !bnc.DisablePortSecurity() {
+		lsp.PortSecurity = append(lsp.PortSecurity, lsp.Addresses...)
+	}
+	if bnc.AllowL2Unknown() {
+		const allowUnknownAddresses = "unknown"
+		lsp.Addresses = append(lsp.Addresses, allowUnknownAddresses)
 	}
 
 	// On layer2 topology with interconnect, we need to add specific port config

--- a/go-controller/pkg/ovn/multi_homed_pods_test.go
+++ b/go-controller/pkg/ovn/multi_homed_pods_test.go
@@ -1,0 +1,246 @@
+package ovn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/urfave/cli/v2"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+type secondaryNetInfo struct {
+	netName  string
+	nadName  string
+	podIP    string
+	podMAC   string
+	topology string
+}
+
+var _ = Describe("OVN Multi-Homed pod operations", func() {
+	const (
+		nadName              = "blue-net"
+		nodeName             = "node1"
+		ns                   = "namespace1"
+		secondaryNetworkName = "isolatednet"
+	)
+	var (
+		app       *cli.App
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed()) // reset defaults
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true)
+		initialDB = libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name: nodeName,
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	It("reconciles a new pod", func() {
+		app.Action = func(ctx *cli.Context) error {
+			namespaceT := *newNamespace(ns)
+			isolatedNetInfo := secondaryNetInfo{
+				netName:  secondaryNetworkName,
+				nadName:  namespacedName(ns, nadName),
+				podMAC:   "02:03:04:05:06:07",
+				podIP:    "192.168.200.10",
+				topology: ovntypes.Layer2Topology,
+			}
+			t := newMultiHomedTestPod(
+				nodeName,
+				"10.128.1.0/24",
+				"10.128.1.2",
+				"10.128.1.1",
+				"myPod",
+				"10.128.1.3",
+				"0a:58:0a:80:01:03",
+				namespaceT.Name,
+				isolatedNetInfo,
+			)
+
+			netConf := newNetconf(
+				isolatedNetInfo.netName,
+				isolatedNetInfo.topology,
+				isolatedNetInfo.nadName,
+			)
+			nad, err := newNetworkAttachmentDefinition(
+				ns,
+				nadName,
+				netConf,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isolatedNetInfo.setupOVNDependencies(&initialDB, netConf)).To(Succeed())
+
+			fakeOvn.startWithDBSetup(
+				initialDB,
+				&v1.NamespaceList{
+					Items: []v1.Namespace{
+						namespaceT,
+					},
+				},
+				&v1.NodeList{
+					Items: []v1.Node{
+						*newNode(nodeName, "192.168.126.202/24"),
+					},
+				},
+				&v1.PodList{
+					Items: []v1.Pod{
+						*newMultiHomedPod(t.namespace, t.podName, t.nodeName, t.podIP, isolatedNetInfo),
+					},
+				},
+				&nadapi.NetworkAttachmentDefinitionList{
+					Items: []nadapi.NetworkAttachmentDefinition{*nad},
+				},
+			)
+			t.populateLogicalSwitchCache(fakeOvn)
+
+			// pod exists, networks annotations don't
+			pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := pod.Annotations[util.OvnPodAnnotationName]
+			Expect(ok).To(BeFalse())
+
+			Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
+			Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
+			secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
+			Expect(ok).To(BeTrue())
+
+			t.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+			Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
+			Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+
+			// check that after start networks annotations and nbdb will be updated
+			Eventually(func() string {
+				return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
+			}).WithTimeout(2 * time.Second).Should(MatchJSON(t.getAnnotationsJson()))
+
+			Eventually(fakeOvn.nbClient).Should(
+				libovsdbtest.HaveData(
+					append(
+						getExpectedDataPodsAndSwitches([]testPod{t}, []string{nodeName}),
+						getExpectedDataPodsAndSwitchesForSecondaryNetwork(fakeOvn, []testPod{t})...)))
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+})
+
+func newNetconf(networkName, topology, nadName string, subnets ...string) ovncnitypes.NetConf {
+	const plugin = "ovn-k8s-cni-overlay"
+	return ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: networkName,
+			Type: plugin,
+		},
+		Topology: topology,
+		NADName:  nadName,
+		Subnets:  strings.Join(subnets, ","),
+	}
+}
+
+func newMultiHomedTestPod(
+	nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace string,
+	multiHomingConfigs ...secondaryNetInfo,
+) testPod {
+	pod := newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace)
+	for _, multiHomingConf := range multiHomingConfigs {
+		pod.addNetwork(
+			multiHomingConf.netName,
+			multiHomingConf.nadName,
+			"",
+			"",
+			"",
+			multiHomingConf.podIP,
+			multiHomingConf.podMAC,
+			0,
+		)
+	}
+	return pod
+}
+
+func newMultiHomedPod(namespace, name, node, podIP string, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
+	pod := newPod(namespace, name, node, podIP)
+	var secondaryNetworks []nadapi.NetworkSelectionElement
+	for _, multiHomingConf := range multiHomingConfigs {
+		nadNamePair := strings.Split(multiHomingConf.nadName, "/")
+		ns := namespace
+		attachmentName := multiHomingConf.nadName
+		if len(nadNamePair) > 1 {
+			ns = nadNamePair[0]
+			attachmentName = nadNamePair[1]
+		}
+		nse := nadapi.NetworkSelectionElement{
+			Name:       attachmentName,
+			Namespace:  ns,
+			MacRequest: multiHomingConf.podMAC,
+		}
+		if len(multiHomingConf.podIP) > 0 {
+			nse.IPRequest = []string{multiHomingConf.podIP + "/24"}
+		}
+		secondaryNetworks = append(secondaryNetworks, nse)
+	}
+	serializedNetworkSelectionElements, _ := json.Marshal(secondaryNetworks)
+	pod.Annotations = map[string]string{nadapi.NetworkAttachmentAnnot: string(serializedNetworkSelectionElements)}
+	return pod
+}
+
+func namespacedName(ns, name string) string { return fmt.Sprintf("%s/%s", ns, name) }
+
+func (sni *secondaryNetInfo) setupOVNDependencies(dbData *libovsdbtest.TestSetup, netConf ovncnitypes.NetConf) error {
+	netInfo, err := util.NewNetInfo(&netConf)
+	if err != nil {
+		return err
+	}
+
+	switch sni.topology {
+	case ovntypes.Layer2Topology:
+		dbData.NBData = append(dbData.NBData, &nbdb.LogicalSwitch{
+			Name:        netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch),
+			UUID:        netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch) + "_UUID",
+			ExternalIDs: map[string]string{ovntypes.NetworkExternalID: sni.netName},
+		})
+	case ovntypes.LocalnetTopology:
+		dbData.NBData = append(dbData.NBData, &nbdb.LogicalSwitch{
+			Name:        netInfo.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch),
+			UUID:        netInfo.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch) + "_UUID",
+			ExternalIDs: map[string]string{ovntypes.NetworkExternalID: sni.netName},
+		})
+	default:
+		return fmt.Errorf("missing topology in the network configuration: %v", sni)
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -145,13 +145,26 @@ func (p testPod) populateSecondaryNetworkLogicalSwitchCache(fakeOvn *FakeOVN, oc
 		podInfo := p.secondaryPodInfos[ocInfo.bnc.GetNetworkName()]
 		err = ocInfo.bnc.lsManager.AddOrUpdateSwitch(ocInfo.bnc.GetNetworkScopedName(p.nodeName), []*net.IPNet{ovntest.MustParseIPNet(podInfo.nodeSubnet)})
 	case ovntypes.Layer2Topology:
-		subnet := ocInfo.bnc.Subnets()[0]
-		err = ocInfo.bnc.lsManager.AddOrUpdateSwitch(ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch), []*net.IPNet{subnet.CIDR})
+		err = ocInfo.bnc.lsManager.AddOrUpdateSwitch(
+			ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch),
+			subnetCIDR(ocInfo.bnc.Subnets()),
+		)
 	case ovntypes.LocalnetTopology:
-		subnet := ocInfo.bnc.Subnets()[0]
-		err = ocInfo.bnc.lsManager.AddOrUpdateSwitch(ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch), []*net.IPNet{subnet.CIDR})
+		err = ocInfo.bnc.lsManager.AddOrUpdateSwitch(
+			ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch),
+			subnetCIDR(ocInfo.bnc.Subnets()),
+		)
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func subnetCIDR(subnets []config.CIDRNetworkEntry) []*net.IPNet {
+	var subnetCIDRs []*net.IPNet
+	if len(subnets) > 0 {
+		subnet := subnets[0]
+		subnetCIDRs = []*net.IPNet{subnet.CIDR}
+	}
+	return subnetCIDRs
 }
 
 func getExpectedDataPodsAndSwitchesForSecondaryNetwork(fakeOvn *FakeOVN, pods []testPod) []libovsdb.TestData {

--- a/go-controller/pkg/ovn/ovn_suite_test.go
+++ b/go-controller/pkg/ovn/ovn_suite_test.go
@@ -92,6 +92,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 				}
 				if em.allowSendingToUnknown {
 					lsp.Addresses = append(lsp.Addresses, "unknown")
+					lsp.Options["force_fdb_lookup"] = "true"
 				}
 
 				if pod.noIfaceIdVer {

--- a/go-controller/pkg/ovn/ovn_suite_test.go
+++ b/go-controller/pkg/ovn/ovn_suite_test.go
@@ -1,13 +1,120 @@
 package ovn
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 func TestClusterNode(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "OVN Operations Suite")
+}
+
+type option func(machine *secondaryNetworkExpectationMachine)
+
+type secondaryNetworkExpectationMachine struct {
+	fakeOvn               *FakeOVN
+	pods                  []testPod
+	disablePortSecurity   bool
+	allowSendingToUnknown bool
+}
+
+func newSecondaryNetworkExpectationMachine(fakeOvn *FakeOVN, pods []testPod, opts ...option) *secondaryNetworkExpectationMachine {
+	machine := &secondaryNetworkExpectationMachine{
+		fakeOvn: fakeOvn,
+		pods:    pods,
+	}
+
+	for _, opt := range opts {
+		opt(machine)
+	}
+	return machine
+}
+
+func withoutPortSecurity() option {
+	return func(machine *secondaryNetworkExpectationMachine) {
+		machine.disablePortSecurity = true
+	}
+}
+
+func allowSendingToUnknownL2Addrs() option {
+	return func(machine *secondaryNetworkExpectationMachine) {
+		machine.allowSendingToUnknown = true
+	}
+}
+
+func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() []libovsdb.TestData {
+	data := []libovsdb.TestData{}
+	for _, ocInfo := range em.fakeOvn.secondaryControllers {
+		nodeslsps := make(map[string][]string)
+		var switchName string
+		for _, pod := range em.pods {
+			podInfo, ok := pod.secondaryPodInfos[ocInfo.bnc.GetNetworkName()]
+			if !ok {
+				continue
+			}
+			for nad, portInfo := range podInfo.allportInfo {
+				portName := portInfo.portName
+				var lspUUID string
+				if len(portInfo.portUUID) == 0 {
+					lspUUID = portName + "-UUID"
+				} else {
+					lspUUID = portInfo.portUUID
+				}
+				podAddr := fmt.Sprintf("%s %s", portInfo.podMAC, portInfo.podIP)
+				lsp := &nbdb.LogicalSwitchPort{
+					UUID:      lspUUID,
+					Name:      portName,
+					Addresses: []string{podAddr},
+					ExternalIDs: map[string]string{
+						"pod":                       "true",
+						"namespace":                 pod.namespace,
+						ovntypes.NetworkExternalID:  ocInfo.bnc.GetNetworkName(),
+						ovntypes.NADExternalID:      nad,
+						ovntypes.TopologyExternalID: ocInfo.bnc.TopologyType(),
+					},
+					Options: map[string]string{
+						"requested-chassis": pod.nodeName,
+						"iface-id-ver":      pod.podName,
+					},
+					PortSecurity: []string{podAddr},
+				}
+
+				if em.disablePortSecurity {
+					lsp.PortSecurity = nil
+				}
+				if em.allowSendingToUnknown {
+					lsp.Addresses = append(lsp.Addresses, "unknown")
+				}
+
+				if pod.noIfaceIdVer {
+					delete(lsp.Options, "iface-id-ver")
+				}
+				data = append(data, lsp)
+				switch ocInfo.bnc.TopologyType() {
+				case ovntypes.Layer3Topology:
+					switchName = ocInfo.bnc.GetNetworkScopedName(pod.nodeName)
+				case ovntypes.Layer2Topology:
+					switchName = ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
+				case ovntypes.LocalnetTopology:
+					switchName = ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch)
+				}
+				nodeslsps[switchName] = append(nodeslsps[switchName], lspUUID)
+			}
+			data = append(data, &nbdb.LogicalSwitch{
+				UUID:        switchName + "-UUID",
+				Name:        switchName,
+				Ports:       nodeslsps[switchName],
+				ExternalIDs: map[string]string{ovntypes.NetworkExternalID: ocInfo.bnc.GetNetworkName()},
+			})
+		}
+	}
+	return data
 }

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -37,6 +37,7 @@ type BasicNetInfo interface {
 	Vlan() uint
 	AllowsPersistentIPs() bool
 	DisablePortSecurity() bool
+	AllowL2Unknown() bool
 
 	// utility methods
 	CompareNetInfo(BasicNetInfo) bool
@@ -139,6 +140,11 @@ func (nInfo *DefaultNetInfo) DisablePortSecurity() bool {
 	return false
 }
 
+// AllowL2Unknown returns the defaultNetConfInfo's AllowL2Unknown value
+func (nInfo *DefaultNetInfo) AllowL2Unknown() bool {
+	return false
+}
+
 // SecondaryNetInfo holds the network name information for secondary network if non-nil
 type secondaryNetInfo struct {
 	netName             string
@@ -147,6 +153,7 @@ type secondaryNetInfo struct {
 	vlan                uint
 	allowPersistentIPs  bool
 	disablePortSecurity bool
+	allowL2Unknown      bool
 
 	ipv4mode, ipv6mode bool
 	subnets            []config.CIDRNetworkEntry
@@ -242,6 +249,11 @@ func (nInfo *secondaryNetInfo) DisablePortSecurity() bool {
 	return nInfo.disablePortSecurity
 }
 
+// AllowL2Unknown returns the defaultNetConfInfo's AllowL2Unknown value
+func (nInfo *secondaryNetInfo) AllowL2Unknown() bool {
+	return nInfo.allowL2Unknown
+}
+
 // CompareNetInfo compares for equality this network information with the other
 func (nInfo *secondaryNetInfo) CompareNetInfo(other BasicNetInfo) bool {
 	if nInfo.netName != other.GetNetworkName() {
@@ -260,6 +272,9 @@ func (nInfo *secondaryNetInfo) CompareNetInfo(other BasicNetInfo) bool {
 		return false
 	}
 	if nInfo.disablePortSecurity != other.DisablePortSecurity() {
+		return false
+	}
+	if nInfo.allowL2Unknown != other.AllowL2Unknown() {
 		return false
 	}
 
@@ -303,6 +318,7 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (NetInfo, error) {
 		mtu:                 netconf.MTU,
 		allowPersistentIPs:  netconf.AllowPersistentIPs,
 		disablePortSecurity: netconf.DisablePortSecurity,
+		allowL2Unknown:      netconf.EnableL2Unknown,
 	}
 	ni.ipv4mode, ni.ipv6mode = getIPMode(subnets)
 	return ni, nil
@@ -323,6 +339,7 @@ func newLocalnetNetConfInfo(netconf *ovncnitypes.NetConf) (NetInfo, error) {
 		vlan:                uint(netconf.VLANID),
 		allowPersistentIPs:  netconf.AllowPersistentIPs,
 		disablePortSecurity: netconf.DisablePortSecurity,
+		allowL2Unknown:      netconf.EnableL2Unknown,
 	}
 	ni.ipv4mode, ni.ipv6mode = getIPMode(subnets)
 	return ni, nil

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -337,6 +337,107 @@ func TestParseNetconf(t *testing.T) {
 `,
 			expectedError: fmt.Errorf("layer3 topology does not allow persistent IPs"),
 		},
+		{
+			desc: "disabling port security on a layer2 topology with a subnet is valid",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "layer2",
+			"subnets": "192.168.200.0/16",
+			"disablePortSecurity": true,
+			"netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				Topology:            "layer2",
+				NADName:             "ns1/nad1",
+				MTU:                 1400,
+				DisablePortSecurity: true,
+				Subnets:             "192.168.200.0/16",
+				NetConf:             cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+			},
+		},
+		{
+			desc: "disabling port security on a localnet topology with a subnet is valid",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "localnet",
+			"subnets": "192.168.200.0/16",
+			"disablePortSecurity": true,
+			"netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				Topology:            "localnet",
+				NADName:             "ns1/nad1",
+				MTU:                 1400,
+				DisablePortSecurity: true,
+				Subnets:             "192.168.200.0/16",
+				NetConf:             cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+			},
+		},
+		{
+			desc: "disabling port security on a layer3 topology with a subnet is valid",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "layer3",
+			"subnets": "192.168.200.0/16",
+			"disablePortSecurity": true,
+			"netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				Topology:            "layer3",
+				NADName:             "ns1/nad1",
+				MTU:                 1400,
+				DisablePortSecurity: true,
+				Subnets:             "192.168.200.0/16",
+				NetConf:             cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+			},
+		},
+		{
+			desc: "disabling port security on a layer2 topology without subnets is valid",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "layer2",
+			"disablePortSecurity": true,
+			"netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				Topology:            "layer2",
+				NADName:             "ns1/nad1",
+				MTU:                 1400,
+				DisablePortSecurity: true,
+				NetConf:             cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+			},
+		},
+		{
+			desc: "disabling port security on a localnet topology without subnets is valid",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "localnet",
+			"disablePortSecurity": true,
+			"netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				Topology:            "localnet",
+				NADName:             "ns1/nad1",
+				MTU:                 1400,
+				DisablePortSecurity: true,
+				NetConf:             cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -639,6 +639,24 @@ var _ = Describe("Multi Homing", func() {
 					nodeSelector: map[string]string{nodeHostnameKey: workerTwoNodeName},
 				},
 			),
+			ginkgo.Entry(
+				"can communicate over an unsafe layer2 secondary network (opted out of port security)",
+				networkAttachmentConfigParams{
+					name:                secondaryNetworkName,
+					topology:            "layer2",
+					cidr:                strings.Join([]string{secondaryLocalnetNetworkCIDR, secondaryIPv6CIDR}, ","),
+					disablePortSecurity: true,
+				},
+				podConfiguration{
+					attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+					name:        clientPodName,
+				},
+				podConfiguration{
+					attachments:  []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+					name:         podName,
+					containerCmd: httpServerContainerCmd(port),
+				},
+			),
 		)
 
 		Context("localnet OVN-K secondary network", func() {

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -36,14 +36,16 @@ func getNetCIDRSubnet(netCIDR string) (string, error) {
 }
 
 type networkAttachmentConfigParams struct {
-	cidr               string
-	excludeCIDRs       []string
-	namespace          string
-	name               string
-	topology           string
-	networkName        string
-	vlanID             int
-	allowPersistentIPs bool
+	cidr                string
+	excludeCIDRs        []string
+	namespace           string
+	name                string
+	topology            string
+	networkName         string
+	vlanID              int
+	allowPersistentIPs  bool
+	disablePortSecurity bool
+	enableL2Unknown     bool
 }
 
 type networkAttachmentConfig struct {
@@ -78,7 +80,9 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
         "mtu": 1300,
         "netAttachDefName": %q,
         "vlanID": %d,
-        "allowPersistentIPs": %t
+        "allowPersistentIPs": %t,
+        "disablePortSecurity": %t,
+        "enableL2Unknown": %t
 }
 `,
 		config.networkName,
@@ -88,6 +92,8 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
 		namespacedName(config.namespace, config.name),
 		config.vlanID,
 		config.allowPersistentIPs,
+		config.disablePortSecurity,
+		config.enableL2Unknown,
 	)
 	return generateNetAttachDef(config.namespace, config.name, nadSpec)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This PR introduces knobs to the NAD of the secondary networks (all topologies) for the admins to:
- opt-out of port security for their networks
- allow traffic to unknown addresses

Both these knobs are required for L2 switched nested virtualization, while routed nested virtualization can be achieved with opting out of port security.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3926 

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
Unit tests were added, to assert the expected logical entities are created.

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Includes both e2e and unit tests to test these new features.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
Add a configuration knob for secondary networks allowing users to opt-out of port security.
```
