### PR TITLE
kubevirt, l2, udpn: send unsolicited router advertisement after live migration to reconcile ipv6 default gw

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/k8snetworkplumbingwg/sriovnet v1.2.1-0.20230427090635-4929697df2dc
 	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875
 	github.com/mdlayher/ndp v1.0.1
+	github.com/mdlayher/socket v0.2.1
 	github.com/metallb/frr-k8s v0.0.15
 	github.com/miekg/dns v1.1.31
 	github.com/mitchellh/copystructure v1.2.0
@@ -103,7 +104,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 // indirect
 	github.com/mdlayher/packet v1.0.0 // indirect
-	github.com/mdlayher/socket v0.2.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -22,7 +22,28 @@ import (
 	logicalswitchmanager "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/ndp"
 )
+
+// DefaultGatewayReconciler is responsible for reconciling the default gateway
+// configuration of a virtual machine's network interface after a live migration.
+// It supports both IPv4 and IPv6 configurations.
+type DefaultGatewayReconciler struct {
+	watchFactory  *factory.WatchFactory
+	netInfo       util.NetInfo
+	interfaceName string
+}
+
+// NewDefaultGatewayReconciler creates a new instance of DefaultGatewayReconciler.
+// It takes a WatchFactory for managing resource watches, a NetInfo object for network information,
+// and the name of the network interface to send ARPs or RAs as parameters.
+func NewDefaultGatewayReconciler(watchFactory *factory.WatchFactory, netInfo util.NetInfo, interfaceName string) *DefaultGatewayReconciler {
+	return &DefaultGatewayReconciler{
+		watchFactory:  watchFactory,
+		netInfo:       netInfo,
+		interfaceName: interfaceName,
+	}
+}
 
 // IsPodLiveMigratable will return true if the pod belongs
 // to kubevirt and should use the live migration features
@@ -482,17 +503,20 @@ func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) 
 	return &status, nil
 }
 
-func ReconcileIPv4DefaultGatewayAfterLiveMigration(watchFactory *factory.WatchFactory, netInfo util.NetInfo, liveMigrationStatus *LiveMigrationStatus, interfaceName string) error {
+// ReconcileIPv4AfterLiveMigration will send a GARP after live migration
+// to update the default gw mac address to the node where the VM is running
+// now.
+func (r *DefaultGatewayReconciler) ReconcileIPv4AfterLiveMigration(liveMigrationStatus *LiveMigrationStatus) error {
 	if liveMigrationStatus.State != LiveMigrationTargetDomainReady {
 		return nil
 	}
 
-	targetNode, err := watchFactory.GetNode(liveMigrationStatus.TargetPod.Spec.NodeName)
+	targetNode, err := r.watchFactory.GetNode(liveMigrationStatus.TargetPod.Spec.NodeName)
 	if err != nil {
 		return err
 	}
 
-	lrpJoinAddress, err := util.ParseNodeGatewayRouterJoinNetwork(targetNode, netInfo.GetNetworkName())
+	lrpJoinAddress, err := util.ParseNodeGatewayRouterJoinNetwork(targetNode, r.netInfo.GetNetworkName())
 	if err != nil {
 		return err
 	}
@@ -503,16 +527,104 @@ func ReconcileIPv4DefaultGatewayAfterLiveMigration(watchFactory *factory.WatchFa
 	}
 
 	lrpMAC := util.IPAddrToHWAddr(lrpJoinIPv4)
-	for _, subnet := range netInfo.Subnets() {
+	for _, subnet := range r.netInfo.Subnets() {
 		gwIP := util.GetNodeGatewayIfAddr(subnet.CIDR).IP.To4()
 		if gwIP == nil {
 			continue
 		}
 		garp := util.GARP{IP: gwIP, MAC: &lrpMAC}
-		if err := util.BroadcastGARP(interfaceName, garp); err != nil {
+		if err := util.BroadcastGARP(r.interfaceName, garp); err != nil {
 			return err
 		}
 	}
-
 	return nil
+}
+
+// ReconcileIPv6AfterLiveMigration will do two things at VM's:
+// - Remove ipv6 default gw path from VM's node before live migration
+// - Add ipv6 default gw path from VM's node after live migration
+// This is done by sending a pair of unsolicited RA's one with lifetime=0
+// (to remove the gateway path) another with lifetime=max to add the new
+// default gateway path
+func (r *DefaultGatewayReconciler) ReconcileIPv6AfterLiveMigration(liveMigration *LiveMigrationStatus) error {
+	if !liveMigration.IsTargetDomainReady() {
+		return nil
+	}
+	nodes, err := r.watchFactory.GetNodes()
+	if err != nil {
+		return err
+	}
+
+	targetPod := liveMigration.TargetPod
+	if len(r.netInfo.GetNADs()) != 1 {
+		return fmt.Errorf("expected only one nad for network %q, got %d", r.netInfo.GetNetworkName(), len(r.netInfo.GetNADs()))
+	}
+
+	targetPodAnnotation, err := util.UnmarshalPodAnnotation(targetPod.Annotations, r.netInfo.GetNADs()[0])
+	if err != nil {
+		return ovntypes.NewSuppressedError(fmt.Errorf("failed parsing ovn pod annotation for pod '%s/%s' and network %q: %w", targetPod.Namespace, targetPod.Name, r.netInfo.GetNetworkName(), err))
+	}
+
+	destinationIP, err := util.MatchFirstIPNetFamily(true /* ipv6 */, targetPodAnnotation.IPs)
+	if err != nil {
+		return err
+	}
+	destinationMAC := targetPodAnnotation.MAC
+
+	ras := make([]ndp.RouterAdvertisement, 0, len(nodes))
+	for _, node := range nodes {
+		if node.Name == liveMigration.TargetPod.Spec.NodeName {
+			// skip the target node since this is the proper gateway
+			continue
+		}
+		nodeJoinAddrs, err := util.ParseNodeGatewayRouterJoinAddrs(node, r.netInfo.GetNetworkName())
+		if err != nil {
+			return ovntypes.NewSuppressedError(fmt.Errorf("failed parsing join addresss from node %q and network %q to reconcile ipv6 gateway: %w", node.Name, r.netInfo.GetNetworkName(), err))
+		}
+		// During upgrades, nftables blocks Router Advertisements (RAs) from other nodes.
+		// However, Virtual Machines (VMs) may still retain old default gateway paths.
+		// To address this, we create a new Router Advertisement with a lifetime of 0
+		// to signal the removal of the old default gateway.
+		// NOTE: This is a workaround for the issue and may not be needed in the future, after
+		//       upgrading to a version that supports the new behavior.
+		ras = append(ras, newRouterAdvertisementFromJoinIPAndLifetime(nodeJoinAddrs[0].IP, destinationMAC, destinationIP.IP, 0))
+	}
+	targetNode, err := r.watchFactory.GetNode(liveMigration.TargetPod.Spec.NodeName)
+	if err != nil {
+		return fmt.Errorf("failed fetching node %q to reconcile ipv6 gateway: %w", liveMigration.TargetPod.Spec.NodeName, err)
+	}
+	targetNodeJoinAddrs, err := util.ParseNodeGatewayRouterJoinAddrs(targetNode, r.netInfo.GetNetworkName())
+	if err != nil {
+		return ovntypes.NewSuppressedError(fmt.Errorf("failed parsing join addresss from live migration target node %q and network %q to reconcile ipv6 gateway: %w", targetNode.Name, r.netInfo.GetNetworkName(), err))
+	}
+	ras = append(ras, newRouterAdvertisementFromJoinIPAndLifetime(targetNodeJoinAddrs[0].IP, destinationMAC, destinationIP.IP, 65535))
+	return ndp.SendRouterAdvertisements(r.interfaceName, ras...)
+}
+
+// newRouterAdvertisementFromJoinIPAndLifetime creates a new Router Advertisement (RA) message
+// using the provided join IP address, destination MAC, destination IP, and lifetime.
+//
+// This function performs the following:
+// - Derives the source MAC address from the given IP using util.IPAddrToHWAddr.
+// - Calculates the link-local address (LLA) from the source MAC using util.HWAddrToIPv6LLA.
+// - Configures the destination IP and MAC address to use the provided values.
+// - Sets the RA message's lifetime to the specified value.
+//
+// Parameters:
+// - ip: The join IP address used to derive the source MAC and LLA.
+// - destinationMAC: The MAC address to which the RA message will be sent.
+// - destinationIP: The IP address to which the RA message will be sent.
+// - lifetime: The lifetime value for the RA message, in seconds.
+//
+// Returns:
+// - An ndp.RouterAdvertisement object configured with the calculated source MAC, LLA, and the provided destination MAC, IP, and lifetime.
+func newRouterAdvertisementFromJoinIPAndLifetime(ip net.IP, destinationMAC net.HardwareAddr, destinationIP net.IP, lifetime uint16) ndp.RouterAdvertisement {
+	sourceMAC := util.IPAddrToHWAddr(ip)
+	return ndp.RouterAdvertisement{
+		SourceMAC:      sourceMAC,
+		SourceIP:       util.HWAddrToIPv6LLA(sourceMAC),
+		DestinationMAC: destinationMAC,
+		DestinationIP:  destinationIP,
+		Lifetime:       lifetime,
+	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -915,7 +915,7 @@ func (oc *SecondaryLayer2NetworkController) reconcileLiveMigrationTargetZone(kub
 	mgmtInterfaceName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(oc.GetNetworkID()))
 
 	if hasIPv4Subnet, _ := oc.IPMode(); hasIPv4Subnet {
-		if err := kubevirt.ReconcileIPv4DefaultGatewayAfterLiveMigration(oc.watchFactory, oc.GetNetInfo(), kubevirtLiveMigrationStatus, mgmtInterfaceName); err != nil {
+		if err := kubevirt.NewDefaultGatewayReconciler(oc.watchFactory, oc.GetNetInfo(), mgmtInterfaceName).ReconcileIPv4AfterLiveMigration(kubevirtLiveMigrationStatus); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -293,6 +293,9 @@ type SecondaryLayer2NetworkController struct {
 
 	// EgressIP controller utilized only to initialize a network with OVN polices to support EgressIP functionality.
 	eIPController *EgressIPController
+
+	// reconcile the virtual machine default gateway sending GARPs and RAs
+	defaultGatewayReconciler *kubevirt.DefaultGatewayReconciler
 }
 
 // NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
@@ -363,6 +366,7 @@ func NewSecondaryLayer2NetworkController(
 		if err != nil {
 			return nil, fmt.Errorf("unable to create new service controller while creating new layer2 network controller: %w", err)
 		}
+		oc.defaultGatewayReconciler = kubevirt.NewDefaultGatewayReconciler(oc.watchFactory, oc.GetNetInfo(), util.GetNetworkScopedK8sMgmtHostIntfName(uint(oc.GetNetworkID())))
 	}
 
 	if oc.allocatesPodAnnotation() {
@@ -908,15 +912,20 @@ func (oc *SecondaryLayer2NetworkController) updateLocalPodEvent(pod *corev1.Pod)
 }
 
 func (oc *SecondaryLayer2NetworkController) reconcileLiveMigrationTargetZone(kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus) error {
-	// Only primary networks has a gateway to reconcile
-	if !oc.IsPrimaryNetwork() {
+	if oc.defaultGatewayReconciler == nil {
 		return nil
 	}
-	mgmtInterfaceName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(oc.GetNetworkID()))
-
-	if hasIPv4Subnet, _ := oc.IPMode(); hasIPv4Subnet {
-		if err := kubevirt.NewDefaultGatewayReconciler(oc.watchFactory, oc.GetNetInfo(), mgmtInterfaceName).ReconcileIPv4AfterLiveMigration(kubevirtLiveMigrationStatus); err != nil {
-			return err
+	hasIPv4Subnet, hasIPv6Subnet := oc.IPMode()
+	if hasIPv4Subnet {
+		if err := oc.defaultGatewayReconciler.ReconcileIPv4AfterLiveMigration(kubevirtLiveMigrationStatus); err != nil {
+			return fmt.Errorf("failed reconciling IPv4 default gw after live migration at target pod '%s/%s': %w",
+				kubevirtLiveMigrationStatus.TargetPod.Namespace, kubevirtLiveMigrationStatus.TargetPod.Name, err)
+		}
+	}
+	if hasIPv6Subnet {
+		if err := oc.defaultGatewayReconciler.ReconcileIPv6AfterLiveMigration(kubevirtLiveMigrationStatus); err != nil {
+			return fmt.Errorf("failed reconciling IPv6 default gw after live migration at target pod '%s/%s': %w",
+				kubevirtLiveMigrationStatus.TargetPod.Namespace, kubevirtLiveMigrationStatus.TargetPod.Name, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/util/ndp/ra.go
+++ b/go-controller/pkg/util/ndp/ra.go
@@ -1,0 +1,125 @@
+package ndp
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/mdlayher/socket"
+	"golang.org/x/sys/unix"
+)
+
+// RouterAdvertisement with mac, ips and lifetime field to send
+type RouterAdvertisement struct {
+	SourceMAC, DestinationMAC net.HardwareAddr
+	SourceIP, DestinationIP   net.IP
+	Lifetime                  uint16
+}
+
+// SendRouterAdvertisements sends one or more Router Advertisements (RAs) on the specified network interface.
+// This function requires raw socket capabilities because the source MAC and IP addresses in the RAs
+// are not the ones from the interface used to send the packets.
+//
+// Parameters:
+// - interfaceName: The name of the network interface to send the RAs on.
+// - ras: A variadic list of RouterAdvertisement objects containing the details of each RA to be sent.
+//
+// Returns:
+// - error: An error object if an error occurs, otherwise nil.
+//
+// The function performs the following steps:
+// 1. Retrieves the network interface by name.
+// 2. Creates a raw socket for sending packets.
+// 3. Serializes each Router Advertisement into a byte slice.
+// 4. Sends the serialized RAs using the raw socket.
+func SendRouterAdvertisements(interfaceName string, ras ...RouterAdvertisement) error {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed to find interface %s: %w", interfaceName, err)
+	}
+	c, err := socket.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, syscall.ETH_P_ALL, "ra", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create raw socket to send unsolicited RAs: %w", err)
+	}
+	defer c.Close()
+
+	serializedRAs := [][]byte{}
+	for _, ra := range ras {
+		serializeBuffer := gopacket.NewSerializeBuffer()
+
+		// Create the Ethernet layer with destination and source MAC addresses.
+		ethernetLayer := layers.Ethernet{
+			DstMAC:       ra.DestinationMAC,
+			SrcMAC:       ra.SourceMAC,
+			EthernetType: layers.EthernetTypeIPv6,
+		}
+
+		// Create the IPv6 layer with source and destination IP addresses.
+		ip6Layer := layers.IPv6{
+			Version:    6,
+			NextHeader: layers.IPProtocolICMPv6,
+			HopLimit:   255,
+			SrcIP:      ra.SourceIP,
+			DstIP:      ra.DestinationIP,
+		}
+
+		// Create the ICMPv6 layer for the Router Advertisement.
+		icmp6Layer := layers.ICMPv6{
+			TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeRouterAdvertisement, 0),
+		}
+		if err := icmp6Layer.SetNetworkLayerForChecksum(&ip6Layer); err != nil {
+			return err
+		}
+
+		// https://datatracker.ietf.org/doc/html/rfc4861#section-4.2
+		// Managed address configuration flag.
+		managedAddressFlag := uint8(0x80)
+
+		// https://datatracker.ietf.org/doc/html/rfc4191#section-2.2
+		// Prf (Default Router Preference)
+		//   2-bit signed integer.  Indicates whether to prefer this
+		//    router over other default routers.  If the Router Lifetime
+		//    is zero, the preference value MUST be set to (00) by the
+		//    sender and MUST be ignored by the receiver.  If the Reserved
+		//    (10) value is received, the receiver MUST treat the value as
+		//    if it were (00).
+		defaultRoutePreferenceFlag := uint8(0x08)
+		if ra.Lifetime == 0 {
+			defaultRoutePreferenceFlag = uint8(0x00)
+		}
+
+		// Create the ICMPv6 Router Advertisement layer.
+		raLayer := layers.ICMPv6RouterAdvertisement{
+			HopLimit:       255,
+			Flags:          managedAddressFlag | defaultRoutePreferenceFlag,
+			RouterLifetime: ra.Lifetime,
+			ReachableTime:  0,
+			RetransTimer:   0,
+			Options: layers.ICMPv6Options{{
+				Type: layers.ICMPv6OptSourceAddress,
+				Data: ra.SourceMAC,
+			}},
+		}
+
+		// Serialize the layers into a byte slice.
+		if err := gopacket.SerializeLayers(serializeBuffer, gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true},
+			&ethernetLayer,
+			&ip6Layer,
+			&icmp6Layer,
+			&raLayer,
+		); err != nil {
+			return err
+		}
+		serializedRAs = append(serializedRAs, serializeBuffer.Bytes())
+	}
+
+	// Send each serialized Router Advertisement using the raw socket.
+	for _, serializedRA := range serializedRAs {
+		if err := c.Sendto(serializedRA, &unix.SockaddrLinklayer{Ifindex: iface.Index}, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1555,7 +1555,7 @@ runcmd:
 				l[RequiredUDNNamespaceLabel] = ""
 			}
 			ns, err := fr.CreateNamespace(context.TODO(), fr.BaseName, l)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			fr.Namespace = ns
 			namespace = fr.Namespace.Name
 
@@ -1705,22 +1705,38 @@ runcmd:
 				checkNorthSouthEgressICMPTraffic(vmi, []string{externalContainerIPV4Address, externalContainerIPV6Address}, step)
 			}
 
-			if td.role == "primary" && td.test.description == liveMigrate.description && isIPv4Supported() && isInterconnectEnabled() {
-				step = by(vm.Name, fmt.Sprintf("Checking IPv4 gateway cached mac after %s %s", td.resource.description, td.test.description))
-				Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
+			if td.role == "primary" && td.test.description == liveMigrate.description && isInterconnectEnabled() {
+				if isIPv4Supported() {
+					step = by(vmi.Name, fmt.Sprintf("Checking IPv4 gateway cached mac after %s %s", td.resource.description, td.test.description))
+					Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
 
-				targetNode, err := fr.ClientSet.CoreV1().Nodes().Get(context.Background(), vmi.Status.MigrationState.TargetNode, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), step)
+					targetNode, err := fr.ClientSet.CoreV1().Nodes().Get(context.Background(), vmi.Status.MigrationState.TargetNode, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred(), step)
 
-				expectedGatewayMAC, err := kubevirt.GenerateGatewayMAC(targetNode, netConfig.networkName)
-				Expect(err).ToNot(HaveOccurred(), step)
+					expectedGatewayMAC, err := kubevirt.GenerateGatewayMAC(targetNode, netConfig.networkName)
+					Expect(err).NotTo(HaveOccurred(), step)
 
-				Expect(err).ToNot(HaveOccurred(), step)
-				Eventually(kubevirt.RetrieveCachedGatewayMAC).
-					WithArguments(vmi, "enp1s0", cidrIPv4).
-					WithTimeout(10*time.Second).
-					WithPolling(time.Second).
-					Should(Equal(expectedGatewayMAC), step)
+					Expect(err).NotTo(HaveOccurred(), step)
+					Eventually(kubevirt.RetrieveCachedGatewayMAC).
+						WithArguments(vmi, "enp1s0", cidrIPv4).
+						WithTimeout(10*time.Second).
+						WithPolling(time.Second).
+						Should(Equal(expectedGatewayMAC), step)
+				}
+				if isIPv6Supported() {
+					step = by(vmi.Name, fmt.Sprintf("Checking IPv6 gateway after %s %s", td.resource.description, td.test.description))
+
+					targetNode, err := fr.ClientSet.CoreV1().Nodes().Get(context.Background(), vmi.Status.MigrationState.TargetNode, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred(), step)
+
+					targetNodeIPv6GatewayPath, err := kubevirt.GenerateGatewayIPv6RouterLLA(targetNode, netConfig.networkName)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(kubevirt.RetrieveIPv6Gateways).
+						WithArguments(vmi).
+						WithTimeout(5*time.Second).
+						WithPolling(time.Second).
+						Should(Equal([]string{targetNodeIPv6GatewayPath}), "should reconcile ipv6 gateway nexthop after live migration")
+				}
 			}
 		},
 			func(td testData) string {

--- a/test/e2e/kubevirt/types.go
+++ b/test/e2e/kubevirt/types.go
@@ -1,7 +1,8 @@
 package kubevirt
 
 const (
-	FedoraCoreOSContainerDiskImage = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
-	FedoraContainerDiskImage       = "quay.io/kubevirtci/fedora-with-test-tooling:v20241128-4d4c8fe"
-	FakeLauncherImage              = "quay.io/nmstate/c10s-nmstate-dev:latest"
+	FedoraCoreOSContainerDiskImage          = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
+	FedoraWithTestToolingContainerDiskImage = "quay.io/kubevirtci/fedora-with-test-tooling:v20241128-4d4c8fe"
+	FedoraContainerDiskImage                = "quay.io/containerdisks/fedora:39"
+	FakeLauncherImage                       = "quay.io/nmstate/c10s-nmstate-dev:latest"
 )


### PR DESCRIPTION
## 📑 Description
At current layer2 topology each node has gateway router ipv6 link local ip and mac addresses, this end up with a multipath ipv6 defaujl gateways at VMs.

This change send a router advertisment with lifetime 0 to remove the ipv6 default gw path using the node where the VM was running before migration and send another one with lifetime max with the gw path where the VM is currently running after migration (after live migration the VM is not going to send a router solicitation so the router advertisment should be generated from ovn-k).

Fixes https://issues.redhat.com/browse/SDN-5424

## Additional Information for reviewers
Note that another [PR](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4852) that uses nftables to block RAs from external nodes is in progress, this PR should work in conjuntion with that.

Also note that proper solution is to use the future [OVN transit router](https://issues.redhat.com/browse/FDP-872) topology where the gw will have the same ip and mac addresses independently of the node where the VM is running, when that lands at OVN the changes introduced by this PR will no longer be needed.

The helper that send the RAs is being placed at `pkg/util/ndp/ra.go` instead of `pkg/util/ra.go` so the PR do not breaks windows compilation, the hybrid overlay binary depends on `pkg/util`.

Also instead of using the high level NDP library `mdlayher/ndp`  we use `github.com/google/gopacket` (already included on the project), with the mdlayher/ndp the src(ip, mac) from the RA is the one from the interface we are sending the message from, in our case the mgmt one, but instead we need them to be the gateway routers join IP LLA/MAC (this is how the VM's recognice what route path are we talking about).

Related-to:
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4852

**NOTE**: For this to work the VM guest need to fully support IPv6 standard, specially understanding router advertisments with lifetime=0, for example fedora35 do not.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it
The PR has e2e check to ipv6 default gw path after live migration.
