### PR TITLE
l2, udpn: Add ipv6 lla gateway field to the ovn pod annotation

### DIFF
--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -537,6 +537,8 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				mock.AnythingOfType(fmt.Sprintf("%T", &ipamclaimsapi.IPAMClaim{})),
 			).Return(nil)
 
+			kubeMock.On("GetNode", mock.AnythingOfType("string")).Return(&corev1.Node{}, nil)
+
 			netConf := &ovncnitypes.NetConf{
 				Topology:           types.Layer2Topology,
 				AllowPersistentIPs: tt.ipam && tt.args.ipamClaim != nil,

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -539,6 +539,7 @@ func hairpinMasqueradeIPToRoute(isIPv6 bool, gatewayIP net.IP) PodRoute {
 // with the gateways derived from the allocated IPs
 func AddRoutesGatewayIP(
 	netinfo NetInfo,
+	node *v1.Node,
 	pod *v1.Pod,
 	podAnnotation *PodAnnotation,
 	network *nadapi.NetworkSelectionElement) error {
@@ -573,6 +574,13 @@ func AddRoutesGatewayIP(
 				if network != nil && len(network.GatewayRequest) == 0 { // if specific default route for pod was not requested then add gatewayIP
 					podAnnotation.Gateways = append(podAnnotation.Gateways, gatewayIPnet.IP)
 				}
+			}
+			if _, isIPv6Mode := netinfo.IPMode(); isIPv6Mode {
+				joinAddrs, err := ParseNodeGatewayRouterJoinAddrs(node, netinfo.GetNetworkName())
+				if err != nil {
+					return err
+				}
+				podAnnotation.IPv6LLAGateway = HWAddrToIPv6LLA(IPAddrToHWAddr(joinAddrs[0].IP))
 			}
 			return nil
 		case types.Layer3Topology:

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -110,6 +110,13 @@ func TestMarshalPodAnnotation(t *testing.T) {
 			},
 			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","routes":[{"dest":"192.168.1.0/24","nextHop":""}]}}`},
 		},
+		{
+			desc: "ipv6 LLA gateway ip is set",
+			inpPodAnnot: PodAnnotation{
+				IPv6LLAGateway: ovntest.MustParseIP("fe80::"),
+			},
+			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","ipv6_lla_gateway_ip":"fe80::"}}`},
+		},
 	}
 
 	for i, tc := range tests {
@@ -210,6 +217,10 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 		{
 			desc:        "verify successful unmarshal of pod annotation when *only* the MAC address is present",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"mac_address":"0a:58:fd:98:00:01"}}`},
+		},
+		{
+			desc:        "verify successful unmarshal of pod annotation with ipv6 lla gateway ip",
+			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"mac_address":"0a:58:fd:98:00:01","ipv6_lla_gateway_ip":"fe80::"}}`},
 		},
 	}
 	for i, tc := range tests {


### PR DESCRIPTION
## 📑 Description
For primary UDN layer2 the proper IPv6 gateway that should be configured
with received router advertisements is the one from the local GR IPv6
LLA, this change add field to the ovn pod annotations with that
information so it can be consumed by follow up PRs that will ensure
remove GRs are ignore as layer2 ipv6 gateways.

## Additional Information for reviewers
This is related to the following PRs that remove multipath ipv6 gateway for l2 primary UDNs:
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4852
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4847

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
It include unit tests
