### PR TITLE
crd, udn: Improve minimum MTU validations

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -123,7 +123,7 @@ spec:
                           MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
                         format: int32
                         maximum: 65536
-                        minimum: 0
+                        minimum: 576
                         type: integer
                       role:
                         description: |-
@@ -184,7 +184,7 @@ spec:
                           MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
                         format: int32
                         maximum: 65536
-                        minimum: 0
+                        minimum: 576
                         type: integer
                       role:
                         description: |-

--- a/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
@@ -71,7 +71,7 @@ spec:
                       MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
                     format: int32
                     maximum: 65536
-                    minimum: 0
+                    minimum: 576
                     type: integer
                   role:
                     description: |-
@@ -132,7 +132,7 @@ spec:
                       MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
                     format: int32
                     maximum: 65536
-                    minimum: 0
+                    minimum: 576
                     type: integer
                   role:
                     description: |-

--- a/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
@@ -26,6 +26,7 @@ const (
 
 // +kubebuilder:validation:XValidation:rule="has(self.subnets) && size(self.subnets) > 0", message="Subnets is required for Layer3 topology"
 // +kubebuilder:validation:XValidation:rule="!has(self.joinSubnets) || has(self.role) && self.role == 'Primary'", message="JoinSubnets is only supported for Primary network"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnets) || !self.subnets.exists_one(i, cidr(i.cidr).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subent is used"
 type Layer3Config struct {
 	// Role describes the network role in the pod.
 	//
@@ -41,7 +42,7 @@ type Layer3Config struct {
 	//
 	// MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
 	//
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=576
 	// +kubebuilder:validation:Maximum=65536
 	// +optional
 	MTU int32 `json:"mtu,omitempty"`
@@ -93,6 +94,7 @@ type Layer3Subnet struct {
 // +kubebuilder:validation:XValidation:rule="self.role != 'Primary' || has(self.subnets) && size(self.subnets) > 0", message="Subnets is required for Primary Layer2 topology"
 // +kubebuilder:validation:XValidation:rule="!has(self.joinSubnets) || has(self.role) && self.role == 'Primary'", message="JoinSubnets is only supported for Primary network"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipamLifecycle) || has(self.subnets) && size(self.subnets) > 0", message="IPAMLifecycle is only supported when subnets are set"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnets) || !self.subnets.exists_one(i, cidr(i).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subent is used"
 type Layer2Config struct {
 	// Role describes the network role in the pod.
 	//
@@ -106,7 +108,7 @@ type Layer2Config struct {
 	// MTU is the maximum transmission unit for a network.
 	// MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
 	//
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=576
 	// +kubebuilder:validation:Maximum=65536
 	// +optional
 	MTU int32 `json:"mtu,omitempty"`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR changes the UserDefinedNetwork & ClusterUserDefinedNetwork CRDs validations, 
making them fit IPv4 and IPv6* minimum MTU according to RFC [1] [2].

[1] https://datatracker.ietf.org/doc/html/rfc791
[2] https://datatracker.ietf.org/doc/html/rfc2460

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

The IPv6 validation require some CEL verbs that will be avaiable once the project transition to use kubernetes 1.31, tracking issue [1].

[1] https://github.com/ovn-org/ovn-kubernetes/issues/4607

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
