### PR TITLE
Add some more ExpectNoError checks to the e2e tests

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -898,7 +898,8 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 				!strings.HasPrefix(pod.Name, "ovnkube-identity") &&
 				!strings.HasPrefix(pod.Name, "ovs-node") {
 				framework.Logf("%q", pod.Namespace)
-				deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				err = deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				framework.ExpectNoError(err, fmt.Sprintf("failed to delete pod %s", pod.Name))
 				framework.Logf("Deleted control plane pod %q", pod.Name)
 			}
 		}
@@ -931,7 +932,8 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		for _, pod := range podList.Items {
 			if strings.HasPrefix(pod.Name, controlPlanePodName) && !strings.HasPrefix(pod.Name, "ovs-node") {
 				framework.Logf("%q", pod.Namespace)
-				deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				err = deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				framework.ExpectNoError(err, fmt.Sprintf("failed to delete pod %s", pod.Name))
 				framework.Logf("Deleted control plane pod %q", pod.Name)
 			}
 		}
@@ -2186,8 +2188,10 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 		var (
 			command = []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=" + port)}
 		)
-		createGenericPod(f, pod1Name, node1Name, f.Namespace.Name, command)
-		createGenericPod(f, pod2Name, node2Name, f.Namespace.Name, command)
+		_, err := createGenericPod(f, pod1Name, node1Name, f.Namespace.Name, command)
+		framework.ExpectNoError(err, "failed to create pod %s/%s", f.Namespace.Name, pod1Name)
+		_, err = createGenericPod(f, pod2Name, node2Name, f.Namespace.Name, command)
+		framework.ExpectNoError(err, "failed to create pod %s/%s", f.Namespace.Name, pod2Name)
 
 		pod2IP := getPodAddress(pod2Name, f.Namespace.Name)
 
@@ -2340,7 +2344,8 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 		}
 
 		framework.Logf("wait for all the Deployment to become ready again after pod deletion")
-		e2edeployment.WaitForDeploymentComplete(f.ClientSet, dbDeployment)
+		err = e2edeployment.WaitForDeploymentComplete(f.ClientSet, dbDeployment)
+		framework.ExpectNoError(err, "failed to wait for DB deployment to complete")
 
 		framework.Logf("all the pods finish full restart")
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -613,7 +613,7 @@ func restartOVNKubeNodePod(clientset kubernetes.Interface, namespace string, nod
 		return fmt.Errorf("could not find ovnkube-node pod running on node %s", nodeName)
 	}
 	for _, pod := range ovnKubeNodePods.Items {
-		if err := e2epod.DeletePodWithWait(context.TODO(), clientset, &pod); err != nil {
+		if err := deletePodWithWait(context.TODO(), clientset, &pod); err != nil {
 			return fmt.Errorf("could not delete ovnkube-node pod on node %s: %w", nodeName, err)
 		}
 	}
@@ -852,7 +852,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		}
 
 		ginkgo.By("Deleting ovnkube control plane pod " + podName)
-		e2epod.DeletePodWithWaitByName(context.TODO(), f.ClientSet, podName, ovnNamespace)
+		deletePodWithWaitByName(context.TODO(), f.ClientSet, podName, ovnNamespace)
 		framework.Logf("Deleted ovnkube control plane pod %q", podName)
 
 		ginkgo.By("Ensuring there were no connectivity errors")
@@ -898,7 +898,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 				!strings.HasPrefix(pod.Name, "ovnkube-identity") &&
 				!strings.HasPrefix(pod.Name, "ovs-node") {
 				framework.Logf("%q", pod.Namespace)
-				e2epod.DeletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
 				framework.Logf("Deleted control plane pod %q", pod.Name)
 			}
 		}
@@ -931,7 +931,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		for _, pod := range podList.Items {
 			if strings.HasPrefix(pod.Name, controlPlanePodName) && !strings.HasPrefix(pod.Name, "ovs-node") {
 				framework.Logf("%q", pod.Namespace)
-				e2epod.DeletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
 				framework.Logf("Deleted control plane pod %q", pod.Name)
 			}
 		}
@@ -1009,11 +1009,12 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 				}
 				framework.Failf("could not restart ovnkube-node pod: %s", err)
 			}
-			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{ResourceVersion: "0"})
-			if err != nil {
-				framework.Failf("could not find node resource: %s", err)
-			}
+
 			gomega.Eventually(func() bool {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{ResourceVersion: "0"})
+				if err != nil {
+					framework.Failf("could not find node resource: %s", err)
+				}
 				return e2enode.IsNodeReady(node)
 			}, 30*time.Second).Should(gomega.BeFalse())
 		})
@@ -1031,11 +1032,11 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 			}
 
 			// validate that node is in Ready state
-			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{ResourceVersion: "0"})
-			if err != nil {
-				framework.Failf("could not find node resource: %s", err)
-			}
 			gomega.Eventually(func() bool {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{ResourceVersion: "0"})
+				if err != nil {
+					framework.Failf("could not find node resource: %s", err)
+				}
 				return e2enode.IsNodeReady(node)
 			}, 30*time.Second).Should(gomega.BeTrue())
 		})

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
-	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -171,12 +170,7 @@ var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
 						return
 					}
 				}
-				err := e2epod.DeletePodWithWait(context.TODO(), f.ClientSet, &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: f.Namespace.Name,
-						Name:      podName,
-					},
-				})
+				err := deletePodWithWaitByName(context.TODO(), f.ClientSet, podName, f.Namespace.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 			framework.Failf("Failed to create pod %s that can reach %s:%d after %d retries", podName, reachableDst, reachablePort, retries)

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
-	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
 	utilnet "k8s.io/utils/net"
 )
@@ -1505,7 +1504,7 @@ var _ = ginkgo.Describe("External Gateway", func() {
 					// https://github.com/ovn-org/ovn-kubernetes/pull/4114#issuecomment-1940916326
 					// TODO(trozet) change this back to 2 gateways once github actions kernel is updated
 					ginkgo.By(fmt.Sprintf("Reducing to one gateway. Removing gateway: %s", gatewayPodName2))
-					e2epod.DeletePodWithWaitByName(context.TODO(), f.ClientSet, gatewayPodName2, servingNamespace)
+					deletePodWithWaitByName(context.TODO(), f.ClientSet, gatewayPodName2, servingNamespace)
 					time.Sleep(1 * time.Second)
 
 					ginkgo.By("Checking if one of the external gateways are reachable via Egress")

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -175,7 +175,8 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				framework.Failf("failed to add the loopback ip to dev lo on the test container: %v", err)
 			}
 			// Create the pod that will be used as the source for the connectivity test
-			createGenericPod(f, srcPingPodName, ciWorkerNodeSrc, f.Namespace.Name, command)
+			_, err = createGenericPod(f, srcPingPodName, ciWorkerNodeSrc, f.Namespace.Name, command)
+			framework.ExpectNoError(err, "failed to create pod %s/%s", f.Namespace.Name, srcPingPodName)
 			// wait for pod setup to return a valid address
 			err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 				pingSrc = getPodAddress(srcPingPodName, f.Namespace.Name)
@@ -348,7 +349,8 @@ var _ = ginkgo.Describe("External Gateway", func() {
 			framework.Logf("the pod cidr for node %s is %s", workerNodeInfo.name, podCIDR)
 
 			// Create the pod that will be used as the source for the connectivity test
-			createGenericPod(f, dstPingPodName, workerNodeInfo.name, f.Namespace.Name, command)
+			_, err = createGenericPod(f, dstPingPodName, workerNodeInfo.name, f.Namespace.Name, command)
+			framework.ExpectNoError(err, "failed to create pod %s/%s", f.Namespace.Name, dstPingPodName)
 			// wait for the pod setup to return a valid address
 			err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 				pingDstPod = getPodAddress(dstPingPodName, f.Namespace.Name)
@@ -1504,7 +1506,8 @@ var _ = ginkgo.Describe("External Gateway", func() {
 					// https://github.com/ovn-org/ovn-kubernetes/pull/4114#issuecomment-1940916326
 					// TODO(trozet) change this back to 2 gateways once github actions kernel is updated
 					ginkgo.By(fmt.Sprintf("Reducing to one gateway. Removing gateway: %s", gatewayPodName2))
-					deletePodWithWaitByName(context.TODO(), f.ClientSet, gatewayPodName2, servingNamespace)
+					err := deletePodWithWaitByName(context.TODO(), f.ClientSet, gatewayPodName2, servingNamespace)
+					framework.ExpectNoError(err, "failed to delete pod %s/%s", servingNamespace, gatewayPodName2)
 					time.Sleep(1 * time.Second)
 
 					ginkgo.By("Checking if one of the external gateways are reachable via Egress")

--- a/test/e2e/multi_node_zones_interconnect.go
+++ b/test/e2e/multi_node_zones_interconnect.go
@@ -158,22 +158,27 @@ var _ = ginkgo.Describe("Multi node zones interconnect", func() {
 		e2epod.NewPodClient(fr).CreateSync(context.TODO(), clientPod)
 
 		ginkgo.By("asserting the *client* pod can contact the server pod exposed endpoint")
-		checkPodsInterconnectivity(clientPod, serverPod, fr.Namespace.Name, cs)
+		err := checkPodsInterconnectivity(clientPod, serverPod, fr.Namespace.Name, cs)
+		framework.ExpectNoError(err, "failed to check pods interconnectivity")
 
 		// Change the zone of client-pod node to that of server-pod node
 		s := fmt.Sprintf("Changing the client-pod node %s zone from %s to %s", clientPodNodeName, clientPodNodeZone, serverPodNodeZone)
 		ginkgo.By(s)
-		changeNodeZone(clientPodNode, serverPodNodeZone, cs)
+		err = changeNodeZone(clientPodNode, serverPodNodeZone, cs)
+		framework.ExpectNoError(err, "failed to change node zone")
 
 		ginkgo.By("Checking that the client-pod can connect to the server pod when they are in same zone")
-		checkPodsInterconnectivity(clientPod, serverPod, fr.Namespace.Name, cs)
+		err = checkPodsInterconnectivity(clientPod, serverPod, fr.Namespace.Name, cs)
+		framework.ExpectNoError(err, "failed to check pods interconnectivity")
 
 		// Change back the zone of client-pod node
 		s = fmt.Sprintf("Changing back the client-pod node %s zone from %s to %s", clientPodNodeName, serverPodNodeZone, clientPodNodeZone)
 		ginkgo.By(s)
-		changeNodeZone(clientPodNode, clientPodNodeZone, cs)
+		err = changeNodeZone(clientPodNode, clientPodNodeZone, cs)
+		framework.ExpectNoError(err, "failed to change node zone")
 
 		ginkgo.By("Checking again that the client-pod can connect to the server-pod when they are in different zone")
-		checkPodsInterconnectivity(clientPod, serverPod, fr.Namespace.Name, cs)
+		err = checkPodsInterconnectivity(clientPod, serverPod, fr.Namespace.Name, cs)
+		framework.ExpectNoError(err, "failed to check pods interconnectivity")
 	})
 })

--- a/test/e2e/node_ip_mac_migration.go
+++ b/test/e2e/node_ip_mac_migration.go
@@ -235,7 +235,7 @@ spec:
 						return isOVNEncapIPReady(workerNode.Name, workerNodeIPs[ipAddrFamily], ovnkubePodWorkerNode.Name)
 					}, pollingTimeout, pollingInterval).Should(BeTrue())
 
-					err = e2epod.DeletePodWithWait(context.TODO(), f.ClientSet, &ovnkubePodWorkerNode)
+					err = deletePodWithWait(context.TODO(), f.ClientSet, &ovnkubePodWorkerNode)
 					Expect(err).NotTo(HaveOccurred())
 
 					By(fmt.Sprintf("Sleeping for %d seconds to give things time to settle", settleTimeout))

--- a/test/e2e/node_ip_mac_migration.go
+++ b/test/e2e/node_ip_mac_migration.go
@@ -555,7 +555,8 @@ spec:
 		JustAfterEach(func() {
 			if len(workerNodeMAC) > 0 {
 				By("Reverting to original MAC address")
-				setMACAddress(ovnkPod, workerNodeMAC.String())
+				err := setMACAddress(ovnkPod, workerNodeMAC.String())
+				framework.ExpectNoError(err, "failed to revert MAC address")
 			}
 		})
 


### PR DESCRIPTION
#### What this PR does and why is it needed
More fixes pulled out of @martinkennelly 's branch to start adding support for running ovn-k e2e downstream in OCP. This just takes a bunch of places where the test cases were doing something and ignoring possible errors, and changes them to assert that an error didn't occur instead.

(In theory, this should not result in us discovering any new bugs in the _existing_ code, since if something actually went wrong, the test would presumably fail later on anyway. It just means that in case of _future_ bugs, the tests should fail closer to the point where something actually went wrong, rather than failing more mysteriously later.)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
