### PR TITLE
OCPBUGS-38151: NAD controller: emit err/event for NADs we cannot sync at startup

### DIFF
--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -549,10 +549,13 @@ func TestSyncAll(t *testing.T) {
 			Name: "network_A",
 			Type: "ovn-k8s-cni-overlay",
 		},
-		Role: types.NetworkRolePrimary,
-		MTU:  1400,
+		Subnets: "10.20.0.0/16/24",
+		Role:    types.NetworkRolePrimary,
+		MTU:     1400,
 	}
 	network_A_Copy := *network_A
+	network_A_Copy_InvalidSubnet := *network_A
+	network_A_Copy_InvalidSubnet.Subnets = "20.20.0.0/16/24" // network subnet was previously defined as "10.20.0.0/16/24"
 	network_B := &ovncnitypes.NetConf{
 		Topology: types.LocalnetTopology,
 		NetConf: cnitypes.NetConf{
@@ -587,6 +590,19 @@ func TestSyncAll(t *testing.T) {
 				},
 			},
 			syncAllError: ErrNetworkControllerTopologyNotManaged,
+		},
+		{
+			name: "invalid network reference with erroneous subnet entry doesn't block sync",
+			testNADs: []TestNAD{
+				{
+					name:    "test/nad1",
+					netconf: network_A,
+				},
+				{
+					name:    "test2/nad2",
+					netconf: &network_A_Copy_InvalidSubnet,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
.. instead of blocking ovnkube controller startup. This can occur when one NAD has an invalid config and this leads to DOS for other services ovnkube controller offers because it cannot sync the nad controller at startup.

The sync can fail for reasons that retry will not fix:
* `namespace, _, err := cache.SplitMetaNamespaceKey(key)`
* `if nadNetwork != nil && nadNetwork.IsPrimaryNetwork() && primaryNAD != "" && primaryNAD != key {`
* `	err = fmt.Errorf("%s: NAD %s CNI config does not match that of network %s", nadController.name, key, nadNetworkName)`

Retry wont fix this and for NAD controllers startup `syncAll()`, a config error can cause ovnkube controller not to start. I think its best to log and emit event.