### PR TITLE
Import learnt BGP routes into OVN

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -618,6 +618,10 @@ set_default_params() {
     echo "Route advertisements requires multi-network to be enabled (-mne)"
     exit 1
   fi
+  if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ] && [ "$OVN_ENABLE_INTERCONNECT" != true ]; then
+    echo "Route advertisements requires interconnect to be enabled (-ic)"
+    exit 1
+  fi
   OVN_COMPACT_MODE=${OVN_COMPACT_MODE:-false}
   if [ "$OVN_COMPACT_MODE" == true ]; then
     KIND_NUM_WORKER=0

--- a/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
+++ b/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
@@ -132,8 +132,4 @@ rules:
       resources:
           - frrconfigurations
       verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
-    - apiGroups: [ "k8s.cni.cncf.io" ]
-      resources:
-      - network-attachment-definitions
-      verbs: ["patch"]
     {%- endif %}

--- a/dist/templates/rbac-ovnkube-master.yaml.j2
+++ b/dist/templates/rbac-ovnkube-master.yaml.j2
@@ -85,7 +85,6 @@ rules:
           - adminpolicybasedexternalroutes
           - userdefinednetworks
           - clusteruserdefinednetworks
-          - routeadvertisements
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.cni.cncf.io"]
       resources:
@@ -120,7 +119,6 @@ rules:
           - clusteruserdefinednetworks
           - clusteruserdefinednetworks/status
           - clusteruserdefinednetworks/finalizers
-          - routeadvertisements/status
       verbs: [ "patch", "update" ]
     - apiGroups: [""]
       resources:
@@ -144,17 +142,6 @@ rules:
       resources:
           - dnsnameresolvers
       verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
-    {%- endif %}
-
-    {% if ovn_route_advertisements_enable == "true" -%}
-    - apiGroups: ["frrk8s.metallb.io"]
-      resources:
-          - frrconfigurations
-      verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
-    - apiGroups: [ "k8s.cni.cncf.io" ]
-      resources:
-      - network-attachment-definitions
-      verbs: ["patch"]
     {%- endif %}
 
 

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -602,6 +602,30 @@ func FindLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client, 
 	return found, err
 }
 
+// GetRouterLogicalRouterStaticRoutesWithPredicate looks up logical router
+// static routes associated to the provided logical router from the cache based
+// on a given predicate
+func GetRouterLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter, p logicalRouterStaticRoutePredicate) ([]*nbdb.LogicalRouterStaticRoute, error) {
+	r, err := GetLogicalRouter(nbClient, router)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get router: %s, error: %w", router.Name, err)
+	}
+
+	lrsrs := []*nbdb.LogicalRouterStaticRoute{}
+	for _, uuid := range r.StaticRoutes {
+		lrsr := &nbdb.LogicalRouterStaticRoute{UUID: uuid}
+		err := nbClient.Get(context.Background(), lrsr)
+		if err != nil {
+			return nil, err
+		}
+		if p(lrsr) {
+			lrsrs = append(lrsrs, lrsr)
+		}
+	}
+
+	return lrsrs, nil
+}
+
 // CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps looks up a logical
 // router static route from the cache based on a given predicate. If it does not
 // exist, it creates the provided logical router static route. If it does, it
@@ -664,25 +688,12 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 	lrsr *nbdb.LogicalRouterStaticRoute, p logicalRouterStaticRoutePredicate, fields ...interface{}) error {
 
 	lr := &nbdb.LogicalRouter{Name: routerName}
-	router, err := GetLogicalRouter(nbClient, lr)
-	if err != nil {
-		return fmt.Errorf("unable to get logical router %s: %w", routerName, err)
-	}
-	newPredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
-		for _, routeUUID := range router.StaticRoutes {
-			if routeUUID == item.UUID && p(item) {
-				return true
-			}
-		}
-		return false
-	}
-	routes, err := FindLogicalRouterStaticRoutesWithPredicate(nbClient, newPredicate)
+	routes, err := GetRouterLogicalRouterStaticRoutesWithPredicate(nbClient, lr, p)
 	if err != nil {
 		return fmt.Errorf("unable to get logical router static routes with predicate on router %s: %w", routerName, err)
 	}
 
 	var ops []libovsdb.Operation
-	m := newModelClient(nbClient)
 
 	if len(routes) > 0 {
 		lrsr.UUID = routes[0].UUID
@@ -691,27 +702,7 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 	if len(routes) > 1 {
 		// should only be a single route remove all except the first
 		routes = routes[1:]
-		opModels := make([]operationModel, 0, len(routes)+1)
-		router.StaticRoutes = []string{}
-		for _, route := range routes {
-			route := route
-			router.StaticRoutes = append(router.StaticRoutes, route.UUID)
-			opModel := operationModel{
-				Model:       route,
-				ErrNotFound: false,
-				BulkOp:      false,
-			}
-			opModels = append(opModels, opModel)
-		}
-		opModel := operationModel{
-			Model:            router,
-			OnModelMutations: []interface{}{&router.StaticRoutes},
-			ErrNotFound:      true,
-			BulkOp:           false,
-		}
-		opModels = append(opModels, opModel)
-
-		ops, err = m.DeleteOps(nil, opModels...)
+		ops, err = DeleteLogicalRouterStaticRoutesOps(nbClient, ops, routerName, routes...)
 		if err != nil {
 			return err
 		}
@@ -768,9 +759,9 @@ func DeleteLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbclient.Cli
 	return m.DeleteOps(ops, opModels...)
 }
 
-// DeleteLogicalRouterStaticRoutes deletes the logical router static routes and
-// removes them from the provided logical router
-func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName string, lrsrs ...*nbdb.LogicalRouterStaticRoute) error {
+// DeleteLogicalRouterStaticRoutesOps deletes the logical router static routes and
+// returns the ops to remove them from the provided logical router
+func DeleteLogicalRouterStaticRoutesOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrsrs ...*nbdb.LogicalRouterStaticRoute) ([]libovsdb.Operation, error) {
 	router := &nbdb.LogicalRouter{
 		Name:         routerName,
 		StaticRoutes: make([]string, 0, len(lrsrs)),
@@ -780,24 +771,31 @@ func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName 
 	for _, lrsr := range lrsrs {
 		lrsr := lrsr
 		router.StaticRoutes = append(router.StaticRoutes, lrsr.UUID)
-		opModel := operationModel{
-			Model:       lrsr,
-			ErrNotFound: false,
-			BulkOp:      false,
-		}
-		opModels = append(opModels, opModel)
 	}
 
 	opModel := operationModel{
 		Model:            router,
 		OnModelMutations: []interface{}{&router.StaticRoutes},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
 
 	m := newModelClient(nbClient)
-	return m.Delete(opModels...)
+	return m.DeleteOps(ops, opModels...)
+}
+
+// DeleteLogicalRouterStaticRoutes deletes the logical router static routes and
+// removes them from the provided logical router
+func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName string, lrsrs ...*nbdb.LogicalRouterStaticRoute) error {
+	var ops []libovsdb.Operation
+	var err error
+	ops, err = DeleteLogicalRouterStaticRoutesOps(nbClient, ops, routerName, lrsrs...)
+	if err != nil {
+		return err
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
 }
 
 // BFD ops

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/observability"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/routeimport"
 	zoneic "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
 	ovnretry "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
@@ -177,6 +178,8 @@ type BaseNetworkController struct {
 	ovnClusterLRPToJoinIfAddrs []*net.IPNet
 
 	observManager *observability.Manager
+
+	routeImportManager routeimport.Manager
 }
 
 // BaseSecondaryNetworkController structure holds per-network fields and network specific

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -378,7 +378,7 @@ func NewOvnController(
 		return nil, err
 	}
 
-	dnc, err := newDefaultNetworkControllerCommon(cnci, stopChan, wg, addressSetFactory, networkManager, nil, eIPController, portCache)
+	dnc, err := newDefaultNetworkControllerCommon(cnci, stopChan, wg, addressSetFactory, networkManager, nil, nil, eIPController, portCache)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	if nbZoneFailed {

--- a/go-controller/pkg/ovn/routeimport/route_import.go
+++ b/go-controller/pkg/ovn/routeimport/route_import.go
@@ -1,0 +1,569 @@
+package routeimport
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	controllerutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/controller"
+	nbdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
+)
+
+const (
+	subscribePeriod         = 1 * time.Second
+	subscribeBuffer         = 100
+	reconcileDelay          = 500 * time.Millisecond
+	noTable                 = -1
+	controllerExternalIDKey = string(nbdbops.OwnerControllerKey)
+	controllerName          = "RouteImport"
+)
+
+type Manager interface {
+	// AddNetwork instructs the manager to continously reconcile BGP routes from
+	// the network host vrf to the network gateway router. A network can only be
+	// added once otherwise an error will be returned.
+	AddNetwork(network util.NetInfo) error
+
+	// NeedsReconciliation checks the provided network information against the
+	// stored one and returns whether there is any change requires
+	// reconciliation. If the network is not known to the manager, it returns
+	// false.
+	NeedsReconciliation(network util.NetInfo) bool
+
+	// ReconcileNetwork triggers a manual reconciliation.
+	ReconcileNetwork(name string) error
+
+	// ForgetNetwork instructs the manager to stop reconciling BGP routes from
+	// the network host vrf to the network gateway router.
+	ForgetNetwork(name string)
+}
+
+type Controller interface {
+	Manager
+	Start() error
+	Stop()
+}
+
+func New(node string, nbClient client.Client) Controller {
+	c := &controller{
+		ctx:        util.NewCancelableContext(),
+		node:       node,
+		nbClient:   nbClient,
+		networkIDs: map[int]string{},
+		networks:   map[string]*netInfo{},
+		tables:     map[int]int{},
+		log:        klog.LoggerWithName(klog.Background(), controllerName),
+		netlink:    util.GetNetLinkOps(),
+	}
+
+	c.reconciler = controllerutil.NewReconciler(
+		controllerName,
+		&controllerutil.ReconcilerConfig{
+			Threadiness: 1,
+			Reconcile:   c.syncNetwork,
+			RateLimiter: workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
+		},
+	)
+
+	return c
+}
+
+type netInfo struct {
+	util.NetInfo
+	id    int
+	table int
+}
+
+type controller struct {
+	ctx        util.CancelableContext
+	nbClient   client.Client
+	node       string
+	log        logr.Logger
+	reconciler controllerutil.Reconciler
+	netlink    util.NetLinkOps
+
+	sync.RWMutex
+	networkIDs map[int]string
+	networks   map[string]*netInfo
+	tables     map[int]int
+}
+
+func (c *controller) AddNetwork(network util.NetInfo) error {
+	c.Lock()
+	defer c.Unlock()
+
+	networkID := network.GetNetworkID()
+	if c.networkIDs[networkID] != "" {
+		return fmt.Errorf("already tracking network %q with ID %d",
+			c.networkIDs[networkID],
+			networkID,
+		)
+	}
+
+	name := network.GetNetworkName()
+	if c.networks[name] != nil {
+		// this shouldn't happen as the network ID is correlated uniquely with
+		// the network name, but do the check anyway in case this is not being
+		// handled correctly
+		return fmt.Errorf("already tracking network name %q", name)
+	}
+
+	info := &netInfo{NetInfo: network, id: networkID, table: noTable}
+	if network.IsDefault() {
+		c.tables[unix.RT_TABLE_MAIN] = networkID
+		info.table = unix.RT_TABLE_MAIN
+	}
+	c.networkIDs[networkID] = name
+	c.networks[name] = info
+
+	c.log.V(5).Info("Started tracking network", "name", name, "id", networkID)
+	c.reconcile(name)
+
+	return nil
+}
+
+func (c *controller) ForgetNetwork(name string) {
+	c.Lock()
+	defer c.Unlock()
+
+	network := c.networks[name]
+	if network == nil {
+		return
+	}
+
+	delete(c.networkIDs, network.id)
+	delete(c.networks, name)
+
+	c.log.V(5).Info("Stopped tracking network", "name", name)
+}
+
+func (c *controller) NeedsReconciliation(network util.NetInfo) bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.networks[network.GetNetworkName()] == nil {
+		return false
+	}
+
+	// TODO check if overlay mode changed
+	return false
+}
+
+func (c *controller) ReconcileNetwork(name string) error {
+	c.RLock()
+	defer c.RUnlock()
+	if c.networks[name] == nil {
+		return fmt.Errorf("unknown network with name %q", name)
+	}
+	c.log.V(5).Info("Reconciling network", "name", name)
+	c.reconcile(name)
+	return nil
+}
+
+func (c *controller) Start() error {
+	defer c.log.Info("Controller started")
+	c.subscribe(c.ctx.Done())
+	return controllerutil.Start(c.reconciler)
+}
+
+func (c *controller) Stop() {
+	controllerutil.Stop(c.reconciler)
+	c.ctx.Cancel()
+	c.log.Info("Controller stopped")
+}
+
+func (c *controller) subscribe(stop <-chan struct{}) {
+	// helper function to set a new timer or reset an existing timer
+	setTimer := func(t *time.Timer, d time.Duration) *time.Timer {
+		if t == nil {
+			return time.NewTimer(d)
+		}
+		t.Stop()
+		select {
+		case <-t.C:
+		default:
+		}
+		t.Reset(d)
+		return t
+	}
+
+	go func() {
+		onError := func(err error) {
+			c.log.Error(err, "Error on netlink route event subscription")
+		}
+		routeEventCh := subscribeNetlinkRouteEvents(c.netlink, stop, onError)
+		t := setTimer(nil, subscribePeriod)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				if routeEventCh != nil {
+					continue
+				}
+				routeEventCh = subscribeNetlinkRouteEvents(c.netlink, stop, onError)
+				if routeEventCh == nil {
+					t = setTimer(t, subscribePeriod)
+				}
+			case r, open := <-routeEventCh:
+				if !open {
+					c.log.Info("Subscription to netlink route events closed")
+					routeEventCh = nil
+					t = setTimer(t, subscribePeriod)
+					continue
+				}
+				c.log.V(5).Info("Received route event", "event", r)
+				c.syncRouteUpdate(&r)
+			}
+		}
+	}()
+
+	go func() {
+		onError := func(err error) {
+			c.log.Error(err, "Error on netlink link event subscription")
+		}
+		linkEventCh := subscribeNetlinkLinkEvents(c.netlink, stop, onError)
+		t := setTimer(nil, subscribePeriod)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				if linkEventCh != nil {
+					continue
+				}
+				linkEventCh = subscribeNetlinkLinkEvents(c.netlink, stop, onError)
+				if linkEventCh == nil {
+					t = setTimer(t, subscribePeriod)
+					continue
+				}
+				c.tables = map[int]int{}
+			case l, open := <-linkEventCh:
+				if !open {
+					c.log.Info("Subscription to netlink link events closed")
+					linkEventCh = nil
+					t = setTimer(t, subscribePeriod)
+					continue
+				}
+				c.log.V(5).Info("Received link event", "event", l)
+				c.syncLinkUpdate(&l)
+			}
+		}
+	}()
+}
+
+func (c *controller) syncRouteUpdate(update *netlink.RouteUpdate) {
+	if update.Protocol != unix.RTPROT_BGP {
+		return
+	}
+
+	table := update.Table
+	network := c.getNetworkForTable(table)
+	if network != nil {
+		c.reconcile(network.GetNetworkName())
+	}
+}
+
+func (c *controller) syncLinkUpdate(update *netlink.LinkUpdate) {
+	vrf, isVrf := update.Link.(*netlink.Vrf)
+	if !isVrf {
+		return
+	}
+
+	name := vrf.Name
+	if !strings.HasPrefix(name, types.UDNVRFDevicePrefix) {
+		return
+	}
+	if !strings.HasSuffix(name, types.UDNVRFDeviceSuffix) {
+		return
+	}
+
+	id, err := strconv.Atoi(name[len(types.UDNVRFDevicePrefix) : len(name)-len(types.UDNVRFDeviceSuffix)])
+	if err != nil {
+		c.log.Error(err, "Failed to parse network ID from device name", "name", name)
+		return
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	table := int(vrf.Table)
+	network := c.networkIDs[id]
+	info := c.networks[network]
+	current := c.tables[table] == id
+	var old int
+	if info != nil {
+		old = info.table
+	}
+
+	switch update.IfInfomsg.Type {
+	case unix.RTM_DELLINK:
+		if !current {
+			c.log.Info("Ignoring VRF delete for old network", "network", id)
+			return
+		}
+		delete(c.tables, table)
+		table = noTable
+	case unix.RTM_NEWLINK:
+		delete(c.tables, old)
+		c.tables[table] = id
+	default:
+		c.log.Info("Unexpected VRF update event type", "type", update.IfInfomsg.Type)
+		return
+	}
+	if info != nil {
+		info.table = table
+	}
+
+	needsReconcile := info != nil && table != noTable && !current
+
+	c.log.V(5).Info("Associated table with network", "table", table, "network", id, "needsReconcile", needsReconcile)
+	if needsReconcile {
+		c.reconcile(network)
+	}
+}
+
+func (c *controller) reconcile(network string) {
+	c.reconciler.ReconcileAfter(network, reconcileDelay)
+}
+
+type route struct {
+	dst string
+	gw  string
+}
+
+type stringer struct {
+	v any
+}
+
+func (s stringer) String() string {
+	return fmt.Sprintf("%v", s.v)
+}
+
+func (c *controller) syncNetwork(network string) error {
+	start := time.Now()
+	c.log.V(5).Info("Reconciling network", "network", network)
+
+	info := c.getNetwork(network)
+	if info == nil {
+		return nil
+	}
+	router := info.GetNetworkScopedGWRouterName(c.node)
+
+	// skip routes in the pod network
+	// TODO do not skip these routes in no overlay mode
+	ignoreSubnets := make([]*net.IPNet, len(info.Subnets()))
+	for i, subnet := range info.Subnets() {
+		ignoreSubnets[i] = subnet.CIDR
+	}
+
+	table := c.getTableForNetwork(info.id)
+	if table == noTable {
+		return nil
+	}
+
+	expected, err := c.getBGPRoutes(table, ignoreSubnets)
+	if err != nil {
+		return err
+	}
+
+	actual, uuids, err := c.getOVNRoutes(router)
+	if err != nil {
+		return fmt.Errorf("failed to get routes from OVN: %w", err)
+	}
+
+	deletes := actual.Difference(expected)
+	adds := expected.Difference(actual)
+	if len(deletes)+len(adds) == 0 {
+		c.log.V(5).Info("Found no updates for router", "router", router)
+		return nil
+	}
+	c.log.V(5).Info("Found updates for router", "router", router, "adds", stringer{adds}, "deletes", stringer{deletes})
+
+	var errs []error
+	var ops []ovsdb.Operation
+
+	p := func(new, db *nbdb.LogicalRouterStaticRoute) bool {
+		return db.ExternalIDs[controllerExternalIDKey] == controllerName && db.IPPrefix == new.IPPrefix && db.Nexthop == new.Nexthop
+	}
+	for add := range adds {
+		lrsr := &nbdb.LogicalRouterStaticRoute{
+			UUID:        uuids[add],
+			IPPrefix:    add.dst,
+			Nexthop:     add.gw,
+			ExternalIDs: map[string]string{controllerExternalIDKey: controllerName},
+		}
+		p := func(db *nbdb.LogicalRouterStaticRoute) bool { return p(lrsr, db) }
+		ops, err = nbdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, router, lrsr, p)
+		if err != nil {
+			err := fmt.Errorf("failed to add routes on router %s: %w", router, err)
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	lrsrs := make([]*nbdb.LogicalRouterStaticRoute, 0, len(deletes))
+	for delete := range deletes {
+		lrsrs = append(lrsrs, &nbdb.LogicalRouterStaticRoute{UUID: uuids[delete]})
+	}
+	if len(lrsrs) > 0 {
+		ops, err = nbdbops.DeleteLogicalRouterStaticRoutesOps(c.nbClient, ops, router, lrsrs...)
+		if err != nil {
+			err := fmt.Errorf("failed to delete routes on router %s: %w", router, err)
+			errs = append(errs, err)
+		}
+	}
+
+	_, err = nbdbops.TransactAndCheck(c.nbClient, ops)
+	if err != nil {
+		err := fmt.Errorf("failed to transact ops %v: %w", ops, err)
+		errs = append(errs, err)
+	}
+
+	err = errors.Join(errs...)
+	c.log.V(5).Info("Reconciled network", "network", network, "took", time.Since(start), "ops", ops, "errors", err)
+	return err
+}
+
+func (c *controller) getBGPRoutes(table int, ignoreSubnets []*net.IPNet) (sets.Set[route], error) {
+	start := time.Now()
+	filter := &netlink.Route{
+		Protocol: unix.RTPROT_BGP,
+		Table:    table,
+	}
+	nlroutes, err := c.netlink.RouteListFiltered(netlink.FAMILY_ALL, filter, netlink.RT_FILTER_PROTOCOL|netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list BGP routes: %w", err)
+	}
+
+	routes := sets.New[route]()
+	for _, nlroute := range nlroutes {
+		if util.IsContainedInAnyCIDR(nlroute.Dst, ignoreSubnets...) {
+			continue
+		}
+		routes.Insert(routesFromNetlinkRoute(&nlroute)...)
+	}
+
+	c.log.V(5).Info("Listed BGP routes", "table", table, "routes", stringer{routes}, "took", time.Since(start))
+	return routes, nil
+}
+
+func (c *controller) getOVNRoutes(router string) (sets.Set[route], map[route]string, error) {
+	start := time.Now()
+	lr := &nbdb.LogicalRouter{
+		Name: router,
+	}
+	p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+		return lrsr.ExternalIDs[controllerExternalIDKey] == controllerName
+	}
+	lrsrs, err := nbdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(c.nbClient, lr, p)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get routes from router %s: %w", router, err)
+	}
+	uuids := make(map[route]string, len(lrsrs))
+	routes := make(sets.Set[route], len(lrsrs))
+	for _, lrsr := range lrsrs {
+		r := route{dst: lrsr.IPPrefix, gw: lrsr.Nexthop}
+		routes.Insert(r)
+		uuids[r] = lrsr.UUID
+	}
+	c.log.V(5).Info("Listed OVN routes", "router", router, "routes", stringer{routes}, "took", time.Since(start))
+	return routes, uuids, nil
+}
+
+func (c *controller) getNetwork(network string) *netInfo {
+	c.RLock()
+	defer c.RUnlock()
+	return c.networks[network]
+}
+
+func (c *controller) getTableForNetwork(network int) int {
+	c.RLock()
+	defer c.RUnlock()
+	if info := c.networks[c.networkIDs[network]]; info != nil {
+		return info.table
+	}
+	return noTable
+}
+
+func (c *controller) getNetworkForTable(table int) *netInfo {
+	c.RLock()
+	defer c.RUnlock()
+	if network, known := c.tables[table]; known {
+		return c.networks[c.networkIDs[network]]
+	}
+	return nil
+}
+
+func routesFromNetlinkRoute(r *netlink.Route) []route {
+	validIP := func(ip string) bool {
+		if ip == "" || ip == "<nil>" {
+			return false
+		}
+		return true
+	}
+	if r.Dst == nil {
+		return nil
+	}
+	dst := r.Dst.String()
+	if !validIP(dst) {
+		return nil
+	}
+	var routes []route
+	gw := r.Gw.String()
+	if validIP(gw) {
+		routes = append(routes, route{dst: dst, gw: gw})
+	}
+	for _, nh := range r.MultiPath {
+		gw = nh.Gw.String()
+		if validIP(gw) {
+			routes = append(routes, route{dst: dst, gw: gw})
+		}
+	}
+	return routes
+}
+
+func subscribeNetlinkRouteEvents(nlops util.NetLinkOps, stopCh <-chan struct{}, onError func(error)) chan netlink.RouteUpdate {
+	routeEventCh := make(chan netlink.RouteUpdate, subscribeBuffer)
+	options := netlink.RouteSubscribeOptions{
+		ErrorCallback: onError,
+		ListExisting:  true,
+	}
+	err := nlops.RouteSubscribeWithOptions(routeEventCh, stopCh, options)
+	if err != nil {
+		onError(err)
+		return nil
+	}
+	return routeEventCh
+}
+
+func subscribeNetlinkLinkEvents(nlops util.NetLinkOps, stopCh <-chan struct{}, onError func(error)) chan netlink.LinkUpdate {
+	linkEventCh := make(chan netlink.LinkUpdate, subscribeBuffer)
+	options := netlink.LinkSubscribeOptions{
+		ErrorCallback: onError,
+		ListExisting:  true,
+	}
+	if err := nlops.LinkSubscribeWithOptions(linkEventCh, stopCh, options); err != nil {
+		onError(err)
+		return nil
+	}
+	return linkEventCh
+}

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -1,0 +1,469 @@
+package routeimport
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+	"k8s.io/client-go/util/workqueue"
+
+	controllerutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/controller"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	ovntesting "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
+)
+
+func Test_controller_syncNetwork(t *testing.T) {
+	node := "testnode"
+	defaultNetwork := &util.DefaultNetInfo{}
+	type fields struct {
+		networkIDs map[int]string
+		networks   map[string]*netInfo
+		tables     map[int]int
+	}
+	type args struct {
+		network string
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		initial   []libovsdb.TestData
+		expected  []libovsdb.TestData
+		routes    []netlink.Route
+		routesErr bool
+		wantErr   bool
+	}{
+		{
+			name: "reconciled ignored if network not known",
+			args: args{"default"},
+		},
+		{
+			name: "reconciled ignored if network table not known",
+			args: args{"default"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default"},
+				networks:   map[string]*netInfo{"default": {NetInfo: defaultNetwork, id: noTable}},
+			},
+		},
+		{
+			name: "fails if kernel routes cannot be fetched",
+			args: args{"default"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default"},
+				networks:   map[string]*netInfo{"default": {NetInfo: defaultNetwork, id: 0, table: unix.RT_TABLE_MAIN}},
+			},
+			routesErr: true,
+			wantErr:   true,
+		},
+		{
+			name: "fails if OVN routes cannot be fetched (i.e. router does not exist)",
+			args: args{"default"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default"},
+				networks:   map[string]*netInfo{"default": {NetInfo: defaultNetwork, id: 0, table: unix.RT_TABLE_MAIN}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "adds and removes routes as necessary",
+			args: args{"default"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default"},
+				networks:   map[string]*netInfo{"default": {NetInfo: defaultNetwork, id: 0, table: unix.RT_TABLE_MAIN}},
+			},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: defaultNetwork.GetNetworkScopedGWRouterName(node), StaticRoutes: []string{"keep-1", "keep-2", "remove"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-2", IPPrefix: "5.5.5.0/24", Nexthop: "5.5.5.1"},
+				&nbdb.LogicalRouterStaticRoute{UUID: "remove", IPPrefix: "6.6.6.0/24", Nexthop: "6.6.6.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("2.2.2.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+				{Dst: ovntesting.MustParseIPNet("3.3.3.0/24"), MultiPath: []*netlink.NexthopInfo{{Gw: ovntesting.MustParseIP("3.3.3.1")}, {Gw: ovntesting.MustParseIP("3.3.3.2")}}},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: defaultNetwork.GetNetworkScopedGWRouterName(node), StaticRoutes: []string{"keep-1", "keep-2", "add-1", "add-2", "add-3"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-2", IPPrefix: "5.5.5.0/24", Nexthop: "5.5.5.1"},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "2.2.2.0/24", Nexthop: "2.2.2.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-2", IPPrefix: "3.3.3.0/24", Nexthop: "3.3.3.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-3", IPPrefix: "3.3.3.0/24", Nexthop: "3.3.3.2", ExternalIDs: map[string]string{"controller": "routeimport"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			nlmock := &mocks.NetLinkOps{}
+			if info := tt.fields.networks[tt.args.network]; info != nil && info.table != 0 {
+				matchFilter := func(r *netlink.Route) bool {
+					return r != nil && r.Equal(netlink.Route{Protocol: unix.RTPROT_BGP, Table: info.table})
+				}
+				nlcall := nlmock.On("RouteListFiltered", netlink.FAMILY_ALL, mock.MatchedBy(matchFilter), netlink.RT_FILTER_PROTOCOL|netlink.RT_FILTER_TABLE)
+				if tt.routesErr {
+					nlcall.Return(nil, errors.New("test error"))
+				} else {
+					nlcall.Return(tt.routes, nil)
+				}
+			}
+
+			client, ctx, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: tt.initial}, nil)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			t.Cleanup(ctx.Cleanup)
+
+			c := &controller{
+				nbClient:   client,
+				node:       node,
+				log:        testr.New(t),
+				networkIDs: tt.fields.networkIDs,
+				networks:   tt.fields.networks,
+				tables:     tt.fields.tables,
+				netlink:    nlmock,
+			}
+
+			err = c.syncNetwork(tt.args.network)
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(client).To(libovsdb.HaveData(tt.expected...))
+		})
+	}
+}
+
+func Test_controller_syncRouteUpdate(t *testing.T) {
+	defaultNetwork := &util.DefaultNetInfo{}
+	type fields struct {
+		networkIDs map[int]string
+		networks   map[string]*netInfo
+		tables     map[int]int
+	}
+	type args struct {
+		update *netlink.RouteUpdate
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		expected []string
+	}{
+		{
+			name: "ignores route updates with protocol != BGP",
+			args: args{&netlink.RouteUpdate{Route: netlink.Route{Protocol: unix.RTPROT_STATIC}}},
+		},
+		{
+			name: "ignores route updates for unknown tables",
+			args: args{&netlink.RouteUpdate{Route: netlink.Route{Protocol: unix.RTPROT_BGP, Table: unix.RT_TABLE_UNSPEC}}},
+		},
+		{
+			name:   "ignores route updates for unknown networks",
+			fields: fields{tables: map[int]int{unix.RT_TABLE_MAIN: 0}},
+			args:   args{&netlink.RouteUpdate{Route: netlink.Route{Protocol: unix.RTPROT_BGP, Table: unix.RT_TABLE_MAIN}}},
+		},
+		{
+			name: "processes route updates",
+			fields: fields{
+				networkIDs: map[int]string{0: "default"},
+				networks:   map[string]*netInfo{"default": {NetInfo: defaultNetwork, id: 0, table: unix.RT_TABLE_MAIN}},
+				tables:     map[int]int{unix.RT_TABLE_MAIN: 0},
+			},
+			args:     args{&netlink.RouteUpdate{Route: netlink.Route{Protocol: unix.RTPROT_BGP, Table: unix.RT_TABLE_MAIN}}},
+			expected: []string{"default"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			var reconciled []string
+			var m sync.Mutex
+			reconcile := func(key string) error {
+				m.Lock()
+				defer m.Unlock()
+				reconciled = append(reconciled, key)
+				return nil
+			}
+			matchReconcile := func(g gomega.Gomega, expected []string) {
+				m.Lock()
+				defer m.Unlock()
+				g.Expect(reconciled).To(gomega.Equal(expected))
+			}
+			r := controllerutil.NewReconciler(
+				"test",
+				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemFastSlowRateLimiter[string](0, 0, 0)})
+			c := &controller{
+				log:        testr.New(t),
+				networkIDs: tt.fields.networkIDs,
+				networks:   tt.fields.networks,
+				tables:     tt.fields.tables,
+				reconciler: r,
+			}
+			err := controllerutil.Start(r)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+
+			c.syncRouteUpdate(tt.args.update)
+
+			g.Eventually(matchReconcile).WithArguments(tt.expected).Should(gomega.Succeed())
+			g.Consistently(matchReconcile).WithArguments(tt.expected).Should(gomega.Succeed())
+		})
+	}
+}
+
+func Test_controller_syncLinkUpdate(t *testing.T) {
+	someNetwork := &util.DefaultNetInfo{}
+	type fields struct {
+		networkIDs map[int]string
+		networks   map[string]*netInfo
+		tables     map[int]int
+	}
+	type args struct {
+		update *netlink.LinkUpdate
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		expectTables     map[int]int
+		expectReconciles []string
+	}{
+		{
+			name: "ignores link updates with type != VRF",
+			args: args{&netlink.LinkUpdate{Link: &netlink.Dummy{}}},
+		},
+		{
+			name: "ignores link updates with incorrect prefix",
+			args: args{&netlink.LinkUpdate{Link: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "something10" + types.UDNVRFDeviceSuffix}}}},
+		},
+		{
+			name: "ignores link updates with incorrect suffix",
+			args: args{&netlink.LinkUpdate{Link: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "10-something"}}}},
+		},
+		{
+			name: "ignores link updates with incorrect format",
+			args: args{&netlink.LinkUpdate{Link: &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "something" + types.UDNVRFDeviceSuffix}}}},
+		},
+		{
+			name: "ignores unknown event types",
+			fields: fields{
+				networkIDs: map[int]string{1: "net1"},
+				networks:   map[string]*netInfo{"net1": {NetInfo: someNetwork, id: 1, table: 2}},
+				tables:     map[int]int{2: 1},
+			},
+			args: args{&netlink.LinkUpdate{
+				IfInfomsg: nl.IfInfomsg{IfInfomsg: unix.IfInfomsg{Type: unix.RTM_BASE}},
+				Link:      &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "1" + types.UDNVRFDeviceSuffix}, Table: 2}},
+			},
+			expectTables: map[int]int{2: 1},
+		},
+		{
+			name: "ignores removal of old VRFs",
+			fields: fields{
+				networkIDs: map[int]string{1: "net1", 2: "net2"},
+				networks:   map[string]*netInfo{"net1": {NetInfo: someNetwork, id: 1, table: 2}, "net2": {NetInfo: someNetwork, id: 2, table: 2}},
+				tables:     map[int]int{2: 2},
+			},
+			args: args{&netlink.LinkUpdate{
+				IfInfomsg: nl.IfInfomsg{IfInfomsg: unix.IfInfomsg{Type: unix.RTM_DELLINK}},
+				Link:      &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "1" + types.UDNVRFDeviceSuffix}, Table: 2}},
+			},
+			expectTables: map[int]int{2: 2},
+		},
+		{
+			name: "processes link removals",
+			fields: fields{
+				networkIDs: map[int]string{1: "net1"},
+				networks:   map[string]*netInfo{"net1": {NetInfo: someNetwork, id: 1, table: 2}},
+				tables:     map[int]int{2: 1},
+			},
+			args: args{&netlink.LinkUpdate{
+				IfInfomsg: nl.IfInfomsg{IfInfomsg: unix.IfInfomsg{Type: unix.RTM_DELLINK}},
+				Link:      &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "1" + types.UDNVRFDeviceSuffix}, Table: 2}},
+			},
+			expectTables: map[int]int{},
+		},
+		{
+			name: "does not reconcile on link updates with no actual changes",
+			fields: fields{
+				networkIDs: map[int]string{1: "net1"},
+				networks:   map[string]*netInfo{"net1": {NetInfo: someNetwork, id: 1, table: 2}},
+				tables:     map[int]int{2: 1},
+			},
+			args: args{&netlink.LinkUpdate{
+				IfInfomsg: nl.IfInfomsg{IfInfomsg: unix.IfInfomsg{Type: unix.RTM_NEWLINK}},
+				Link:      &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "1" + types.UDNVRFDeviceSuffix}, Table: 2}},
+			},
+			expectTables: map[int]int{2: 1},
+		},
+		{
+			name: "does reconcile on link updates with actual changes",
+			fields: fields{
+				networkIDs: map[int]string{1: "net1"},
+				networks:   map[string]*netInfo{"net1": {NetInfo: someNetwork, id: 1, table: 2}},
+				tables:     map[int]int{2: 1},
+			},
+			args: args{&netlink.LinkUpdate{
+				IfInfomsg: nl.IfInfomsg{IfInfomsg: unix.IfInfomsg{Type: unix.RTM_NEWLINK}},
+				Link:      &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: types.UDNVRFDevicePrefix + "1" + types.UDNVRFDeviceSuffix}, Table: 3}},
+			},
+			expectTables:     map[int]int{3: 1},
+			expectReconciles: []string{"net1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			var reconciled []string
+			var m sync.Mutex
+			reconcile := func(key string) error {
+				m.Lock()
+				defer m.Unlock()
+				reconciled = append(reconciled, key)
+				return nil
+			}
+			matchReconcile := func(g gomega.Gomega, expected []string) {
+				m.Lock()
+				defer m.Unlock()
+				g.Expect(reconciled).To(gomega.Equal(expected))
+			}
+			r := controllerutil.NewReconciler(
+				"test",
+				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemFastSlowRateLimiter[string](0, 0, 0)})
+			c := &controller{
+				log:        testr.New(t),
+				networkIDs: tt.fields.networkIDs,
+				networks:   tt.fields.networks,
+				tables:     tt.fields.tables,
+				reconciler: r,
+			}
+			err := controllerutil.Start(r)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+
+			c.syncLinkUpdate(tt.args.update)
+
+			g.Expect(c.tables).To(gomega.Equal(tt.expectTables))
+			g.Eventually(matchReconcile).WithArguments(tt.expectReconciles).Should(gomega.Succeed())
+			g.Consistently(matchReconcile).WithArguments(tt.expectReconciles).Should(gomega.Succeed())
+		})
+	}
+}
+
+func Test_controller_subscribe(t *testing.T) {
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+
+	var m sync.Mutex
+	var routeEventCh chan<- netlink.RouteUpdate
+	var linkEventCh chan<- netlink.LinkUpdate
+	setRouteEventCh := func(ch chan<- netlink.RouteUpdate) {
+		m.Lock()
+		defer m.Unlock()
+		routeEventCh = ch
+	}
+	setLinkEventCh := func(ch chan<- netlink.LinkUpdate) {
+		m.Lock()
+		defer m.Unlock()
+		linkEventCh = ch
+	}
+	isRouteEventChSet := func(g gomega.Gomega) {
+		m.Lock()
+		defer m.Unlock()
+		g.Expect(routeEventCh).ToNot(gomega.BeNil())
+	}
+	isLinkEventChSet := func(g gomega.Gomega) {
+		m.Lock()
+		defer m.Unlock()
+		g.Expect(linkEventCh).ToNot(gomega.BeNil())
+	}
+
+	matchOptions := func(options any) bool {
+		switch o := options.(type) {
+		case netlink.RouteSubscribeOptions:
+			return o.ListExisting == true
+		case netlink.LinkSubscribeOptions:
+			return o.ListExisting == true
+		}
+		return false
+	}
+
+	var stopArg <-chan struct{} = stop
+	nlmock := &mocks.NetLinkOps{}
+	nlmock.On("RouteSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.RouteUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Run(func(args mock.Arguments) { setRouteEventCh(args.Get(0).(chan<- netlink.RouteUpdate)) }).
+		Return(nil).Twice()
+	nlmock.On("RouteSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.RouteUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Return(errors.New("test error")).Once()
+	nlmock.On("RouteSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.RouteUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Run(func(args mock.Arguments) { setRouteEventCh(args.Get(0).(chan<- netlink.RouteUpdate)) }).
+		Return(nil).Once()
+
+	nlmock.On("LinkSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.LinkUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Run(func(args mock.Arguments) { setLinkEventCh(args.Get(0).(chan<- netlink.LinkUpdate)) }).
+		Return(nil).Twice()
+	nlmock.On("LinkSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.LinkUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Return(errors.New("test error")).Once()
+	nlmock.On("LinkSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.LinkUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Run(func(args mock.Arguments) { setLinkEventCh(args.Get(0).(chan<- netlink.LinkUpdate)) }).
+		Return(nil).Once()
+	nlmock.On("LinkSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.LinkUpdate"), stopArg, mock.MatchedBy(matchOptions)).
+		Run(func(args mock.Arguments) { setLinkEventCh(args.Get(0).(chan<- netlink.LinkUpdate)) }).
+		Return(errors.New("test error"))
+
+	c := &controller{
+		log:     testr.New(t),
+		netlink: nlmock,
+		tables:  map[int]int{1: 1},
+	}
+
+	c.subscribe(stop)
+
+	g := gomega.NewWithT(t)
+
+	g.Eventually(isRouteEventChSet).Should(gomega.Succeed())
+	g.Eventually(isLinkEventChSet).Should(gomega.Succeed())
+
+	rch := routeEventCh
+	routeEventCh = nil
+	close(rch)
+
+	g.Eventually(isRouteEventChSet).WithTimeout(subscribePeriod * 3).Should(gomega.Succeed())
+
+	rch = routeEventCh
+	routeEventCh = nil
+	close(rch)
+
+	g.Eventually(isRouteEventChSet).WithTimeout(subscribePeriod * 3).Should(gomega.Succeed())
+
+	lch := linkEventCh
+	linkEventCh = nil
+	close(lch)
+
+	g.Eventually(isLinkEventChSet).WithTimeout(subscribePeriod * 3).Should(gomega.Succeed())
+
+	lch = linkEventCh
+	linkEventCh = nil
+	close(lch)
+
+	g.Eventually(isLinkEventChSet).WithTimeout(subscribePeriod * 3).Should(gomega.Succeed())
+
+	lch = linkEventCh
+	linkEventCh = nil
+	close(lch)
+
+	g.Eventually(isLinkEventChSet).WithTimeout(subscribePeriod * 3).Should(gomega.Succeed())
+	g.Expect(c.tables).To(gomega.BeEmpty())
+}

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -83,9 +83,9 @@ func Test_controller_syncNetwork(t *testing.T) {
 			},
 			initial: []libovsdb.TestData{
 				&nbdb.LogicalRouter{Name: defaultNetwork.GetNetworkScopedGWRouterName(node), StaticRoutes: []string{"keep-1", "keep-2", "remove"}},
-				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "keep-2", IPPrefix: "5.5.5.0/24", Nexthop: "5.5.5.1"},
-				&nbdb.LogicalRouterStaticRoute{UUID: "remove", IPPrefix: "6.6.6.0/24", Nexthop: "6.6.6.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "remove", IPPrefix: "6.6.6.0/24", Nexthop: "6.6.6.1", ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 			},
 			routes: []netlink.Route{
 				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
@@ -94,11 +94,11 @@ func Test_controller_syncNetwork(t *testing.T) {
 			},
 			expected: []libovsdb.TestData{
 				&nbdb.LogicalRouter{UUID: "router", Name: defaultNetwork.GetNetworkScopedGWRouterName(node), StaticRoutes: []string{"keep-1", "keep-2", "add-1", "add-2", "add-3"}},
-				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "keep-2", IPPrefix: "5.5.5.0/24", Nexthop: "5.5.5.1"},
-				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "2.2.2.0/24", Nexthop: "2.2.2.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
-				&nbdb.LogicalRouterStaticRoute{UUID: "add-2", IPPrefix: "3.3.3.0/24", Nexthop: "3.3.3.1", ExternalIDs: map[string]string{"controller": "routeimport"}},
-				&nbdb.LogicalRouterStaticRoute{UUID: "add-3", IPPrefix: "3.3.3.0/24", Nexthop: "3.3.3.2", ExternalIDs: map[string]string{"controller": "routeimport"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "2.2.2.0/24", Nexthop: "2.2.2.1", ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-2", IPPrefix: "3.3.3.0/24", Nexthop: "3.3.3.1", ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-3", IPPrefix: "3.3.3.0/24", Nexthop: "3.3.3.2", ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 			},
 		},
 	}
@@ -406,7 +406,7 @@ func Test_controller_subscribe(t *testing.T) {
 		Run(func(args mock.Arguments) { setRouteEventCh(args.Get(0).(chan<- netlink.RouteUpdate)) }).
 		Return(nil).Twice()
 	nlmock.On("RouteSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.RouteUpdate"), stopArg, mock.MatchedBy(matchOptions)).
-		Return(errors.New("test error")).Once()
+		Return(errors.New("test error")).Twice()
 	nlmock.On("RouteSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.RouteUpdate"), stopArg, mock.MatchedBy(matchOptions)).
 		Run(func(args mock.Arguments) { setRouteEventCh(args.Get(0).(chan<- netlink.RouteUpdate)) }).
 		Return(nil).Once()
@@ -415,7 +415,7 @@ func Test_controller_subscribe(t *testing.T) {
 		Run(func(args mock.Arguments) { setLinkEventCh(args.Get(0).(chan<- netlink.LinkUpdate)) }).
 		Return(nil).Twice()
 	nlmock.On("LinkSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.LinkUpdate"), stopArg, mock.MatchedBy(matchOptions)).
-		Return(errors.New("test error")).Once()
+		Return(errors.New("test error")).Twice()
 	nlmock.On("LinkSubscribeWithOptions", mock.AnythingOfType("chan<- netlink.LinkUpdate"), stopArg, mock.MatchedBy(matchOptions)).
 		Run(func(args mock.Arguments) { setLinkEventCh(args.Get(0).(chan<- netlink.LinkUpdate)) }).
 		Return(nil).Once()

--- a/go-controller/pkg/testing/libovsdb/matchers.go
+++ b/go-controller/pkg/testing/libovsdb/matchers.go
@@ -224,9 +224,11 @@ func HaveEmptyData() gomegatypes.GomegaMatcher {
 }
 
 func haveData(ignoreUUIDs, nameUUIDs bool, expected []TestData) gomegatypes.GomegaMatcher {
-	if e, ok := expected[0].([]TestData); len(expected) == 1 && ok {
-		// flatten
-		expected = e
+	if len(expected) == 1 {
+		if e, ok := expected[0].([]TestData); ok {
+			// flatten
+			expected = e
+		}
 	}
 	matchers := []*testDataMatcher{}
 	for _, e := range expected {

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -433,6 +433,24 @@ func (_m *NetLinkOps) LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hw
 	return r0
 }
 
+// LinkSubscribeWithOptions provides a mock function with given fields: ch, done, options
+func (_m *NetLinkOps) LinkSubscribeWithOptions(ch chan<- netlink.LinkUpdate, done <-chan struct{}, options netlink.LinkSubscribeOptions) error {
+	ret := _m.Called(ch, done, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LinkSubscribeWithOptions")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(chan<- netlink.LinkUpdate, <-chan struct{}, netlink.LinkSubscribeOptions) error); ok {
+		r0 = rf(ch, done, options)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NeighAdd provides a mock function with given fields: neigh
 func (_m *NetLinkOps) NeighAdd(neigh *netlink.Neigh) error {
 	ret := _m.Called(neigh)
@@ -606,6 +624,24 @@ func (_m *NetLinkOps) RouteReplace(route *netlink.Route) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*netlink.Route) error); ok {
 		r0 = rf(route)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// RouteSubscribeWithOptions provides a mock function with given fields: ch, done, options
+func (_m *NetLinkOps) RouteSubscribeWithOptions(ch chan<- netlink.RouteUpdate, done <-chan struct{}, options netlink.RouteSubscribeOptions) error {
+	ret := _m.Called(ch, done, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RouteSubscribeWithOptions")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(chan<- netlink.RouteUpdate, <-chan struct{}, netlink.RouteSubscribeOptions) error); ok {
+		r0 = rf(ch, done, options)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -53,6 +53,8 @@ type NetLinkOps interface {
 	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
 	ConntrackDeleteFilter(table netlink.ConntrackTableType, family netlink.InetFamily, filter netlink.CustomConntrackFilter) (uint, error)
 	LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hwaddr net.HardwareAddr) error
+	RouteSubscribeWithOptions(ch chan<- netlink.RouteUpdate, done <-chan struct{}, options netlink.RouteSubscribeOptions) error
+	LinkSubscribeWithOptions(ch chan<- netlink.LinkUpdate, done <-chan struct{}, options netlink.LinkSubscribeOptions) error
 }
 
 type defaultNetLinkOps struct {
@@ -185,6 +187,14 @@ func (defaultNetLinkOps) NeighList(linkIndex, family int) ([]netlink.Neigh, erro
 
 func (defaultNetLinkOps) ConntrackDeleteFilter(table netlink.ConntrackTableType, family netlink.InetFamily, filter netlink.CustomConntrackFilter) (uint, error) {
 	return netlink.ConntrackDeleteFilter(table, family, filter)
+}
+
+func (defaultNetLinkOps) RouteSubscribeWithOptions(ch chan<- netlink.RouteUpdate, done <-chan struct{}, options netlink.RouteSubscribeOptions) error {
+	return netlink.RouteSubscribeWithOptions(ch, done, options)
+}
+
+func (defaultNetLinkOps) LinkSubscribeWithOptions(ch chan<- netlink.LinkUpdate, done <-chan struct{}, options netlink.LinkSubscribeOptions) error {
+	return netlink.LinkSubscribeWithOptions(ch, done, options)
 }
 
 func getFamily(ip net.IP) int {

--- a/go-controller/vendor/github.com/go-logr/logr/testr/testr.go
+++ b/go-controller/vendor/github.com/go-logr/logr/testr/testr.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testr provides support for using logr in tests.
+package testr
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+// New returns a logr.Logger that prints through a testing.T object.
+// Info logs are only enabled at V(0).
+func New(t *testing.T) logr.Logger {
+	return NewWithOptions(t, Options{})
+}
+
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogTimestamp tells the logger to add a "ts" key to log
+	// lines. This has some overhead, so some users might not want
+	// it.
+	LogTimestamp bool
+
+	// Verbosity tells the logger which V logs to be write.
+	// Higher values enable more logs.
+	Verbosity int
+}
+
+// NewWithOptions returns a logr.Logger that prints through a testing.T object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithOptions(t *testing.T, opts Options) logr.Logger {
+	l := &testlogger{
+		testloggerInterface: newLoggerInterfaceWithOptions(t, opts),
+	}
+	return logr.New(l)
+}
+
+// TestingT is an interface wrapper around testing.T, testing.B and testing.F.
+type TestingT interface {
+	Helper()
+	Log(args ...any)
+}
+
+// NewWithInterface returns a logr.Logger that prints through a
+// TestingT object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithInterface(t TestingT, opts Options) logr.Logger {
+	l := newLoggerInterfaceWithOptions(t, opts)
+	return logr.New(&l)
+}
+
+func newLoggerInterfaceWithOptions(t TestingT, opts Options) testloggerInterface {
+	return testloggerInterface{
+		t: t,
+		Formatter: funcr.NewFormatter(funcr.Options{
+			LogTimestamp: opts.LogTimestamp,
+			Verbosity:    opts.Verbosity,
+		}),
+	}
+}
+
+// Underlier exposes access to the underlying testing.T instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type Underlier interface {
+	GetUnderlying() *testing.T
+}
+
+// UnderlierInterface exposes access to the underlying TestingT instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type UnderlierInterface interface {
+	GetUnderlying() TestingT
+}
+
+// Info logging implementation shared between testLogger and testLoggerInterface.
+func logInfo(t TestingT, formatInfo func(int, string, []any) (string, string), level int, msg string, kvList ...any) {
+	prefix, args := formatInfo(level, msg, kvList)
+	t.Helper()
+	if prefix != "" {
+		args = prefix + ": " + args
+	}
+	t.Log(args)
+}
+
+// Error logging implementation shared between testLogger and testLoggerInterface.
+func logError(t TestingT, formatError func(error, string, []any) (string, string), err error, msg string, kvList ...any) {
+	prefix, args := formatError(err, msg, kvList)
+	t.Helper()
+	if prefix != "" {
+		args = prefix + ": " + args
+	}
+	t.Log(args)
+}
+
+// This type exists to wrap and modify the method-set of testloggerInterface.
+// In particular, it changes the GetUnderlying() method.
+type testlogger struct {
+	testloggerInterface
+}
+
+func (l testlogger) GetUnderlying() *testing.T {
+	// This method is defined on testlogger, so the only type this could
+	// possibly be is testing.T, even though that's not guaranteed by the type
+	// system itself.
+	return l.t.(*testing.T) //nolint:forcetypeassert
+}
+
+type testloggerInterface struct {
+	funcr.Formatter
+	t TestingT
+}
+
+func (l testloggerInterface) WithName(name string) logr.LogSink {
+	l.Formatter.AddName(name)
+	return &l
+}
+
+func (l testloggerInterface) WithValues(kvList ...any) logr.LogSink {
+	l.Formatter.AddValues(kvList)
+	return &l
+}
+
+func (l testloggerInterface) GetCallStackHelper() func() {
+	return l.t.Helper
+}
+
+func (l testloggerInterface) Info(level int, msg string, kvList ...any) {
+	l.t.Helper()
+	logInfo(l.t, l.FormatInfo, level, msg, kvList...)
+}
+
+func (l testloggerInterface) Error(err error, msg string, kvList ...any) {
+	l.t.Helper()
+	logError(l.t, l.FormatError, err, msg, kvList...)
+}
+
+func (l testloggerInterface) GetUnderlying() TestingT {
+	return l.t
+}
+
+// Assert conformance to the interfaces.
+var _ logr.LogSink = &testlogger{}
+var _ logr.CallStackHelperLogSink = &testlogger{}
+var _ Underlier = &testlogger{}
+
+var _ logr.LogSink = &testloggerInterface{}
+var _ logr.CallStackHelperLogSink = &testloggerInterface{}
+var _ UnderlierInterface = &testloggerInterface{}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -107,6 +107,7 @@ github.com/gaissmai/cidrtree
 ## explicit; go 1.18
 github.com/go-logr/logr
 github.com/go-logr/logr/funcr
+github.com/go-logr/logr/testr
 # github.com/go-logr/stdr v1.2.2
 ## explicit; go 1.16
 github.com/go-logr/stdr


### PR DESCRIPTION
This commit adds a new controller to import BGP learnt routes into OVN.

The controller runs in ovnkube-controller so it only supports IC
architecture where ovnkube-controller has kernel access on each node.

Networks should register to this controller to have routes imported for
them. Routes are imported into the network's gateway router. Multipath
routes are supported.

The controller subscribes for netlink route events. When a route is
updated, the corresponding network is queued to be sync'ed. A network is
also sync'ed when registered to the controller.

Synchronizations are delayed by a small amount of time to prevent a
series of consecutive route updates so synchornize the same network
twice. Synchronizations apply the difference between current and desired
state.

The controller subscribes to netlink link events to learn the routing
table associated to a network vrf. The network is inferred from the vrf
device name. When learning the routing table, the corresponding network
is queued to be sync'ed.

Currently based on top of https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4691