### PR TITLE
node network controller: Add CUDN check to GetActiveNetworkForNamespace

### DIFF
--- a/go-controller/pkg/factory/mocks/NodeWatchFactory.go
+++ b/go-controller/pkg/factory/mocks/NodeWatchFactory.go
@@ -200,6 +200,26 @@ func (_m *NodeWatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHa
 	return r0, r1
 }
 
+// ClusterUserDefinedNetworkInformer provides a mock function with given fields:
+func (_m *NodeWatchFactory) ClusterUserDefinedNetworkInformer() userdefinednetworkv1.ClusterUserDefinedNetworkInformer {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClusterUserDefinedNetworkInformer")
+	}
+
+	var r0 userdefinednetworkv1.ClusterUserDefinedNetworkInformer
+	if rf, ok := ret.Get(0).(func() userdefinednetworkv1.ClusterUserDefinedNetworkInformer); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(userdefinednetworkv1.ClusterUserDefinedNetworkInformer)
+		}
+	}
+
+	return r0
+}
+
 // EgressIPInformer provides a mock function with given fields:
 func (_m *NodeWatchFactory) EgressIPInformer() egressipv1.EgressIPInformer {
 	ret := _m.Called()

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -62,6 +62,7 @@ type NodeWatchFactory interface {
 	EgressIPInformer() egressipinformer.EgressIPInformer
 	NADInformer() nadinformer.NetworkAttachmentDefinitionInformer
 	UserDefinedNetworkInformer() userdefinednetworkinformer.UserDefinedNetworkInformer
+	ClusterUserDefinedNetworkInformer() userdefinednetworkinformer.ClusterUserDefinedNetworkInformer
 
 	GetPods(namespace string) ([]*kapi.Pod, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -224,6 +224,8 @@ var _ = Describe("Healthcheck tests", func() {
 			factoryMock.On("GetNodes").Return(nodeList, nil)
 			factoryMock.On("NADInformer").Return(nil)
 			factoryMock.On("UserDefinedNetworkInformer").Return(nil)
+			factoryMock.On("ClusterUserDefinedNetworkInformer").Return(nil)
+			factoryMock.On("NamespaceInformer").Return(nil)
 
 			ncm, err := NewNodeNetworkControllerManager(fakeClient, &factoryMock, nodeName, &sync.WaitGroup{}, nil, routeManager)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Following #4612 this PR add support for the NAD controller to take in account CUDN objects when looking for active namespace in a namespace, similar to the UDN case introduced by  https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4662.

<!--

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
