### PR TITLE
Localnet ux e2e test idempotent vlan creation

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -931,7 +931,7 @@ var _ = Describe("Multi Homing", func() {
 					underlayBridgeName, err = findInterfaceByIP(gatewayIP)
 					Expect(err).NotTo(HaveOccurred())
 					vlanIface = newVLANIface(underlayBridgeName, vlanID, withIP(underlayIP))
-					Expect(vlanIface.create()).To(
+					Expect(vlanIface.ensureExistence()).To(
 						Succeed(),
 						"create a VLAN interface on the bridge interconnecting the cluster nodes",
 					)

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -2,10 +2,11 @@ package e2e
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -654,7 +655,7 @@ var _ = Describe("Multi Homing", func() {
 			var netConfig networkAttachmentConfig
 			var nodes []v1.Pod
 			var underlayBridgeName string
-			var cmdWebServer *exec.Cmd
+			var httpSrv *httpServer
 
 			underlayIP := underlayServiceIP + "/24"
 			Context("with a service running on the underlay", func() {
@@ -694,9 +695,8 @@ var _ = Describe("Multi Homing", func() {
 
 				BeforeEach(func() {
 					By("starting a service, connected to the underlay")
-					cmdWebServer = exec.Command("python3", "-m", "http.server", "--bind", underlayServiceIP, strconv.Itoa(servicePort))
-					cmdWebServer.Stderr = os.Stderr
-					Expect(cmdWebServer.Start()).NotTo(HaveOccurred(), "failed to create web server, port might be busy")
+					httpSrv = newHTTPServer(underlayServiceIP, servicePort)
+					Expect(httpSrv.listen()).To(Succeed())
 				})
 
 				BeforeEach(func() {
@@ -710,8 +710,7 @@ var _ = Describe("Multi Homing", func() {
 				})
 
 				AfterEach(func() {
-					err := cmdWebServer.Process.Kill()
-					Expect(err).NotTo(HaveOccurred())
+					Expect(httpSrv.stop()).To(Succeed())
 				})
 
 				AfterEach(func() {
@@ -939,13 +938,12 @@ var _ = Describe("Multi Homing", func() {
 					)
 
 					By("starting a service, connected to the underlay")
-					cmdWebServer = exec.Command("python3", "-m", "http.server", "--bind", underlayServiceIP, strconv.Itoa(port))
-					cmdWebServer.Stderr = os.Stderr
-					Expect(cmdWebServer.Start()).NotTo(HaveOccurred(), "failed to create web server, port might be busy")
+					httpSrv = newHTTPServer(underlayServiceIP, servicePort)
+					Expect(httpSrv.listen()).To(Succeed())
 				})
 
 				AfterEach(func() {
-					Expect(cmdWebServer.Process.Kill()).NotTo(HaveOccurred(), "kill the python webserver")
+					Expect(httpSrv.stop()).To(Succeed())
 					Expect(vlanIface.delete()).NotTo(HaveOccurred(), "remove the underlay physical configuration")
 					Expect(teardownUnderlay(nodes)).To(Succeed(), "tear down the localnet underlay")
 				})
@@ -1746,4 +1744,38 @@ func createMultiNetworkPolicy(mnpClient mnpclient.K8sCniCncfIoV1beta1Interface, 
 		metav1.CreateOptions{},
 	)
 	return err
+}
+
+type httpServer struct {
+	srv *http.Server
+}
+
+func newHTTPServer(ip string, port int) *httpServer {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return &httpServer{
+		srv: &http.Server{
+			Addr:    fmt.Sprintf("%s:%d", ip, port),
+			Handler: mux,
+		},
+	}
+}
+
+func (hs *httpServer) listen() error {
+	var err error
+	go func() {
+		err = hs.srv.ListenAndServe()
+		if err != nil && !goerrors.Is(err, http.ErrServerClosed) {
+			_, _ = fmt.Fprintf(os.Stderr, "error shutting down http server: %v\n", err)
+		}
+	}()
+	return err
+}
+
+func (hs *httpServer) stop() error {
+	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFn()
+	return hs.srv.Shutdown(ctx)
 }

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -902,6 +902,7 @@ var _ = Describe("Multi Homing", func() {
 
 			Context("with a trunked configuration", func() {
 				const vlanID = 20
+				var vlanIface *Vlan
 				BeforeEach(func() {
 					nodes = ovsPods(cs)
 					Expect(nodes).NotTo(BeEmpty())
@@ -929,7 +930,8 @@ var _ = Describe("Multi Homing", func() {
 
 					underlayBridgeName, err = findInterfaceByIP(gatewayIP)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(createVLANInterface(underlayBridgeName, strconv.Itoa(vlanID), &underlayIP)).To(
+					vlanIface = newVLANIface(underlayBridgeName, vlanID, withIP(underlayIP))
+					Expect(vlanIface.create()).To(
 						Succeed(),
 						"create a VLAN interface on the bridge interconnecting the cluster nodes",
 					)
@@ -942,7 +944,7 @@ var _ = Describe("Multi Homing", func() {
 
 				AfterEach(func() {
 					Expect(cmdWebServer.Process.Kill()).NotTo(HaveOccurred(), "kill the python webserver")
-					Expect(deleteVLANInterface(underlayBridgeName, strconv.Itoa(vlanID))).NotTo(HaveOccurred(), "remove the underlay physical configuration")
+					Expect(vlanIface.delete()).NotTo(HaveOccurred(), "remove the underlay physical configuration")
 					Expect(teardownUnderlay(nodes)).To(Succeed(), "tear down the localnet underlay")
 				})
 

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -930,7 +930,9 @@ var _ = Describe("Multi Homing", func() {
 
 					underlayBridgeName, err = findInterfaceByIP(gatewayIP)
 					Expect(err).NotTo(HaveOccurred())
-					vlanIface = newVLANIface(underlayBridgeName, vlanID, withIP(underlayIP))
+
+					vlanIface, err = newVLANIface(underlayBridgeName, vlanID, withIP(underlayIP))
+					Expect(err).NotTo(HaveOccurred())
 					Expect(vlanIface.ensureExistence()).To(
 						Succeed(),
 						"create a VLAN interface on the bridge interconnecting the cluster nodes",

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -920,16 +920,19 @@ var _ = Describe("Multi Homing", func() {
 					By("setting up the localnet underlay with a trunked configuration")
 					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed(), "configuring the OVS bridge")
 
-					By(fmt.Sprintf("creating a VLAN interface on top of the bridge connecting the cluster nodes with IP: %s", underlayIP))
+					By("creating a CRI API client")
 					cli, err := client.NewClientWithOpts(client.FromEnv)
 					Expect(err).NotTo(HaveOccurred())
 
+					By(fmt.Sprintf("extracting the GW IP on the %q logical network", dockerNetworkName))
 					gatewayIP, err := getNetworkGateway(cli, dockerNetworkName)
 					Expect(err).NotTo(HaveOccurred())
 
+					By(fmt.Sprintf("finding which bridge has the GW IP %q configured", gatewayIP))
 					underlayBridgeName, err = findInterfaceByIP(gatewayIP)
 					Expect(err).NotTo(HaveOccurred())
 
+					By(fmt.Sprintf("creating a VLAN on top of bridge %q with ID: %d", underlayBridgeName, vlanID))
 					vlanIface, err = newVLANIface(underlayBridgeName, vlanID, withIP(underlayIP))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(vlanIface.ensureExistence()).To(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR makes the localnet helpers to create / configure the ovs bridges / vlans idempotent.

I've initially tried to both **read** and **create/update** the links using golang's netlink library, but that requires CAP_NETADMIN, which we do not have in CI. Hence, I've changed the tests to use netlink for **read** operations, while create / configure the links with `sudo ip link` ... 

Hopefully in the future we can use netlink for both reading and configuring the interfaces.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
