### PR TITLE
Remove stale LRSRs from default and network scopped cluster router

### DIFF
--- a/go-controller/pkg/libovsdb/util/router_test.go
+++ b/go-controller/pkg/libovsdb/util/router_test.go
@@ -111,6 +111,20 @@ func TestCreateDefaultRouteToExternal(t *testing.T) {
 		Ports: []string{gwRouterPort.UUID},
 	}
 
+	// to test that we remove route with next hop from old join subnet and add route with next hop from current join subnet
+	oldNextHopClusterSubnetRouteV4 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: clusterSubnetV4.String(),
+		Nexthop:  "100.66.0.3",
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "old-join-subnet-route-v4-uuid",
+	}
+	oldNextHopClusterSubnetRouteV6 := &nbdb.LogicalRouterStaticRoute{
+		IPPrefix: clusterSubnetV6.String(),
+		Nexthop:  "fd96::3",
+		Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+		UUID:     "old-join-subnet-route-v6-uuid",
+	}
+
 	tests := []struct {
 		desc          string
 		initialNbdb   libovsdbtest.TestSetup
@@ -158,6 +172,39 @@ func TestCreateDefaultRouteToExternal(t *testing.T) {
 						Name:         ovnClusterRouterName,
 						UUID:         ovnClusterRouterName + "-uuid",
 						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, wrongNextHopClusterSubnetRouteV4.UUID, wrongNextHopClusterSubnetRouteV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+				},
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, clusterSubnetRouteV4.UUID, clusterSubnetRouteV6.UUID},
+					},
+					gatewayRouter,
+					gwRouterPort,
+					nodeSubnetRouteV4,
+					nodeSubnetRouteV6,
+					clusterSubnetRouteV4,
+					clusterSubnetRouteV6,
+				},
+			},
+		},
+		{
+			desc: "Remove route with next hop from old join subnet and add route with next hop from current join subnet", // should replace the existing one
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					oldNextHopClusterSubnetRouteV4,
+					oldNextHopClusterSubnetRouteV6,
+					&nbdb.LogicalRouter{
+						Name:         ovnClusterRouterName,
+						UUID:         ovnClusterRouterName + "-uuid",
+						StaticRoutes: []string{nodeSubnetRouteV4.UUID, nodeSubnetRouteV6.UUID, oldNextHopClusterSubnetRouteV4.UUID, oldNextHopClusterSubnetRouteV6.UUID},
 					},
 					gatewayRouter,
 					gwRouterPort,

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -749,7 +749,6 @@ func (gw *GatewayManager) updateClusterRouterStaticRoutes(gwConfig *GatewayConfi
 	// to the same gateway router
 	//
 	// This can be removed once https://bugzilla.redhat.com/show_bug.cgi?id=1891516 is fixed.
-	// FIXME(trozet): if LRP IP is changed, we do not remove stale instances of these routes
 	nextHops := gwRouterIPs
 	if gw.netInfo.TopologyType() == types.Layer2Topology && gw.transitRouterInfo != nil {
 		nextHops = util.IPNetsToIPs(gw.transitRouterInfo.gatewayRouterNets)
@@ -785,6 +784,12 @@ func (gw *GatewayManager) updateClusterRouterStaticRoutes(gwConfig *GatewayConfi
 		}
 
 		if gw.clusterRouterName != "" {
+			// delete stale static routes from ovn_cluster_router specific to default network
+			if gw.clusterRouterName == types.OVNClusterRouter {
+				if err = gw.deleteStaleJoinSubnetRoutes(gwRouterIP.String()); err != nil {
+					klog.Errorf("Could not remove stale static route %v", err)
+				}
+			}
 			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient,
 				gw.clusterRouterName, &lrsr, p, &lrsr.Nexthop)
 			if err != nil {
@@ -1705,6 +1710,33 @@ func (gw *GatewayManager) staticRouteCleanup(nextHops []net.IP, ipPrefix *net.IP
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		klog.Errorf("Failed to delete static route for nexthops %+v: %v", ips.UnsortedList(), err)
 	}
+}
+
+// deleteStaleJoinSubnetRoutes removes static routes referencing old join switch IP as either NextHop or IPPrefix.
+// It acts on following LRSRs:
+// 100.64.0.4               100.64.0.4 dst-ip
+func (gw *GatewayManager) deleteStaleJoinSubnetRoutes(gwLRPIP string) error {
+	p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+		if lrsr.Nexthop != gwLRPIP && utilnet.IPFamilyOfString(lrsr.Nexthop) == utilnet.IPFamilyOfString(gwLRPIP) &&
+			lrsr.Nexthop == lrsr.IPPrefix {
+			networkName, isSecondaryNetwork := lrsr.ExternalIDs[types.NetworkExternalID]
+			if isSecondaryNetwork && networkName == gw.netInfo.GetNetworkName() {
+				klog.Infof("Removing stale join subnet route %s via %s from router %s for network %s",
+					lrsr.IPPrefix, lrsr.Nexthop, gw.clusterRouterName, networkName)
+				return true
+			} else if !isSecondaryNetwork {
+				klog.Infof("Removing stale join subnet route %s via %s from router %s",
+					lrsr.IPPrefix, lrsr.Nexthop, gw.clusterRouterName)
+				return true
+			}
+		}
+		return false
+	}
+
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(gw.nbClient, gw.clusterRouterName, p); err != nil {
+		return fmt.Errorf("failed to delete static route from router %s: %v", gw.clusterRouterName, err)
+	}
+	return nil
 }
 
 // policyRouteCleanup cleans up all policies on cluster router that have a nextHop

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -785,6 +785,102 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
+		ginkgo.It("removes stale static route for old join subnet", func() {
+			routeUUID1 := "route1-UUID"
+			leftoverMasqueradeIPRoute1 := &nbdb.LogicalRouterStaticRoute{
+				Nexthop:  "100.66.0.2",
+				IPPrefix: "100.66.0.2",
+				UUID:     routeUUID1,
+			}
+			routeUUID2 := "route2-UUID"
+			leftoverMasqueradeIPRoute2 := &nbdb.LogicalRouterStaticRoute{
+				Nexthop:  "100.66.0.2",
+				IPPrefix: "10.130.0.0/23",
+				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
+				UUID:     routeUUID2,
+			}
+			expectedOVNClusterRouter := &nbdb.LogicalRouter{
+				UUID: types.OVNClusterRouter + "-UUID",
+				Name: types.OVNClusterRouter,
+			}
+			expectedNodeSwitch := &nbdb.LogicalSwitch{
+				UUID: nodeName + "-UUID",
+				Name: nodeName,
+			}
+			expectedClusterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterLBGroupName + "-UUID",
+				Name: types.ClusterLBGroupName,
+			}
+			expectedSwitchLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterSwitchLBGroupName + "-UUID",
+				Name: types.ClusterSwitchLBGroupName,
+			}
+			expectedRouterLBGroup := &nbdb.LoadBalancerGroup{
+				UUID: types.ClusterRouterLBGroupName + "-UUID",
+				Name: types.ClusterRouterLBGroupName,
+			}
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					// tests migration from local to shared
+					leftoverMasqueradeIPRoute1,
+					leftoverMasqueradeIPRoute2,
+					&nbdb.LogicalSwitch{
+						UUID: types.OVNJoinSwitch + "-UUID",
+						Name: types.OVNJoinSwitch,
+					},
+					expectedOVNClusterRouter,
+					expectedNodeSwitch,
+					expectedClusterLBGroup,
+					expectedSwitchLBGroup,
+					expectedRouterLBGroup,
+				},
+			})
+
+			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
+			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
+			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16")
+			defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16")
+			l3GatewayConfig := &util.L3GatewayConfig{
+				Mode:           config.GatewayModeLocal,
+				ChassisID:      "SYSTEM-ID",
+				BridgeID:       "BRIDGE-ID",
+				InterfaceID:    "INTERFACE-ID",
+				MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+				IPAddresses:    ovntest.MustParseIPNets("169.255.33.2/24"),
+				NextHops:       ovntest.MustParseIPs("169.255.33.1"),
+				NodePortEnable: true,
+			}
+			gwConfig := &GatewayConfig{
+				annoConfig:                 l3GatewayConfig,
+				hostSubnets:                hostSubnets,
+				clusterSubnets:             clusterIPSubnets,
+				gwRouterJoinCIDRs:          joinLRPIPs,
+				hostAddrs:                  nil,
+				externalIPs:                extractExternalIPs(l3GatewayConfig),
+				ovnClusterLRPToJoinIfAddrs: defLRPIPs,
+			}
+
+			var err error
+			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = newGatewayManager(fakeOvn, nodeName).gatewayInit(
+				nodeName,
+				gwConfig,
+				true,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			testData := []libovsdbtest.TestData{}
+			skipSnat := false
+			expectedOVNClusterRouter.StaticRoutes = []string{} // the leftover LGW route should have got deleted
+			// We don't set up the Allow from mgmt port ACL here
+			mgmtPortIP := ""
+			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
+				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
+				"1400")
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+		})
+
 		ginkgo.It("creates an IPv4 gateway in OVN without next hops", func() {
 			routeUUID := "route-UUID"
 			leftoverMgmtIPRoute := &nbdb.LogicalRouterStaticRoute{
@@ -1053,7 +1149,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			ginkgo.By("modifying the node join IP")
-			oldJoinLRPIPs := joinLRPIPs
 			joinLRPIPs = ovntest.MustParseIPNets("100.64.0.99/16")
 			gwConfig.gwRouterJoinCIDRs = joinLRPIPs
 			expectedOVNClusterRouter.StaticRoutes = []string{}
@@ -1066,16 +1161,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState = generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch,
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
-			// FIXME(trozet): we do not clean up stale routes after join IP changes
-			for i, joinLRPIP := range oldJoinLRPIPs {
-				joinStaticRouteNamedUUID := fmt.Sprintf("hack-join-static-route-ovn-cluster-router-%v-UUID", i)
-				expectedOVNClusterRouter.StaticRoutes = append(expectedOVNClusterRouter.StaticRoutes, joinStaticRouteNamedUUID)
-				expectedDatabaseState = append(expectedDatabaseState, &nbdb.LogicalRouterStaticRoute{
-					UUID:     joinStaticRouteNamedUUID,
-					IPPrefix: joinLRPIP.IP.String(),
-					Nexthop:  joinLRPIP.IP.String(),
-				})
-			}
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -540,6 +540,10 @@ func (zic *ZoneInterconnectHandler) createRemoteZoneNodeResources(node *corev1.N
 		return err
 	}
 
+	if err := zic.deleteStaleStaticRoutes(node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs); err != nil {
+		return err
+	}
+
 	if err := zic.addRemoteNodeStaticRoutes(node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs); err != nil {
 		return err
 	}
@@ -781,6 +785,44 @@ func (zic *ZoneInterconnectHandler) getStaticRoutes(ipPrefixes []*net.IPNet, nex
 	}
 
 	return staticRoutes
+}
+
+// deleteStaleStaticRoutes removes the static route no longer match the ones
+// addRemoteNodeStaticRoutes would create for it.Those are left behind when the
+// node transit switch IP or the node gateway router join IP change as part of a
+// day 2 operation, since the routes are keyed by IPPrefix and a changed IPPrefix
+// ends up creating a new route instead of replacing the old one.
+func (zic *ZoneInterconnectHandler) deleteStaleStaticRoutes(node *corev1.Node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs []*net.IPNet) error {
+	routeKey := func(prefix, nexthop string) string {
+		return prefix + " " + nexthop
+	}
+
+	expectedRoutes := sets.New[string]()
+	for _, staticRoute := range zic.getStaticRoutes(nodeSubnets, nodeTransitSwitchPortIPs, false) {
+		expectedRoutes.Insert(routeKey(staticRoute.prefix, staticRoute.nexthop))
+	}
+	for _, staticRoute := range zic.getStaticRoutes(nodeGRPIPs, nodeTransitSwitchPortIPs, true) {
+		expectedRoutes.Insert(routeKey(staticRoute.prefix, staticRoute.nexthop))
+	}
+
+	p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+		if lrsr.ExternalIDs["ic-node"] != node.Name {
+			return false
+		}
+		if networkName, isSet := lrsr.ExternalIDs[types.NetworkExternalID]; isSet && networkName != zic.GetNetworkName() {
+			return false
+		}
+		if !expectedRoutes.Has(routeKey(lrsr.IPPrefix, lrsr.Nexthop)) {
+			klog.Infof("Removing stale static route %s via %s from router %s for node %s network %s",
+				lrsr.IPPrefix, lrsr.Nexthop, zic.networkClusterRouterName, node.Name, zic.GetNetworkName())
+			return true
+		}
+		return false
+	}
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(zic.nbClient, zic.networkClusterRouterName, p); err != nil {
+		return fmt.Errorf("failed to delete stale static routes of node %s from router %s: %w", node.Name, zic.networkClusterRouterName, err)
+	}
+	return nil
 }
 
 func getUserDefinedNetTransitSwitchExtIDs(networkName, topology string, isPrimaryUDN bool) map[string]string {

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -20,6 +20,7 @@ import (
 
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/sbdb"
@@ -1015,6 +1016,200 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(nodeRoutes).To(gomega.BeEmpty())
 
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("removes stale static routes", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalRouterStaticRoute{
+							Nexthop:  "100.90.0.4",
+							IPPrefix: "10.244.4.0/24",
+							UUID:     "route1-UUID",
+							ExternalIDs: map[string]string{
+								types.NetworkExternalID: types.DefaultNetworkName,
+								"ic-node":               testNode3.Name,
+							},
+						},
+						&nbdb.LogicalRouterStaticRoute{
+							Nexthop:  "100.90.0.4",
+							IPPrefix: "100.66.0.4/32",
+							UUID:     "route2-UUID",
+							ExternalIDs: map[string]string{
+								types.NetworkExternalID: types.DefaultNetworkName,
+								"ic-node":               testNode3.Name,
+							},
+						},
+						&nbdb.LogicalRouterStaticRoute{
+							Nexthop:  "100.88.0.4",
+							IPPrefix: "100.68.0.4/32",
+							UUID:     "route3-UUID",
+							ExternalIDs: map[string]string{
+								types.NetworkExternalID: types.DefaultNetworkName,
+								"ic-node":               testNode3.Name,
+							},
+						},
+						&nbdb.LogicalRouterStaticRoute{
+							Nexthop:  "100.90.0.4",
+							IPPrefix: "100.64.0.4/32",
+							UUID:     "route4-UUID",
+							ExternalIDs: map[string]string{
+								types.NetworkExternalID: types.DefaultNetworkName,
+								"ic-node":               testNode3.Name,
+							},
+						},
+						&nbdb.LogicalRouter{
+							UUID:         types.OVNClusterRouter + "-UUID",
+							Name:         types.OVNClusterRouter,
+							StaticRoutes: []string{"route1-UUID", "route2-UUID", "route3-UUID", "route4-UUID"},
+						},
+					},
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				config.Kubernetes.HostNetworkNamespace = ""
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("removes stale static routes of a remote node", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(1)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// The route to the old node subnet is keyed by its IPPrefix, so it is not
+				// replaced by the route to the new subnet and must be removed explicitly.
+				ginkgo.By("changing the remote node subnet")
+				testNode3.Annotations[ovnNodeSubnetsAnnotation] = "{\"default\":[\"10.244.44.0/24\"]}"
+				testNodesRouteInfo["node3"]["node-subnets"] = "10.244.44.0/24"
+				gomega.Expect(zoneICHandler.AddRemoteZoneNode(&testNode3)).To(gomega.Succeed())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("deleteStaleStaticRoutes does not remove valid routes", func() {
+			app.Action = func(ctx *cli.Context) error {
+				nodeSubnetRoute := &nbdb.LogicalRouterStaticRoute{
+					Nexthop:  "100.88.0.4",
+					IPPrefix: "10.244.4.0/24",
+					UUID:     "valid-subnet-route-UUID",
+					ExternalIDs: map[string]string{
+						types.NetworkExternalID: types.DefaultNetworkName,
+						"ic-node":               testNode3.Name,
+					},
+				}
+				grpRoute := &nbdb.LogicalRouterStaticRoute{
+					Nexthop:  "100.88.0.4",
+					IPPrefix: "100.64.0.4/32",
+					UUID:     "valid-grp-route-UUID",
+					ExternalIDs: map[string]string{
+						types.NetworkExternalID: types.DefaultNetworkName,
+						"ic-node":               testNode3.Name,
+					},
+				}
+				clusterRouter := &nbdb.LogicalRouter{
+					UUID:         types.OVNClusterRouter + "-UUID",
+					Name:         types.OVNClusterRouter,
+					StaticRoutes: []string{nodeSubnetRoute.UUID, grpRoute.UUID},
+				}
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{nodeSubnetRoute, grpRoute, clusterRouter},
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				nodeTransitSwitchPortIPs, err := util.ParseNodeTransitSwitchPortAddrs(&testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(&testNode3, types.DefaultNetworkName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nodeGRPIPs, err := udn.GetGWRouterIPs(&testNode3, &util.DefaultNetInfo{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.deleteStaleStaticRoutes(&testNode3, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Both routes must still exist — neither is stale.
+				allRoutesPredicate := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+					return lrsr.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				remaining, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(
+					libovsdbOvnNBClient,
+					&nbdb.LogicalRouter{Name: types.OVNClusterRouter},
+					allRoutesPredicate,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(remaining).To(gomega.HaveLen(2), "valid node-subnet and GRP routes must not be deleted")
 				return nil
 			}
 


### PR DESCRIPTION
This PR removes logical router static routes with stale IPs when join or transit switch IP gets changed as part of day 2 operation.

arghosh@arghosh-thinkpadp1gen7:~/go/delete_stale_static_route/ovn-kubernetes/contrib$ oc set env -n ovn-kubernetes deploy/ovnkube-control-plane OVN_V4_JOIN_SUBNET=100.67.0.0/16 OVN_V4_TRANSIT_SUBNET=100.91.0.0/16 --overwrite ; oc set env -n ovn-kubernetes ds/ovnkube-node OVN_V4_JOIN_SUBNET=100.67.0.0/16 --overwrite

sh-5.3# ovn-nbctl lr-route-list ovn_cluster_router
IPv4 Routes
Route Table <main>:
               100.64.0.2                100.64.0.2 dst-ip
               100.64.0.3                100.91.0.3 dst-ip
               100.64.0.4                100.91.0.4 dst-ip
               100.67.0.2                100.67.0.2 dst-ip
               100.67.0.3                100.91.0.3 dst-ip
               100.67.0.4                100.91.0.4 dst-ip
            10.244.0.0/24                100.91.0.3 dst-ip
            10.244.2.0/24                100.91.0.4 dst-ip
            10.244.1.0/24                100.67.0.2 src-ip
            10.244.0.0/16                100.67.0.2 src-ip
sh-5.3# ovn-nbctl lr-route-list GR_ovn-worker2    
IPv4 Routes
Route Table <main>:
           169.254.0.0/17               169.254.0.4 dst-ip rtoe-GR_ovn-worker2
            10.244.0.0/16                100.67.0.1 dst-ip
                0.0.0.0/0                172.18.0.1 dst-ip rtoe-GR_ovn-worker2

arghosh@arghosh-thinkpadp1gen7:~/go/delete_stale_static_route/ovn-kubernetes/contrib$ oc set env -n ovn-kubernetes deploy/ovnkube-control-plane OVN_V4_TRANSIT_SUBNET=100.92.0.0/16 --overwrite

sh-5.3# ovn-nbctl lr-route-list ovn_cluster_router
IPv4 Routes
Route Table <main>:
               100.64.0.2                100.64.0.2 dst-ip
               100.64.0.3                100.91.0.3 dst-ip
               100.64.0.4                100.91.0.4 dst-ip
               100.67.0.2                100.67.0.2 dst-ip
               100.67.0.3                100.92.0.3 dst-ip
               100.67.0.4                100.92.0.4 dst-ip
            10.244.0.0/24                100.92.0.3 dst-ip
            10.244.2.0/24                100.92.0.4 dst-ip
            10.244.1.0/24                100.67.0.2 src-ip
            10.244.0.0/16                100.67.0.2 src-ip


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
