### PR TITLE
Do not update EncapIP if it is configured

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -232,9 +232,11 @@ type DefaultConfig struct {
 	// EncapType value defines the encapsulation protocol to use to transmit packets between
 	// hypervisors. By default the value is 'geneve'
 	EncapType string `gcfg:"encap-type"`
-	// The IP address of the encapsulation endpoint. If not specified, the IP address the
-	// NodeName resolves to will be used
+	// Configured IP address of the encapsulation endpoint.
 	EncapIP string `gcfg:"encap-ip"`
+	// Effective encap IP. It may be different from EncapIP if EncapIP meant to be
+	// the node's primary IP which can be updated when node's primary IP changes.
+	EffectiveEncapIP string
 	// The UDP Port of the encapsulation endpoint. If not specified, the IP default port
 	// of 6081 will be used
 	EncapPort uint `gcfg:"encap-port"`

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Node", func() {
 			}
 
 			config.Default.MTU = configDefaultMTU
-			config.Default.EncapIP = "10.1.0.40"
+			config.Default.EffectiveEncapIP = "10.1.0.40"
 
 		})
 
@@ -219,7 +219,7 @@ var _ = Describe("Node", func() {
 			BeforeEach(func() {
 				config.IPv4Mode = true
 				config.IPv6Mode = false
-				config.Default.EncapIP = "10.1.0.40,10.2.0.50"
+				config.Default.EffectiveEncapIP = "10.1.0.40,10.2.0.50"
 				netlinkOpsMock.On("LinkByIndex", 5).Return(netlinkLinkMock, nil)
 			})
 

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -50,12 +50,12 @@ func newAddressManager(nodeName string, k kube.Interface, config *managementPort
 // newAddressManagerInternal creates a new address manager; this function is
 // only expose for testcases to disable netlink subscription to ensure
 // reproducibility of unit tests.
-func newAddressManagerInternal(nodeName string, k kube.Interface, config *managementPortConfig, watchFactory factory.NodeWatchFactory, gwBridge *bridgeConfiguration, useNetlink bool) *addressManager {
+func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtConfig *managementPortConfig, watchFactory factory.NodeWatchFactory, gwBridge *bridgeConfiguration, useNetlink bool) *addressManager {
 	mgr := &addressManager{
 		nodeName:       nodeName,
 		watchFactory:   watchFactory,
 		cidrs:          sets.New[string](),
-		mgmtPortConfig: config,
+		mgmtPortConfig: mgmtConfig,
 		gatewayBridge:  gwBridge,
 		OnChanged:      func() {},
 		useNetlink:     useNetlink,
@@ -228,7 +228,7 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
 		return
 	}
-	if nodePrimaryAddrChanged {
+	if nodePrimaryAddrChanged && config.Default.EncapIP == "" {
 		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
 		updateOVNEncapIPAndReconnect(c.nodePrimaryAddr)
 	}
@@ -502,6 +502,7 @@ func updateOVNEncapIPAndReconnect(newIP net.IP) {
 		}
 	}
 
+	config.Default.EffectiveEncapIP = newIP.String()
 	confCmd := []string{
 		"set",
 		"Open_vSwitch",


### PR DESCRIPTION
If EncapIP is configurated, it means it is different from the node's primary address. Do not update EncapIP when node's primary address changes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
