### PR TITLE
kubevirt, e2e, udn: Add north south traffic and tcp connection checks for e/w and n/s.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,7 +433,7 @@ jobs:
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3"}
-          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
+          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/clarketm/json v1.17.1 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containernetworking/cni v1.1.2 // indirect
+	github.com/containernetworking/plugins v1.2.0 // indirect
 	github.com/coreos/go-iptables v0.6.0 // indirect
 	github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
@@ -172,7 +173,6 @@ require (
 )
 
 require (
-	github.com/containernetworking/plugins v1.2.0
 	github.com/coreos/butane v0.18.0
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -96,7 +96,6 @@ require (
 	github.com/openshift/api v0.0.0-20231120222239-b86761094ee3 // indirect
 	github.com/openshift/client-go v0.0.0-20231121143148-910ca30a1a9a // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
-	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
@@ -182,7 +181,7 @@ require (
 	go.universe.tf/metallb v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.65.0
 	k8s.io/kubectl v0.31.1
-	kubevirt.io/api v1.1.0
+	kubevirt.io/api v1.4.0
 	sigs.k8s.io/controller-runtime v0.19.0
 )
 

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -272,7 +272,6 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2Rrd27c3VGxi6a/6HNq8QmHRKM=
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -416,8 +415,6 @@ github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPf
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20241008155748-956f8fa6b868 h1:mBnSZD1o4Kz2nB6WoktSsLVOdcrSdOH/mgWPVxfEykk=
 github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20241008155748-956f8fa6b868/go.mod h1:5oVtJoJgxCHohAghvIMkdQZ40XueMQeQwu+6Rk+U1Oc=
-github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
-github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1021,8 +1018,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-kubevirt.io/api v1.1.0 h1:G6/32Emr8cout4MUc2Gi3tfp92rq/rMh5LyhKhMxntw=
-kubevirt.io/api v1.1.0/go.mod h1:CJ4vZsaWhVN3jNbyc9y3lIZhw8nUHbWjap0xHABQiqc=
+kubevirt.io/api v1.4.0 h1:dDLyQLSp9obzsDrv3cyL1olIc/66IWVaGiR3gfPfgT0=
+kubevirt.io/api v1.4.0/go.mod h1:qcnumjJeOCo+qdYXf0OjpHGMhad0SAn4i0h6IAP+6Eg=
 kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 h1:IWo12+ei3jltSN5jQN1xjgakfvRSF3G3Rr4GXVOOy2I=
 kubevirt.io/containerized-data-importer-api v1.57.0-alpha1/go.mod h1:Y/8ETgHS1GjO89bl682DPtQOYEU/1ctPFBz6Sjxm4DM=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=

--- a/test/e2e/images/crictl.go
+++ b/test/e2e/images/crictl.go
@@ -1,0 +1,32 @@
+package images
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type minimalCrictlImage struct {
+	ID          string   `json:"id"`
+	RepoDigests []string `json:"repoDigests"`
+}
+
+type minimalCrictlImages struct {
+	Images []minimalCrictlImage `json:"images"`
+}
+
+func ImageIDByImageURL(desiredImage, jsonData string) (string, error) {
+	var imagesData minimalCrictlImages
+	if err := json.Unmarshal([]byte(jsonData), &imagesData); err != nil {
+		return "", fmt.Errorf("failed to parse crictl JSON: %w", err)
+	}
+
+	for _, img := range imagesData.Images {
+		for _, repoDigest := range img.RepoDigests {
+			if strings.Contains(repoDigest, desiredImage) {
+				return img.ID, nil
+			}
+		}
+	}
+	return "", nil
+}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/diagnostics"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/kubevirt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -84,23 +85,24 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 
 var _ = Describe("Kubevirt Virtual Machines", func() {
 	var (
-		fr                 = wrappedTestFramework("kv-live-migration")
-		d                  = diagnostics.New(fr)
-		crClient           crclient.Client
-		namespace          string
-		tcpServerPort      = int32(9900)
-		wg                 sync.WaitGroup
-		selectedNodes      = []corev1.Node{}
-		httpServerTestPods = []*corev1.Pod{}
-		clientSet          kubernetes.Interface
+		fr                  = wrappedTestFramework("kv-live-migration")
+		d                   = diagnostics.New(fr)
+		crClient            crclient.Client
+		namespace           string
+		tcpServerPort       = int32(9900)
+		wg                  sync.WaitGroup
+		selectedNodes       = []corev1.Node{}
+		httpServerTestPods  = []*corev1.Pod{}
+		iperfServerTestPods = []*corev1.Pod{}
+		clientSet           kubernetes.Interface
 		// Systemd resolvd prevent resolving kube api service by fqdn, so
 		// we replace it here with NetworkManager
 
 		isDualStack = func() bool {
 			GinkgoHelper()
 			nodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nodeList.Items).ToNot(BeEmpty())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeList.Items).NotTo(BeEmpty())
 			hasIPv4Address, hasIPv6Address := false, false
 			for _, addr := range nodeList.Items[0].Status.Addresses {
 				if addr.Type == corev1.NodeInternalIP {
@@ -268,6 +270,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 
 		checkEastWestTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
 			GinkgoHelper()
+			Expect(podIPsByName).NotTo(BeEmpty())
 			polling := 15 * time.Second
 			timeout := time.Minute
 			for podName, podIPs := range podIPsByName {
@@ -276,6 +279,26 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 					Eventually(func() error {
 						var err error
 						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("curl http://%s", net.JoinHostPort(podIP, "8000")), polling)
+						return err
+					}).
+						WithPolling(polling).
+						WithTimeout(timeout).
+						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
+				}
+			}
+		}
+
+		checkEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
+			GinkgoHelper()
+			Expect(podIPsByName).NotTo(BeEmpty())
+			polling := 15 * time.Second
+			timeout := time.Minute
+			for podName, podIPs := range podIPsByName {
+				for _, podIP := range podIPs {
+					output := ""
+					Eventually(func() error {
+						var err error
+						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("iperf3 -t 1 -c %s", podIP), polling)
 						return err
 					}).
 						WithPolling(polling).
@@ -295,41 +318,21 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			return ips
 		}
 
-		checkPodHasIPsAtNetwork = func(netName string, expectedNumberOfAddresses int) func(Gomega, *corev1.Pod) {
-			return func(g Gomega, pod *corev1.Pod) {
-				GinkgoHelper()
-				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
-					return status.Name == netName
-				})
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(netStatus).To(HaveLen(1))
-				g.Expect(netStatus[0].IPs).To(HaveLen(expectedNumberOfAddresses))
-			}
-		}
-
-		checkPodRunningReady = func() func(Gomega, *corev1.Pod) {
-			return func(g Gomega, pod *corev1.Pod) {
-				ok, err := testutils.PodRunningReady(pod)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(ok).To(BeTrue())
-			}
-		}
-
-		httpServerTestPodsMultusNetworkIPs = func(nadName string) map[string][]string {
+		podsMultusNetworkIPs = func(pods []*corev1.Pod, networkStatusPredicate func(nadapi.NetworkStatus) bool) map[string][]string {
 			GinkgoHelper()
 			ips := map[string][]string{}
-			for _, pod := range httpServerTestPods {
-				var ovnPodAnnotation *util.PodAnnotation
-				Eventually(func() (*util.PodAnnotation, error) {
+			for _, pod := range pods {
+				var networkStatuses []nadapi.NetworkStatus
+				Eventually(func() ([]nadapi.NetworkStatus, error) {
 					var err error
-					ovnPodAnnotation, err = util.UnmarshalPodAnnotation(pod.Annotations, nadName)
-					return ovnPodAnnotation, err
+					networkStatuses, err = podNetworkStatus(pod, networkStatusPredicate)
+					return networkStatuses, err
 				}).
 					WithTimeout(5 * time.Second).
 					WithPolling(200 * time.Millisecond).
-					ShouldNot(BeNil())
-				for _, ipnet := range ovnPodAnnotation.IPs {
-					ips[pod.Name] = append(ips[pod.Name], ipnet.IP.String())
+					Should(HaveLen(1))
+				for _, ip := range networkStatuses[0].IPs {
+					ips[pod.Name] = append(ips[pod.Name], ip)
 				}
 			}
 			return ips
@@ -345,7 +348,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			polling := 6 * time.Second
 			timeout := 2 * time.Minute
 			step := by(vmName, stage+": Check tcp connection is not broken")
@@ -382,7 +385,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			/*
 				step := by(vmName, stage+": Create deny all network policy")
 				policy, err := createDenyAllPolicy(vmName)
-				Expect(err).ToNot(HaveOccurred(), step)
+				Expect(err).NotTo(HaveOccurred(), step)
 
 				step = by(vmName, stage+": Check connectivity block after create deny all network policy")
 				Eventually(func() error { return sendEchos(endpoints) }).
@@ -442,26 +445,26 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi")
+			Expect(err).NotTo(HaveOccurred(), "should success retrieving vmi")
 			currentNode := vmi.Status.NodeName
 
 			Eventually(func() *kubevirtv1.VirtualMachineInstanceMigrationState {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return vmi.Status.MigrationState
 			}).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(BeNil(), "should have a MigrationState")
 			Eventually(func() string {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return vmi.Status.MigrationState.TargetNode
 			}).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(Equal(currentNode), "should refresh MigrationState")
 			Eventually(func() bool {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return vmi.Status.MigrationState.Completed
 			}).WithPolling(time.Second).WithTimeout(20*time.Minute).Should(BeTrue(), "should complete migration")
 			err = crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi after migration")
+			Expect(err).NotTo(HaveOccurred(), "should success retrieving vmi after migration")
 			Expect(vmi.Status.MigrationState.Failed).To(BeFalse(), func() string {
 				vmiJSON, err := json.Marshal(vmi)
 				if err != nil {
@@ -512,7 +515,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi")
+			Expect(err).NotTo(HaveOccurred(), "should success retrieving vmi")
 
 			Eventually(func() (kubevirtv1.VirtualMachineInstanceMigrationPhase, error) {
 				migrations, err := vmiMigrations(crClient)
@@ -633,10 +636,10 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				WithTimeout(5*time.Minute).
 				Should(HaveLen(1), step)
 			addresses, err := addressByFamily(ipv4, vmi)()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			if isDualStack() {
 				output, err := kubevirt.RunCommand(vmi, `echo '{"interfaces":[{"name":"enp1s0","type":"ethernet","state":"up","ipv4":{"enabled":true,"dhcp":true},"ipv6":{"enabled":true,"dhcp":true,"autoconf":false}}],"routes":{"config":[{"destination":"::/0","next-hop-interface":"enp1s0","next-hop-address":"fe80::1"}]}}' |nmstatectl apply`, 5*time.Second)
-				Expect(err).ToNot(HaveOccurred(), output)
+				Expect(err).NotTo(HaveOccurred(), output)
 				step = by(vmi.Name, "Wait for virtual machine to receive IPv6 address from DHCP")
 				Eventually(addressByFamily(ipv6, vmi)).
 					WithPolling(time.Second).
@@ -646,7 +649,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 						return step + " -> journal nmstate: " + output
 					})
 				ipv6Addresses, err := addressByFamily(ipv6, vmi)()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				addresses = append(addresses, ipv6Addresses...)
 			}
 			return addresses
@@ -661,42 +664,17 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 				Should(HaveLen(expectedNumberOfAddresses), step)
 
 			addresses, err := addressesFromStatus(vmi)()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return addresses
 		}
 
-		virtualMachineAddressesFromGuest = func(vmi *kubevirtv1.VirtualMachineInstance) []string {
-			GinkgoHelper()
-			addresses := waitVirtualMachineAddresses(vmi)
-			ips := []string{}
-			for _, address := range addresses {
-				if net.ParseIP(address.Ip).IsLinkLocalUnicast() {
-					continue
-				}
-				ips = append(ips, address.Ip)
-			}
-			return ips
-		}
-
-		fcosVMI = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachineInstance, error) {
-			workingDirectory, err := os.Getwd()
-			if err != nil {
-				return nil, err
-			}
-			ignition, _, err := butaneconfig.TranslateBytes([]byte(butane), butanecommon.TranslateBytesOptions{
-				TranslateOptions: butanecommon.TranslateOptions{
-					FilesDir: workingDirectory,
-				},
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed translating butane: %w", err)
-			}
+		generateVMI = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, cloudInitVolumeSource kubevirtv1.VolumeSource, image string) *kubevirtv1.VirtualMachineInstance {
 			return &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   namespace,
-					Name:        fmt.Sprintf("worker%d", idx),
-					Annotations: annotations,
-					Labels:      labels,
+					Namespace:    namespace,
+					GenerateName: "worker-",
+					Annotations:  annotations,
+					Labels:       labels,
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
 					NodeSelector: nodeSelector,
@@ -748,46 +726,79 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 							Name: "containerdisk",
 							VolumeSource: kubevirtv1.VolumeSource{
 								ContainerDisk: &kubevirtv1.ContainerDiskSource{
-									Image: "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50",
+									Image: image,
 								},
 							},
 						},
 						{
-							Name: "cloudinitdisk",
-							VolumeSource: kubevirtv1.VolumeSource{
-								CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
-									UserData: string(ignition),
-								},
-							},
+							Name:         "cloudinitdisk",
+							VolumeSource: cloudInitVolumeSource,
 						},
 					},
 				},
-			}, nil
-		}
-		fcosVM = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachine, error) {
-			vmi, err := fcosVMI(idx, labels, annotations, nodeSelector, networkSource, butane)
-			if err != nil {
-				return nil, err
 			}
+		}
+
+		generateVM = func(vmi *kubevirtv1.VirtualMachineInstance) *kubevirtv1.VirtualMachine {
 			return &kubevirtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      fmt.Sprintf("worker%d", idx),
+					Namespace:    namespace,
+					GenerateName: vmi.GenerateName,
 				},
 				Spec: kubevirtv1.VirtualMachineSpec{
 					Running: pointer.Bool(true),
 					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: annotations,
-							Labels:      labels,
+							Annotations: vmi.Annotations,
+							Labels:      vmi.Labels,
 						},
 						Spec: vmi.Spec,
 					},
 				},
-			}, nil
+			}
 		}
 
-		composeDefaultNetworkLiveMigratableVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
+		fcosVMI = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachineInstance, error) {
+			workingDirectory, err := os.Getwd()
+			if err != nil {
+				return nil, err
+			}
+			ignition, _, err := butaneconfig.TranslateBytes([]byte(butane), butanecommon.TranslateBytesOptions{
+				TranslateOptions: butanecommon.TranslateOptions{
+					FilesDir: workingDirectory,
+				},
+			})
+			cloudInitVolumeSource := kubevirtv1.VolumeSource{
+				CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
+					UserData: string(ignition),
+				},
+			}
+			return generateVMI(labels, annotations, nodeSelector, networkSource, cloudInitVolumeSource, kubevirt.FedoraCoreOSContainerDiskImage), nil
+		}
+
+		fcosVM = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachine, error) {
+			vmi, err := fcosVMI(labels, annotations, nodeSelector, networkSource, butane)
+			if err != nil {
+				return nil, err
+			}
+			return generateVM(vmi), nil
+		}
+
+		fedoraWithTestToolingVMI = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, userData, networkData string) *kubevirtv1.VirtualMachineInstance {
+			cloudInitVolumeSource := kubevirtv1.VolumeSource{
+				CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+					UserData:    userData,
+					NetworkData: networkData,
+				},
+			}
+			return generateVMI(labels, annotations, nodeSelector, networkSource, cloudInitVolumeSource, kubevirt.FedoraContainerDiskImage)
+		}
+
+		fedoraWithTestToolingVM = func(labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, userData, networkData string) *kubevirtv1.VirtualMachine {
+			return generateVM(fedoraWithTestToolingVMI(labels, annotations, nodeSelector, networkSource, userData, networkData))
+		}
+
+		composeDefaultNetworkLiveMigratableVM = func(labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
 			annotations := map[string]string{
 				"kubevirt.io/allow-pod-bridge-network-live-migration": "",
 			}
@@ -797,7 +808,7 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			networkSource := kubevirtv1.NetworkSource{
 				Pod: &kubevirtv1.PodNetwork{},
 			}
-			return fcosVM(idx, labels, annotations, nodeSelector, networkSource, butane)
+			return fcosVM(labels, annotations, nodeSelector, networkSource, butane)
 		}
 
 		composeDefaultNetworkLiveMigratableVMs = func(numberOfVMs int, labels map[string]string) ([]*kubevirtv1.VirtualMachine, error) {
@@ -845,7 +856,7 @@ passwd:
 
 			vms := []*kubevirtv1.VirtualMachine{}
 			for i := 1; i <= numberOfVMs; i++ {
-				vm, err := composeDefaultNetworkLiveMigratableVM(i, labels, butane)
+				vm, err := composeDefaultNetworkLiveMigratableVM(labels, butane)
 				if err != nil {
 					return nil, err
 				}
@@ -871,17 +882,17 @@ passwd:
 				},
 			}
 			err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
 
 			waitVirtualMachineAddresses(vmi)
 
 			step = by(vm.Name, "Expose tcpServer as a service")
 			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("tcpserver", vm.Name, tcpServerPort), metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred(), step)
+			Expect(err).NotTo(HaveOccurred(), step)
 			defer func() {
 				output, err := kubevirt.RunCommand(vmi, "podman logs tcpserver", 10*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				fmt.Printf("%s tcpserver logs: %s", vmi.Name, output)
 			}()
 
@@ -925,7 +936,7 @@ passwd:
 		}
 
 		checkPodHasIPAtStatus = func(g Gomega, pod *corev1.Pod) {
-			g.Expect(pod.Status.PodIP).ToNot(BeEmpty(), "pod %s has no valid IP address yet", pod.Name)
+			g.Expect(pod.Status.PodIP).NotTo(BeEmpty(), "pod %s has no valid IP address yet", pod.Name)
 		}
 
 		createHTTPServerPods = func(annotations map[string]string) []*corev1.Pod {
@@ -942,12 +953,31 @@ passwd:
 			return pods
 		}
 
+		createIperfServerPods = func(nodes []corev1.Node, netConfig networkAttachmentConfig) ([]*corev1.Pod, error) {
+			annotations := map[string]string{}
+			if netConfig.role != "primary" {
+				annotations["k8s.v1.cni.cncf.io/networks"] = fmt.Sprintf(`[{"name": %q}]`, netConfig.name)
+			}
+			var pods []*corev1.Pod
+			for _, node := range nodes {
+				pod, err := createPod(fr, "testpod-"+node.Name, node.Name, namespace, []string{"iperf3", "-s"}, map[string]string{}, func(pod *corev1.Pod) {
+					pod.Annotations = annotations
+					pod.Spec.Containers[0].Image = iperf3Image
+				})
+				if err != nil {
+					return nil, err
+				}
+				pods = append(pods, pod)
+			}
+			return pods, nil
+		}
+
 		waitForPodsCondition = func(pods []*corev1.Pod, conditionFn func(g Gomega, pod *corev1.Pod)) {
 			for _, pod := range pods {
 				Eventually(func(g Gomega) {
 					var err error
 					pod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).NotTo(HaveOccurred())
 					conditionFn(g, pod)
 				}).
 					WithTimeout(time.Minute).
@@ -960,7 +990,7 @@ passwd:
 			for i, pod := range pods {
 				var err error
 				pod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				pods[i] = pod
 			}
 			return pods
@@ -972,6 +1002,47 @@ passwd:
 			waitForPodsCondition(httpServerTestPods, conditionFn)
 			httpServerTestPods = updatePods(httpServerTestPods)
 		}
+
+		removeImagesInNode = func(node, imageURL string) error {
+			By("Removing unused images in node " + node)
+			output, err := runCommand(containerRuntime, "exec", node,
+				"crictl", "images", "-o", "json")
+			if err != nil {
+				return err
+			}
+
+			// Remove tag if exists.
+			taglessImageURL := strings.Split(imageURL, ":")[0]
+			imageID, err := images.ImageIDByImageURL(taglessImageURL, output)
+			if err != nil {
+				return err
+			}
+			if imageID != "" {
+				_, err = runCommand(containerRuntime, "exec", node,
+					"crictl", "rmi", imageID)
+				if err != nil {
+					return err
+				}
+				_, err = runCommand(containerRuntime, "exec", node,
+					"crictl", "rmi", "--prune")
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		removeImagesInNodes = func(imageURL string) error {
+			nodesList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for nodeIdx, _ := range nodesList.Items {
+				err = removeImagesInNode(nodesList.Items[nodeIdx].Name, imageURL)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 	)
 	BeforeEach(func() {
 		// So we can use it at AfterEach, since fr.ClientSet is nil there
@@ -979,10 +1050,10 @@ passwd:
 
 		var err error
 		crClient, err = newControllerRuntimeClient()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("with default pod network", func() {
+	Context("with default pod network", Ordered, func() {
 
 		BeforeEach(func() {
 			ns, err := fr.CreateNamespace(context.TODO(), fr.BaseName, map[string]string{
@@ -991,7 +1062,7 @@ passwd:
 			fr.Namespace = ns
 			namespace = fr.Namespace.Name
 			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			nodesByOVNZone := map[string][]corev1.Node{}
 			for _, workerNode := range workerNodeList.Items {
 				ovnZone, ok := workerNode.Labels["k8s.ovn.org/zone-name"]
@@ -1043,6 +1114,10 @@ passwd:
 			}
 		})
 
+		AfterAll(func() {
+			Expect(removeImagesInNodes(kubevirt.FedoraCoreOSContainerDiskImage)).To(Succeed())
+		})
+
 		DescribeTable("when live migration", func(td liveMigrationTestData) {
 			if td.mode == kubevirtv1.MigrationPostCopy && os.Getenv("GITHUB_ACTIONS") == "true" {
 				Skip("Post copy live migration not working at github actions")
@@ -1054,7 +1129,7 @@ passwd:
 				err error
 			)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			d.ConntrackDumpingDaemonSet()
 			d.OVSFlowsDumpingDaemonSet("breth0")
@@ -1078,7 +1153,7 @@ passwd:
 			}
 			if td.mode == kubevirtv1.MigrationPostCopy {
 				err = crClient.Create(context.TODO(), forcePostCopyMigrationPolicy)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				defer func() {
 					Expect(crClient.Delete(context.TODO(), forcePostCopyMigrationPolicy)).To(Succeed())
 				}()
@@ -1089,7 +1164,7 @@ passwd:
 				vmLabels = forcePostCopyMigrationPolicy.Spec.Selectors.VirtualMachineInstanceSelector
 			}
 			vms, err := composeDefaultNetworkLiveMigratableVMs(td.numberOfVMs, vmLabels)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			for _, vm := range vms {
 				By(fmt.Sprintf("Create virtual machine %s", vm.Name))
@@ -1106,26 +1181,29 @@ passwd:
 				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
 			}
 
-			if td.shouldExpectFailure {
-				By("annotating the VMI with `fail fast`")
-				vmKey := types.NamespacedName{Namespace: namespace, Name: "worker1"}
-				var vmi kubevirtv1.VirtualMachineInstance
+			for _, vm := range vms {
+				By(fmt.Sprintf("Create virtual machine %s", vm.Name))
+				if td.shouldExpectFailure {
+					By("annotating the VMI with `fail fast`")
+					vmKey := types.NamespacedName{Namespace: namespace, Name: vm.Name}
+					var vmi kubevirtv1.VirtualMachineInstance
 
-				Eventually(func() error {
-					err = crClient.Get(context.TODO(), vmKey, &vmi)
-					if err == nil {
-						vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
-						err = crClient.Update(context.TODO(), &vmi)
-					}
-					return err
-				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+					Eventually(func() error {
+						err = crClient.Get(context.TODO(), vmKey, &vmi)
+						if err == nil {
+							vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
+							err = crClient.Update(context.TODO(), &vmi)
+						}
+						return err
+					}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+				}
 			}
 
 			for _, vm := range vms {
 				By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vm.Name))
 				Eventually(func() bool {
 					err = crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vm), vm)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					return vm.Status.Ready
 				}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(BeTrue())
 			}
@@ -1150,7 +1228,10 @@ passwd:
 			}),
 		)
 	})
-	Context("with user defined networks and persistent ips configured", func() {
+	Context("with user defined networks and persistent ips configured", Ordered, func() {
+		AfterAll(func() {
+			Expect(removeImagesInNodes(kubevirt.FedoraContainerDiskImage)).To(Succeed())
+		})
 		type testCommand struct {
 			description string
 			cmd         func()
@@ -1160,18 +1241,17 @@ passwd:
 			cmd         func() string
 		}
 		var (
-			nad              *nadv1.NetworkAttachmentDefinition
-			vm               *kubevirtv1.VirtualMachine
-			vmi              *kubevirtv1.VirtualMachineInstance
-			cidrIPv4         = "10.128.0.0/24"
-			cidrIPv6         = "2010:100:200::0/60"
-			expectedAddreses []string
-			restart          = testCommand{
+			nad      *nadv1.NetworkAttachmentDefinition
+			vm       *kubevirtv1.VirtualMachine
+			vmi      *kubevirtv1.VirtualMachineInstance
+			cidrIPv4 = "10.128.0.0/24"
+			cidrIPv6 = "2010:100:200::0/60"
+			restart  = testCommand{
 				description: "restart",
 				cmd: func() {
 					By("Restarting vm")
 					output, err := exec.Command("virtctl", "restart", "-n", namespace, vmi.Name).CombinedOutput()
-					Expect(err).ToNot(HaveOccurred(), output)
+					Expect(err).NotTo(HaveOccurred(), output)
 
 					By("Wait some time to vmi conditions to catch up after restart")
 					time.Sleep(3 * time.Second)
@@ -1186,24 +1266,23 @@ passwd:
 					checkLiveMigrationSucceeded(vmi.Name, kubevirtv1.MigrationPreCopy)
 				},
 			}
-			butane = `
-variant: fcos
-version: 1.4.0
-passwd:
-  users:
-  - name: core
-    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
-`
+			networkData = `version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+    dhcp6: true
+    ipv6-address-generation: eui64`
+			userData = `#cloud-config
+password: fedora
+chpasswd: { expire: False }`
 			virtualMachine = resourceCommand{
 				description: "VirtualMachine",
 				cmd: func() string {
-					var err error
-					vm, err = fcosVM(1, nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
+					vm = fedoraWithTestToolingVM(nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
 						Multus: &kubevirtv1.MultusNetwork{
 							NetworkName: nad.Name,
 						},
-					}, butane)
-					Expect(err).ToNot(HaveOccurred())
+					}, userData, networkData)
 					createVirtualMachine(vm)
 					return vm.Name
 				},
@@ -1212,12 +1291,10 @@ passwd:
 			virtualMachineWithUDN = resourceCommand{
 				description: "VirtualMachine with interface binding for UDN",
 				cmd: func() string {
-					var err error
-					vm, err = fcosVM(1, nil /*labels*/, nil /*annotations*/, nil, /*nodeSelector*/
+					vm = fedoraWithTestToolingVM(nil /*labels*/, nil /*annotations*/, nil, /*nodeSelector*/
 						kubevirtv1.NetworkSource{
 							Pod: &kubevirtv1.PodNetwork{},
-						}, butane)
-					Expect(err).ToNot(HaveOccurred())
+						}, userData, networkData)
 					vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].Bridge = nil
 					vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].Binding = &kubevirtv1.PluginBinding{Name: "l2bridge"}
 					createVirtualMachine(vm)
@@ -1228,13 +1305,11 @@ passwd:
 			virtualMachineInstance = resourceCommand{
 				description: "VirtualMachineInstance",
 				cmd: func() string {
-					var err error
-					vmi, err = fcosVMI(1, nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
+					vmi = fedoraWithTestToolingVMI(nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
 						Multus: &kubevirtv1.MultusNetwork{
 							NetworkName: nad.Name,
 						},
-					}, butane)
-					Expect(err).ToNot(HaveOccurred())
+					}, userData, networkData)
 					createVirtualMachineInstance(vmi)
 					return vmi.Name
 				},
@@ -1243,18 +1318,17 @@ passwd:
 			virtualMachineInstanceWithUDN = resourceCommand{
 				description: "VirtualMachineInstance with interface binding for UDN",
 				cmd: func() string {
-					var err error
-					vmi, err = fcosVMI(1, nil /*labels*/, nil /*annotations*/, nil, /*nodeSelector*/
+					vmi = fedoraWithTestToolingVMI(nil /*labels*/, nil /*annotations*/, nil, /*nodeSelector*/
 						kubevirtv1.NetworkSource{
 							Pod: &kubevirtv1.PodNetwork{},
-						}, butane)
-					Expect(err).ToNot(HaveOccurred())
+						}, userData, networkData)
 					vmi.Spec.Domain.Devices.Interfaces[0].Bridge = nil
 					vmi.Spec.Domain.Devices.Interfaces[0].Binding = &kubevirtv1.PluginBinding{Name: "l2bridge"}
 					createVirtualMachineInstance(vmi)
 					return vmi.Name
 				},
 			}
+
 			filterOutIPv6 = func(ips map[string][]string) map[string][]string {
 				filteredOutIPs := map[string][]string{}
 				for podName, podIPs := range ips {
@@ -1317,22 +1391,12 @@ passwd:
 			nad = generateNAD(netConfig)
 			Expect(crClient.Create(context.Background(), nad)).To(Succeed())
 			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			selectedNodes = workerNodeList.Items
-			networkName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
-			httpServerPodsAnnotations := map[string]string{}
-			if td.role != "primary" {
-				httpServerPodsAnnotations["k8s.v1.cni.cncf.io/networks"] = fmt.Sprintf(`[{"name": %q}]`, nad.Name)
-			}
-			var httpServerPodCondition func(Gomega, *corev1.Pod)
-			if td.role != "primary" {
-				expectedNumberOfAddresses := len(strings.Split(netConfig.cidr, ","))
-				httpServerPodCondition = checkPodHasIPsAtNetwork(networkName, expectedNumberOfAddresses)
-			} else {
-				httpServerPodCondition = checkPodRunningReady()
-			}
+			Expect(selectedNodes).NotTo(BeEmpty())
 
-			prepareHTTPServerPods(httpServerPodsAnnotations, httpServerPodCondition)
+			iperfServerTestPods, err = createIperfServerPods(selectedNodes, netConfig)
+			Expect(err).NotTo(HaveOccurred())
 
 			vmiName := td.resource.cmd()
 			vmi = &kubevirtv1.VirtualMachineInstance{
@@ -1341,54 +1405,62 @@ passwd:
 					Name:      vmiName,
 				},
 			}
+
 			waitVirtualMachineInstanceReadiness(vmi)
 			Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
 
 			step := by(vmi.Name, "Login to virtual machine for the first time")
 			Eventually(func() error {
-				return kubevirt.LoginToFedora(vmi, "core", "fedora")
+				return kubevirt.LoginToFedora(vmi, "fedora", "fedora")
 			}).
 				WithTimeout(5*time.Second).
 				WithPolling(time.Second).
 				Should(Succeed(), step)
 
 			step = by(vmi.Name, "Wait for addresses at the virtual machine")
+
+			// expect 2 addresses on dual-stack deployments; 1 on single-stack
+			expectedNumberOfAddresses := len(strings.Split(netConfig.cidr, ","))
+			expectedAddreses := virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
+			expectedAddresesAtGuest := expectedAddreses
+			testPodsIPs := podsMultusNetworkIPs(iperfServerTestPods, podNetworkStatusByNetConfigPredicate(netConfig))
+
+			// IPv6 is not support for secondaries with IPAM so guest will
+			// have only ipv4.
 			if td.role != "primary" {
-				// expect 2 addresses on dual-stack deployments; 1 on single-stack
-				expectedNumberOfAddresses := len(strings.Split(netConfig.cidr, ","))
-				expectedAddreses = virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
-			} else {
-				expectedAddreses = virtualMachineAddressesFromGuest(vmi)
+				expectedAddresesAtGuest, err = util.MatchAllIPStringFamily(false /*ipv4*/, expectedAddreses)
+				Expect(err).NotTo(HaveOccurred())
+				testPodsIPs = filterOutIPv6(testPodsIPs)
 			}
 
+			Eventually(kubevirt.RetrieveAllGlobalAddressesFromGuest).
+				WithArguments(vmi).
+				WithTimeout(5*time.Second).
+				WithPolling(time.Second).
+				Should(ConsistOf(expectedAddresesAtGuest), step)
+
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
-			testPodsIPs := httpServerTestPodsMultusNetworkIPs(networkName)
 
-			//TODO: We do support it with primary, since passt do support it
-			// kubevirt secondary IPAM do not support IPv6, so guest is not
-			// going to have an ipv6 address at the interface
-			testPodsIPs = filterOutIPv6(testPodsIPs)
-
-			checkEastWestTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 
 			by(vmi.Name, fmt.Sprintf("Running %s for %s", td.test.description, td.resource.description))
 			td.test.cmd()
 
-			step = by(vm.Name, fmt.Sprintf("Login to virtual machine after %s %s", td.resource.description, td.test.description))
-			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
+			step = by(vmi.Name, fmt.Sprintf("Login to virtual machine after %s %s", td.resource.description, td.test.description))
+			Expect(kubevirt.LoginToFedora(vmi, "fedora", "fedora")).To(Succeed(), step)
 			var obtainedAddresses []string
 
-			if td.role != "primary" { // expect 2 addresses on dual-stack deployments; 1 on single-stack
-				expectedNumberOfAddresses := len(strings.Split(netConfig.cidr, ","))
-				obtainedAddresses = virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
-			} else {
-				obtainedAddresses = virtualMachineAddressesFromGuest(vmi)
-			}
+			obtainedAddresses = virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
 
 			Expect(obtainedAddresses).To(Equal(expectedAddreses))
+			Eventually(kubevirt.RetrieveAllGlobalAddressesFromGuest).
+				WithArguments(vmi).
+				WithTimeout(5*time.Second).
+				WithPolling(time.Second).
+				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
-			checkEastWestTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 		},
 			func(td testData) string {
 				role := "secondary"
@@ -1447,7 +1519,7 @@ passwd:
 			}),
 		)
 	})
-	Context("with kubevirt VM using layer2 UDPN", func() {
+	Context("with kubevirt VM using layer2 UDPN", Ordered, func() {
 		var (
 			podName                 = "virt-launcher-vm1"
 			cidrIPv4                = "10.128.0.0/24"
@@ -1474,6 +1546,9 @@ passwd:
 				return primaryUDNValueFor("device", field)
 			}
 		)
+		AfterAll(func() {
+			Expect(removeImagesInNodes(kubevirt.FakeLauncherImage)).To(Succeed())
+		})
 		BeforeEach(func() {
 			ns, err := fr.CreateNamespace(context.TODO(), fr.BaseName, map[string]string{
 				"e2e-framework":           fr.BaseName,
@@ -1501,13 +1576,13 @@ passwd:
 			By("Wait for virt-launcher pod to be ready and primary UDN network status to pop up")
 			waitForPodsCondition([]*corev1.Pod{kubevirtPod}, func(g Gomega, pod *corev1.Pod) {
 				ok, err := testutils.PodRunningReady(pod)
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(ok).To(BeTrue())
 
 				primaryUDNNetworkStatuses, err := podNetworkStatus(pod, func(networkStatus nadapi.NetworkStatus) bool {
 					return networkStatus.Default
 				})
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(primaryUDNNetworkStatuses).To(HaveLen(1))
 				primaryUDNNetworkStatus = primaryUDNNetworkStatuses[0]
 			})
@@ -1523,23 +1598,23 @@ passwd:
 
 			By("Reconfigure primary UDN interface to use dhcp/nd for ipv4 and ipv6")
 			_, err = virtLauncherCommand(kubevirt.GenerateAddressDiscoveryConfigurationCommand("ovn-udn1"))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 		})
 		It("should configure IPv4 and IPv6 using DHCP and NDP", func() {
 			dnsService, err := fr.ClientSet.CoreV1().Services(config.Kubernetes.DNSServiceNamespace).
 				Get(context.Background(), config.Kubernetes.DNSServiceName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			if isIPv4Supported() {
 				expectedIP, err := matchIPv4StringFamily(primaryUDNNetworkStatus.IPs)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				expectedDNS, err := matchIPv4StringFamily(dnsService.Spec.ClusterIPs)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				_, cidr, err := net.ParseCIDR(cidrIPv4)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				expectedGateway := util.GetNodeGatewayIfAddr(cidr).IP.String()
 
 				Eventually(primaryUDNValueForConnection).
@@ -1561,7 +1636,7 @@ passwd:
 
 			if isIPv6Supported() {
 				expectedIP, err := matchIPv6StringFamily(primaryUDNNetworkStatus.IPs)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(primaryUDNValueFor).
 					WithArguments("connection", "DHCP6.OPTION").
 					WithTimeout(10 * time.Second).

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/kubevirt"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +35,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	testutils "k8s.io/kubernetes/test/utils"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
@@ -305,6 +308,24 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 						WithTimeout(timeout).
 						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
 				}
+			}
+		}
+
+		checkNorthSouthIperfTraffic = func(containerName string, addresses []string, port int32, stage string) {
+			GinkgoHelper()
+			Expect(addresses).NotTo(BeEmpty())
+			polling := 15 * time.Second
+			timeout := time.Minute
+			for _, address := range addresses {
+				output := ""
+				Eventually(func() error {
+					var err error
+					output, err = runCommand(containerRuntime, "exec", containerName, "bash", "-c", fmt.Sprintf("iperf3 -t 1 -c %s -p %d", address, port))
+					return err
+				}).
+					WithPolling(polling).
+					WithTimeout(timeout).
+					Should(Succeed(), func() string { return stage + ": external server : " + output })
 			}
 		}
 
@@ -1043,6 +1064,15 @@ passwd:
 			}
 			return nil
 		}
+
+		createIperfExternalContainer = func(name string) {
+			createClusterExternalContainer(
+				name,
+				iperf3Image,
+				[]string{"--network", "kind", "--entrypoint", "/bin/bash"},
+				[]string{"-c", "sleep infinity"},
+			)
+		}
 	)
 	BeforeEach(func() {
 		// So we can use it at AfterEach, since fr.ClientSet is nil there
@@ -1272,9 +1302,12 @@ ethernets:
     dhcp4: true
     dhcp6: true
     ipv6-address-generation: eui64`
-			userData = `#cloud-config
+			userData = fmt.Sprintf(`#cloud-config
 password: fedora
-chpasswd: { expire: False }`
+chpasswd: { expire: False }
+runcmd:
+- iperf3 -s -D --logfile /tmp/iperf3.log
+`)
 			virtualMachine = resourceCommand{
 				description: "VirtualMachine",
 				cmd: func() string {
@@ -1353,6 +1386,13 @@ chpasswd: { expire: False }`
 			role        string
 		}
 		DescribeTable("should keep ip", func(td testData) {
+			if td.role == "primary" && !isInterconnectEnabled() {
+				const upstreamIssue = "https://github.com/ovn-org/ovn-kubernetes/issues/4528"
+				e2eskipper.Skipf(
+					"The egress check of tests are known to fail on non-IC deployments. Upstream issue: %s", upstreamIssue,
+				)
+			}
+
 			l := map[string]string{
 				"e2e-framework": fr.BaseName,
 			}
@@ -1398,6 +1438,14 @@ chpasswd: { expire: False }`
 			iperfServerTestPods, err = createIperfServerPods(selectedNodes, netConfig)
 			Expect(err).NotTo(HaveOccurred())
 
+			externalContainerName := namespace + "-iperf"
+			createIperfExternalContainer(externalContainerName)
+			DeferCleanup(func() {
+				if e2eframework.TestContext.DeleteNamespace && (e2eframework.TestContext.DeleteNamespaceOnFailure || !CurrentSpecReport().Failed()) {
+					deleteClusterExternalContainer(externalContainerName)
+				}
+			})
+
 			vmiName := td.resource.cmd()
 			vmi = &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1425,6 +1473,10 @@ chpasswd: { expire: False }`
 			expectedAddresesAtGuest := expectedAddreses
 			testPodsIPs := podsMultusNetworkIPs(iperfServerTestPods, podNetworkStatusByNetConfigPredicate(netConfig))
 
+			step = by(vmi.Name, "Expose VM iperf server as a service")
+			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("iperf3-vm-server", vm.Name, 5201), metav1.CreateOptions{})
+			Expect(svc.Spec.Ports[0].NodePort).NotTo(Equal(0), step)
+
 			// IPv6 is not support for secondaries with IPAM so guest will
 			// have only ipv4.
 			if td.role != "primary" {
@@ -1440,8 +1492,17 @@ chpasswd: { expire: False }`
 				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
-
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), fr.ClientSet, 1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nodeIPs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
+
+			if td.role == "primary" {
+				step = by(vmi.Name, fmt.Sprintf("Check north/south traffic before %s %s", td.resource.description, td.test.description))
+				checkNorthSouthIperfTraffic(externalContainerName, nodeIPs, svc.Spec.Ports[0].NodePort, step)
+			}
 
 			by(vmi.Name, fmt.Sprintf("Running %s for %s", td.test.description, td.resource.description))
 			td.test.cmd()
@@ -1461,6 +1522,10 @@ chpasswd: { expire: False }`
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			if td.role == "primary" {
+				step = by(vmi.Name, fmt.Sprintf("Check north/south traffic after %s %s", td.resource.description, td.test.description))
+				checkNorthSouthIperfTraffic(externalContainerName, nodeIPs, svc.Spec.Ports[0].NodePort, step)
+			}
 		},
 			func(td testData) string {
 				role := "secondary"

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -780,7 +780,7 @@ iperf3 -t 0 -c %[1]s -p %[2]d --logfile %[3]s &
 					Domain: kubevirtv1.DomainSpec{
 						Resources: kubevirtv1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("512Mi"),
+								corev1.ResourceMemory: resource.MustParse("1024Mi"),
 							},
 						},
 						Devices: kubevirtv1.Devices{

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1388,6 +1388,25 @@ fi
 					checkLiveMigrationSucceeded(vmi.Name, kubevirtv1.MigrationPreCopy)
 				},
 			}
+			liveMigrateFailed = testCommand{
+				description: "live migration failed",
+				cmd: func() {
+					forceLiveMigrationFailureAnnotationName := kubevirtv1.FuncTestForceLauncherMigrationFailureAnnotation
+					By(fmt.Sprintf("Forcing live migration failure by annotating VM with %s", forceLiveMigrationFailureAnnotationName))
+					vmiKey := types.NamespacedName{Namespace: namespace, Name: vmi.Name}
+					Eventually(func() error {
+						err := crClient.Get(context.TODO(), vmiKey, vmi)
+						if err == nil {
+							vmi.ObjectMeta.Annotations[forceLiveMigrationFailureAnnotationName] = "true"
+							err = crClient.Update(context.TODO(), vmi)
+						}
+						return err
+					}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+
+					liveMigrateVirtualMachine(vmi.Name)
+					checkLiveMigrationFailed(vmi.Name)
+				},
+			}
 			networkData = `version: 2
 ethernets:
   eth0:
@@ -1696,6 +1715,12 @@ runcmd:
 			Entry(nil, testData{
 				resource: virtualMachineInstanceWithUDN,
 				test:     liveMigrate,
+				topology: "layer2",
+				role:     "primary",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachineInstanceWithUDN,
+				test:     liveMigrateFailed,
 				topology: "layer2",
 				role:     "primary",
 			}),

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -291,22 +291,45 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			}
 		}
 
+		startEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, serverPodIPsByName map[string][]string, stage string) error {
+			GinkgoHelper()
+			Expect(serverPodIPsByName).NotTo(BeEmpty())
+			polling := 15 * time.Second
+			for podName, serverPodIPs := range serverPodIPsByName {
+				for _, serverPodIP := range serverPodIPs {
+					output, err := kubevirt.RunCommand(vmi, fmt.Sprintf("iperf3 -t 0 -c %[2]s --logfile /tmp/%[1]s_%[2]s_iperf3.log &", podName, serverPodIP), polling)
+					if err != nil {
+						return fmt.Errorf("%s: %w", output, err)
+					}
+				}
+			}
+			return nil
+		}
+
 		checkEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
 			GinkgoHelper()
-			Expect(podIPsByName).NotTo(BeEmpty())
-			polling := 15 * time.Second
-			timeout := time.Minute
 			for podName, podIPs := range podIPsByName {
 				for _, podIP := range podIPs {
-					output := ""
-					Eventually(func() error {
-						var err error
-						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("iperf3 -t 1 -c %s", podIP), polling)
-						return err
+					// Check the last line eventually show traffic flowing
+					Eventually(func() (string, error) {
+						iperfLog, err := kubevirt.RunCommand(vmi, fmt.Sprintf("cat /tmp/%s_%s_iperf3.log", podName, podIP), 2*time.Second)
+						if err != nil {
+							return "", err
+						}
+						iperfLogLines := strings.Split(iperfLog, "\n")
+						if len(iperfLogLines) == 0 {
+							return "", nil
+						}
+						return iperfLogLines[len(iperfLogLines)-1], nil
 					}).
-						WithPolling(polling).
-						WithTimeout(timeout).
-						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
+						WithPolling(time.Second).
+						WithTimeout(3 * time.Minute).
+						Should(
+							SatisfyAll(
+								ContainSubstring(" sec "),
+								Not(ContainSubstring("0.00 Bytes  0.00 bits/sec")),
+							),
+						)
 				}
 			}
 		}
@@ -974,6 +997,19 @@ passwd:
 			return pods
 		}
 
+		iperfServerScript = `
+dnf install -y psmisc procps
+iface=$(ifconfig  |grep flags |grep -v "eth0\|lo" | sed "s/: .*//")
+ipv4=$(ifconfig $iface | grep "inet "|awk '{print $2}'| sed "s#/.*##")
+ipv6=$(ifconfig $iface | grep inet6 |grep -v fe80 |awk '{print $2}'| sed "s#/.*##")
+if [ "$ipv4" != "" ]; then
+	iperf3 -s -D --bind $ipv4 --logfile /tmp/test_${ipv4}_iperf3.log
+fi
+if [ "$ipv6" != "" ]; then
+	iperf3 -s -D --bind $ipv6 --logfile /tmp/test_${ipv6}_iperf3.log
+fi
+sleep infinity
+`
 		createIperfServerPods = func(nodes []corev1.Node, netConfig networkAttachmentConfig) ([]*corev1.Pod, error) {
 			annotations := map[string]string{}
 			if netConfig.role != "primary" {
@@ -981,9 +1017,11 @@ passwd:
 			}
 			var pods []*corev1.Pod
 			for _, node := range nodes {
-				pod, err := createPod(fr, "testpod-"+node.Name, node.Name, namespace, []string{"iperf3", "-s"}, map[string]string{}, func(pod *corev1.Pod) {
+				pod, err := createPod(fr, "testpod-"+node.Name, node.Name, namespace, []string{"bash", "-c"}, map[string]string{}, func(pod *corev1.Pod) {
 					pod.Annotations = annotations
 					pod.Spec.Containers[0].Image = iperf3Image
+					pod.Spec.Containers[0].Args = []string{iperfServerScript}
+
 				})
 				if err != nil {
 					return nil, err
@@ -1484,6 +1522,7 @@ runcmd:
 				Expect(err).NotTo(HaveOccurred())
 				testPodsIPs = filterOutIPv6(testPodsIPs)
 			}
+			Expect(testPodsIPs).NotTo(BeEmpty())
 
 			Eventually(kubevirt.RetrieveAllGlobalAddressesFromGuest).
 				WithArguments(vmi).
@@ -1492,6 +1531,7 @@ runcmd:
 				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
+			Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 
 			nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), fr.ClientSet, 1)
@@ -1521,6 +1561,10 @@ runcmd:
 				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
+			if td.test.description == restart.description {
+				// At restart we need re-connect
+				Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
+			}
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 			if td.role == "primary" {
 				step = by(vmi.Name, fmt.Sprintf("Check north/south traffic after %s %s", td.resource.description, td.test.description))
@@ -1550,7 +1594,7 @@ runcmd:
 				topology: "layer2",
 				role:     "primary",
 			}),
-			Entry(nil, testData{
+			XEntry(nil, Label("TODO", "SDN-5490"), testData{
 				resource: virtualMachine,
 				test:     liveMigrate,
 				topology: "localnet",
@@ -1566,7 +1610,7 @@ runcmd:
 				topology: "layer2",
 				role:     "primary",
 			}),
-			Entry(nil, testData{
+			XEntry(nil, Label("TODO", "SDN-5490"), testData{
 				resource: virtualMachineInstance,
 				test:     liveMigrate,
 				topology: "localnet",

--- a/test/e2e/kubevirt/ip.go
+++ b/test/e2e/kubevirt/ip.go
@@ -1,0 +1,41 @@
+package kubevirt
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func RetrieveAllGlobalAddressesFromGuest(vmi *v1.VirtualMachineInstance) ([]string, error) {
+	ifaces := []struct {
+		Name      string `json:"ifname"`
+		Addresses []struct {
+			Family string `json:"family"`
+			Scope  string `json:"scope"`
+			Local  string `json:"local"`
+		} `json:"addr_info"`
+	}{}
+
+	output, err := RunCommand(vmi, "ip -j a show", 2*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving adresses with ip command: %s: %w", output, err)
+	}
+	if err := json.Unmarshal([]byte(output), &ifaces); err != nil {
+		return nil, fmt.Errorf("failed unmarshaling ip command addresses: %s: %w", output, err)
+	}
+	addresses := []string{}
+	for _, iface := range ifaces {
+		if iface.Name == "lo" {
+			continue
+		}
+		for _, address := range iface.Addresses {
+			if address.Scope != "global" {
+				continue
+			}
+			addresses = append(addresses, address.Local)
+		}
+	}
+	return addresses, nil
+}

--- a/test/e2e/kubevirt/ip.go
+++ b/test/e2e/kubevirt/ip.go
@@ -12,9 +12,10 @@ func RetrieveAllGlobalAddressesFromGuest(vmi *v1.VirtualMachineInstance) ([]stri
 	ifaces := []struct {
 		Name      string `json:"ifname"`
 		Addresses []struct {
-			Family string `json:"family"`
-			Scope  string `json:"scope"`
-			Local  string `json:"local"`
+			Family    string `json:"family"`
+			Scope     string `json:"scope"`
+			Local     string `json:"local"`
+			PrefixLen uint   `json:"prefixlen"`
 		} `json:"addr_info"`
 	}{}
 
@@ -31,7 +32,8 @@ func RetrieveAllGlobalAddressesFromGuest(vmi *v1.VirtualMachineInstance) ([]stri
 			continue
 		}
 		for _, address := range iface.Addresses {
-			if address.Scope != "global" {
+			// Skip non DHCPv6 address
+			if address.Family == "inet6" && address.PrefixLen != 128 {
 				continue
 			}
 			addresses = append(addresses, address.Local)

--- a/test/e2e/kubevirt/pod.go
+++ b/test/e2e/kubevirt/pod.go
@@ -20,7 +20,7 @@ func GenerateFakeVirtLauncherPod(namespace, vmName string) *corev1.Pod {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:  "compute",
-				Image: "quay.io/nmstate/c10s-nmstate-dev:latest",
+				Image: FakeLauncherImage,
 				SecurityContext: &corev1.SecurityContext{
 					Privileged: ptr.To(true),
 					Capabilities: &corev1.Capabilities{

--- a/test/e2e/kubevirt/types.go
+++ b/test/e2e/kubevirt/types.go
@@ -1,0 +1,7 @@
+package kubevirt
+
+const (
+	FedoraCoreOSContainerDiskImage = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
+	FedoraContainerDiskImage       = "quay.io/kubevirtci/fedora-with-test-tooling:v20241128-4d4c8fe"
+	FakeLauncherImage              = "quay.io/nmstate/c10s-nmstate-dev:latest"
+)

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -191,6 +191,16 @@ func podNetworkStatus(pod *v1.Pod, predicates ...func(nadapi.NetworkStatus) bool
 	return netStatusMeetingPredicates, nil
 }
 
+func podNetworkStatusByNetConfigPredicate(netConfig networkAttachmentConfig) func(nadapi.NetworkStatus) bool {
+	return func(networkStatus nadapi.NetworkStatus) bool {
+		if netConfig.role == "primary" {
+			return networkStatus.Default
+		} else {
+			return networkStatus.Name == netConfig.namespace+"/"+netConfig.name
+		}
+	}
+}
+
 func namespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }


### PR DESCRIPTION
## 📑 Description
This PR add e2e test to check tcp connection are not broken during live migration for UDN and north/south traffic for primary UDN.

TODO:
- [x] Don't use --one-off for iperf is not needed and complicate the tests.
- [x] Localnet e/w tcp connection get broken
   - Localnet + IPAM live migration is broken until we don't fix LSP enabled for localnet, let's mark the test.
- [x] non IC + local gw + layer2 + egress not working.
   - We should skip. 
- [x] n/s tcp connection broken at live migration with ipv6
   - Fixed with https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4774  
- [x] n/s tcp connection check

## Additional Information for reviewers
Depends-on:
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4773
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4774

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->
