### PR TITLE
multihoming: Add NAD reconciliation e2e tests

### DIFF
--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -45,6 +45,20 @@ func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmen
 	return nil
 }
 
+func ovsRemoveSwitchPort(ovsPods []v1.Pod, portName string, newVLANID int) error {
+	for _, ovsPod := range ovsPods {
+		if err := ovsRemoveVLANAccessPort(ovsPod.Name, bridgeName, portName); err != nil {
+			return fmt.Errorf("failed to remove old VLAN port: %v", err)
+		}
+
+		if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, newVLANID); err != nil {
+			return fmt.Errorf("failed to add new VLAN port: %v", err)
+		}
+	}
+
+	return nil
+}
+
 func teardownUnderlay(ovsPods []v1.Pod) error {
 	for _, ovsPod := range ovsPods {
 		if err := removeOVSBridge(ovsPod.Name, bridgeName); err != nil {
@@ -112,6 +126,19 @@ func ovsEnableVLANAccessPort(ovsNodeName string, bridgeName string, portName str
 
 	if _, err := runCommand(cmd...); err != nil {
 		return fmt.Errorf("failed to add port %s to OVS bridge %s: %v", portName, bridgeName, err)
+	}
+
+	return nil
+}
+
+func ovsRemoveVLANAccessPort(ovsNodeName string, bridgeName string, portName string) error {
+	cmd := []string{
+		"kubectl", "-n", ovnNamespace, "exec", ovsNodeName, "--",
+		"ovs-vsctl", "del-port", bridgeName, portName,
+	}
+
+	if _, err := runCommand(cmd...); err != nil {
+		return fmt.Errorf("failed to remove port %s from OVS bridge %s: %v", portName, bridgeName, err)
 	}
 
 	return nil

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -838,12 +838,15 @@ var _ = Describe("Multi Homing", func() {
 						excludedSubnetLowerRange2 = "60.128.0.128/26" // Excludes IPs from 60.128.0.128 to 60.128.0.191
 						excludedSubnetUpperRange1 = "60.128.0.208/28" // Excludes IPs from 60.128.0.208 to 60.128.0.223
 						excludedSubnetUpperRange2 = "60.128.0.224/27" // Excludes IPs from 60.128.0.224 to 60.128.0.255
+						newLocalnetVLANID         = 30
 					)
 					BeforeEach(func() {
 						By("setting new MTU")
 						netConfig.mtu = expectedChangedMTU
 						By("setting new subnets to leave a smaller range")
 						netConfig.excludeCIDRs = []string{excludedSubnetLowerRange1, excludedSubnetLowerRange2, excludedSubnetUpperRange1, excludedSubnetUpperRange2}
+						By("setting new VLAN-ID")
+						netConfig.vlanID = newLocalnetVLANID
 						p := []byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/config","value":%q}]`, generateNADSpec(netConfig)))
 						Expect(patchNADSpec(nadClient, netConfig.name, netConfig.namespace, p)).To(Succeed())
 					})
@@ -895,6 +898,55 @@ var _ = Describe("Multi Homing", func() {
 							}
 							return nil
 						}).Should(Succeed(), "pod's secondary NIC is not allocated in the desired range")
+					})
+
+					It("can no longer communicate over a localnet secondary network from pod to the underlay service", func() {
+						Eventually(func() error {
+							clientPodConfig := podConfiguration{
+								name:        clientPodName,
+								namespace:   f.Namespace.Name,
+								attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+							}
+							kickstartPod(cs, clientPodConfig)
+
+							By("asserting the *client* pod can no longer contact the underlay service")
+							var err error
+							if err = connectToServer(clientPodConfig, underlayServiceIP, servicePort); err != nil && strings.Contains(err.Error(), "exit code 28") {
+								return nil
+							}
+							err = fmt.Errorf("expected exit code 28 from underlay service, got err %w", err)
+
+							if delErr := cs.CoreV1().Pods(clientPodConfig.namespace).Delete(context.Background(), clientPodConfig.name, metav1.DeleteOptions{}); delErr != nil {
+								err = errors.Join(err, fmt.Errorf("pod delete failed: %w", delErr))
+							}
+							return err
+						}).Should(Succeed(), "pod should be disconnected from underlay")
+					})
+
+					Context("and the service connected to the underlay is reconfigured to connect to the new VLAN-ID", func() {
+						BeforeEach(func() {
+							Expect(ovsRemoveSwitchPort(nodes, secondaryInterfaceName, newLocalnetVLANID)).To(Succeed())
+						})
+
+						It("can now communicate over a localnet secondary network from pod to the underlay service", func() {
+							Eventually(func() error {
+								clientPodConfig := podConfiguration{
+									name:        clientPodName,
+									namespace:   f.Namespace.Name,
+									attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+								}
+								kickstartPod(cs, clientPodConfig)
+
+								By("asserting the *client* pod can contact the underlay service")
+								if err := connectToServer(clientPodConfig, underlayServiceIP, servicePort); err != nil {
+									if delErr := cs.CoreV1().Pods(clientPodConfig.namespace).Delete(context.Background(), clientPodConfig.name, metav1.DeleteOptions{}); delErr != nil {
+										err = errors.Join(err, fmt.Errorf("pod delete failed: %w", delErr))
+									}
+									return err
+								}
+								return nil
+							}).Should(Succeed(), "pod should be connected to underlay")
+						})
 					})
 				})
 

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -84,11 +84,11 @@ func uniqueNadName(originalNetName string) string {
 	return fmt.Sprintf("%s_%s", rand.String(randomStringLength), originalNetName)
 }
 
-func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefinition {
+func generateNADSpec(config networkAttachmentConfig) string {
 	if config.mtu == 0 {
 		config.mtu = 1300
 	}
-	nadSpec := fmt.Sprintf(
+	return fmt.Sprintf(
 		`
 {
         "cniVersion": "0.3.0",
@@ -116,6 +116,10 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
 		config.physicalNetworkName,
 		config.role,
 	)
+}
+
+func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefinition {
+	nadSpec := generateNADSpec(config)
 	return generateNetAttachDef(config.namespace, config.name, nadSpec)
 }
 

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -7,10 +7,13 @@ import (
 	"net"
 	"strings"
 
+	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	clientset "k8s.io/client-go/kubernetes"
@@ -133,6 +136,17 @@ func generateNetAttachDef(namespace, nadName, nadSpec string) *nadapi.NetworkAtt
 	}
 }
 
+func patchNADSpec(nadClient nadclient.K8sCniCncfIoV1Interface, name, namespace string, patch []byte) error {
+	_, err := nadClient.NetworkAttachmentDefinitions(namespace).Patch(
+		context.Background(),
+		name,
+		kapitypes.JSONPatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+	return err
+}
+
 type podConfiguration struct {
 	attachments            []nadapi.NetworkSelectionElement
 	containerCmd           []string
@@ -234,6 +248,47 @@ func connectToServer(clientPodConfig podConfiguration, serverIP string, port int
 		net.JoinHostPort(serverIP, fmt.Sprintf("%d", port)),
 	)
 	return err
+}
+
+func getMTUByInterfaceName(output, interfaceName string) (int, error) {
+	var ifaces []struct {
+		Name string `json:"ifname"`
+		MTU  int    `json:"mtu"`
+	}
+
+	if err := json.Unmarshal([]byte(output), &ifaces); err != nil {
+		return 0, fmt.Errorf("%s: %v", output, err)
+	}
+
+	for _, iface := range ifaces {
+		if iface.Name == interfaceName {
+			return iface.MTU, nil
+		}
+	}
+	return 0, fmt.Errorf("interface %s not found", interfaceName)
+}
+
+func getSecondaryInterfaceMTU(clientPodConfig podConfiguration) (int, error) {
+	const podSecondaryInterface = "net1"
+	deviceInfoJSON, err := e2ekubectl.RunKubectl(
+		clientPodConfig.namespace,
+		"exec",
+		clientPodConfig.name,
+		"--",
+		"ip",
+		"-j",
+		"link",
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	mtu, err := getMTUByInterfaceName(deviceInfoJSON, podSecondaryInterface)
+	if err != nil {
+		return 0, err
+	}
+
+	return mtu, nil
 }
 
 func newAttachmentConfigWithOverriddenName(name, namespace, networkName, topology, cidr string) networkAttachmentConfig {


### PR DESCRIPTION
## 📑 Description
This PR adds e2e tests asserting that after a consistent network config change, and subsequent workload "restart", the restarted workload is configured w/ the updated configuration.
updated fields checked:
- MTU
- VLAN-ID
- excluded IPs

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
