### PR TITLE
[WIP] Refactor legacy informer/handler framework

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -869,6 +869,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				time.Sleep(5 * time.Second)
 				// Ensure first egressIP object is assigned, since only node1 is an egressNode, only 1IP will be assigned, other will be pending
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(1))
@@ -1337,6 +1338,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				time.Sleep(5 * time.Second)
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
 				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
@@ -3262,9 +3264,44 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				time.Sleep(1 * time.Second)
+				gomega.Eventually(func() error {
+					egressIPs, nodes := getEgressIPStatus(egressIPName)
+					found1, found2 := false, false
+					for _, node := range nodes {
+						if node == egressNode1.name {
+							found1 = true
+						}
+						if node == egressNode2.name {
+							found2 = true
+						}
+					}
+					if !found1 || !found2 {
+						return fmt.Errorf("did not find both nodes: node1: %t, node2: %t", found1, found2)
+					}
+
+					found1, found2 = false, false
+					for _, eip := range egressIPs {
+
+						if eip == eIP.Status.Items[0].EgressIP {
+							found1 = true
+						}
+
+						if eip == eIP.Status.Items[1].EgressIP {
+							found2 = true
+						}
+					}
+					if !found1 || !found2 {
+						return fmt.Errorf("did not find both eips: %s: %t, %s: %t",
+							eIP.Status.Items[0].EgressIP, found1,
+							eIP.Status.Items[1].EgressIP, found2)
+					}
+					return nil
+				}, 2*time.Second, 100*time.Millisecond)
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
 				gomega.Expect(nodes).To(gomega.ConsistOf(egressNode1.name, egressNode2.name))
 				gomega.Expect(egressIPs).To(gomega.ConsistOf(eIP.Status.Items[0].EgressIP, eIP.Status.Items[1].EgressIP))
+
 				return nil
 			}
 
@@ -3349,6 +3386,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode2.name] = &egressNode2
 
 				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				time.Sleep(5 * time.Second)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				egressIPs, nodes := getEgressIPStatus(egressIPName)

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -716,6 +716,7 @@ var _ = Describe("Watch Factory Operations", func() {
 					UpdateFunc: func(old, new interface{}) {},
 					DeleteFunc: func(obj interface{}) {},
 				}, nil, wf.GetHandlerPriority(objType))
+			Eventually(h.NumberOfProcessedItems).Should(Equal(2))
 			Expect(int(addCalls)).To(Equal(2))
 			Expect(err).NotTo(HaveOccurred())
 			wf.removeHandler(objType, h)

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -25,6 +25,7 @@ import (
 
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	ipamclaimsapifake "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned/fake"
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadsfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 
 	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
@@ -284,6 +285,13 @@ func ipamClaimsObjSetup(c *ipamclaimsapifake.Clientset, objType string, listFn f
 	return w
 }
 
+func nadObjSetup(c *nadsfake.Clientset, objType string, listFn func(core.Action) (bool, runtime.Object, error)) *watch.FakeWatcher {
+	w := watch.NewFake()
+	c.AddWatchReactor(objType, core.DefaultWatchReactor(w, nil))
+	c.AddReactor("list", objType, listFn)
+	return w
+}
+
 type handlerCalls struct {
 	added   int32
 	updated int32
@@ -326,23 +334,25 @@ var _ = Describe("Watch Factory Operations", func() {
 		adminNetPolWatch                    *watch.FakeWatcher
 		baselineAdminNetPolWatch            *watch.FakeWatcher
 		ipamClaimsWatch                     *watch.FakeWatcher
-		pods                                []*v1.Pod
-		namespaces                          []*v1.Namespace
-		nodes                               []*v1.Node
-		policies                            []*knet.NetworkPolicy
-		endpointSlices                      []*discovery.EndpointSlice
-		services                            []*v1.Service
-		egressIPs                           []*egressip.EgressIP
-		cloudPrivateIPConfigs               []*ocpcloudnetworkapi.CloudPrivateIPConfig
-		wf                                  *WatchFactory
-		egressFirewalls                     []*egressfirewall.EgressFirewall
-		egressQoSes                         []*egressqos.EgressQoS
-		egressServices                      []*egressservice.EgressService
-		adminNetworkPolicies                []*anpapi.AdminNetworkPolicy
-		baselineAdminNetworkPolicies        []*anpapi.BaselineAdminNetworkPolicy
-		ipamClaims                          []*ipamclaimsapi.IPAMClaim
-		err                                 error
-		shutdown                            bool
+		//nadWatch                            *watch.FakeWatcher
+		pods                         []*v1.Pod
+		namespaces                   []*v1.Namespace
+		nodes                        []*v1.Node
+		policies                     []*knet.NetworkPolicy
+		endpointSlices               []*discovery.EndpointSlice
+		services                     []*v1.Service
+		egressIPs                    []*egressip.EgressIP
+		cloudPrivateIPConfigs        []*ocpcloudnetworkapi.CloudPrivateIPConfig
+		wf                           *WatchFactory
+		egressFirewalls              []*egressfirewall.EgressFirewall
+		egressQoSes                  []*egressqos.EgressQoS
+		egressServices               []*egressservice.EgressService
+		adminNetworkPolicies         []*anpapi.AdminNetworkPolicy
+		baselineAdminNetworkPolicies []*anpapi.BaselineAdminNetworkPolicy
+		ipamClaims                   []*ipamclaimsapi.IPAMClaim
+		nads                         []*nadapi.NetworkAttachmentDefinition
+		err                          error
+		shutdown                     bool
 	)
 
 	const (
@@ -518,6 +528,16 @@ var _ = Describe("Watch Factory Operations", func() {
 			}
 			return true, obj, nil
 		})
+
+		nads = make([]*nadapi.NetworkAttachmentDefinition, 0)
+		nadObjSetup(nadsFakeClient, "network-attachment-definitions", func(core.Action) (bool, runtime.Object, error) {
+			obj := &nadapi.NetworkAttachmentDefinitionList{}
+			for _, p := range nads {
+				obj.Items = append(obj.Items, *p)
+			}
+			return true, obj, nil
+		})
+
 		shutdown = false
 	})
 
@@ -1307,7 +1327,8 @@ var _ = Describe("Watch Factory Operations", func() {
 			done <- true
 		}()
 
-		// Adds are done synchronously at handler addition time
+		// Adds are done async at handler addition time
+		Eventually(c.getAdded, 10).Should(Equal(len(testNodes)))
 		for _, ot := range testNodes {
 			ot.mu.Lock()
 			Expect(ot.added).To(Equal(1), "missing add for node %s", ot.node.Name)
@@ -1606,7 +1627,11 @@ var _ = Describe("Watch Factory Operations", func() {
 			done <- true
 		}()
 
-		// Adds are done synchronously at handler addition time
+		Eventually(c1.getAdded, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c2.getAdded, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c3.getAdded, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c4.getAdded, 10).Should(Equal(len(testNamespaces)))
+		// Adds are done asynchronously at handler addition time
 		for _, ot := range testNamespaces {
 			ot.mu.Lock()
 			// ((((0 + 1) * 10) - 2) / 2) = 4

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -477,6 +477,8 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 func (i *informer) removeAllHandlers() {
 	i.Lock()
 	defer i.Unlock()
+	i.handlerMutex.Lock()
+	defer i.handlerMutex.Unlock()
 	for _, handlers := range i.handlers {
 		for _, handler := range handlers {
 			i.removeHandler(handler)


### PR DESCRIPTION
The legacy event driven informer/handler framework has flaws with performance. The regular "informer" object is not multi-threaded and handles events without a queue. The federated "queued informer" sends events to queues where worker threads pull items off and process them. In either informer version, the processing of objects is paused when a new handler is added to the informer. When a new handler is added, all existing objects in the cluster are processed as ADDs. This is extremely slow with UDN and adding new handlers on the fly as UDNs are created. Additionally, the previous model for queued informer did not actually stop the shared informer from enqueuing objects directly. It only paused the workers, which indirectly would eventually stop the shared informer from enqueuing after the channel buffer (size 10) was full.

To address this, the following has been changed:
 1. Classic informer type object is removed, all legacy informers now use a queued informer. These queued informers only use 1 worker thread.
 2. The queued informer now only enqueues events on initial add. The queue size has been adjusted to 10k to account for buffering initial add objects. Can tweak this later.
 3. Locking has been modified. The informer lock is now used to control event flow into the queues. In order to enqueue events from the informer cache, a read lock must be obtained. When a handler is added the informer lock is temporarily taken, to stop the informer cache so that initial objects can be enqueued. Additionally a new handlerMutex is introduced to control adding/removing handlers on an queued informer object.
 4. Since now all objects are enqueued when a handler is added and all handlers will iterate over these already processed objects, a map has been added to the handler. This processedInitialAdd map allows the handler to determine if it has already processed the object or not. In the case of existing handlers, they will ignore adds for objects they already procesed. For newly added handlers, they will ignore updates and deletes received before they have first added the object.


