### PR TITLE
Do not configure ports for host-networked pods in secondary networks

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -231,7 +231,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 		return nil
 	}
 
-	if util.PodWantsHostNetwork(pod) && !addPort {
+	if util.PodWantsHostNetwork(pod) || !addPort {
 		return nil
 	}
 


### PR DESCRIPTION
The previous condition was incorrect and was ignoring host-networked pods only when `addPort` was false, additionally it didn't ignore cluster-networked pods that do not want a port configured(`addPort==false`). 
This means that the controller tried to configure the logical port for new host-networked pods and on updates for cluster-networked pods. 
Fix the condition by exiting when the pod is host networked **or** `addPort` is false.

This is likely a mistake from reversing the default network condition:
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/d20b22110a912a244f4cd42f0969df60eaf434fc/go-controller/pkg/ovn/ovn.go#L166


The issue can be reproduced by creating a host networked pod in a UDN namespace:
```
E1125 13:40:08.269965   17921 obj_retry.go:671] Failed to update *v1.Pod, old=nad-l3/host-network-pod, new=nad-l3/host-network-pod, error: failed to add logical port of Pod nad-l3/host-network-pod for NAD nad-l3/l3-network: failed to update pod nad-l3/host-network-pod: admission webhook "ovn-kubernetes-admission-webhook-pod.k8s.io" denied the request: user: "system:ovn-node:ovn-worker" is not allowed to set k8s.ovn.org/pod-networks on pod "host-network-pod": the annotation is not allowed on host networked pods
```

@cathy-zhou ptal