### PR TITLE
ipam: Fix init flow in case there are sticky ips in the system

### DIFF
--- a/go-controller/pkg/allocator/ip/subnet/allocator_test.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator_test.go
@@ -5,12 +5,14 @@ import (
 
 	ipam "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/ip"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
 var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
+	const subnetName = "subnet1"
 	var (
 		allocator Allocator
 	)
@@ -21,7 +23,6 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 
 	ginkgo.Context("when adding subnets", func() {
 		ginkgo.It("creates each IPAM and reserves IPs correctly", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 				"2000::/64",
@@ -40,7 +41,6 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 		})
 
 		ginkgo.It("handles updates to the subnets correctly", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 				"2000::/64",
@@ -69,7 +69,6 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 		})
 
 		ginkgo.It("excludes subnets correctly", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 			}
@@ -93,7 +92,6 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 
 	ginkgo.Context("when allocating IP addresses", func() {
 		ginkgo.It("IPAM for each subnet allocates IPs contiguously", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 				"2000::/64",
@@ -116,7 +114,6 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 		})
 
 		ginkgo.It("IPAM allocates, releases, and reallocates IPs correctly", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 			}
@@ -141,8 +138,19 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 			}
 		})
 
+		ginkgo.It("fails to allocate multiple IPs from the same subnet", func() {
+			subnets := []string{"10.1.1.0/24", "2000::/64"}
+
+			gomega.Expect(allocator.AddOrUpdateSubnet(subnetName, ovntest.MustParseIPNets(subnets...))).To(gomega.Succeed())
+
+			ips, err := util.ParseIPNets([]string{"10.1.1.1/24", "10.1.1.2/24"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(allocator.AllocateIPs(subnetName, ips)).To(gomega.MatchError(
+				"failed to allocate IP 10.1.1.2 for subnet1: attempted to reserve multiple IPs in the same IPAM instance",
+			))
+		})
+
 		ginkgo.It("releases IPs for other subnets when any other subnet allocation fails", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 				"10.1.2.0/29",
@@ -184,7 +192,6 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 		})
 
 		ginkgo.It("fails correctly when trying to block a previously allocated IP", func() {
-			subnetName := "subnet1"
 			subnets := []string{
 				"10.1.1.0/24",
 				"2000::/64",

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -359,10 +359,12 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 		ginkgo.Context("persistent IP allocations", func() {
 			const (
 				claimName   = "claim1"
+				claimName2  = "claim2"
 				namespace   = "ns"
 				networkName = "blue"
 				subnetCIDR  = "192.168.200.0/24"
 				subnetIP    = "192.168.200.2/24"
+				subnetIP2   = "192.168.200.3/24"
 			)
 
 			var netInfo util.NetInfo
@@ -387,6 +389,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							KubeClient: fake.NewSimpleClientset(),
 							IPAMClaimsClient: fakeipamclaimclient.NewSimpleClientset(
 								ipamClaimWithIPAddr(claimName, namespace, networkName, subnetIP),
+								ipamClaimWithIPAddr(claimName2, namespace, networkName, subnetIP2),
 							),
 							NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
 						}
@@ -420,8 +423,11 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						ips, err := util.ParseIPNets([]string{subnetIP})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 						gomega.Expect(nc.subnetAllocator.AllocateIPs(netInfo.GetNetworkName(), ips)).To(gomega.Equal(ip.ErrAllocated))
+
+						ips2, err := util.ParseIPNets([]string{subnetIP2})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						gomega.Expect(nc.subnetAllocator.AllocateIPs(netInfo.GetNetworkName(), ips2)).To(gomega.Equal(ip.ErrAllocated))
 
 						return nil
 					}

--- a/go-controller/pkg/persistentips/allocator_test.go
+++ b/go-controller/pkg/persistentips/allocator_test.go
@@ -112,7 +112,9 @@ var _ = Describe("Persistent IP allocator operations", func() {
 		},
 			Entry("no objects to sync with"),
 			Entry("an IPAMClaim without persisted IPs", emptyDummyIPAMClaim(namespace, claimName, networkName)),
-			Entry("an IPAMClaim with persisted IPs", ipamClaimWithIPs(namespace, claimName, networkName, "192.168.200.2/24", "fd10::1/64")),
+			Entry("an IPAMClaim with persisted IPs",
+				ipamClaimWithIPs(namespace, claimName, networkName, "192.168.200.2/24", "fd10::1/64"),
+				ipamClaimWithIPs(namespace, claimName, networkName, "192.168.200.3/24", "fd10::2/64")),
 		)
 	})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

In case the `ovnkube-control-plane` pod is restarted,
(for example, node restart, upgrade, or any pod restart reason),
the ipam claim Sync function creates an array of all the ipams
belonging to a specific network, and used named allocator `AllocateIPs`
method to allocate them, so the allocator will reflect the current
cluster state.

The problem is `AllocateIPs` allows to allocate only one IP per given subnet,
so once it is used for all the IPs in the network at once, it will fail,
causing the control plane to have a crash loop.

Fix it by calling `AllocateIPs` per each claim on its own.
The claims were already created correctly, so each claim on its
own is safe to call `AllocateIPs`.

Add unit test to show the relevant assertion.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
Seen by deleting the pod while there were 2 ipam claims with IPs, from the same NAD
in the system.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->