### PR TITLE
NAD validations: Fix typo in error message

### DIFF
--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -828,7 +828,7 @@ func ValidateNetConf(nadName string, netconf *ovncnitypes.NetConf) error {
 
 	if netconf.Topology != types.LocalnetTopology && netconf.Name != types.DefaultNetworkName {
 		if err := subnetOverlapCheck(netconf); err != nil {
-			return fmt.Errorf("invalid subnet cnfiguration: %w", err)
+			return fmt.Errorf("invalid subnet configuration: %w", err)
 		}
 	}
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1083,7 +1083,7 @@ func TestSubnetOverlapCheck(t *testing.T) {
                     "netAttachDefName": "ns1/nad1"
                 }
 			`,
-			expectedError: fmt.Errorf("invalid subnet cnfiguration: pod or join subnet overlaps with already configured internal subnets: " +
+			expectedError: fmt.Errorf("invalid subnet configuration: pod or join subnet overlaps with already configured internal subnets: " +
 				"illegal network configuration: user defined subnet \"10.129.0.0/16\" overlaps cluster subnet \"10.128.0.0/14\""),
 		},
 		{
@@ -1099,7 +1099,7 @@ func TestSubnetOverlapCheck(t *testing.T) {
                     "netAttachDefName": "ns1/nad1"
                 }
 			`,
-			expectedError: fmt.Errorf("invalid subnet cnfiguration: pod or join subnet overlaps with already configured internal subnets: " +
+			expectedError: fmt.Errorf("invalid subnet configuration: pod or join subnet overlaps with already configured internal subnets: " +
 				"illegal network configuration: user defined join subnet \"100.64.0.0/24\" overlaps built-in join subnet \"100.64.0.0/16\""),
 		},
 		{
@@ -1115,7 +1115,7 @@ func TestSubnetOverlapCheck(t *testing.T) {
                     "netAttachDefName": "ns1/nad1"
                 }
 			`,
-			expectedError: fmt.Errorf("invalid subnet cnfiguration: pod or join subnet overlaps with already configured internal subnets: " +
+			expectedError: fmt.Errorf("invalid subnet configuration: pod or join subnet overlaps with already configured internal subnets: " +
 				"illegal network configuration: user defined subnet \"fe01::/24\" overlaps service subnet \"fe01::/16\""),
 		},
 		{
@@ -1131,7 +1131,7 @@ func TestSubnetOverlapCheck(t *testing.T) {
                     "netAttachDefName": "ns1/nad1"
                 }
 			`,
-			expectedError: fmt.Errorf("invalid subnet cnfiguration: pod or join subnet overlaps with already configured internal subnets: " +
+			expectedError: fmt.Errorf("invalid subnet configuration: pod or join subnet overlaps with already configured internal subnets: " +
 				"illegal network configuration: user defined join subnet \"fd69::/112\" overlaps masquerade subnet \"fd69::/125\""),
 		},
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Following https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4604, fix typo in NAD validation error message.

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
