### PR TITLE
Fix Panic in ClusterManager: Release IDs only for Primary L2 UDNs

### DIFF
--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -307,8 +307,10 @@ func (na *NodeAllocator) syncNodeNetworkAnnotations(node *corev1.Node) error {
 			if errR := na.clusterSubnetAllocator.ReleaseNetworks(node.Name, allocatedSubnets...); errR != nil {
 				klog.Warningf("Error releasing node %s subnets: %v", node.Name, errR)
 			}
-			na.idAllocator.ReleaseID(networkName + "_" + node.Name)
-			klog.Infof("Releasing node %s tunnelID for network %s since annotation update failed", node.Name, networkName)
+			if util.IsNetworkSegmentationSupportEnabled() && na.netInfo.IsPrimaryNetwork() && util.DoesNetworkRequireTunnelIDs(na.netInfo) {
+				na.idAllocator.ReleaseID(networkName + "_" + node.Name)
+				klog.Infof("Releasing node %s tunnelID for network %s since annotation update failed", node.Name, networkName)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION

## 📑 Description
TunnelID Allocator is only present for L2 UDNs. It is nil otherwise, while releasing we forgot to check for the L2 Primary UDN condition and this leads to panic:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1e54748]

goroutine 77 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2cbd3d8, 0x441f7e0}, {0x2458780, 0x42641b0}, {0x441f7e0, 0x0, 0x10000c0017b41c0?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:89 +0xee
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x5?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:59 +0x108
panic({0x2458780?, 0x42641b0?})
	/usr/lib/golang/src/runtime/panic.go:770 +0x132
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/node.(*NodeAllocator).syncNodeNetworkAnnotations(0xc000fda100, 0xc00105c008)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/clustermanager/node/node_allocator.go:310 +0x11e8
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/node.(*NodeAllocator).HandleAddUpdateNodeEvent(0xc000fda100, 0xc00105c008)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/clustermanager/node/node_allocator.go:199 +0x3ec
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager.(*networkClusterControllerEventHandler).UpdateResource(0xc001000460, {0x284ff60?, 0xc000a72f08?}, {0x284ff60, 0xc00105c008}, 0x0?)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/clustermanager/network_cluster_controller.go:517 +0x129
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).WatchResourceFiltered.func2.2({0xc0017b4108, 0x5})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:669 +0x61e
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).DoWithLock(0xc0004d81e0, {0xc0017b4108, 0x5}, 0xc0006dba60)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:137 +0xbe
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry.(*RetryFramework).WatchResourceFiltered.func2({0x284ff60, 0xc000a72f08}, {0x284ff60, 0xc00105c008})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/retry/obj_retry.go:609 +0xb56
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:253
k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate({0xc000fce600?, {0x2cad820?, 0xc000f863c0?}}, {0x284ff60, 0xc000a72f08}, {0x284ff60, 0xc00105c008})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:318 +0xdc
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*Handler).OnUpdate(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/handler.go:61
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*informer).newFederatedHandler.func2.1(0xc000fc56e0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/handler.go:464 +0x1b0
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*informer).forEachHandler(0xc000270070, {0x284ff60?, 0xc00105c008?}, 0xc0011a5d98)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/handler.go:152 +0x29c
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*informer).newFederatedHandler.func2({0x284ff60, 0xc000a72f08}, {0x284ff60, 0xc00105c008})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/handler.go:455 +0x125
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
