### PR TITLE
Udn cni unconfigure follow up

### DIFF
--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -255,7 +255,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 
 		// In the case where ovnkube-node is running in Unprivileged mode, all the work
-		result, err = getCNIResult(pr, clientset, response.PodIFInfo)
+		result, err = pr.getCNIResult(clientset, response.PodIFInfo)
 		if err != nil {
 			err = fmt.Errorf("failed to get CNI Result from pod interface info %v: %v", response.PodIFInfo, err)
 			klog.Error(err.Error())

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -170,7 +170,6 @@ type PodRequest struct {
 }
 
 type podRequestFunc func(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error)
-type getCNIResultFunc func(request *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error)
 
 type PodInfoGetter interface {
 	getPod(namespace, name string) (*kapi.Pod, error)

--- a/go-controller/pkg/cni/udn/primary_network.go
+++ b/go-controller/pkg/cni/udn/primary_network.go
@@ -64,10 +64,14 @@ func (p *UserDefinedPrimaryNetwork) MTU() int {
 	return p.activeNetwork.MTU()
 }
 
+// Found will return true if a primary UDN is configured for this pod's
+// context
 func (p *UserDefinedPrimaryNetwork) Found() bool {
 	return p.annotation != nil && p.activeNetwork != nil
 }
 
+// WaitForPrimaryAnnotationFn wrap the annotCondFn with a function that will
+// also call "Ensure" to check for UDN primary network
 func (p *UserDefinedPrimaryNetwork) WaitForPrimaryAnnotationFn(namespace string, annotCondFn podAnnotWaitCond) podAnnotWaitCond {
 	return func(annotations map[string]string, nadName string) (*util.PodAnnotation, bool) {
 		annotation, isReady := annotCondFn(annotations, nadName)
@@ -82,10 +86,16 @@ func (p *UserDefinedPrimaryNetwork) WaitForPrimaryAnnotationFn(namespace string,
 	}
 }
 
+// Ensure method filter out non default pod network operations and then look
+// for a primary non default pod network at ovn pod annotations and for the
+// primary UDN nad, if non of those are found it returns an error
 func (p *UserDefinedPrimaryNetwork) Ensure(namespace string, annotations map[string]string, nadName string) error {
 	return p.ensure(namespace, annotations, nadName, nil /* parse annotation */)
 }
 
+// ensure method filter out non default pod network operations and then look
+// for a primary non default pod network at ovn pod annotations and for the
+// primary UDN nad, if non of those are found it returns an error
 func (p *UserDefinedPrimaryNetwork) ensure(namespace string, annotations map[string]string, nadName string, annotation *util.PodAnnotation) error {
 	// non default network is not related to primary UDNs
 	if nadName != types.DefaultNetworkName {


### PR DESCRIPTION
#### What this PR does and why is it needed
Follow up changes after https://github.com/ovn-org/ovn-kubernetes/pull/4568 got merged:
- Add more cmdDel tests
- Remove the getCNIResult stub
- Use ConfigureInterface stub at cmdDel tests
- Document primary UDN relevant methods.

```release-note
NONE
```
