### PR TITLE
correctly remove stale EgressService rules at startup

### DIFF
--- a/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
+++ b/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
@@ -613,6 +613,11 @@ func (c *Controller) repairIPTables(v4EpsToServices, v6EpsToServices map[string]
 		errorList := []error{}
 		for _, rule := range rulesToDel {
 			args := strings.Fields(rule)
+			if len(args) < 2 {
+				continue
+			}
+			// strip "-A OVN-KUBE-EGRESS-SVC"
+			args = args[2:]
 			err := ipt.Delete("nat", Chain, args...)
 			if err != nil {
 				errorList = append(errorList, err)

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -281,8 +281,8 @@ var _ = Describe("Egress Service Operations", func() {
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-EGRESS-SVC": []string{
-							"-A OVN-KUBE-EGRESS-SVC -m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-							"-A OVN-KUBE-EGRESS-SVC -s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
+							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
+							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
 						},
 					},
 					"filter": {},

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -156,10 +156,11 @@ func (f *FakeIPTables) List(tableName, chainName string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	ret := make([]string, len(chain))
 	for i := range chain {
-		chain[i] = fmt.Sprintf("-A %s %s", chainName, chain[i])
+		ret[i] = fmt.Sprintf("-A %s %s", chainName, chain[i])
 	}
-	return chain, nil
+	return ret, nil
 }
 
 // ListChains returns the names of all chains in the table


### PR DESCRIPTION
Discovered while porting to nftables; there was a bug in the `FakeIPTables` implementation used for unit tests (when you called `List()` it would mutate its own internal state rather than only mutating its return value), and the EgressService controller startup cleanup code only worked correctly in the presence of that bug. (It passed the entire rule returned from `List()`, including the "`-A OVN-KUBE-EGRESS-SVC`", as the argument to `Delete()`, which ended up working with `FakeIPTables` because it had accidentally modified its internal state to include that string as part of the rule, but with real iptables it would have ended up trying to do `iptables -D OVN-KUBE-EGRESS-SVC -A OVN-KUBE-EGRESS-SVC -s 10.128.0.3 ...`.)

But this code only runs when ovnkube-node starts up on a node that already has EgressService rules, so it doesn't get tested in the e2e tests, so no one noticed.

I'm going to replace this with nftables code soon but I figured I'd submit this separately since it's a bugfix.