### PR TITLE
Ensure UDN namespace is configured when MultiNetPolicy is disabled

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -333,7 +333,9 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 			return err
 		}
 	}
-	if bsnc.doesNetworkRequireIPAM() && (util.IsMultiNetworkPoliciesSupportEnabled() || bsnc.multicastSupport) {
+
+	if bsnc.doesNetworkRequireIPAM() &&
+		(util.IsMultiNetworkPoliciesSupportEnabled() || (util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork())) {
 		// Ensure the namespace/nsInfo exists
 		portUUID := ""
 		if lsp != nil {
@@ -432,7 +434,8 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *ka
 
 	// otherwise just delete pod IPs from the namespace address set
 	if !hasLogicalPort {
-		if bsnc.doesNetworkRequireIPAM() && util.IsMultiNetworkPoliciesSupportEnabled() {
+		if bsnc.doesNetworkRequireIPAM() &&
+			(util.IsMultiNetworkPoliciesSupportEnabled() || (util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork())) {
 			return bsnc.removeRemoteZonePodFromNamespaceAddressSet(pod)
 		}
 

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -401,23 +401,25 @@ func enableICFeatureConfig() *config.OVNKubernetesFeatureConfig {
 	return featConfig
 }
 
-func icClusterTestConfiguration() testConfiguration {
-	return testConfiguration{
+type testConfigOpt = func(*testConfiguration)
+
+func icClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
+	config := testConfiguration{
 		configToOverride:   enableICFeatureConfig(),
 		expectationOptions: []option{withInterconnectCluster()},
 	}
-}
-
-func nonICClusterTestConfiguration() testConfiguration {
-	return testConfiguration{}
-}
-
-func icClusterWithDisableSNATTestConfiguration() testConfiguration {
-	return testConfiguration{
-		configToOverride:   enableICFeatureConfig(),
-		expectationOptions: []option{withInterconnectCluster()},
-		gatewayConfig:      &config.GatewayConfig{DisableSNATMultipleGWs: true},
+	for _, opt := range opts {
+		opt(&config)
 	}
+	return config
+}
+
+func nonICClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
+	config := testConfiguration{}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return config
 }
 
 func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -451,8 +451,13 @@ func getNamespaceWithMultiplePoliciesExpectedData(networkPolicies []*knet.Networ
 }
 
 func getHairpinningACLsV4AndPortGroup() []libovsdbtest.TestData {
-	clusterPortGroup := newClusterPortGroup()
-	fakeController := getFakeController(DefaultNetworkControllerName)
+	return getHairpinningACLsV4AndPortGroupForNetwork(&util.DefaultNetInfo{}, nil)
+}
+
+func getHairpinningACLsV4AndPortGroupForNetwork(netInfo util.NetInfo, ports []string) []libovsdbtest.TestData {
+	controllerName := getNetworkControllerName(netInfo.GetNetworkName())
+	clusterPortGroup := newNetworkClusterPortGroup(netInfo)
+	fakeController := getFakeController(controllerName)
 	egressIDs := fakeController.getNetpolDefaultACLDbIDs("Egress")
 	egressACL := libovsdbops.BuildACL(
 		"",
@@ -469,7 +474,7 @@ func getHairpinningACLsV4AndPortGroup() []libovsdbtest.TestData {
 		},
 		types.DefaultACLTier,
 	)
-	egressACL.UUID = "hairpinning-egress-UUID"
+	egressACL.UUID = fmt.Sprintf("hp-egress-%s", controllerName)
 	ingressIDs := fakeController.getNetpolDefaultACLDbIDs("Ingress")
 	ingressACL := libovsdbops.BuildACL(
 		"",
@@ -484,8 +489,9 @@ func getHairpinningACLsV4AndPortGroup() []libovsdbtest.TestData {
 		nil,
 		types.DefaultACLTier,
 	)
-	ingressACL.UUID = "hairpinning-ingress-UUID"
+	ingressACL.UUID = fmt.Sprintf("hp-ingress-%s", controllerName)
 	clusterPortGroup.ACLs = []string{egressACL.UUID, ingressACL.UUID}
+	clusterPortGroup.Ports = ports
 	return []libovsdbtest.TestData{egressACL, ingressACL, clusterPortGroup}
 }
 

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -211,7 +211,9 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 
 		Entry("pod on a user defined primary network on an IC cluster with per-pod SNATs enabled",
 			dummyPrimaryLayer2UserDefinedNetwork("100.200.0.0/16"),
-			icClusterWithDisableSNATTestConfiguration(),
+			icClusterTestConfiguration(func(testConfig *testConfiguration) {
+				testConfig.gatewayConfig = &config.GatewayConfig{DisableSNATMultipleGWs: true}
+			}),
 			config.GatewayModeShared,
 		),
 		/** FIXME: tests do not support ipv6 yet
@@ -339,7 +341,9 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 		),
 		Entry("pod on a user defined primary network on an IC cluster with per-pod SNATs enabled",
 			dummyLayer2PrimaryUserDefinedNetwork("192.168.0.0/16"),
-			icClusterWithDisableSNATTestConfiguration(),
+			icClusterTestConfiguration(func(testConfig *testConfiguration) {
+				testConfig.gatewayConfig = &config.GatewayConfig{DisableSNATMultipleGWs: true}
+			}),
 		),
 	)
 


### PR DESCRIPTION
The namespace is currently not getting configured in ovnk and ovn for user defined network when multi network policy is disabled for the cluster. But multinet policy is not a requirement for UDN network policies, hence fixing it so that namespaces get configured for those namespaces on secondary controller and network policies can be created for the same.