### PR TITLE
VM migration: Reduce downtime using LSP Enabled

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -353,6 +353,11 @@ func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
 	return ExtractVMNameFromPod(pod) != nil
 }
 
+// IsPodAllowedForMigration determines whether a given pod is eligible for live migration
+func IsPodAllowedForMigration(pod *corev1.Pod, netInfo util.NetInfo) bool {
+	return IsPodOwnedByVirtualMachine(pod) && netInfo.TopologyType() == ovntypes.Layer2Topology
+}
+
 func isTargetPodReady(targetPod *corev1.Pod) bool {
 	if targetPod == nil {
 		return false
@@ -406,6 +411,11 @@ type LiveMigrationStatus struct {
 	SourcePod *corev1.Pod        // SourcePod is the original pod.
 	TargetPod *corev1.Pod        // TargetPod is the destination pod.
 	State     LiveMigrationState // State is the current state of the live migration.
+}
+
+// IsTargetDomainReady returns true if the target domain in the live migration process is ready.
+func (lm LiveMigrationStatus) IsTargetDomainReady() bool {
+	return lm.State == LiveMigrationTargetDomainReady
 }
 
 // DiscoverLiveMigrationStatus determines the status of a live migration for a given pod.

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -3,6 +3,8 @@ package kubevirt
 import (
 	"fmt"
 	"net"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +14,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
@@ -348,4 +351,121 @@ func ZoneContainsPodSubnetOrUntracked(watchFactory *factory.WatchFactory, lsMana
 // kubevirt virtual machine, false otherwise.
 func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
 	return ExtractVMNameFromPod(pod) != nil
+}
+
+func isTargetPodReady(targetPod *corev1.Pod) bool {
+	if targetPod == nil {
+		return false
+	}
+
+	// This annotation only appears on live migration scenarios, and it signals
+	// that target VM pod is ready to receive traffic, so we can route
+	// traffic to it.
+	targetReadyTimestamp := targetPod.Annotations[kubevirtv1.MigrationTargetReadyTimestamp]
+
+	// VM is ready to receive traffic
+	return targetReadyTimestamp != ""
+}
+
+func filterNotComplete(vmPods []*corev1.Pod) []*corev1.Pod {
+	var notCompletePods []*corev1.Pod
+	for _, vmPod := range vmPods {
+		if !util.PodCompleted(vmPod) {
+			notCompletePods = append(notCompletePods, vmPod)
+		}
+	}
+
+	return notCompletePods
+}
+
+func tooManyPodsError(livingPods []*corev1.Pod) error {
+	var podNames = make([]string, len(livingPods))
+	for i := range livingPods {
+		podNames[i] = livingPods[i].Namespace + "/" + livingPods[i].Name
+	}
+	return fmt.Errorf("unexpected live migration state at pods: %s", strings.Join(podNames, ","))
+}
+
+// LiveMigrationState represents the various states of a live migration process.
+type LiveMigrationState string
+
+const (
+	// LiveMigrationInProgress indicates that a live migration is currently ongoing.
+	LiveMigrationInProgress LiveMigrationState = "InProgress"
+
+	// LiveMigrationTargetDomainReady indicates that the target domain is ready to take over.
+	LiveMigrationTargetDomainReady LiveMigrationState = "TargetDomainReady"
+
+	// LiveMigrationFailed indicates that the live migration process has failed.
+	LiveMigrationFailed LiveMigrationState = "Failed"
+)
+
+// LiveMigrationStatus provides details about the current status of a live migration.
+// It includes information about the source and target pods as well as the migration state.
+type LiveMigrationStatus struct {
+	SourcePod *corev1.Pod        // SourcePod is the original pod.
+	TargetPod *corev1.Pod        // TargetPod is the destination pod.
+	State     LiveMigrationState // State is the current state of the live migration.
+}
+
+// DiscoverLiveMigrationStatus determines the status of a live migration for a given pod.
+// It analyzes the state of pods associated with a VirtualMachine (VM) to identify whether
+// a live migration is in progress, the target domain is ready, or the migration has failed.
+//
+// Note: The function assumes that the pod is part of a VirtualMachine resource managed
+// by KubeVirt.
+func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) (*LiveMigrationStatus, error) {
+	vmKey := ExtractVMNameFromPod(pod)
+	if vmKey == nil {
+		return nil, nil
+	}
+
+	vmPods, err := client.GetPodsBySelector(pod.Namespace, metav1.LabelSelector{MatchLabels: map[string]string{kubevirtv1.VirtualMachineNameLabel: vmKey.Name}})
+	if err != nil {
+		return nil, err
+	}
+
+	// no migration
+	if len(vmPods) < 2 {
+		return nil, nil
+	}
+
+	// Sort vmPods by creation time
+	sort.Slice(vmPods, func(i, j int) bool {
+		return vmPods[j].CreationTimestamp.After(vmPods[i].CreationTimestamp.Time)
+	})
+
+	targetPod := vmPods[len(vmPods)-1]
+	livingPods := filterNotComplete(vmPods)
+	if util.PodCompleted(targetPod) {
+		// if target pod failed, then there should be only one living source pod.
+		if len(livingPods) != 1 {
+			return nil, fmt.Errorf("unexpected live migration state: should have a single living pod")
+		}
+		return &LiveMigrationStatus{
+			SourcePod: livingPods[0],
+			TargetPod: targetPod,
+			State:     LiveMigrationFailed,
+		}, nil
+	}
+
+	// no active migration
+	if len(livingPods) < 2 {
+		return nil, nil
+	}
+
+	if len(livingPods) > 2 {
+		return nil, tooManyPodsError(livingPods)
+	}
+
+	status := LiveMigrationStatus{
+		SourcePod: livingPods[0],
+		TargetPod: livingPods[1],
+		State:     LiveMigrationInProgress,
+	}
+
+	if isTargetPodReady(status.TargetPod) {
+		status.State = LiveMigrationTargetDomainReady
+	}
+	return &status, nil
 }

--- a/go-controller/pkg/kubevirt/pod_test.go
+++ b/go-controller/pkg/kubevirt/pod_test.go
@@ -1,0 +1,212 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+const vmName = "test-vm"
+
+var _ = Describe("Kubevirt Pod", func() {
+	const (
+		t0 = time.Duration(0)
+		t1 = time.Duration(1)
+		t2 = time.Duration(2)
+		t3 = time.Duration(3)
+		t4 = time.Duration(4)
+	)
+	runningKvSourcePod := runningKubevirtPod(t0)
+	successfullyMigratedKvSourcePod := completedKubevirtPod(t1)
+
+	failedMigrationKvTargetPod := failedKubevirtPod(t2)
+	successfulMigrationKvTargetPod := runningKubevirtPod(t3)
+	anotherFailedMigrationKvTargetPod := failedKubevirtPod(t4)
+	duringMigrationKvTargetPod := runningKubevirtPod(t4)
+	yetAnotherDuringMigrationKvTargetPod := runningKubevirtPod(t4)
+	readyMigrationKvTargetPod := domainReadyKubevirtPod(t4)
+
+	type testParams struct {
+		pods                    []corev1.Pod
+		expectedError           error
+		expectedMigrationStatus *LiveMigrationStatus
+	}
+	DescribeTable("DiscoverLiveMigrationStatus", func(params testParams) {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+
+		fakeClient := util.GetOVNClientset().GetOVNKubeControllerClientset()
+		wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, pod := range params.pods {
+			_, err := fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		Expect(wf.Start()).To(Succeed())
+		defer wf.Shutdown()
+
+		currentPod := params.pods[0]
+		migrationStatus, err := DiscoverLiveMigrationStatus(wf, &currentPod)
+		if params.expectedError == nil {
+			Expect(err).To(BeNil())
+		} else {
+			Expect(err).To(MatchError(ContainSubstring(params.expectedError.Error())))
+		}
+
+		if params.expectedMigrationStatus == nil {
+			Expect(migrationStatus).To(BeNil())
+		} else {
+			Expect(migrationStatus.State).To(Equal(params.expectedMigrationStatus.State))
+			Expect(migrationStatus.SourcePod.Name).To(Equal(params.expectedMigrationStatus.SourcePod.Name))
+			Expect(migrationStatus.TargetPod.Name).To(Equal(params.expectedMigrationStatus.TargetPod.Name))
+		}
+	},
+		Entry("returns nil when pod is not kubevirt related",
+			testParams{
+				pods: []corev1.Pod{nonKubevirtPod()},
+			},
+		),
+		Entry("returns nil when migration was not performed",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod},
+			},
+		),
+		Entry("returns nil when there is no active migration",
+			testParams{
+				pods: []corev1.Pod{successfullyMigratedKvSourcePod, successfulMigrationKvTargetPod},
+			},
+		),
+		Entry("returns nil when there is no active migration (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{successfullyMigratedKvSourcePod, failedMigrationKvTargetPod, successfulMigrationKvTargetPod},
+			},
+		),
+		Entry("returns Migration in progress status when 2 pods are running, target pod is not yet ready",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, duringMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &duringMigrationKvTargetPod,
+					State:     LiveMigrationInProgress,
+				},
+			},
+		),
+		Entry("returns Migration Failed status when latest target pod failed",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &failedMigrationKvTargetPod,
+					State:     LiveMigrationFailed,
+				},
+			},
+		),
+		Entry("returns Migration Failed status when latest target pod failed (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod, anotherFailedMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &anotherFailedMigrationKvTargetPod,
+					State:     LiveMigrationFailed,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when latest target pod is ready",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when latest target pod is ready (multiple migrations)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePod, failedMigrationKvTargetPod, readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePod,
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns err when kubevirt VM has several living pods and target pod failed",
+			testParams{
+				pods:          []corev1.Pod{runningKvSourcePod, successfulMigrationKvTargetPod, anotherFailedMigrationKvTargetPod},
+				expectedError: fmt.Errorf("unexpected live migration state: should have a single living pod"),
+			},
+		),
+		Entry("returns err when kubevirt VM has several living pods",
+			testParams{
+				pods:          []corev1.Pod{runningKvSourcePod, duringMigrationKvTargetPod, yetAnotherDuringMigrationKvTargetPod},
+				expectedError: fmt.Errorf("unexpected live migration state at pods"),
+			},
+		),
+	)
+})
+
+func completedKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodSucceeded, nil, creationOffset)
+}
+
+func failedKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodFailed, nil, creationOffset)
+}
+
+func runningKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodRunning, nil, creationOffset)
+}
+
+func domainReadyKubevirtPod(creationOffset time.Duration) corev1.Pod {
+	return newKubevirtPod(corev1.PodRunning, map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"}, creationOffset)
+}
+
+func nonKubevirtPod() corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-pod",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: corev1.PodSpec{},
+	}
+}
+func newKubevirtPod(phase corev1.PodPhase, annotations map[string]string, creationOffset time.Duration) corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "virt-launcher-" + vmName + rand.String(5),
+			Namespace:         corev1.NamespaceDefault,
+			Annotations:       annotations,
+			Labels:            map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -286,28 +286,42 @@ func GetLogicalSwitchPort(nbClient libovsdbclient.Client, lsp *nbdb.LogicalSwitc
 	return found[0], nil
 }
 
-func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, createSwitch bool, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+func createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw *nbdb.LogicalSwitch, lsp *nbdb.LogicalSwitchPort, createLSP bool, customFields []ModelUpdateField) operationModel {
+	var fieldInterfaces []interface{}
+	if len(customFields) != 0 {
+		fieldInterfaces = getFieldsToUpdate(lsp, customFields)
+	} else {
+		fieldInterfaces = getAllUpdatableFields(lsp)
+	}
+	return operationModel{
+		Model:          lsp,
+		OnModelUpdates: fieldInterfaces,
+		DoAfter: func() {
+			// lsp.UUID should be set here
+			sw.Ports = append(sw.Ports, lsp.UUID)
+		},
+		ErrNotFound: !createLSP,
+		BulkOp:      false,
+	}
+}
+
+func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, createSwitch, createLSP bool, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
 	originalPorts := sw.Ports
 	sw.Ports = make([]string, 0, len(lsps))
 	opModels := make([]operationModel, 0, len(lsps)+1)
-	for i := range lsps {
-		lsp := lsps[i]
-		opModel := operationModel{
-			Model:          lsp,
-			OnModelUpdates: getAllUpdatableFields(lsp),
-			DoAfter:        func() { sw.Ports = append(sw.Ports, lsp.UUID) },
-			ErrNotFound:    false,
-			BulkOp:         false,
-		}
+
+	for _, lsp := range lsps {
+		opModel := createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw, lsp, createLSP, customFields)
 		opModels = append(opModels, opModel)
 	}
-	opModel := operationModel{
+
+	opModelSwitch := operationModel{
 		Model:            sw,
 		OnModelMutations: []interface{}{&sw.Ports},
 		ErrNotFound:      !createSwitch,
 		BulkOp:           false,
 	}
-	opModels = append(opModels, opModel)
+	opModels = append(opModels, opModelSwitch)
 
 	m := newModelClient(nbClient)
 	ops, err := m.CreateOrUpdateOps(ops, opModels...)
@@ -319,7 +333,7 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []l
 }
 
 func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch, createSwitch bool, lsps ...*nbdb.LogicalSwitchPort) error {
-	ops, err := createOrUpdateLogicalSwitchPortsOps(nbClient, nil, sw, createSwitch, lsps...)
+	ops, err := createOrUpdateLogicalSwitchPortsOps(nbClient, nil, sw, createSwitch, true, nil, lsps...)
 	if err != nil {
 		return err
 	}
@@ -328,11 +342,18 @@ func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.L
 	return err
 }
 
-// CreateOrUpdateLogicalSwitchPortsOnSwitchOps creates or updates the provided
+// CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps creates or updates the provided
 // logical switch ports, adds them to the provided logical switch and returns
 // the corresponding ops
-func CreateOrUpdateLogicalSwitchPortsOnSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
-	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, lsps...)
+func CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, true, customFields, lsps...)
+}
+
+// UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps updates the provided
+// logical switch ports, adds them to the provided logical switch and returns
+// the corresponding ops
+func UpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, sw *nbdb.LogicalSwitch, customFields []ModelUpdateField, lsps ...*nbdb.LogicalSwitchPort) ([]libovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, false, customFields, lsps...)
 }
 
 // CreateOrUpdateLogicalSwitchPortsOnSwitch creates or updates the provided

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -444,7 +444,7 @@ func (bnc *BaseNetworkController) ensurePodAnnotation(pod *kapi.Pod, nadName str
 }
 
 func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName string,
-	network *nadapi.NetworkSelectionElement) (ops []ovsdb.Operation,
+	network *nadapi.NetworkSelectionElement, enable *bool) (ops []ovsdb.Operation,
 	lsp *nbdb.LogicalSwitchPort, podAnnotation *util.PodAnnotation, newlyCreatedPort bool, err error) {
 	var ls *nbdb.LogicalSwitch
 
@@ -598,6 +598,10 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
 	}
 
+	lsp.Enabled = enable
+	if lsp.Enabled != nil {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortEnabled)
+	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {
 		return nil, nil, nil, false,

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -511,6 +511,8 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		}
 	}
 
+	var customFields []libovsdbops.ModelUpdateField
+
 	lsp.Options = make(map[string]string)
 	// Unique identifier to distinguish interfaces for recreated pods, also set by ovnkube-node
 	// ovn-controller will claim the OVS interface only if external_ids:iface-id
@@ -567,6 +569,7 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 	}
 
 	lsp.Addresses = addresses
+	customFields = append(customFields, libovsdbops.LogicalSwitchPortAddresses)
 
 	// add external ids
 	lsp.ExternalIDs = map[string]string{"namespace": pod.Namespace, "pod": "true"}
@@ -578,6 +581,7 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 
 	// CNI depends on the flows from port security, delay setting it until end
 	lsp.PortSecurity = addresses
+	customFields = append(customFields, libovsdbops.LogicalSwitchPortPortSecurity)
 
 	// On layer2 topology with interconnect, we need to add specific port config
 	if bnc.isLayer2Interconnect() {
@@ -586,9 +590,15 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
+		if isRemotePort {
+			customFields = append(customFields, libovsdbops.LogicalSwitchPortType)
+		}
+	}
+	if len(lsp.Options) != 0 {
+		customFields = append(customFields, libovsdbops.LogicalSwitchPortOptions)
 	}
 
-	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchOps(bnc.nbClient, nil, ls, lsp)
+	ops, err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps(bnc.nbClient, nil, ls, customFields, lsp)
 	if err != nil {
 		return nil, nil, nil, false,
 			fmt.Errorf("error creating logical switch port %+v on switch %+v: %+v", *lsp, *ls, err)

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -8,6 +8,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -118,6 +120,10 @@ func withClusterPortGroup() option {
 }
 
 func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(isPrimary bool) []libovsdbtest.TestData {
+	return em.expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary, nil)
+}
+
+func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary bool, expectedPodLspEnabled map[string]*bool) []libovsdbtest.TestData {
 	data := []libovsdbtest.TestData{}
 	for _, ocInfo := range em.fakeOvn.secondaryControllers {
 		nodeslsps := make(map[string][]string)
@@ -150,6 +156,9 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(is
 				}
 				podAddr := fmt.Sprintf("%s %s", portInfo.podMAC, portInfo.podIP)
 				lsp := newExpectedSwitchPort(lspUUID, portName, podAddr, pod, ocInfo.bnc, nad)
+				if expectedPodLspEnabled != nil {
+					lsp.Enabled = expectedPodLspEnabled[pod.podName]
+				}
 
 				if pod.noIfaceIdVer {
 					delete(lsp.Options, "iface-id-ver")
@@ -433,6 +442,17 @@ func nonICClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
 		opt(&config)
 	}
 	return config
+}
+
+func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
+	pod := newMultiHomedPod(testPod, multiHomingConfigs...)
+	pod.Labels[kubevirtv1.VirtualMachineNameLabel] = vmName
+	pod.Status.Phase = liveMigrationInfo.podPhase
+	for key, val := range liveMigrationInfo.annotation {
+		pod.Annotations[key] = val
+	}
+	pod.CreationTimestamp = liveMigrationInfo.creationTimestamp
+	return pod
 }
 
 func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -254,7 +254,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	}()
 
 	nadName := ovntypes.DefaultNetworkName
-	ops, lsp, podAnnotation, newlyCreatedPort, err = oc.addLogicalPortToNetwork(pod, nadName, network)
+	ops, lsp, podAnnotation, newlyCreatedPort, err = oc.addLogicalPortToNetwork(pod, nadName, network, nil)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -245,12 +245,17 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 				By("asserting the OVN entities provisioned in the NBDB are the expected ones after migration")
 				expectedPodLspEnabled := map[string]*bool{}
 				expectedPodLspEnabled[sourcePodInfo.podName] = migrationInfo.sourcePodInfo.expectedLspEnabled
-				expectedPodLspEnabled[targetPodInfo.podName] = migrationInfo.targetPodInfo.expectedLspEnabled
+
+				testPods := []testPod{sourcePodInfo}
+				if !util.PodCompleted(targetKvPod) {
+					testPods = append(testPods, targetPodInfo)
+					expectedPodLspEnabled[targetPodInfo.podName] = migrationInfo.targetPodInfo.expectedLspEnabled
+				}
 				Eventually(fakeOvn.nbClient).Should(
 					libovsdbtest.HaveData(
 						newSecondaryNetworkExpectationMachine(
 							fakeOvn,
-							[]testPod{sourcePodInfo, targetPodInfo},
+							testPods,
 							expectationOptions...,
 						).expectedLogicalSwitchesAndPortsWithLspEnabled(netInfo.isPrimary, expectedPodLspEnabled)...))
 				return nil
@@ -283,6 +288,12 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 			readyMigrationInfo(),
 		),
 
+		Entry("on a layer2 topology with user defined secondary network and an IC cluster, when target pod failed",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			failedMigrationInfo(),
+		),
+
 		Entry("on a layer2 topology with user defined primary network, when target pod is not yet ready",
 			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
 			nonICClusterTestConfiguration(),
@@ -305,6 +316,12 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
 			icClusterTestConfiguration(),
 			readyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined primary network and an IC cluster, when target pod failed",
+			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			failedMigrationInfo(),
 		),
 	)
 
@@ -809,6 +826,22 @@ func readyMigrationInfo() *liveMigrationInfo {
 			creationTimestamp:  metav1.NewTime(time.Now()),
 			annotation:         map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"},
 			expectedLspEnabled: lspEnableExplicitlyTrue,
+		},
+	}
+}
+
+func failedMigrationInfo() *liveMigrationInfo {
+	const vmName = "my-vm"
+	return &liveMigrationInfo{
+		vmName: vmName,
+		sourcePodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now().Add(-time.Hour)),
+			expectedLspEnabled: lspEnableExplicitlyTrue,
+		},
+		targetPodInfo: liveMigrationPodInfo{
+			podPhase:          v1.PodFailed,
+			creationTimestamp: metav1.NewTime(time.Now()),
 		},
 	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -16,6 +16,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -26,6 +29,27 @@ import (
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
+
+type lspEnableValue *bool
+
+var (
+	lspEnableNotSpecified    lspEnableValue = nil
+	lspEnableExplicitlyTrue  lspEnableValue = ptr.To(true)
+	lspEnableExplicitlyFalse lspEnableValue = ptr.To(false)
+)
+
+type liveMigrationPodInfo struct {
+	podPhase           v1.PodPhase
+	annotation         map[string]string
+	creationTimestamp  metav1.Time
+	expectedLspEnabled lspEnableValue
+}
+
+type liveMigrationInfo struct {
+	vmName        string
+	sourcePodInfo liveMigrationPodInfo
+	targetPodInfo liveMigrationPodInfo
+}
 
 var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 	var (
@@ -154,6 +178,137 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 	)
 
 	DescribeTable(
+		"reconciles a new kubevirt-related pod during its live-migration phases",
+		func(netInfo secondaryNetInfo, testConfig testConfiguration, migrationInfo *liveMigrationInfo) {
+			const (
+				sourcePodInfoIdx = 0
+				targetPodInfoIdx = 1
+			)
+			sourcePodInfo := dummyL2TestPod(ns, netInfo, sourcePodInfoIdx)
+			setupConfig(netInfo, testConfig, config.GatewayModeShared)
+			app.Action = func(ctx *cli.Context) error {
+				sourcePod := newMultiHomedKubevirtPod(
+					migrationInfo.vmName,
+					migrationInfo.sourcePodInfo,
+					sourcePodInfo,
+					netInfo)
+
+				const nodeIPv4CIDR = "192.168.126.202/24"
+				By(fmt.Sprintf("Creating a node named %q, with IP: %s", nodeName, nodeIPv4CIDR))
+				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, testNode, sourcePodInfo, sourcePod)).To(Succeed())
+
+				// for layer2 on interconnect, it is the cluster manager that
+				// allocates the OVN annotation; on unit tests, this just
+				// doesn't happen, and we create the pod with these annotations
+				// set. Hence, no point checking they're the expected ones.
+				// TODO: align the mocked annotations with the production code
+				//   - currently missing setting the routes.
+				if !config.OVNKubernetesFeature.EnableInterconnect {
+					By("asserting the pod OVN pod networks annotation are the expected ones")
+					// check that after start networks annotations and nbdb will be updated
+					Eventually(func() string {
+						return getPodAnnotations(fakeOvn.fakeClient.KubeClient, sourcePodInfo.namespace, sourcePodInfo.podName)
+					}).WithTimeout(2 * time.Second).Should(MatchJSON(sourcePodInfo.getAnnotationsJson()))
+				}
+
+				expectationOptions := testConfig.expectationOptions
+				if netInfo.isPrimary {
+					By("configuring the expectation machine with the GW related configuration")
+					gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(gwConfig.NextHops).NotTo(BeEmpty())
+					expectationOptions = append(expectationOptions, withGatewayConfig(gwConfig))
+					expectationOptions = append(expectationOptions, withClusterPortGroup())
+				}
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones before migration started")
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						newSecondaryNetworkExpectationMachine(
+							fakeOvn,
+							[]testPod{sourcePodInfo},
+							expectationOptions...,
+						).expectedLogicalSwitchesAndPorts(netInfo.isPrimary)...))
+
+				targetPodInfo := dummyL2TestPod(ns, netInfo, targetPodInfoIdx)
+				targetKvPod := newMultiHomedKubevirtPod(
+					migrationInfo.vmName,
+					migrationInfo.targetPodInfo,
+					targetPodInfo,
+					netInfo)
+
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(targetKvPod.Namespace).Create(context.Background(), targetKvPod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones after migration")
+				expectedPodLspEnabled := map[string]*bool{}
+				expectedPodLspEnabled[sourcePodInfo.podName] = migrationInfo.sourcePodInfo.expectedLspEnabled
+				expectedPodLspEnabled[targetPodInfo.podName] = migrationInfo.targetPodInfo.expectedLspEnabled
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						newSecondaryNetworkExpectationMachine(
+							fakeOvn,
+							[]testPod{sourcePodInfo, targetPodInfo},
+							expectationOptions...,
+						).expectedLogicalSwitchesAndPortsWithLspEnabled(netInfo.isPrimary, expectedPodLspEnabled)...))
+				return nil
+			}
+
+			Expect(app.Run([]string{app.Name})).To(Succeed())
+		},
+
+		Entry("on a layer2 topology with user defined secondary network, when target pod is not yet ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined secondary network, when target pod is ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined secondary network and an IC cluster, when target pod is not yet ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined secondary network and an IC cluster, when target pod is ready",
+			dummySecondaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined primary network, when target pod is not yet ready",
+			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined primary network, when target pod is ready",
+			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			nonICClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined primary network and an IC cluster, when target pod is not yet ready",
+			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			notReadyMigrationInfo(),
+		),
+
+		Entry("on a layer2 topology with user defined primary network and an IC cluster, when target pod is ready",
+			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
+			icClusterTestConfiguration(),
+			readyMigrationInfo(),
+		),
+	)
+
+	DescribeTable(
 		"the gateway is properly cleaned up",
 		func(netInfo secondaryNetInfo, testConfig testConfiguration) {
 			podInfo := dummyTestPod(ns, netInfo)
@@ -276,6 +431,15 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 	)
 
 })
+
+func dummyLocalnetWithSecondaryUserDefinedNetwork(subnets string) secondaryNetInfo {
+	return secondaryNetInfo{
+		netName:        secondaryNetworkName,
+		nadName:        namespacedName(ns, nadName),
+		topology:       ovntypes.LocalnetTopology,
+		clustersubnets: subnets,
+	}
+}
 
 func dummySecondaryLayer2UserDefinedNetwork(subnets string) secondaryNetInfo {
 	return secondaryNetInfo{
@@ -611,5 +775,40 @@ func setupConfig(netInfo secondaryNetInfo, testConfig testConfiguration, gateway
 		config.IPv6Mode = true
 		// tests dont support dualstack yet
 		config.IPv4Mode = false
+	}
+}
+
+func notReadyMigrationInfo() *liveMigrationInfo {
+	const vmName = "my-vm"
+	return &liveMigrationInfo{
+		vmName: vmName,
+		sourcePodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now().Add(-time.Hour)),
+			expectedLspEnabled: lspEnableNotSpecified,
+		},
+		targetPodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now()),
+			expectedLspEnabled: lspEnableExplicitlyFalse,
+		},
+	}
+}
+
+func readyMigrationInfo() *liveMigrationInfo {
+	const vmName = "my-vm"
+	return &liveMigrationInfo{
+		vmName: vmName,
+		sourcePodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now().Add(-time.Hour)),
+			expectedLspEnabled: lspEnableExplicitlyFalse,
+		},
+		targetPodInfo: liveMigrationPodInfo{
+			podPhase:           v1.PodRunning,
+			creationTimestamp:  metav1.NewTime(time.Now()),
+			annotation:         map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"},
+			expectedLspEnabled: lspEnableExplicitlyTrue,
+		},
 	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -59,89 +59,16 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 		func(netInfo secondaryNetInfo, testConfig testConfiguration, gatewayMode config.GatewayMode) {
 			const podIdx = 0
 			podInfo := dummyL2TestPod(ns, netInfo, podIdx)
-			if testConfig.configToOverride != nil {
-				config.OVNKubernetesFeature = *testConfig.configToOverride
-				if testConfig.gatewayConfig != nil {
-					config.Gateway.DisableSNATMultipleGWs = testConfig.gatewayConfig.DisableSNATMultipleGWs
-				}
-			}
-			config.Gateway.Mode = gatewayMode
-			if knet.IsIPv6CIDRString(netInfo.clustersubnets) {
-				config.IPv6Mode = true
-				// tests dont support dualstack yet
-				config.IPv4Mode = false
-			}
+			setupConfig(netInfo, testConfig, gatewayMode)
 			app.Action = func(ctx *cli.Context) error {
-				By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
-				nad, err := newNetworkAttachmentDefinition(
-					ns,
-					nadName,
-					*netInfo.netconf(),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				By("setting up the OVN DB without any entities in it")
-				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
-
-				if netInfo.isPrimary {
-					networkConfig, err := util.NewNetInfo(netInfo.netconf())
-					Expect(err).NotTo(HaveOccurred())
-
-					initialDB.NBData = append(
-						initialDB.NBData,
-						&nbdb.LogicalRouter{
-							Name:        fmt.Sprintf("GR_%s_%s", networkConfig.GetNetworkName(), nodeName),
-							ExternalIDs: standardNonDefaultNetworkExtIDs(networkConfig),
-						},
-						newNetworkClusterPortGroup(networkConfig),
-					)
-				}
+				pod := newMultiHomedPod(podInfo, netInfo)
 
 				const nodeIPv4CIDR = "192.168.126.202/24"
 				By(fmt.Sprintf("Creating a node named %q, with IP: %s", nodeName, nodeIPv4CIDR))
 				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvn.startWithDBSetup(
-					initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							*newNamespace(ns),
-						},
-					},
-					&v1.NodeList{Items: []v1.Node{*testNode}},
-					&v1.PodList{
-						Items: []v1.Pod{
-							*newMultiHomedPod(podInfo, netInfo),
-						},
-					},
-					&nadapi.NetworkAttachmentDefinitionList{
-						Items: []nadapi.NetworkAttachmentDefinition{*nad},
-					},
-				)
-				podInfo.populateLogicalSwitchCache(fakeOvn)
 
-				// on IC, the test itself spits out the pod with the
-				// annotations set, since on production it would be the
-				// clustermanager to annotate the pod.
-				if !config.OVNKubernetesFeature.EnableInterconnect {
-					By("asserting the pod originally does *not* feature the OVN pod networks annotation")
-					// pod exists, networks annotations don't
-					pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					_, ok := pod.Annotations[util.OvnPodAnnotationName]
-					Expect(ok).To(BeFalse())
-				}
-				Expect(fakeOvn.controller.nadController.Start()).NotTo(HaveOccurred())
-
-				Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
-				Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
-				By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
-				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
-				Expect(ok).To(BeTrue())
-
-				secondaryNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
-				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
-				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
-				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, testNode, podInfo, pod)).To(Succeed())
 
 				// for layer2 on interconnect, it is the cluster manager that
 				// allocates the OVN annotation; on unit tests, this just
@@ -581,5 +508,108 @@ func nodeCIDR() *net.IPNet {
 	return &net.IPNet{
 		IP:   net.ParseIP("192.168.126.0"),
 		Mask: net.CIDRMask(24, 32),
+	}
+}
+
+func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.TestSetup, netInfo secondaryNetInfo, testNode *v1.Node, podInfo testPod, pod *v1.Pod) error {
+	By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
+	By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
+	nad, err := newNetworkAttachmentDefinition(
+		ns,
+		nadName,
+		*netInfo.netconf(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	By("setting up the OVN DB without any entities in it")
+	Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
+
+	if netInfo.isPrimary {
+		networkConfig, err := util.NewNetInfo(netInfo.netconf())
+		Expect(err).NotTo(HaveOccurred())
+
+		initialDB.NBData = append(
+			initialDB.NBData,
+			&nbdb.LogicalRouter{
+				Name:        fmt.Sprintf("GR_%s_%s", networkConfig.GetNetworkName(), nodeName),
+				ExternalIDs: standardNonDefaultNetworkExtIDs(networkConfig),
+			},
+			newNetworkClusterPortGroup(networkConfig),
+		)
+	}
+
+	fakeOvn.startWithDBSetup(
+		initialDB,
+		&v1.NamespaceList{
+			Items: []v1.Namespace{
+				*newNamespace(ns),
+			},
+		},
+		&v1.NodeList{Items: []v1.Node{*testNode}},
+		&v1.PodList{
+			Items: []v1.Pod{
+				*pod,
+			},
+		},
+		&nadapi.NetworkAttachmentDefinitionList{
+			Items: []nadapi.NetworkAttachmentDefinition{*nad},
+		},
+	)
+	podInfo.populateLogicalSwitchCache(fakeOvn)
+
+	// on IC, the test itself spits out the pod with the
+	// annotations set, since on production it would be the
+	// clustermanager to annotate the pod.
+	if !config.OVNKubernetesFeature.EnableInterconnect {
+		By("asserting the pod originally does *not* feature the OVN pod networks annotation")
+		// pod exists, networks annotations don't
+		pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		_, ok := pod.Annotations[util.OvnPodAnnotationName]
+		if ok {
+			return fmt.Errorf("expected pod annotation %q", util.OvnPodAnnotationName)
+		}
+	}
+	if err = fakeOvn.controller.nadController.Start(); err != nil {
+		return err
+	}
+
+	if err = fakeOvn.controller.WatchNamespaces(); err != nil {
+		return err
+	}
+	if err = fakeOvn.controller.WatchPods(); err != nil {
+		return err
+	}
+	By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
+	secondaryNetController, doesControllerExist := fakeOvn.secondaryControllers[secondaryNetworkName]
+	if !doesControllerExist {
+		return fmt.Errorf("expected secondary network controller to exist")
+	}
+
+	secondaryNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+	podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+	if err = secondaryNetController.bnc.WatchNodes(); err != nil {
+		return err
+	}
+	if err = secondaryNetController.bnc.WatchPods(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupConfig(netInfo secondaryNetInfo, testConfig testConfiguration, gatewayMode config.GatewayMode) {
+	if testConfig.configToOverride != nil {
+		config.OVNKubernetesFeature = *testConfig.configToOverride
+		if testConfig.gatewayConfig != nil {
+			config.Gateway.DisableSNATMultipleGWs = testConfig.gatewayConfig.DisableSNATMultipleGWs
+		}
+	}
+	config.Gateway.Mode = gatewayMode
+	if knet.IsIPv6CIDRString(netInfo.clustersubnets) {
+		config.IPv6Mode = true
+		// tests dont support dualstack yet
+		config.IPv4Mode = false
 	}
 }


### PR DESCRIPTION
#### What this PR does and why is it needed
Currently all pods have the LSP.Enabled option set to nil (which later 
translates to &true) by default.

During live-migrationof kubevirt pods, in order to prevent unneeded 
packet loss the lsp.Enabled of the migration pods (source and target) 
need to be as follows:
1. until target pod is domain ready: source pod lsp is enabled, target
pod lsp is disabled.
2. when target pod is domain-ready: source pod lsp is disabled, target
pod lsp is enabled.

This switch significantly reduces the migration downtime to <0.5s (see details below).

This PR also handles the scenario of a failed migration, where the lsp 
of the source pod needs to be re-enabled.

Note: 
Currently this change is restricted to VM with secondary/primary UDNs, and
layer2 topology.

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for reviewers
e2e will be introduced in a follow-up PR https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4834

#### How to verify it
Run migration tests.

#### Details to documentation updates
Migration downtime results:
pre-copy:
* before change: 13s
* After change: <0.5s

post-copy:
* before change: 26s
* After change: <0.5s

#### Description for the changelog

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
