### PR TITLE
ut,multi net: Fix assertion in case of unexpected error

### DIFF
--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1049,6 +1049,7 @@ func TestGetPodNADToNetworkMappingWithActiveNetwork(t *testing.T) {
 			)
 
 			if err != nil {
+				g.Expect(test.expectedError).NotTo(gomega.BeNil(), err.Error())
 				g.Expect(err).To(gomega.MatchError(test.expectedError))
 			}
 			g.Expect(isAttachmentRequested).To(gomega.Equal(test.expectedIsAttachmentRequested))


### PR DESCRIPTION
#### What this PR does and why is it needed
In case there is an unexpected error, for a test that should pass, 
there will be a panic because `MatchError` expects non nil value.
```
panic: reflect: call of reflect.Value.Type on zero Value [recovered]
	panic: reflect: call of reflect.Value.Type on zero Value
```

Fix it to be explicit and also print the error to ease debug.


#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
