### PR TITLE
e2e EgressQoS: Tolerate Single-Stack Cluster

### DIFF
--- a/test/e2e/egressqos.go
+++ b/test/e2e/egressqos.go
@@ -93,6 +93,12 @@ var _ = ginkgo.Describe("e2e EgressQoS validation", func() {
 	ginkgo.DescribeTable("Should validate correct DSCP value on EgressQoS resource changes",
 		func(tcpDumpTpl string, dst1IP *string, prefix1 string, dst2IP *string, podBeforeQoS bool) {
 			dscpValue := 50
+
+			// Check if dst1IP is empty and skip the test if it is
+			if dst1IP == nil || *dst1IP == "" {
+				ginkgo.Skip("Skipping test because dst1IP is empty")
+			}
+
 			if podBeforeQoS {
 				_, err := createPod(f, srcPodName, srcNode, f.Namespace.Name, []string{}, map[string]string{"app": "test"})
 				framework.ExpectNoError(err)
@@ -174,6 +180,11 @@ spec:
 	ginkgo.DescribeTable("Should validate correct DSCP value on pod labels changes",
 		func(tcpDumpTpl string, dst1IP *string, prefix1 string, dst2IP *string, prefix2 string) {
 			dscpValue := 50
+
+			// Check if dst1IP is empty and skip the test if it is
+			if dst1IP == nil || *dst1IP == "" {
+				ginkgo.Skip("Skipping test because dst1IP is empty")
+			}
 
 			// create without labels, no packets should be marked
 			pod, err := createPod(f, srcPodName, srcNode, f.Namespace.Name, []string{}, nil)


### PR DESCRIPTION
Change "e2e EgressQoS Validation" to accommodate cases when the cluster has only one IP family configured.

To verify fix, consider using these steps:

```
$ cd .../ovn-kubernetes.git/contrib && \
  KIND_IPV4_SUPPORT=true KIND_IPV6_SUPPORT=false \
    ./kind.sh && echo ok

$ cd ../test/e2e && \
  go mod download && \
  go test -test.timeout 5m -v . -ginkgo.v \
    -ginkgo.focus 'e2e\sEgressQoS\svalidation' \
    -ginkgo.flake-attempts 1 -ginkgo.fail-fast \
    -provider skeleton -kubeconfig $KUBECONFIG --num-nodes=2 && echo ok
```
