### PR TITLE
UDN: Filter RA according local GW Router LLA only to avoid multi path

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -250,6 +251,13 @@ func setupInterface(netns ns.NetNS, containerID, ifName string, ifInfo *PodInter
 		// to generate the unique host interface name, postfix it with the podInterface index for non-default network
 		if ifInfo.NetName != types.DefaultNetworkName {
 			ifnameSuffix = fmt.Sprintf("_%d", containerVeth.Index)
+		}
+
+		// If we have the ipv6 gateway LLA then this is a primary layer2 UDN
+		if len(ifInfo.GatewayIPv6LLA) > 0 {
+			if err = setupIngressFilter(ifName, ifInfo.GatewayIPv6LLA.String()); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -597,6 +605,7 @@ func (*defaultPodRequestInterfaceOps) ConfigureInterface(pr *PodRequest, getter 
 			return nil, fmt.Errorf("unexpected configuration, pod request on dpu host. " +
 				"device ID must be provided")
 		}
+
 		// General case
 		hostIface, contIface, err = setupInterface(netns, pr.SandboxID, pr.IfName, ifInfo)
 	}
@@ -817,4 +826,69 @@ func (pr *PodRequest) deletePorts(ifaces []string, podNamespace, podName string)
 	for _, iface := range ifaces {
 		pr.deletePort(iface, podNamespace, podName)
 	}
+}
+
+// setupIngressFilter sets up an ingress filter using nftables to block
+// unwanted ICMPv6 Router Advertisement (RA) packets on a specific device.
+// It creates a new nftables table, chain, and rule to drop RA packets
+// that do not match the specified gateway link-local address (gwLLA) and
+// have a Router Advertisement (RA) lifetime not equal to 0.
+//
+// The nftables rule created by this function looks like:
+// `icmpv6 type nd-router-advert ip6 saddr != <gwLLA> @th,48,16 != 0 drop`
+//
+// Parameters:
+//   - ifaceName: The name of the network interface where the ingress filter
+//     should be applied.
+//   - gwLLA: The gateway link-local address to match against in the RA packets.
+//
+// Returns:
+// - error: An error if the nftables setup fails, otherwise nil.
+func setupIngressFilter(ifaceName, gwLLA string) error {
+	const (
+		tableName   = "ingress_filter" // Name of the nftables table to be created
+		rasLifetime = "@th,48,16"      // Offset for RA lifetime field in ICMPv6 packets
+	)
+
+	// Initialize a new nftables table for the ingress filter
+	nft, err := knftables.New(knftables.NetDevFamily, tableName)
+	if err != nil {
+		return fmt.Errorf("failed to initialize table: %w", err)
+	}
+
+	// Delegate the setup of the filter with the specified table and lifetime matcher
+	return setupIngressFilterWithTableAndLifetimeMatcher(nft, ifaceName, gwLLA, rasLifetime)
+}
+
+func setupIngressFilterWithTableAndLifetimeMatcher(nft knftables.Interface, ifaceName, gwLLA, rasLifetime string) error {
+	const (
+		chainName = "input"
+	)
+
+	tx := nft.NewTransaction()
+
+	tx.Add(&knftables.Table{})
+
+	tx.Add(&knftables.Chain{
+		Name:     chainName,
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.IngressHook),
+		Priority: knftables.PtrTo(knftables.FilterPriority),
+		Device:   knftables.PtrTo(ifaceName),
+	})
+
+	tx.Add(&knftables.Rule{
+		Chain: chainName,
+		Rule: knftables.Concat(
+			"icmpv6", "type", "nd-router-advert", "ip6", "saddr", "!=", gwLLA, rasLifetime, "!=", "0", "drop",
+		),
+	})
+
+	// Execute the transaction
+	if err := nft.Run(context.Background(), tx); err != nil {
+		return fmt.Errorf("could not update netdev nftables: %v", err)
+	}
+
+	return nil
+
 }

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	kexec "k8s.io/utils/exec"
+	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/mocks"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -1649,6 +1650,21 @@ func TestConfigureOVS_getPfEncapIpWithError(t *testing.T) {
 			mockLink.AssertExpectations(t)
 		})
 	}
+}
+
+func TestSetupIngressFilter(t *testing.T) {
+	nft := knftables.NewFake(knftables.NetDevFamily, "ingress_filter")
+
+	gwLLA := "fe80::1"
+	err := setupIngressFilterWithTableAndLifetimeMatcher(nft, "test-iface-1", gwLLA, "mark")
+	require.NoError(t, err)
+	output := nft.Dump()
+
+	expectedDump := `add table netdev ingress_filter
+add chain netdev ingress_filter input { type filter hook ingress device "test-iface-1" priority 0 ; }
+add rule netdev ingress_filter input icmpv6 type nd-router-advert ip6 saddr != fe80::1 mark != 0 drop`
+
+	assert.Equal(t, expectedDump, strings.TrimRight(output, "\n"), "The nftables dump output does not match the expected output")
 }
 
 // TODO(leih): Below functions are copied from pkg/node/base_node_network_controller_dpu_test.go.

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1683,6 +1683,20 @@ runcmd:
 			nodeIPs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 
 			if td.role == "primary" {
+				if isIPv6Supported() && isInterconnectEnabled() {
+					step = by(vmi.Name, fmt.Sprintf("Checking IPv6 gateway before %s %s", td.resource.description, td.test.description))
+
+					nodeRunningVMI, err := fr.ClientSet.CoreV1().Nodes().Get(context.Background(), vmi.Status.NodeName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred(), step)
+
+					expectedIPv6GatewayPath, err := kubevirt.GenerateGatewayIPv6RouterLLA(nodeRunningVMI, netConfig.networkName)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(kubevirt.RetrieveIPv6Gateways).
+						WithArguments(vmi).
+						WithTimeout(5*time.Second).
+						WithPolling(time.Second).
+						Should(Equal([]string{expectedIPv6GatewayPath}), "should filter remote ipv6 gateway nexthop")
+				}
 				step = by(vmi.Name, fmt.Sprintf("Check north/south traffic before %s %s", td.resource.description, td.test.description))
 				startNorthSouthIngressIperfTraffic(externalContainerName, nodeIPs, svc.Spec.Ports[0].NodePort, step)
 				checkNorthSouthIngressIperfTraffic(externalContainerName, nodeIPs, svc.Spec.Ports[0].NodePort, step)


### PR DESCRIPTION
## 📑 Description

IPv6 Router Advertisements from non-local sources can interfere with primary UDN interfaces
in multi-gateway setups, resulting in multiple default gateways.

To resolve this, ingress filtering was added using nftables to block unwanted RAs,
allowing only RAs from the node's local gateway and RAs with Lifetime 0,
which are needed to invalidate entries during migration.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
The PR include tests
