### PR TITLE
ip allocator: rename AllocateIPs method

### DIFF
--- a/go-controller/pkg/allocator/ip/subnet/allocator.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator.go
@@ -21,7 +21,7 @@ type Allocator interface {
 	DeleteSubnet(name string)
 	GetSubnets(name string) ([]*net.IPNet, error)
 	AllocateUntilFull(name string) error
-	AllocateIPs(name string, ips []*net.IPNet) error
+	AllocateIPPerSubnet(name string, ips []*net.IPNet) error
 	AllocateNextIPs(name string) ([]*net.IPNet, error)
 	ReleaseIPs(name string, ips []*net.IPNet) error
 	ConditionalIPRelease(name string, ips []*net.IPNet, predicate func() (bool, error)) (bool, error)
@@ -159,9 +159,10 @@ func (allocator *allocator) AllocateUntilFull(name string) error {
 	return nil
 }
 
-// AllocateIPs will block off IPs in the ipnets slice as already allocated
-// for a given subnet set
-func (allocator *allocator) AllocateIPs(name string, ips []*net.IPNet) error {
+// AllocateIPPerSubnet will block off IPs in the ipnets slice as already
+// allocated in each of the subnets it manages. ips *must* feature a single IP
+// on each of the subnets managed by the allocator.
+func (allocator *allocator) AllocateIPPerSubnet(name string, ips []*net.IPNet) error {
 	if len(ips) == 0 {
 		return fmt.Errorf("failed to allocate IPs for %s: no IPs provided", name)
 	}
@@ -364,7 +365,7 @@ type IPAllocator struct {
 
 // AllocateIPs allocates the requested IPs
 func (ipAllocator *IPAllocator) AllocateIPs(ips []*net.IPNet) error {
-	return ipAllocator.allocator.AllocateIPs(ipAllocator.name, ips)
+	return ipAllocator.allocator.AllocateIPPerSubnet(ipAllocator.name, ips)
 }
 
 // AllocateNextIPs allocates the next available IPs

--- a/go-controller/pkg/allocator/ip/subnet/allocator_test.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator_test.go
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 				}
 				err = allocator.ReleaseIPs(subnetName, ips)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = allocator.AllocateIPs(subnetName, ips)
+				err = allocator.AllocateIPPerSubnet(subnetName, ips)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 
 			ips, err := util.ParseIPNets([]string{"10.1.1.1/24", "10.1.1.2/24"})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(allocator.AllocateIPs(subnetName, ips)).To(gomega.MatchError(
+			gomega.Expect(allocator.AllocateIPPerSubnet(subnetName, ips)).To(gomega.MatchError(
 				"failed to allocate IP 10.1.1.2 for subnet1: attempted to reserve multiple IPs in the same IPAM instance",
 			))
 		})
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 				gomega.Expect(ip.String()).To(gomega.Equal(expectedIPs[i]))
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = allocator.AllocateIPs(subnetName, ovntest.MustParseIPNets(expectedIPs...))
+			err = allocator.AllocateIPPerSubnet(subnetName, ovntest.MustParseIPNets(expectedIPs...))
 			gomega.Expect(err).To(gomega.MatchError(ipam.ErrAllocated))
 		})
 

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -98,7 +98,7 @@ func (a *ipAllocatorStub) AllocateUntilFull(name string) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) AllocateIPs(name string, ips []*net.IPNet) error {
+func (a *ipAllocatorStub) AllocateIPPerSubnet(name string, ips []*net.IPNet) error {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -423,11 +423,13 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						ips, err := util.ParseIPNets([]string{subnetIP})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						gomega.Expect(nc.subnetAllocator.AllocateIPs(netInfo.GetNetworkName(), ips)).To(gomega.Equal(ip.ErrAllocated))
+						gomega.Expect(nc.subnetAllocator.AllocateIPPerSubnet(netInfo.GetNetworkName(), ips)).To(
+							gomega.Equal(ip.ErrAllocated))
 
 						ips2, err := util.ParseIPNets([]string{subnetIP2})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						gomega.Expect(nc.subnetAllocator.AllocateIPs(netInfo.GetNetworkName(), ips2)).To(gomega.Equal(ip.ErrAllocated))
+						gomega.Expect(nc.subnetAllocator.AllocateIPPerSubnet(netInfo.GetNetworkName(), ips2)).To(
+							gomega.Equal(ip.ErrAllocated))
 
 						return nil
 					}
@@ -477,7 +479,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						ips, err := util.ParseIPNets([]string{subnetIP})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-						gomega.Expect(nc.subnetAllocator.AllocateIPs(netInfo.GetNetworkName(), ips)).To(gomega.Succeed())
+						gomega.Expect(nc.subnetAllocator.AllocateIPPerSubnet(netInfo.GetNetworkName(), ips)).To(gomega.Succeed())
 
 						return nil
 					}

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -97,7 +97,7 @@ func (manager *LogicalSwitchManager) AllocateUntilFull(switchName string) error 
 // AllocateIPs will block off IPs in the ipnets slice as already allocated
 // for a given switch
 func (manager *LogicalSwitchManager) AllocateIPs(switchName string, ipnets []*net.IPNet) error {
-	return manager.allocator.AllocateIPs(switchName, ipnets)
+	return manager.allocator.AllocateIPPerSubnet(switchName, ipnets)
 }
 
 // AllocateNextIPs allocates IP addresses from each of the host subnets

--- a/go-controller/pkg/persistentips/allocator_test.go
+++ b/go-controller/pkg/persistentips/allocator_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Persistent IP allocator operations", func() {
 			initialIPs = []string{"192.168.200.2/24", "fd10::1/64"}
 			ipAllocator := subnet.NewAllocator()
 			Expect(ipAllocator.AddOrUpdateSubnet(subnetName, ovntest.MustParseIPNets("192.168.200.0/24", "fd10::/64"))).To(Succeed())
-			Expect(ipAllocator.AllocateIPs(subnetName, ovntest.MustParseIPNets(initialIPs...))).To(Succeed())
+			Expect(ipAllocator.AllocateIPPerSubnet(subnetName, ovntest.MustParseIPNets(initialIPs...))).To(Succeed())
 			namedAllocator = ipAllocator.ForSubnet(subnetName)
 
 			netInfo, err := util.NewNetInfo(dummyNetconf(networkName))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
The `AllocateIPs` method name is misleading; it receives a slice of IPs as parameter, which leads the user to think that it can allocate the IPs in the slice in a single subnet - i.e. for subnet 10.0.0.0/24, it could allocate IPs 10.0.0.2 and 10.0.0.3.

That is not the case: that function allocates a **single** IP address in each of the subnets the IP allocator for said network manages. For instance, on a dual-stack network, it could handle the following subnets: 10.0.0.0/24 and fd10::/64. The function could then the invoked with ips=10.0.0.2,fd10::2 to allocate **one** IP in each of the two subnets managed by the IP allocator.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
I've renamed the method, and corrected its docstring, in hope of making its intended usage clearer for future users.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
