### PR TITLE
Add support for ocp-traffic-flow-tests in GitHub workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -406,13 +406,14 @@ jobs:
         # num-nodes-per-zone : "<integer value>"
         # forwarding : ["", "disable-forwarding"]
         # dns-name-resolver : ["", "enable-dns-name-resolver"]
+        # traffic-flow-tests : "<tests range. i.e. 1-24>"
         include:
           - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled",          "dns-name-resolver": "enable-dns-name-resolver"}
-          - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "traffic-flow-tests": "1,2,3"}
           - {"target": "control-plane-helm","ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane-helm","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
@@ -437,6 +438,7 @@ jobs:
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "traffic-flow-test-only","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24"}
           - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
@@ -451,8 +453,8 @@ jobs:
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'multi-homing-helm' }}"
-      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'kv-live-migration'}}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'multi-homing-helm' || matrix.target == 'traffic-flow-test-only' }}"
+      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'kv-live-migration' || matrix.target == 'traffic-flow-test-only' }}"
       DISABLE_UDN_HOST_ISOLATION: "true"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"
@@ -463,6 +465,7 @@ jobs:
       OVN_DISABLE_FORWARDING: "${{ matrix.forwarding == 'disable-forwarding' }}"
       USE_HELM: "${{ matrix.target == 'control-plane-helm' || matrix.target == 'multi-homing-helm' }}"
       OVN_ENABLE_DNSNAMERESOLVER: "${{ matrix.dns-name-resolver == 'enable-dns-name-resolver' }}"
+      TRAFFIC_FLOW_TESTS: "${{ matrix.traffic-flow-tests }}"
     steps:
 
     - name: Install VRF kernel module
@@ -481,6 +484,11 @@ jobs:
           llvm-* microsoft-edge-stable mono-* \
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
+
+    - name: Setup /mnt/runner directory
+      run: |
+        sudo mkdir -pv /mnt/runner
+        sudo chown runner:runner /mnt/runner
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
@@ -523,6 +531,11 @@ jobs:
         export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test install-kind
 
+    - name: traffic-flow-tests setup
+      timeout-minutes: 5
+      if: env.TRAFFIC_FLOW_TESTS != ''
+      run: make -C test traffic-flow-tests WHAT="setup"
+
     - name: Runner Diagnostics
       uses: ./.github/actions/diagnostics
 
@@ -554,11 +567,20 @@ jobs:
         elif [ "${{ matrix.target }}" == "tools" ]; then
           make -C go-controller build
           make -C test tools
+        elif [ "${{ matrix.target }}" == "traffic-flow-test-only" ]; then
+          # Traffic Flow Tests can be ran as part of a target, as an additional
+          # set of test, set via TRAFFIC_FLOW_TESTS. See below.
+          :
         else
           make -C test ${{ matrix.target }}
           if [ "${{ matrix.ipfamily }}" != "ipv6" ]; then
             make -C test conformance
           fi
+        fi
+
+        # If target also specified traffic flow tests to run, do so now
+        if [ -n "${TRAFFIC_FLOW_TESTS}" ]; then
+          make -C test traffic-flow-tests WHAT="run"
         fi
 
     - name: Runner Diagnostics
@@ -569,6 +591,9 @@ jobs:
       run: |
         mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --verbosity 4 /tmp/kind/logs
+        if [ -n "${TRAFFIC_FLOW_TESTS}" ]; then
+            mv -v /tmp/{,kind/logs/}traffic_flow_test_result.json ||:
+        fi
 
     - name: Upload kind logs
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -327,7 +327,7 @@ jobs:
       if: always()
       run: |
         mkdir -p /tmp/kind/logs
-        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --verbosity 4 /tmp/kind/logs
         set -x
         docker ps -a
         docker exec ovn-control-plane crictl images
@@ -375,7 +375,7 @@ jobs:
       if: always()
       run: |
         mkdir -p /tmp/kind/logs-kind-pr-branch
-        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs-kind-pr-branch
+        kind export logs --name ${KIND_CLUSTER_NAME} --verbosity 4 /tmp/kind/logs-kind-pr-branch
 
     - name: Upload kind logs
       if: always()
@@ -568,7 +568,7 @@ jobs:
       if: always()
       run: |
         mkdir -p /tmp/kind/logs
-        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --verbosity 4 /tmp/kind/logs
 
     - name: Upload kind logs
       if: always()
@@ -675,7 +675,7 @@ jobs:
       if: always()
       run: |
         mkdir -p /tmp/kind/logs
-        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --verbosity 4 /tmp/kind/logs
 
     - name: Upload kind logs
       if: always()

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,3 +45,8 @@ conformance:
 .PHONY: tools
 tools:
 	./scripts/test-ovnkube-trace.sh
+
+.PHONY: traffic-flow-tests
+traffic-flow-tests:
+	TRAFFIC_FLOW_TESTS=$(TRAFFIC_FLOW_TESTS) \
+	./scripts/traffic-flow-tests.sh $(WHAT)

--- a/test/scripts/traffic-flow-tests.sh
+++ b/test/scripts/traffic-flow-tests.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Set default values
+export KUBECONFIG="${KUBECONFIG:-${HOME}/ovn.conf}"
+export OCI_BIN="${KIND_EXPERIMENTAL_PROVIDER:-docker}"
+export TFT_TEST_IMAGE="ghcr.io/wizhaoredhat/ocp-traffic-flow-tests:latest"
+export TRAFFIC_FLOW_TESTS_DIRNAME="ocp-traffic-flow-tests"
+export TRAFFIC_FLOW_TESTS_REPO="https://github.com/wizhaoredhat/ocp-traffic-flow-tests.git"
+export TRAFFIC_FLOW_TESTS_COMMIT="eb46da7a3ee1c3cfab5e141f69a3ccd1cdbfbabd"
+export TRAFFIC_FLOW_TESTS="${TRAFFIC_FLOW_TESTS:-1,2,3}"
+
+export SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+export TOP_DIR="/mnt/runner"
+export TRAFFIC_FLOW_TESTS_FULL_PATH="${TOP_DIR}/${TRAFFIC_FLOW_TESTS_DIRNAME}"
+
+log() {
+    local level="$1"
+    shift
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $*"
+}
+
+error_exit() {
+    log "ERROR" "$*"
+    exit 1
+}
+
+check_dependencies() {
+    local dependencies=(sed pip git kubectl kind "${OCI_BIN}")
+    for cmd in "${dependencies[@]}"; do
+        if ! command -v "${cmd}" &> /dev/null; then
+            error_exit "Dependency not met: ${cmd}"
+        fi
+    done
+}
+
+usage() {
+    echo "Usage: $(basename "$0") {setup|run}"
+}
+
+create_config_file_defaults() {
+    local file_name="${1:-config.yaml}"
+
+    cat <<EOT > "$file_name"
+tft:
+  - name: "Github Workflow Test"
+    namespace: "default"
+    test_cases: "TBD"
+    duration: "10"
+    connections:
+      - name: "Connection_1"
+        type: "iperf-tcp"
+        instances: 1
+        server:
+          - name: "ovn-worker"
+            persistent: "false"
+            sriov: "false"
+        client:
+          - name: "ovn-worker2"
+            sriov: "false"
+        plugins: []
+kubeconfig: "TBD"
+kubeconfig_infra:
+EOT
+}
+
+process_test_results() {
+    local result_file="$1"
+
+    log "INFO" "Processing test results from: ${result_file}"
+    ./print_results.py ${result_file} || error_exit "Results evaluation failed."
+}
+
+setup() {
+    check_dependencies
+
+    "${OCI_BIN}" pull "${TFT_TEST_IMAGE}" || error_exit "Failed to pull the test image."
+    local KIND_CLUSTER_NAME
+    KIND_CLUSTER_NAME=$(kind get clusters)
+    kind load docker-image "${TFT_TEST_IMAGE}" --name "${KIND_CLUSTER_NAME}" || error_exit "Failed to load the test image."
+
+    if [ -d "${TRAFFIC_FLOW_TESTS_FULL_PATH}" ]; then
+        error_exit "Install folder already exists: ${TRAFFIC_FLOW_TESTS_FULL_PATH}"
+    fi
+    mkdir -pv "${TRAFFIC_FLOW_TESTS_FULL_PATH}"
+    cd "${TRAFFIC_FLOW_TESTS_FULL_PATH}"
+
+    git init
+    git remote add origin "${TRAFFIC_FLOW_TESTS_REPO}"
+    git fetch --depth=1 origin "${TRAFFIC_FLOW_TESTS_COMMIT}"
+    git checkout "${TRAFFIC_FLOW_TESTS_COMMIT}"
+
+    python -m venv tft-venv
+    source tft-venv/bin/activate
+    pip install --upgrade pip
+    pip install -r requirements.txt
+
+    local CONFIG_FILE="config.yaml"
+    create_config_file_defaults "$CONFIG_FILE"
+
+    sed -i "s|^kubeconfig:.*|kubeconfig: \"$KUBECONFIG\"|" "$CONFIG_FILE"
+    sed -i "s|test_cases:.*|test_cases: \"$TRAFFIC_FLOW_TESTS\"|" "$CONFIG_FILE"
+
+    log "INFO" "Setup complete. Configuration file created: $CONFIG_FILE"
+
+    echo
+    echo "---"
+    cat "$CONFIG_FILE"
+}
+
+run() {
+    cd "${TRAFFIC_FLOW_TESTS_FULL_PATH}" || error_exit "Run folder not found. Missing setup?"
+    source tft-venv/bin/activate || error_exit "Python environment missing. Missing setup?"
+
+    local OUTPUT_BASE="${TRAFFIC_FLOW_TESTS_FULL_PATH}/ft-logs/result-"
+    time ./tft.py config.yaml -o "$OUTPUT_BASE" || error_exit "Test execution FAILED."
+    local RESULT_FILE=$(ls -rt "${OUTPUT_BASE}"*.json | tail -1)
+    cp -vf "${RESULT_FILE}" /tmp/traffic_flow_test_result.json  || error_exit "Unable to locate results.json."
+
+    log "INFO" "Results saved to /tmp/traffic_flow_test_result.json"
+
+    process_test_results "${RESULT_FILE}"
+}
+
+case "${1:-}" in
+    setup)
+        setup
+        ;;
+    run)
+        run
+        ;;
+    -h|--help)
+        usage
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This pull request integrates ocp-traffic-flow-tests into the existing GitHub E2E workflows. The control tests can now be executed as a standalone lane or added to existing targets via the "traffic-flow-tests" matrix parameter. This allows flexibility in running the tests either independently or in conjunction with other pipelines.

External tests and secondary network support are not yet implemented and will be considered in a future pull request.

Currently, the traffic flow tests use a specific commit from the repository https://github.com/wizhaoredhat/ocp-traffic-flow-tests.git. 

Next steps to look into, after this pull-request:
- External and secondary network tests
- Add bandwidth thresholds that would be reasonable for Github
- Move repo to ovn-kubernetes org

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/4756
