### PR TITLE
udn: Add event when ip range full

### DIFF
--- a/go-controller/pkg/allocator/ip/allocator.go
+++ b/go-controller/pkg/allocator/ip/allocator.go
@@ -40,7 +40,7 @@ type Interface interface {
 }
 
 var (
-	ErrFull      = errors.New("range is full")
+	ErrFull      = errors.New("subnet address pool exhausted")
 	ErrAllocated = errors.New("provided IP is already allocated")
 )
 

--- a/go-controller/pkg/allocator/ip/subnet/allocator.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator.go
@@ -264,6 +264,9 @@ func (allocator *allocator) AllocateNextIPs(name string) ([]*net.IPNet, error) {
 	for idx, ipam := range subnetInfo.ipams {
 		ip, err = ipam.AllocateNext()
 		if err != nil {
+			if errors.Is(err, ipallocator.ErrFull) {
+				err = fmt.Errorf("failed to allocate new IPs for %s: %w", name, ipallocator.ErrFull)
+			}
 			return nil, err
 		}
 		ipnet := &net.IPNet{

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -1,6 +1,7 @@
 package pod
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -15,6 +16,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/id"
+	ipallocator "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/ip"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/ip/subnet"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -351,6 +353,9 @@ func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nad string, network *ne
 	)
 
 	if err != nil {
+		if errors.Is(err, ipallocator.ErrFull) {
+			a.recordPodErrorEvent(pod, err)
+		}
 		return err
 	}
 

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -983,6 +983,9 @@ func (bnc *BaseNetworkController) allocatePodAnnotationForSecondaryNetwork(pod *
 	)
 
 	if err != nil {
+		if errors.Is(err, ipallocator.ErrFull) {
+			bnc.recordPodErrorEvent(pod, err)
+		}
 		return nil, false, err
 	}
 


### PR DESCRIPTION
## 📑 Description
When there are no available IP addresses in the IP pool, there is no
indication sent to the pod, and it ends up hanging with the generic
warning event: failed to get pod annotation.

Adding an event indicating the lack of available IP in the pool as the
cause for the failure.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://issues.redhat.com/browse/CNV-45757

## Additional Information for reviewers
The changes are made to the cluster-manager (for l2 ip allocation) and node-controller (for l3 ip allocation)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
1. Create a namespace
```
kubectl create ns localnet-ipam
```

2. Create a NAD with a small IP range. example:
```
cat << EOF | oc create -f - 
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: ipam-localnet-nad
  namespace: localnet-ipam
spec:
  config: |
    {
            "cniVersion": "0.4.0",
            "name": "tenantblue-network",
            "type": "ovn-k8s-cni-overlay",
            "topology":"localnet",
            "subnets": "192.168.10.0/30",
            "excludeSubnets": "192.168.10.1/32",
            "allowPersistentIPs": true,
            "netAttachDefName": "localnet-ipam/ipam-localnet-nad"
    }
EOF
```

4. create one pod (in this example VM) with this network (should succeed, occupying the only IP in the pool)
```
cat << EOF | oc create -f -  
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  creationTimestamp: null
  labels:
    kubevirt.io/vm: vma-localnet-ipam
  name: vma-localnet-ipam
  namespace: localnet-ipam
spec:
  runStrategy: Always
  template:
    metadata:
      creationTimestamp: null
      labels:
        kubevirt.io/domain: vma-localnet-ipam
        kubevirt.io/vm: vma-localnet-ipam
    spec:
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: containerdisk
          - disk:
              bus: virtio
            name: cloudinitdisk
          interfaces:
          - masquerade: {}
            name: default
          - bridge: {}
            name: ipam-network
          rng: {}
        machine:
          type: ''
        resources:
          requests:
            memory: 1024Mi
      networks:
      - name: default
        pod: {}
      - multus:
          networkName: localnet-ipam/ipam-localnet-nad
        name: ipam-network
      volumes:
      - containerDisk:
          image: quay.io/openshift-cnv/qe-cnv-tests-fedora:39
        name: containerdisk
      - cloudInitNoCloud:
          userData: |-
            #cloud-config
            user: fedora
            password: password
            chpasswd: { expire: False }
        name: cloudinitdisk
EOF
```

5. create another pod (in this example VM) with this network (should fail, and the desired event should be added)
```
cat << EOF | oc create -f -  
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  creationTimestamp: null
  labels:
    kubevirt.io/vm: vmb-localnet-ipam
  name: vmb-localnet-ipam
  namespace: localnet-ipam
spec:
  runStrategy: Always
  template:
    metadata:
      creationTimestamp: null
      labels:
        kubevirt.io/domain: vmb-localnet-ipam
        kubevirt.io/vm: vmb-localnet-ipam
    spec:
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: containerdisk
          - disk:
              bus: virtio
            name: cloudinitdisk
          interfaces:
          - masquerade: {}
            name: default
          - bridge: {}
            name: ipam-network
          rng: {}
        machine:
          type: ''
        resources:
          requests:
            memory: 1024Mi
      networks:
      - name: default
        pod: {}
      - multus:
          networkName: localnet-ipam/ipam-localnet-nad
        name: ipam-network
      volumes:
      - containerDisk:
          image: quay.io/openshift-cnv/qe-cnv-tests-fedora:39
        name: containerdisk
      - cloudInitNoCloud:
          userData: |-
            #cloud-config
            user: fedora
            password: password
            chpasswd: { expire: False }
        name: cloudinitdisk
EOF
```
