### PR TITLE
Use friendly names for VFRs

### DIFF
--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -75,7 +75,7 @@ func (ncm *nodeNetworkControllerManager) CleanupDeletedNetworks(validNetworks ..
 			klog.Errorf("Failed to get network identifier for network %s, error: %s", network.GetNetworkName(), err)
 			continue
 		}
-		validVRFDevices.Insert(util.GetVRFDeviceNameForUDN(networkID))
+		validVRFDevices.Insert(util.GetNetworkVRFNameForDevice(network, networkID))
 	}
 	return ncm.vrfManager.Repair(validVRFDevices)
 }

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -174,12 +174,12 @@ var _ = Describe("Healthcheck tests", func() {
 
 	Context("verify cleanup of deleted networks", func() {
 		var (
-			staleNetID uint   = 100
+			staleNetID uint   = 1000
 			nodeName   string = "worker1"
 			nad               = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 				types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
 			netName      = "bluenet"
-			netID        = 3
+			netID        = 1003
 			v4NodeSubnet = "10.128.0.0/24"
 			v6NodeSubnet = "ae70::66/112"
 			testNS       ns.NetNS

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -231,12 +231,12 @@ var _ = Describe("Healthcheck tests", func() {
 			err = testNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				staleVrfDevice := util.GetVRFDeviceNameForUDN(int(staleNetID))
+				staleVrfDevice := util.GetNetworkVRFNameForDevice(NetInfo, int(staleNetID))
 				ovntest.AddVRFLink(staleVrfDevice, uint32(staleNetID))
 				_, err = util.GetNetLinkOps().LinkByName(staleVrfDevice)
 				Expect(err).NotTo(HaveOccurred())
 
-				validVrfDevice := util.GetVRFDeviceNameForUDN(int(netID))
+				validVrfDevice := util.GetNetworkVRFNameForDevice(NetInfo, int(netID))
 				ovntest.AddVRFLink(validVrfDevice, uint32(netID))
 				_, err = util.GetNetLinkOps().LinkByName(validVrfDevice)
 				Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -231,7 +231,7 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 	if err != nil {
 		return fmt.Errorf("could not create management port netdevice for network %s: %w", udng.GetNetworkName(), err)
 	}
-	vrfDeviceName := util.GetVRFDeviceNameForUDN(udng.networkID)
+	vrfDeviceName := util.GetNetworkVRFNameForDevice(udng.NetInfo, udng.networkID)
 	vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
 	routes, err := udng.computeRoutesForUDN(vrfTableId, mplink)
 	if err != nil {
@@ -300,7 +300,7 @@ func (udng *UserDefinedNetworkGateway) GetNetworkRuleMetadata() string {
 // DelNetwork will be responsible to remove all plumbings
 // used by this UDN on the gateway side
 func (udng *UserDefinedNetworkGateway) DelNetwork() error {
-	vrfDeviceName := util.GetVRFDeviceNameForUDN(udng.networkID)
+	vrfDeviceName := util.GetNetworkVRFNameForDevice(udng.NetInfo, udng.networkID)
 	// delete the iprules for this network
 	if err := udng.ruleManager.DeleteWithMetadata(udng.GetNetworkRuleMetadata()); err != nil {
 		return fmt.Errorf("unable to delete iprules for network %s, err: %v", udng.GetNetworkName(), err)

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -335,7 +335,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			Expect(err).NotTo(HaveOccurred())
 
 			By("check management interface and VRF device is created for the network")
-			vrfDeviceName := util.GetVRFDeviceNameForUDN(netID)
+			vrfDeviceName := util.GetNetworkVRFNameForDevice(NetInfo, netID)
 			vrfLink, err := util.GetNetLinkOps().LinkByName(vrfDeviceName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vrfLink.Type()).To(Equal("vrf"))

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -3,13 +3,11 @@ package vrfmanager
 import (
 	"fmt"
 
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
@@ -177,11 +175,14 @@ func (vrfm *Controller) sync(vrf vrf) error {
 	vrfLink, err := util.GetNetLinkOps().LinkByName(vrf.name)
 	var mustRecreate bool
 	if err == nil {
-		if vrfLink.Type() != "vrf" {
+		vrfDev, ok := vrfLink.(*netlink.Vrf)
+		if !ok {
 			return fmt.Errorf("node has another non VRF device with same name %s", vrf.name)
 		}
-		vrfDev, ok := vrfLink.(*netlink.Vrf)
-		if ok && vrfDev.Table != vrf.table {
+		if vrfDev.Table < util.RoutingTableIDStart {
+			return fmt.Errorf("node has another VRF device with same name %s that is not managed by ovn-kubernetes", vrf.name)
+		}
+		if vrfDev.Table != vrf.table {
 			klog.Warningf("Found a conflict with existing VRF device table id for VRF device %s, recreating it", vrf.name)
 			err = vrfm.deleteVRF(vrfLink)
 			if err != nil {
@@ -244,6 +245,9 @@ func (vrfm *Controller) AddVRF(name string, slaveInterface string, table uint32,
 	if len(name) > 15 {
 		return fmt.Errorf("VRF Manager: VRF name %s must be within 15 characters", name)
 	}
+	if table < util.RoutingTableIDStart {
+		return fmt.Errorf("VRF Manager: cannot manage a VRF %s with table %d lower than %d", name, table, util.RoutingTableIDStart)
+	}
 	var (
 		vrfDev vrf
 		ok     bool
@@ -275,9 +279,6 @@ func (vrfm *Controller) AddVRF(name string, slaveInterface string, table uint32,
 
 // Repair deletes stale VRF device(s) on the host. This helps remove
 // device(s) for which DeleteVRF is never invoked.
-// Assumptions: 1) The validVRFs list must contain device for which AddVRF
-// is already invoked. 2) The device name(s) in validVRFs are suffixed
-// with "-vrf" and prefixed with "mp".
 func (vrfm *Controller) Repair(validVRFs sets.Set[string]) error {
 	vrfm.mu.Lock()
 	defer vrfm.mu.Unlock()
@@ -292,20 +293,25 @@ func (vrfm *Controller) repair(validVRFs sets.Set[string]) error {
 	}
 
 	for _, link := range links {
-		name := link.Attrs().Name
-		// Skip if the link is not a vrf type or name is not suffixed with -vrf or is not prefixed with mp.
-		if link.Type() != "vrf" || !strings.HasSuffix(name, types.UDNVRFDeviceSuffix) ||
-			!strings.HasPrefix(name, types.UDNVRFDevicePrefix) {
+		vrf, isVRF := link.(*netlink.Vrf)
+		if !isVRF {
+			// not a vrf device
 			continue
 		}
+		if vrf.Table < util.RoutingTableIDStart {
+			// vrf device not managed by us
+			continue
+		}
+		name := vrf.Name
 		if validVRFs.Has(name) {
+			// vrf not stale
 			continue
 		}
 		err = util.GetNetLinkOps().LinkDelete(link)
 		if err != nil {
 			klog.Errorf("VRF Manager: error deleting stale VRF device %s, err: %v", name, err)
 		}
-		delete(vrfm.vrfs, link.Attrs().Index)
+		delete(vrfm.vrfs, vrf.Index)
 	}
 	return nil
 }

--- a/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
@@ -21,8 +21,9 @@ import (
 
 var (
 	c            *Controller
-	vrfLinkName1 = "mp100-udn-vrf"
+	vrfLinkName1 = "blue"
 	vrfLinkName2 = "mp200-udn-vrf"
+	vrfLinkName3 = "red-not-udn"
 )
 
 var _ = ginkgo.Describe("VRF manager", func() {
@@ -31,10 +32,10 @@ var _ = ginkgo.Describe("VRF manager", func() {
 		enslaveLinkName1 = "dev100"
 		enslaveLinkName2 = "dev101"
 		nlMock           *mocks.NetLinkOps
-		vrfLinkMock1     *netlink_mocks.Link
+		//vrfLinkMock1     *netlink_mocks.Link
 		enslaveLinkMock1 *netlink_mocks.Link
 		enslaveLinkMock2 *netlink_mocks.Link
-		vrfLinkMock2     *netlink_mocks.Link
+		//vrfLinkMock2     *netlink_mocks.Link
 	)
 
 	linkIndexes := map[string]int{
@@ -42,6 +43,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 		enslaveLinkName1: 2,
 		enslaveLinkName2: 3,
 		vrfLinkName2:     4,
+		vrfLinkName3:     5,
 	}
 
 	masterIndexes := map[string]int{
@@ -49,6 +51,13 @@ var _ = ginkgo.Describe("VRF manager", func() {
 		enslaveLinkName1: 1,
 		enslaveLinkName2: 1,
 		vrfLinkName2:     0,
+		vrfLinkName3:     0,
+	}
+
+	vrfTables := map[string]uint32{
+		vrfLinkName1: 1000,
+		vrfLinkName2: 2000,
+		vrfLinkName3: 999,
 	}
 
 	getLinkIndex := func(linkName string) int {
@@ -67,29 +76,41 @@ var _ = ginkgo.Describe("VRF manager", func() {
 		return masterIndex
 	}
 
+	getVRFTable := func(linkName string) uint32 {
+		table, ok := vrfTables[linkName]
+		if !ok {
+			panic(fmt.Sprintf("failed to find table for vrf %q", linkName))
+		}
+		return table
+	}
+
+	buildVRF := func(name string) *netlink.Vrf {
+		return &netlink.Vrf{
+			LinkAttrs: netlink.LinkAttrs{Name: name, MasterIndex: getLinkMasterIndex(name), Index: getLinkIndex(name)},
+			Table:     getVRFTable(name),
+		}
+	}
+
 	ginkgo.BeforeEach(func() {
 		c = NewController(routemanager.NewController())
 
 		nlMock = &mocks.NetLinkOps{}
-		vrfLinkMock1 = new(netlink_mocks.Link)
+
 		enslaveLinkMock1 = new(netlink_mocks.Link)
 		enslaveLinkMock2 = new(netlink_mocks.Link)
-		vrfLinkMock2 = new(netlink_mocks.Link)
 		util.SetNetLinkOpMockInst(nlMock)
 
-		nlMock.On("LinkByName", vrfLinkName1).Return(vrfLinkMock1, nil)
+		nlMock.On("LinkByName", vrfLinkName1).Return(buildVRF(vrfLinkName1), nil)
 		nlMock.On("LinkByName", enslaveLinkName1).Return(enslaveLinkMock1, nil)
 		nlMock.On("LinkByName", enslaveLinkName2).Return(enslaveLinkMock2, nil)
 		nlMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 		nlMock.On("LinkAdd", mock.Anything).Return(nil)
 		nlMock.On("LinkSetUp", mock.Anything).Return(nil)
-		vrfLinkMock1.On("Type").Return("vrf")
-		vrfLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: vrfLinkName1, MasterIndex: getLinkMasterIndex(vrfLinkName1), Index: getLinkIndex(vrfLinkName1)}, nil)
 
-		nlMock.On("LinkByName", vrfLinkName2).Return(vrfLinkMock2, nil)
-		vrfLinkMock2.On("Type").Return("vrf")
-		vrfLinkMock2.On("Attrs").Return(&netlink.LinkAttrs{Name: vrfLinkName2, MasterIndex: getLinkMasterIndex(vrfLinkName2), Index: getLinkIndex(vrfLinkName2), OperState: netlink.OperUp}, nil)
-		nlMock.On("LinkDelete", vrfLinkMock2).Return(nil)
+		nlMock.On("LinkByName", vrfLinkName2).Return(buildVRF(vrfLinkName2), nil)
+		nlMock.On("LinkDelete", buildVRF(vrfLinkName2)).Return(nil)
+
+		nlMock.On("LinkByName", vrfLinkName3).Return(buildVRF(vrfLinkName3), nil)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -98,28 +119,44 @@ var _ = ginkgo.Describe("VRF manager", func() {
 
 	ginkgo.Context("VRFs", func() {
 		ginkgo.It("add VRF with a slave interface", func() {
-			nlMock.On("LinkList").Return([]netlink.Link{vrfLinkMock1, enslaveLinkMock1}, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
 			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: 0, Index: getLinkIndex(enslaveLinkName1)}, nil)
-			nlMock.On("LinkSetMaster", enslaveLinkMock1, vrfLinkMock1).Return(nil)
-			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, 10, nil)
+			nlMock.On("LinkSetMaster", enslaveLinkMock1, buildVRF(vrfLinkName1)).Return(nil)
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("fails if we add a VRF with a long name", func() {
+			err := c.AddVRF("this.name.is.too.long", "other", 0, nil)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("fails if we add a VRF with a non managed routing table", func() {
+			err := c.AddVRF("this.name.is.ok", "other", 999, nil)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("fails if we add VRF with same name as existing non-managed VRF", func() {
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName3)}, nil)
+			err := c.AddVRF(vrfLinkName3, "other", 3000, nil)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("delete VRF", func() {
-			err := c.AddVRF(vrfLinkName2, "", 20, nil)
+			err := c.AddVRF(vrfLinkName2, "", getVRFTable(vrfLinkName2), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			err = c.DeleteVRF(vrfLinkName2)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.It("reconcile VRFs", func() {
-			nlMock.On("LinkList").Return([]netlink.Link{vrfLinkMock1, vrfLinkMock2, enslaveLinkMock1}, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), buildVRF(vrfLinkName2), enslaveLinkMock1}, nil)
 			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkMasterIndex(enslaveLinkName1), Index: getLinkIndex(enslaveLinkName1)}, nil)
-			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, 10, nil)
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			err = c.AddVRF(vrfLinkName2, "", 20, nil)
+			err = c.AddVRF(vrfLinkName2, "", getVRFTable(vrfLinkName2), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			err = util.GetNetLinkOps().LinkDelete(vrfLinkMock2)
+			err = util.GetNetLinkOps().LinkDelete(buildVRF(vrfLinkName2))
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			enslaveLinkMock1.On("Type").Return("dummy")
 			err = c.reconcile()
@@ -130,7 +167,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 		})
 
 		ginkgo.It("repair VRFs", func() {
-			nlMock.On("LinkList").Return([]netlink.Link{vrfLinkMock1, vrfLinkMock2, enslaveLinkMock1}, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), buildVRF(vrfLinkName2), buildVRF(vrfLinkName3), enslaveLinkMock1}, nil)
 			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkMasterIndex(enslaveLinkName1), Index: getLinkIndex(enslaveLinkName1)}, nil)
 			enslaveLinkMock1.On("Type").Return("dummy")
 			validVRFs := make(sets.Set[string])
@@ -202,9 +239,9 @@ var _ = ginkgo.Describe("VRF manager tests with a network namespace", func() {
 	ovntest.OnSupportedPlatformsIt("ensure VRF manager is reconciling configured VRF devices correctly", func() {
 		err := testNS.Do(func(ns.NetNS) error {
 			defer ginkgo.GinkgoRecover()
-			err := c.AddVRF(vrfLinkName1, "", 10, nil)
+			err := c.AddVRF(vrfLinkName1, "", 1000, nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			err = c.AddVRF(vrfLinkName2, "", 20, nil)
+			err = c.AddVRF(vrfLinkName2, "", 2000, nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 			wg3 := &sync.WaitGroup{}

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1026,3 +1026,27 @@ func AllowsPersistentIPs(netInfo NetInfo) bool {
 		return false
 	}
 }
+
+// GetNetworkVRFNameForBGP returns a valid VFR name for the network to use over
+// BGP. Returns "default" for the default network. In case a valid name is not
+// found, returns an empty string
+func GetNetworkVRFNameForBGP(netInfo BasicNetInfo) string {
+	if netInfo.GetNetworkName() == types.DefaultNetworkName {
+		return types.DefaultNetworkName
+	}
+	// only cluster UDN networks with names under 15 char are valid for BGP
+	vrfDeviceName := strings.TrimPrefix(netInfo.GetNetworkName(), "cluster.udn.")
+	if len(vrfDeviceName) > 15 || vrfDeviceName == netInfo.GetNetworkName() || netInfo.GetNetworkName() == types.DefaultNetworkName {
+		return ""
+	}
+	return vrfDeviceName
+}
+
+func GetNetworkVRFNameForDevice(netInfo BasicNetInfo, networkID int) string {
+	// try a valid BGP VRF name first
+	vrfDeviceName := GetNetworkVRFNameForBGP(netInfo)
+	if vrfDeviceName == "" {
+		vrfDeviceName = fmt.Sprintf("%s%d%s", types.UDNVRFDevicePrefix, networkID, types.UDNVRFDeviceSuffix)
+	}
+	return vrfDeviceName
+}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	routingTableIDStart = 1000
+	RoutingTableIDStart = 1000
 )
 
 var ErrorNoIP = errors.New("no IP available")
@@ -332,5 +332,5 @@ func IPNetsIPToStringSlice(ips []*net.IPNet) []string {
 // CalculateRouteTableID will calculate route table ID based on the network
 // interface index
 func CalculateRouteTableID(ifIndex int) int {
-	return ifIndex + routingTableIDStart
+	return ifIndex + RoutingTableIDStart
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -136,10 +136,6 @@ func GetNetworkScopedK8sMgmtHostIntfName(networkID uint) string {
 	return intfName
 }
 
-func GetVRFDeviceNameForUDN(networkID int) string {
-	return fmt.Sprintf("%s%d%s", types.UDNVRFDevicePrefix, networkID, types.UDNVRFDeviceSuffix)
-}
-
 // GetWorkerFromGatewayRouter determines a node's corresponding worker switch name from a gateway router name
 func GetWorkerFromGatewayRouter(gr string) string {
 	return strings.TrimPrefix(gr, types.GWRouterPrefix)


### PR DESCRIPTION
Anticipating that these VRF names are going to be exposed through BGP,
we should use friendlier names for them. The most natural name to
use is the network name. 

For now, this applies only to cluster UDNs with names shorter than 15 
characters.

Giving a cluster UDN a name below 15 characters that matches an already
existing VRF not managed by ovn-k will fail. This is considered an admin
problem and not an ovn-k problem for now.

To allow for this, VRF manager is changed to work with VRFs of any name.
Validation is based on table number rather than on the name.

Some notes to start a discussion though:

- I did not consider normal UDNs as I am not sure the namespace has a 
  useful meaning outside of the cluster and they will be more prone to be
  above 15 characters length. This limitation might not be important as BGP
  advertisements are administered by the cluster admin anyway, so just
  handling cluster UDNs fits the use case. However, we might be interested in
  gaining the flexibility to advertise non cluster UDNs as well.
- I considered adding a VRF name to the CRD. We would have to manage 
  uniqueness across all the UDNs. However, although I admit to the gained
  flexibility, I can imagine an admin would just like to manage a single name
  and not two. Supporting non cluster UDNs can tip the balance though given
  the character limit.
- The table space considered to be managed by ovn-k is anything above 1000.
  I think @martinkennelly is working on defining this better.
- I tried to see if FRR would allow to map a BGP VFR to a Zebra VFR of different
  name so that we don't have to deal with this. But I did not find anything. Last call
  to @fedepaol to see if this would be possible. I am just surprised BGP has to deal 
  with the 15 character limit of the kernel.