### PR TITLE
e2e, multi-homing: Add connectivity tests over secondary network

### DIFF
--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -378,6 +378,100 @@ var _ = Describe("Network Segmentation", func() {
 		)
 	})
 
+	Context("a user defined secondary network", func() {
+		const (
+			nodeHostnameKey              = "kubernetes.io/hostname"
+			port                         = 9000
+			userDefinedNetworkIPv4Subnet = "10.128.0.0/16"
+			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
+			nadName                      = "gryffindor"
+			workerOneNodeName            = "ovn-worker"
+			workerTwoNodeName            = "ovn-worker2"
+		)
+
+		DescribeTableSubtree("created using",
+			func(createNetworkFn func(c networkAttachmentConfigParams) error) {
+
+				DescribeTable(
+					"can perform east/west traffic between nodes",
+					func(
+						netConfig networkAttachmentConfigParams,
+						clientPodConfig podConfiguration,
+						serverPodConfig podConfiguration,
+					) {
+						By("creating the network")
+						netConfig.namespace = f.Namespace.Name
+						Expect(createNetworkFn(netConfig)).To(Succeed())
+
+						By("creating client/server pods")
+						serverPodConfig.namespace = f.Namespace.Name
+						clientPodConfig.namespace = f.Namespace.Name
+						serverPod := runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
+						runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
+
+						By("asserting the *client* pod can contact the server pod exposed endpoint")
+						Eventually(func() error {
+							return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverPod.Status.PodIP, port)
+						}, 2*time.Minute, 6*time.Second).Should(Succeed())
+					},
+					Entry(
+						"two pods connected over a L2 dualstack primary UDN",
+						networkAttachmentConfigParams{
+							name:     nadName,
+							topology: "layer2",
+							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							role:     "secondary",
+						},
+						*podConfig(
+							"client-pod",
+							withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
+						),
+						*podConfig(
+							"server-pod",
+							withCommand(func() []string {
+								return httpServerContainerCmd(port)
+							}),
+							withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
+						),
+					),
+					Entry(
+						"two pods connected over a L3 dualstack primary UDN",
+						networkAttachmentConfigParams{
+							name:     nadName,
+							topology: "layer3",
+							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							role:     "secondary",
+						},
+						*podConfig(
+							"client-pod",
+							withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
+						),
+						*podConfig(
+							"server-pod",
+							withCommand(func() []string {
+								return httpServerContainerCmd(port)
+							}),
+							withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
+						),
+					),
+				)
+			},
+			Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) error {
+				netConfig := newNetworkAttachmentConfig(c)
+				nad := generateNAD(netConfig)
+				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), nad, metav1.CreateOptions{})
+				return err
+			}),
+			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
+				udnManifest := generateUserDefinedNetworkManifest(&c)
+				cleanup, err := createManifest(f.Namespace.Name, udnManifest)
+				DeferCleanup(cleanup)
+				Expect(waitForUserDefinedNetworkReady(f.Namespace.Name, c.name, 5*time.Second)).To(Succeed())
+				return err
+			}),
+		)
+	})
+
 	Context("UserDefinedNetwork", func() {
 		const (
 			testUdnName                = "test-net"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Add e2e tests to cover network connectivity over secondary network using the namespace UDN CRD.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
