### PR TITLE
SDN-5139: Direct ingress for default network in LGW mode with route advertisements 

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -215,6 +215,10 @@ func (oc *DefaultNodeNetworkController) Reconcile(netInfo util.NetInfo) error {
 				klog.Errorf("Failed to reconcile gateway: %v", err)
 			}
 		}
+		for _, mgmtPort := range oc.gatewaySetup.mgmtPorts {
+			mgmtPort.SetPodNetworkAdvertised(isPodNetworkAdvertisedAtNode)
+			mgmtPort.Reconcile()
+		}
 	}
 
 	return nil
@@ -648,7 +652,7 @@ func getMgmtPortAndRepName(node *kapi.Node) (string, string, error) {
 }
 
 func createNodeManagementPorts(node *kapi.Node, nodeLister listers.NodeLister, nodeAnnotator kube.Annotator, kubeInterface kube.Interface, waiter *startupWaiter,
-	subnets []*net.IPNet, routeManager *routemanager.Controller) ([]*managementPortEntry, *managementPortConfig, error) {
+	subnets []*net.IPNet, routeManager *routemanager.Controller, isRoutingAdvertised bool) ([]*managementPortEntry, *managementPortConfig, error) {
 	netdevName, rep, err := getMgmtPortAndRepName(node)
 	if err != nil {
 		return nil, nil, err
@@ -665,11 +669,12 @@ func createNodeManagementPorts(node *kapi.Node, nodeLister listers.NodeLister, n
 	var mgmtPortConfig *managementPortConfig
 	mgmtPorts := make([]*managementPortEntry, 0)
 	for _, port := range ports {
-		config, err := port.Create(routeManager, node, nodeLister, kubeInterface, waiter)
+		config, err := port.Create(isRoutingAdvertised, routeManager, node, nodeLister, kubeInterface, waiter)
 		if err != nil {
 			return nil, nil, err
 		}
 		mgmtPorts = append(mgmtPorts, NewManagementPortEntry(port, config, routeManager))
+
 		// Save this management port config for later usage.
 		// Since only one OVS internal port / Representor config may exist it is fine just to overwrite it
 		if _, ok := port.(*managementPortNetdev); !ok {
@@ -880,8 +885,15 @@ func (nc *DefaultNodeNetworkController) PreStart(ctx context.Context) error {
 	waiter := newStartupWaiter()
 
 	// Setup management ports
-	mgmtPorts, mgmtPortConfig, err := createNodeManagementPorts(node, nc.watchFactory.NodeCoreInformer().Lister(), nodeAnnotator,
-		nc.Kube, waiter, subnets, nc.routeManager)
+	mgmtPorts, mgmtPortConfig, err := createNodeManagementPorts(
+		node,
+		nc.watchFactory.NodeCoreInformer().Lister(),
+		nodeAnnotator,
+		nc.Kube,
+		waiter,
+		subnets,
+		nc.routeManager,
+		nc.isPodNetworkAdvertisedAtNode())
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -207,7 +207,7 @@ func (oc *DefaultNodeNetworkController) Reconcile(netInfo util.NetInfo) error {
 
 	// then reconcile subcontrollers
 	if reconcilePodNetwork {
-		isPodNetworkAdvertisedAtNode := oc.isPodNetworkAdvertisedAtNode()
+		isPodNetworkAdvertisedAtNode := util.IsPodNetworkAdvertisedAtNode(netInfo, oc.name)
 		if oc.Gateway != nil {
 			oc.Gateway.SetPodNetworkAdvertised(isPodNetworkAdvertisedAtNode)
 			err := oc.Gateway.Reconcile()

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -126,7 +126,7 @@ type DefaultNodeNetworkController struct {
 }
 
 type preStartSetup struct {
-	mgmtPorts      []managementPortEntry
+	mgmtPorts      []*managementPortEntry
 	mgmtPortConfig *managementPortConfig
 	nodeAddress    net.IP
 	sbZone         string
@@ -484,11 +484,6 @@ func isOVNControllerReady() (bool, error) {
 	return true, nil
 }
 
-type managementPortEntry struct {
-	port   ManagementPort
-	config *managementPortConfig
-}
-
 // getEnvNameFromResourceName gets the device plugin env variable from the device plugin resource name.
 func getEnvNameFromResourceName(resource string) string {
 	res1 := strings.ReplaceAll(resource, ".", "_")
@@ -653,7 +648,7 @@ func getMgmtPortAndRepName(node *kapi.Node) (string, string, error) {
 }
 
 func createNodeManagementPorts(node *kapi.Node, nodeLister listers.NodeLister, nodeAnnotator kube.Annotator, kubeInterface kube.Interface, waiter *startupWaiter,
-	subnets []*net.IPNet, routeManager *routemanager.Controller) ([]managementPortEntry, *managementPortConfig, error) {
+	subnets []*net.IPNet, routeManager *routemanager.Controller) ([]*managementPortEntry, *managementPortConfig, error) {
 	netdevName, rep, err := getMgmtPortAndRepName(node)
 	if err != nil {
 		return nil, nil, err
@@ -668,13 +663,13 @@ func createNodeManagementPorts(node *kapi.Node, nodeLister listers.NodeLister, n
 	ports := NewManagementPorts(node.Name, subnets, netdevName, rep)
 
 	var mgmtPortConfig *managementPortConfig
-	mgmtPorts := make([]managementPortEntry, 0)
+	mgmtPorts := make([]*managementPortEntry, 0)
 	for _, port := range ports {
 		config, err := port.Create(routeManager, node, nodeLister, kubeInterface, waiter)
 		if err != nil {
 			return nil, nil, err
 		}
-		mgmtPorts = append(mgmtPorts, managementPortEntry{port: port, config: config})
+		mgmtPorts = append(mgmtPorts, NewManagementPortEntry(port, config, routeManager))
 		// Save this management port config for later usage.
 		// Since only one OVS internal port / Representor config may exist it is fine just to overwrite it
 		if _, ok := port.(*managementPortNetdev); !ok {
@@ -1177,7 +1172,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	// start management ports health check
 	for _, mgmtPort := range nc.gatewaySetup.mgmtPorts {
-		mgmtPort.port.CheckManagementPortHealth(nc.routeManager, mgmtPort.config, nc.stopChan)
+		mgmtPort.Start(nc.stopChan)
 		if config.OVNKubernetesFeature.EnableEgressIP {
 			// Start the health checking server used by egressip, if EgressIPNodeHealthCheckPort is specified
 			if err := nc.startEgressIPHealthCheckingServer(mgmtPort); err != nil {
@@ -1280,7 +1275,7 @@ func (nc *DefaultNodeNetworkController) Stop() {
 	nc.wg.Wait()
 }
 
-func (nc *DefaultNodeNetworkController) startEgressIPHealthCheckingServer(mgmtPortEntry managementPortEntry) error {
+func (nc *DefaultNodeNetworkController) startEgressIPHealthCheckingServer(mgmtPortEntry *managementPortEntry) error {
 	healthCheckPort := config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort
 	if healthCheckPort == 0 {
 		klog.Infof("Egress IP health check server skipped: no port specified")

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -57,7 +57,8 @@ type gateway struct {
 	stopChan     <-chan struct{}
 	wg           *sync.WaitGroup
 
-	isPodNetworkAdvertised bool
+	isPodNetworkAdvertisedLock sync.Mutex
+	isPodNetworkAdvertised     bool
 }
 
 func (g *gateway) AddService(svc *kapi.Service) error {
@@ -468,6 +469,8 @@ func (g *gateway) SetDefaultGatewayBridgeMAC(macAddr net.HardwareAddr) {
 }
 
 func (g *gateway) SetPodNetworkAdvertised(isPodNetworkAdvertised bool) {
+	g.isPodNetworkAdvertisedLock.Lock()
+	defer g.isPodNetworkAdvertisedLock.Unlock()
 	g.isPodNetworkAdvertised = isPodNetworkAdvertised
 }
 
@@ -520,6 +523,8 @@ func (g *gateway) addAllServices() []error {
 }
 
 func (g *gateway) updateSNATRules() error {
+	g.isPodNetworkAdvertisedLock.Lock()
+	defer g.isPodNetworkAdvertisedLock.Unlock()
 	var ipnets []*net.IPNet
 	if g.nodeIPManager.mgmtPortConfig.ipv4 != nil {
 		ipnets = append(ipnets, g.nodeIPManager.mgmtPortConfig.ipv4.ifAddr)

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -485,6 +485,10 @@ func (g *gateway) Reconcile() error {
 	if err := g.openflowManager.updateBridgeFlowCache(subnets, g.nodeIPManager.ListAddresses(), g.isPodNetworkAdvertised); err != nil {
 		return err
 	}
+	err = g.updateSNATRules()
+	if err != nil {
+		return err
+	}
 	// Services create OpenFlow flows as well, need to update them all
 	if g.servicesRetryFramework != nil {
 		if errs := g.addAllServices(); errs != nil {
@@ -513,6 +517,23 @@ func (g *gateway) addAllServices() []error {
 	}
 	g.servicesRetryFramework.RequestRetryObjs()
 	return errs
+}
+
+func (g *gateway) updateSNATRules() error {
+	var ipnets []*net.IPNet
+	if g.nodeIPManager.mgmtPortConfig.ipv4 != nil {
+		ipnets = append(ipnets, g.nodeIPManager.mgmtPortConfig.ipv4.ifAddr)
+	}
+	if g.nodeIPManager.mgmtPortConfig.ipv6 != nil {
+		ipnets = append(ipnets, g.nodeIPManager.mgmtPortConfig.ipv6.ifAddr)
+	}
+	subnets := util.IPsToNetworkIPs(ipnets...)
+
+	if g.isPodNetworkAdvertised || config.Gateway.Mode != config.GatewayModeLocal {
+		return delLocalGatewayPodSubnetNATRules(subnets...)
+	}
+
+	return addLocalGatewayPodSubnetNATRules(subnets...)
 }
 
 type bridgeConfiguration struct {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -252,7 +252,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			ifName:    nodeName,
 			link:      nil,
 			routerMAC: nil,
-			nft:       nft,
 			ipv4:      &fakeMgmtPortIPFamilyConfig,
 			ipv6:      nil,
 		}
@@ -690,12 +689,11 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			gwIP:       nodeNet.IP,
 		}
 
-		nft := nodenft.SetFakeNFTablesHelper()
+		_ = nodenft.SetFakeNFTablesHelper()
 		fakeMgmtPortConfig := managementPortConfig{
 			ifName:    nodeName,
 			link:      nil,
 			routerMAC: nil,
-			nft:       nft,
 			ipv4:      &fakeMgmtPortIPFamilyConfig,
 			ipv6:      nil,
 		}
@@ -1149,7 +1147,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			ifName:    types.K8sMgmtIntfName,
 			link:      nil,
 			routerMAC: nil,
-			nft:       nft,
 			ipv4:      &fakeMgmtPortIPFamilyConfig,
 			ipv6:      nil,
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -54,6 +54,7 @@ const baseNFTRulesFmt = `
 add table inet ovn-kubernetes
 add chain inet ovn-kubernetes mgmtport-snat { type nat hook postrouting priority 100 ; comment "OVN SNAT to Management Port" ; }
 add rule inet ovn-kubernetes mgmtport-snat oifname != %q return
+add rule inet ovn-kubernetes mgmtport-snat meta nfproto ipv4 ip saddr 10.1.1.0 counter return
 add rule inet ovn-kubernetes mgmtport-snat meta l4proto . th dport @mgmtport-no-snat-nodeports counter return
 add rule inet ovn-kubernetes mgmtport-snat ip daddr . meta l4proto . th dport @mgmtport-no-snat-services-v4 counter return
 add rule inet ovn-kubernetes mgmtport-snat counter snat ip to 10.1.1.0

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -301,7 +301,6 @@ var _ = Describe("Node Operations", func() {
 			ifName:    fakeNodeName,
 			link:      nil,
 			routerMAC: nil,
-			nft:       nft,
 			ipv4:      &fakeMgmtPortIPFamilyConfig,
 			ipv6:      nil,
 		}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1982,23 +1982,34 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration, isPodNetwork
 	if ofPortPhys != "" {
 		if config.Gateway.DisableSNATMultipleGWs || isPodNetworkAdvertised {
 			// table 1, traffic to pod subnet go directly to OVN
+			output := defaultNetConfig.ofPortPatch
+			if isPodNetworkAdvertised && config.Gateway.Mode == config.GatewayModeLocal {
+				// except if advertised through BGP, go to kernel
+				// TODO: MEG enabled pods should still go through the patch port
+				// but holding this until
+				// https://issues.redhat.com/browse/FDP-646 is fixed, for now we
+				// are assuming MEG & BGP are not used together
+				output = ovsLocalPort
+			}
 			for _, clusterEntry := range config.Default.ClusterSubnets {
 				cidr := clusterEntry.CIDR
 				ipv := getIPv(cidr)
 				dftFlows = append(dftFlows,
 					fmt.Sprintf("cookie=%s, priority=15, table=1, %s, %s_dst=%s, "+
 						"actions=output:%s",
-						defaultOpenFlowCookie, ipv, ipv, cidr, defaultNetConfig.ofPortPatch))
+						defaultOpenFlowCookie, ipv, ipv, cidr, output))
 			}
-			// except node management traffic
-			for _, subnet := range subnets {
-				mgmtIP := util.GetNodeManagementIfAddr(subnet)
-				ipv := getIPv(mgmtIP)
-				dftFlows = append(dftFlows,
-					fmt.Sprintf("cookie=%s, priority=16, table=1, %s, %s_dst=%s, "+
-						"actions=output:%s",
-						defaultOpenFlowCookie, ipv, ipv, mgmtIP.IP, ovsLocalPort),
-				)
+			if output == defaultNetConfig.ofPortPatch {
+				// except node management traffic
+				for _, subnet := range subnets {
+					mgmtIP := util.GetNodeManagementIfAddr(subnet)
+					ipv := getIPv(mgmtIP)
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=16, table=1, %s, %s_dst=%s, "+
+							"actions=output:%s",
+							defaultOpenFlowCookie, ipv, ipv, mgmtIP.IP, ovsLocalPort),
+					)
+				}
 			}
 		}
 

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -572,7 +572,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		_, _ = util.SetFakeIPTablesHelpers()
-		nft := nodenft.SetFakeNFTablesHelper()
+		_ = nodenft.SetFakeNFTablesHelper()
 
 		// Make a fake MgmtPortConfig with only the fields we care about
 		fakeMgmtPortV4IPFamilyConfig := managementPortIPFamilyConfig{
@@ -588,7 +588,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			ifName:    nodeName,
 			link:      nil,
 			routerMAC: nil,
-			nft:       nft,
 			ipv4:      &fakeMgmtPortV4IPFamilyConfig,
 			ipv6:      &fakeMgmtPortV6IPFamilyConfig,
 		}
@@ -795,7 +794,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		err = wf.Start()
 
 		_, _ = util.SetFakeIPTablesHelpers()
-		nft := nodenft.SetFakeNFTablesHelper()
+		_ = nodenft.SetFakeNFTablesHelper()
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -813,7 +812,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			ifName:    nodeName,
 			link:      nil,
 			routerMAC: nil,
-			nft:       nft,
 			ipv4:      &fakeMgmtPortV4IPFamilyConfig,
 			ipv6:      &fakeMgmtPortV6IPFamilyConfig,
 		}

--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
@@ -109,56 +108,50 @@ func (mp *managementPortRepresentor) Create(_ *routemanager.Controller, node *v1
 	}
 
 	mpcfg := &managementPortConfig{
-		ifName: k8sMgmtIntfName,
-		link:   link,
+		ifName:          k8sMgmtIntfName,
+		link:            link,
+		reconcilePeriod: 5 * time.Second,
 	}
 
 	waiter.AddWait(managementPortReady, nil)
 	return mpcfg, nil
 }
 
-func (mp *managementPortRepresentor) checkRepresentorPortHealth(cfg *managementPortConfig) {
+func (mp *managementPortRepresentor) checkRepresentorPortHealth(cfg *managementPortConfig) error {
 	// After host reboot, management port link name changes back to default name.
 	link, err := util.GetNetLinkOps().LinkByName(cfg.ifName)
 	if err != nil {
-		klog.Errorf("Failed to get link device %s, error: %v", cfg.ifName, err)
+		klog.Warningf("Failed to get link device %s: %v", cfg.ifName, err)
 		// Get management port representor by name
 		link, err := util.GetNetLinkOps().LinkByName(mp.repName)
 		if err != nil {
-			klog.Errorf("Failed to get link device %s, error: %v", mp.repName, err)
-			return
+			return fmt.Errorf("failed to get link device %s: %w", mp.repName, err)
 		}
 		if err = util.GetNetLinkOps().LinkSetDown(link); err != nil {
-			klog.Errorf("Failed to set link down for device %s. %v", mp.repName, err)
-			return
+			return fmt.Errorf("failed to set link down for device %s: %w", mp.repName, err)
 		}
 		if err = util.GetNetLinkOps().LinkSetName(link, cfg.ifName); err != nil {
-			klog.Errorf("Rename link from %s to %s failed: %v", mp.repName, cfg.ifName, err)
-			return
+			return fmt.Errorf("failed to rename link from %s to %s: %w", mp.repName, cfg.ifName, err)
 		}
 		if link.Attrs().MTU != config.Default.MTU {
 			if err = util.GetNetLinkOps().LinkSetMTU(link, config.Default.MTU); err != nil {
-				klog.Errorf("Failed to set link MTU for device %s. %v", cfg.ifName, err)
+				return fmt.Errorf("failed to set link MTU for device %s: %w", cfg.ifName, err)
 			}
 		}
 		if err = util.GetNetLinkOps().LinkSetUp(link); err != nil {
-			klog.Errorf("Failed to set link up for device %s. %v", cfg.ifName, err)
+			return fmt.Errorf("failed to set link up for device %s: %w", cfg.ifName, err)
 		}
 		cfg.link = link
 	} else if (link.Attrs().Flags & net.FlagUp) != net.FlagUp {
 		if err = util.GetNetLinkOps().LinkSetUp(link); err != nil {
-			klog.Errorf("Failed to set link up for device %s. %v", cfg.ifName, err)
+			return fmt.Errorf("failed to set link up for device %s: %w", cfg.ifName, err)
 		}
 	}
+	return nil
 }
 
-func (mp *managementPortRepresentor) CheckManagementPortHealth(_ *routemanager.Controller, cfg *managementPortConfig, stopChan chan struct{}) {
-	go wait.Until(
-		func() {
-			mp.checkRepresentorPortHealth(cfg)
-		},
-		5*time.Second,
-		stopChan)
+func (mp *managementPortRepresentor) CheckManagementPortHealth(_ *routemanager.Controller, cfg *managementPortConfig) error {
+	return mp.checkRepresentorPortHealth(cfg)
 }
 
 // Port representors should not have any IP address assignable to them, thus always return false.
@@ -252,13 +245,8 @@ func (mp *managementPortNetdev) Create(routeManager *routemanager.Controller, no
 	return cfg, nil
 }
 
-func (mp *managementPortNetdev) CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig, stopChan chan struct{}) {
-	go wait.Until(
-		func() {
-			checkManagementPortHealth(routeManager, cfg)
-		},
-		30*time.Second,
-		stopChan)
+func (mp *managementPortNetdev) CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig) error {
+	return checkManagementPortHealth(routeManager, cfg)
 }
 
 // Management port Netdev should have IP addresses assignable to them.

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
-
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -24,7 +23,7 @@ import (
 type ManagementPort interface {
 	// Create Management port, use annotator to update node annotation with management port details
 	// and waiter to set up condition to wait on for management port creation
-	Create(routeManager *routemanager.Controller, node *v1.Node, nodeLister listers.NodeLister, kubeInterface kube.Interface, waiter *startupWaiter) (*managementPortConfig, error)
+	Create(isRoutingAdvertised bool, routeManager *routemanager.Controller, node *v1.Node, nodeLister listers.NodeLister, kubeInterface kube.Interface, waiter *startupWaiter) (*managementPortConfig, error)
 	// CheckManagementPortHealth checks periodically for management port health until stopChan is posted
 	// or closed and reports any warnings/errors to log
 	CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig) error
@@ -79,7 +78,7 @@ func newManagementPort(nodeName string, hostSubnets []*net.IPNet) ManagementPort
 	}
 }
 
-func (mp *managementPort) Create(routeManager *routemanager.Controller, node *v1.Node,
+func (mp *managementPort) Create(isRoutingAdvertised bool, routeManager *routemanager.Controller, node *v1.Node,
 	nodeLister listers.NodeLister, kubeInterface kube.Interface, waiter *startupWaiter) (*managementPortConfig, error) {
 	for _, mgmtPortName := range []string{types.K8sMgmtIntfName, types.K8sMgmtIntfName + "_0"} {
 		if err := syncMgmtPortInterface(mp.hostSubnets, mgmtPortName, true); err != nil {
@@ -115,7 +114,7 @@ func (mp *managementPort) Create(routeManager *routemanager.Controller, node *v1
 		return nil, err
 	}
 
-	cfg, err := createPlatformManagementPort(routeManager, types.K8sMgmtIntfName, mp.hostSubnets)
+	cfg, err := createPlatformManagementPort(routeManager, types.K8sMgmtIntfName, mp.hostSubnets, isRoutingAdvertised)
 	if err != nil {
 		return nil, err
 	}
@@ -213,9 +212,17 @@ func (p *managementPortEntry) Start(stopChan <-chan struct{}) {
 }
 
 func (p *managementPortEntry) Reconcile() {
-	p.reconcile <- struct{}{}
+	// trigger a new reconciliation if none was pending
+	select {
+	case p.reconcile <- struct{}{}:
+	default:
+	}
 }
 
 func (p *managementPortEntry) doReconcile() error {
 	return p.port.CheckManagementPortHealth(p.routeManager, p.config)
+}
+
+func (p *managementPortEntry) SetPodNetworkAdvertised(isPodNetworkAdvertised bool) {
+	p.config.isPodNetworkAdvertised.Store(isPodNetworkAdvertised)
 }

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/retry"
 
 	"k8s.io/klog/v2"
 
@@ -26,7 +27,7 @@ type ManagementPort interface {
 	Create(routeManager *routemanager.Controller, node *v1.Node, nodeLister listers.NodeLister, kubeInterface kube.Interface, waiter *startupWaiter) (*managementPortConfig, error)
 	// CheckManagementPortHealth checks periodically for management port health until stopChan is posted
 	// or closed and reports any warnings/errors to log
-	CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig, stopChan chan struct{})
+	CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig) error
 	// Currently, the management port(s) that doesn't have an assignable IP address are the following cases:
 	//   - Full mode with HW backed device (e.g. Virtual Function Representor).
 	//   - DPU mode with Virtual Function Representor.
@@ -123,13 +124,8 @@ func (mp *managementPort) Create(routeManager *routemanager.Controller, node *v1
 	return cfg, nil
 }
 
-func (mp *managementPort) CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig, stopChan chan struct{}) {
-	go wait.Until(
-		func() {
-			checkManagementPortHealth(routeManager, cfg)
-		},
-		30*time.Second,
-		stopChan)
+func (mp *managementPort) CheckManagementPortHealth(routeManager *routemanager.Controller, cfg *managementPortConfig) error {
+	return checkManagementPortHealth(routeManager, cfg)
 }
 
 // OVS Internal Port Netdev should have IP addresses assignable to them.
@@ -161,4 +157,65 @@ func managementPortReady() (bool, error) {
 	}
 	klog.Infof("Management port %s is ready", k8sMgmtIntfName)
 	return true, nil
+}
+
+type managementPortEntry struct {
+	port         ManagementPort
+	config       *managementPortConfig
+	routeManager *routemanager.Controller
+	reconcile    chan struct{}
+}
+
+func NewManagementPortEntry(port ManagementPort, cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortEntry {
+	return &managementPortEntry{
+		port:         port,
+		config:       cfg,
+		routeManager: routeManager,
+		reconcile:    make(chan struct{}, 1),
+	}
+}
+
+func (p *managementPortEntry) Start(stopChan <-chan struct{}) {
+	go func() {
+		timer := time.NewTicker(p.config.reconcilePeriod)
+		defer timer.Stop()
+		for {
+			select {
+			case <-stopChan:
+				return
+			case <-timer.C:
+				p.Reconcile()
+			case <-p.reconcile:
+				err := retry.OnError(
+					wait.Backoff{
+						Duration: 10 * time.Millisecond,
+						Steps:    4,
+						Factor:   5.0,
+						Cap:      p.config.reconcilePeriod,
+					},
+					func(error) bool {
+						select {
+						case <-stopChan:
+							return false
+						default:
+							return true
+						}
+					},
+					p.doReconcile,
+				)
+				if err != nil {
+					klog.Errorf("Failed to reconcile management port %s: %v", p.config.ifName, err)
+				}
+			}
+			timer.Reset(p.config.reconcilePeriod)
+		}
+	}()
+}
+
+func (p *managementPortEntry) Reconcile() {
+	p.reconcile <- struct{}{}
+}
+
+func (p *managementPortEntry) doReconcile() error {
+	return p.port.CheckManagementPortHealth(p.routeManager, p.config)
 }

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 
-			_, err := mgmtPortDpu.Create(nil, nil, nil, nil, waiter)
+			_, err := mgmtPortDpu.Create(false, nil, nil, nil, nil, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).To(HaveOccurred())
 		})
@@ -102,7 +102,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
-			_, err := mgmtPortDpu.Create(nil, nil, nil, nil, waiter)
+			_, err := mgmtPortDpu.Create(false, nil, nil, nil, nil, waiter)
 			Expect(err).To(HaveOccurred())
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 		})
@@ -126,7 +126,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			})
 			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName+"_0")
 
-			_, err := mgmtPortDpu.Create(nil, nil, nil, nil, waiter)
+			_, err := mgmtPortDpu.Create(false, nil, nil, nil, nil, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).To(HaveOccurred())
 		})
@@ -186,7 +186,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(watchFactory.Start()).To(Succeed())
 
-			mpcfg, err := mgmtPortDpu.Create(nil, node, watchFactory.NodeCoreInformer().Lister(), kubeInterface, waiter)
+			mpcfg, err := mgmtPortDpu.Create(false, nil, node, watchFactory.NodeCoreInformer().Lister(), kubeInterface, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName + "_0"))
@@ -242,7 +242,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(watchFactory.Start()).To(Succeed())
 
-			mpcfg, err := mgmtPortDpu.Create(nil, node, watchFactory.NodeCoreInformer().Lister(), kubeInterface, waiter)
+			mpcfg, err := mgmtPortDpu.Create(false, nil, node, watchFactory.NodeCoreInformer().Lister(), kubeInterface, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName + "_0"))
@@ -258,7 +258,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 
-			_, err := mgmtPortDpuHost.Create(nil, nil, nil, nil, waiter)
+			_, err := mgmtPortDpuHost.Create(false, nil, nil, nil, nil, waiter)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -272,7 +272,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
-			_, err := mgmtPortDpuHost.Create(nil, nil, nil, nil, waiter)
+			_, err := mgmtPortDpuHost.Create(false, nil, nil, nil, nil, waiter)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -309,7 +309,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkByName", mock.Anything).Return(nil, fmt.Errorf(
 				"createPlatformManagementPort error"))
 
-			_, err = mgmtPortDpuHost.Create(nil, nil, nil, nil, nil)
+			_, err = mgmtPortDpuHost.Create(false, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("createPlatformManagementPort error"))
 		})
@@ -335,7 +335,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkByName", mock.Anything).Return(nil, fmt.Errorf(
 				"createPlatformManagementPort error")).Once()
 
-			_, err = mgmtPortDpuHost.Create(nil, nil, nil, nil, nil)
+			_, err = mgmtPortDpuHost.Create(false, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(
 				"createPlatformManagementPort error"))

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -52,10 +53,11 @@ type managementPortIPFamilyConfig struct {
 }
 
 type managementPortConfig struct {
-	ifName          string
-	link            netlink.Link
-	routerMAC       net.HardwareAddr
-	reconcilePeriod time.Duration
+	ifName                 string
+	link                   netlink.Link
+	routerMAC              net.HardwareAddr
+	isPodNetworkAdvertised atomic.Bool
+	reconcilePeriod        time.Duration
 
 	ipv4 *managementPortIPFamilyConfig
 	ipv6 *managementPortIPFamilyConfig
@@ -92,11 +94,13 @@ func newManagementPortIPFamilyConfig(hostSubnet *net.IPNet, isIPv6 bool) (*manag
 	return cfg, nil
 }
 
-func newManagementPortConfig(interfaceName string, hostSubnets []*net.IPNet) (*managementPortConfig, error) {
+func newManagementPortConfig(interfaceName string, hostSubnets []*net.IPNet, isPodNetworkAdvertised bool) (*managementPortConfig, error) {
 	mpcfg := &managementPortConfig{
 		ifName:          interfaceName,
 		reconcilePeriod: 30 * time.Second,
 	}
+	mpcfg.isPodNetworkAdvertised.Store(isPodNetworkAdvertised)
+
 	var err error
 	if mpcfg.link, err = util.LinkSetUp(mpcfg.ifName); err != nil {
 		return nil, err
@@ -228,8 +232,13 @@ func setupManagementPortIPFamilyConfig(routeManager *routemanager.Controller, mp
 		return warnings, err
 	}
 
+	protocol := iptables.ProtocolIPv4
+	if mpcfg.ipv6 != nil && cfg == mpcfg.ipv6 {
+		protocol = iptables.ProtocolIPv6
+	}
+
 	// IPv6 forwarding is enabled globally
-	if cfg == mpcfg.ipv4 {
+	if protocol == iptables.ProtocolIPv4 {
 		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.ipv4.conf.%s.forwarding=1", types.K8sMgmtIntfName))
 		if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", types.K8sMgmtIntfName) {
 			return warnings, fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
@@ -311,7 +320,30 @@ func setupManagementPortNFTables(cfg *managementPortConfig) error {
 		),
 	})
 
+	isPodNetworkAdvertised := cfg.isPodNetworkAdvertised.Load()
+
 	if cfg.ipv4 != nil {
+		if isPodNetworkAdvertised {
+			tx.Add(&knftables.Rule{
+				Chain: nftablesMgmtPortChain,
+				Rule: knftables.Concat(
+					"meta nfproto ipv4",
+					"fib saddr type != local",
+					counterIfDebug,
+					"return",
+				),
+			})
+		}
+		// don't SNAT if the source IP is already the Mgmt port IP
+		tx.Add(&knftables.Rule{
+			Chain: nftablesMgmtPortChain,
+			Rule: knftables.Concat(
+				"meta nfproto ipv4",
+				"ip saddr", cfg.ipv4.ifAddr.IP,
+				counterIfDebug,
+				"return",
+			),
+		})
 		tx.Add(&knftables.Rule{
 			Chain: nftablesMgmtPortChain,
 			Rule: knftables.Concat(
@@ -330,6 +362,27 @@ func setupManagementPortNFTables(cfg *managementPortConfig) error {
 	}
 
 	if cfg.ipv6 != nil {
+		if isPodNetworkAdvertised {
+			tx.Add(&knftables.Rule{
+				Chain: nftablesMgmtPortChain,
+				Rule: knftables.Concat(
+					"meta nfproto ipv6",
+					"fib saddr type != local",
+					counterIfDebug,
+					"return",
+				),
+			})
+		}
+		// don't SNAT if the source IP is already the Mgmt port IP
+		tx.Add(&knftables.Rule{
+			Chain: nftablesMgmtPortChain,
+			Rule: knftables.Concat(
+				"meta nfproto ipv6",
+				"ip6 saddr", cfg.ipv6.ifAddr.IP,
+				counterIfDebug,
+				"return",
+			),
+		})
 		tx.Add(&knftables.Rule{
 			Chain: nftablesMgmtPortChain,
 			Rule: knftables.Concat(
@@ -357,11 +410,11 @@ func setupManagementPortNFTables(cfg *managementPortConfig) error {
 // createPlatformManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func createPlatformManagementPort(routeManager *routemanager.Controller, interfaceName string, localSubnets []*net.IPNet) (*managementPortConfig, error) {
+func createPlatformManagementPort(routeManager *routemanager.Controller, interfaceName string, localSubnets []*net.IPNet, isRoutingAdvertised bool) (*managementPortConfig, error) {
 	var cfg *managementPortConfig
 	var err error
 
-	if cfg, err = newManagementPortConfig(interfaceName, localSubnets); err != nil {
+	if cfg, err = newManagementPortConfig(interfaceName, localSubnets, isRoutingAdvertised); err != nil {
 		return nil, err
 	}
 

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -376,11 +376,12 @@ func configureKubeOVNContext(nodeName string, useNetlink bool) *testCtx {
 	err = tc.watchFactory.Start()
 	Expect(err).NotTo(HaveOccurred())
 
+	_ = nodenft.SetFakeNFTablesHelper()
+
 	fakeMgmtPortConfig := &managementPortConfig{
 		ifName:    nodeName,
 		link:      nil,
 		routerMAC: nil,
-		nft:       nodenft.SetFakeNFTablesHelper(),
 		ipv4: &managementPortIPFamilyConfig{
 			allSubnets: nil,
 			ifAddr:     tc.mgmtPortIP4,


### PR DESCRIPTION
If the default network is advertised, inhibit:

- pod IP to node IP SNAT on egress in LGW mode
- source IP to managament port IP SNAT on ingress (through secondary nic)

Currently based on top of https://github.com/ovn-org/ovn-kubernetes/pull/4472 and https://github.com/ovn-org/ovn-kubernetes/pull/4533