### PR TITLE
UDN: L2: Fix router ip on multiple networks set on LRP case

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -356,7 +356,7 @@ func (gw *GatewayManager) GatewayInit(
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
 		}
-		if util.IsNetworkSegmentationSupportEnabled() && gw.netInfo.IsPrimaryNetwork() && gw.netInfo.TopologyType() == types.Layer2Topology {
+		if gw.netInfo.TopologyType() == types.Layer2Topology {
 			node, err := gw.watchFactory.GetNode(nodeName)
 			if err != nil {
 				return fmt.Errorf("failed to fetch node %s from watch factory %w", node, err)
@@ -404,7 +404,7 @@ func (gw *GatewayManager) GatewayInit(
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
 		}
 		_, isNetIPv6 := gw.netInfo.IPMode()
-		if gw.netInfo.IsPrimaryNetwork() && gw.netInfo.TopologyType() == types.Layer2Topology && isNetIPv6 && config.IPv6Mode {
+		if gw.netInfo.TopologyType() == types.Layer2Topology && isNetIPv6 && config.IPv6Mode {
 			logicalRouterPort.Ipv6RaConfigs = map[string]string{
 				"address_mode":      "dhcpv6_stateful",
 				"send_periodic":     "true",

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -249,14 +249,23 @@ func (gw *GatewayManager) GatewayInit(
 	hostSubnets []*net.IPNet,
 	l3GatewayConfig *util.L3GatewayConfig,
 	sctpSupport bool,
-	gwLRPIfAddrs, drLRPIfAddrs []*net.IPNet,
+	gwLRPJoinIPs, drLRPIfAddrs []*net.IPNet,
 	externalIPs []net.IP,
 	enableGatewayMTU bool,
 ) error {
 
 	gwLRPIPs := make([]net.IP, 0)
-	for _, gwLRPIfAddr := range gwLRPIfAddrs {
-		gwLRPIPs = append(gwLRPIPs, gwLRPIfAddr.IP)
+	for _, gwLRPJoinIP := range gwLRPJoinIPs {
+		gwLRPIPs = append(gwLRPIPs, gwLRPJoinIP.IP)
+	}
+	if gw.netInfo.TopologyType() == types.Layer2Topology {
+		// At layer2 GR LRP acts as the layer3 ovn_cluster_router so we need
+		// to configure here the .1 address, this will work only for IC with
+		// one node per zone, since ARPs for .1 will not go beyond local switch.
+		// This is being done to add the ICMP SNATs for .1 podSubnet that OVN GR generates
+		for _, subnet := range hostSubnets {
+			gwLRPIPs = append(gwLRPIPs, util.GetNodeGatewayIfAddr(subnet).IP)
+		}
 	}
 
 	// Create a gateway router.
@@ -277,6 +286,19 @@ func (gw *GatewayManager) GatewayInit(
 	// for UDN's OVN will pick a random one
 	if gw.netInfo.GetNetworkName() == types.DefaultNetworkName {
 		logicalRouterOptions["snat-ct-zone"] = "0"
+	}
+	if gw.netInfo.TopologyType() == types.Layer2Topology {
+		// When multiple networks are set of the same logical-router-port
+		// the networks get lexicographically sorted; thus there is no
+		// ordering or telling on which IP will be chosen as the router-ip
+		// when it comes to SNATing traffic after load balancing.
+		// Hence for Layer2 UDPNs let's set the snat-ip explicitly to the
+		// joinsubnetIP
+		joinIPDualStack := make([]string, len(gwLRPJoinIPs))
+		for i, gwLRPJoinIP := range gwLRPJoinIPs {
+			joinIPDualStack[i] = gwLRPJoinIP.IP.String()
+		}
+		logicalRouterOptions["lb_force_snat_ip"] = strings.Join(joinIPDualStack, " ")
 	}
 	logicalRouterExternalIDs := map[string]string{
 		"physical_ip":  physicalIPs[0],
@@ -382,8 +404,16 @@ func (gw *GatewayManager) GatewayInit(
 
 	gwLRPMAC := util.IPAddrToHWAddr(gwLRPIPs[0])
 	gwLRPNetworks := []string{}
-	for _, gwLRPIfAddr := range gwLRPIfAddrs {
-		gwLRPNetworks = append(gwLRPNetworks, gwLRPIfAddr.String())
+	for _, gwLRPJoinIP := range gwLRPJoinIPs {
+		gwLRPNetworks = append(gwLRPNetworks, gwLRPJoinIP.String())
+	}
+	if gw.netInfo.TopologyType() == types.Layer2Topology {
+		// At layer2 GR LRP acts as the layer3 ovn_cluster_router so we need
+		// to configure here the .1 address, this will work only for IC with
+		// one node per zone, since ARPs for .1 will not go beyond local switch.
+		for _, subnet := range hostSubnets {
+			gwLRPNetworks = append(gwLRPNetworks, util.GetNodeGatewayIfAddr(subnet).String())
+		}
 	}
 
 	var options map[string]string
@@ -1240,7 +1270,7 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 	hostSubnets []*net.IPNet,
 	hostAddrs []string,
 	clusterSubnets []*net.IPNet,
-	gwLRPIPs []*net.IPNet,
+	grLRPJoinIPs []*net.IPNet,
 	isSCTPSupported bool,
 	ovnClusterLRPToJoinIfAddrs []*net.IPNet,
 	externalIPs []net.IP,
@@ -1253,7 +1283,7 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 		hostSubnets,
 		l3GatewayConfig,
 		isSCTPSupported,
-		gwLRPIPs,
+		grLRPJoinIPs, // the joinIP allocated to this node's GR for this controller's network
 		ovnClusterLRPToJoinIfAddrs,
 		externalIPs,
 		enableGatewayMTU,
@@ -1300,7 +1330,7 @@ func (gw *GatewayManager) syncNodeGateway(
 	l3GatewayConfig *util.L3GatewayConfig,
 	hostSubnets []*net.IPNet,
 	hostAddrs []string,
-	clusterSubnets, gwLRPIPs []*net.IPNet,
+	clusterSubnets, grLRPJoinIPs []*net.IPNet,
 	isSCTPSupported bool,
 	joinSwitchIPs []*net.IPNet,
 	externalIPs []net.IP,
@@ -1316,9 +1346,9 @@ func (gw *GatewayManager) syncNodeGateway(
 			hostSubnets,
 			hostAddrs,
 			clusterSubnets,
-			gwLRPIPs,
+			grLRPJoinIPs, // the joinIP allocated to this node for this controller's network
 			isSCTPSupported,
-			joinSwitchIPs,
+			joinSwitchIPs, // the .1 of this controller's global joinSubnet
 			externalIPs,
 		); err != nil {
 			return fmt.Errorf("error creating gateway for node %s: %v", node.Name, err)

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -776,9 +776,9 @@ func (oc *SecondaryLayer2NetworkController) StartServiceController(wg *sync.Wait
 	go func() {
 		defer wg.Done()
 		useLBGroups := oc.clusterLoadBalancerGroupUUID != ""
-		// use 5 workers like most of the kubernetes controllers in the
-		// kubernetes controller-manager
-		err := oc.svcController.Run(5, oc.stopChan, runRepair, useLBGroups, oc.svcTemplateSupport)
+		// use 5 workers like most of the kubernetes controllers in the kubernetes controller-manager
+		// do not use LB templates for UDNs - OVN bug https://issues.redhat.com/browse/FDP-988
+		err := oc.svcController.Run(5, oc.stopChan, runRepair, useLBGroups, false)
 		if err != nil {
 			klog.Errorf("Error running OVN Kubernetes Services controller for network %s: %v", oc.GetNetworkName(), err)
 		}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -519,13 +519,11 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 					errs = append(errs, err)
 					oc.gatewaysFailed.Store(node.Name, true)
 				} else {
-					if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
-						if err := oc.addUDNClusterSubnetEgressSNAT(gwConfig.hostSubnets, gwManager.gwRouterName, node); err != nil {
-							errs = append(errs, err)
-							oc.gatewaysFailed.Store(node.Name, true)
-						} else {
-							oc.gatewaysFailed.Delete(node.Name)
-						}
+					if err := oc.addUDNClusterSubnetEgressSNAT(gwConfig.hostSubnets, gwManager.gwRouterName, node); err != nil {
+						errs = append(errs, err)
+						oc.gatewaysFailed.Store(node.Name, true)
+					} else {
+						oc.gatewaysFailed.Delete(node.Name)
 					}
 				}
 			}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -453,6 +453,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		Options:      gwRouterOptions(gwConfig),
 		Policies:     []string{routerPolicyUUID1},
 	}
+	gr.Options["lb_force_snat_ip"] = gwRouterJoinIPAddress().IP.String()
 	expectedEntities := []libovsdbtest.TestData{
 		gr,
 		expectedGWToNetworkSwitchRouterPort(gwRouterToNetworkSwitchPortName, netInfo, gwRouterJoinIPAddress(), layer2SubnetGWAddr()),

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -1052,9 +1052,9 @@ func (oc *SecondaryLayer3NetworkController) StartServiceController(wg *sync.Wait
 	go func() {
 		defer wg.Done()
 		useLBGroups := oc.clusterLoadBalancerGroupUUID != ""
-		// use 5 workers like most of the kubernetes controllers in the
-		// kubernetes controller-manager
-		err := oc.svcController.Run(5, oc.stopChan, runRepair, useLBGroups, oc.svcTemplateSupport)
+		// use 5 workers like most of the kubernetes controllers in the kubernetes controller-manager
+		// do not use LB templates for UDNs - OVN bug https://issues.redhat.com/browse/FDP-988
+		err := oc.svcController.Run(5, oc.stopChan, runRepair, useLBGroups, false)
 		if err != nil {
 			klog.Errorf("Error running OVN Kubernetes Services controller for network %s: %v", oc.GetNetworkName(), err)
 		}

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -709,9 +709,9 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.N
 					gwConfig.hostSubnets,
 					gwConfig.hostAddrs,
 					gwConfig.clusterSubnets,
-					gwConfig.gwLRPIPs,
+					gwConfig.gwLRPJoinIPs, // the joinIP allocated to this node for this controller's network
 					oc.SCTPSupport,
-					oc.ovnClusterLRPToJoinIfAddrs,
+					oc.ovnClusterLRPToJoinIfAddrs, // the .1 of this controller's global joinSubnet
 					gwConfig.externalIPs,
 				); err != nil {
 					errs = append(errs, fmt.Errorf(
@@ -922,7 +922,7 @@ type SecondaryL3GatewayConfig struct {
 	config         *util.L3GatewayConfig
 	hostSubnets    []*net.IPNet
 	clusterSubnets []*net.IPNet
-	gwLRPIPs       []*net.IPNet
+	gwLRPJoinIPs   []*net.IPNet
 	hostAddrs      []string
 	externalIPs    []net.IP
 }
@@ -972,7 +972,7 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (
 		return nil, fmt.Errorf("failed to get node %q subnet annotation for network %q: %v", node.Name, oc.GetNetworkName(), err)
 	}
 
-	gwLRPIPs, err := util.ParseNodeGatewayRouterJoinAddrs(node, oc.GetNetworkName())
+	gwLRPJoinIPs, err := util.ParseNodeGatewayRouterJoinAddrs(node, oc.GetNetworkName())
 	if err != nil {
 		return nil, fmt.Errorf("failed extracting node %q GW router join subnet IP for layer3 network %q: %w", node.Name, networkName, err)
 	}
@@ -984,7 +984,7 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (
 		config:         l3GatewayConfig,
 		hostSubnets:    hostSubnets,
 		clusterSubnets: clusterSubnets,
-		gwLRPIPs:       gwLRPIPs,
+		gwLRPJoinIPs:   gwLRPJoinIPs,
 		hostAddrs:      hostAddrs,
 		externalIPs:    externalIPs,
 	}, nil

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -33,8 +33,8 @@ var _ = Describe("Network Segmentation: services", func() {
 			nadName                      = "tenant-red"
 			servicePort                  = 80
 			serviceTargetPort            = 80
-			userDefinedNetworkIPv4Subnet = "203.203.0.0/16"
-			userDefinedNetworkIPv6Subnet = "fda9::0/60"
+			userDefinedNetworkIPv4Subnet = "10.128.0.0/16"
+			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
 		)
 
 		var (


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->    
    Since in L2 UDNs, multiple networks
    are set on the rtos-/stor- ports
    when lb_force_snat_ip is set to router-ip
    it picks the lexicographically sorted
    subnet IP to perform the SNAT which
    breaks services on L2.
    
    In this fix we will start using the
    joinIP to explicitly SNAT traffic to.

## Additional Information for reviewers

    Pinning to joinIP is what we used to do before
    except we had to use router-ip to
    deal with the following case:
    
    ext->ovn-workerIP:NodePort backed by
    ovn-worker2 host networked pod:
    
    ext->ovn-worker->br-ex->GR(DNAT to ovn-worker2)->
    GR(SNAT to joinIP)->send it back to br-ex->underlay
    ->ovn-worker2
    ..
    here traffic goes out with joinIP which will
    break this flow.
    
    But in UDNs we don't support host-networked
    pods yet, much less host-networked-pod backends
    to services. So when that support gets added
    we must ensure to add flows to br-ex similar to
    the per network masqueradeIP flows we have but for
    joinIP to do another SNAT to nodeIP before sending
    it out.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Create a KIND cluster; create a L2 UDN, check the following:
```
options             : {always_learn_from_arp_request="false", chassis="14bebd15-494d-468c-b856-50b78a79cbea", dynamic_neigh_routers="true", lb_force_snat_ip="100.65.0.3,fd99::3", mac_binding_age_threshold="300"}
```