### PR TITLE
OVN DNC: ignore all transit switches when cleaning up stale Nodes OVN switch

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -306,10 +306,10 @@ func (oc *DefaultNetworkController) syncNodes(kNodes []interface{}) error {
 		return fmt.Errorf("failed to get node logical switches which have other-config set: %v", err)
 	}
 
-	staleNodes := sets.NewString()
+	staleSwitches := sets.NewString()
 	for _, nodeSwitch := range nodeSwitches {
 		if nodeSwitch.Name != types.TransitSwitch && !foundNodes.Has(nodeSwitch.Name) {
-			staleNodes.Insert(nodeSwitch.Name)
+			staleSwitches.Insert(nodeSwitch.Name)
 		}
 	}
 
@@ -321,7 +321,7 @@ func (oc *DefaultNetworkController) syncNodes(kNodes []interface{}) error {
 		}
 		nodeName := strings.TrimPrefix(item.Name, types.ExternalSwitchPrefix)
 		if nodeName != item.Name && len(nodeName) > 0 && !foundNodes.Has(nodeName) {
-			staleNodes.Insert(nodeName)
+			staleSwitches.Insert(nodeName)
 			return true
 		}
 		return false
@@ -339,7 +339,7 @@ func (oc *DefaultNetworkController) syncNodes(kNodes []interface{}) error {
 		}
 		nodeName := strings.TrimPrefix(item.Name, types.GWRouterPrefix)
 		if nodeName != item.Name && len(nodeName) > 0 && !foundNodes.Has(nodeName) {
-			staleNodes.Insert(nodeName)
+			staleSwitches.Insert(nodeName)
 			return true
 		}
 		return false
@@ -350,9 +350,9 @@ func (oc *DefaultNetworkController) syncNodes(kNodes []interface{}) error {
 	}
 
 	// Cleanup stale nodes (including gateway routers and external logical switches)
-	for _, staleNode := range staleNodes.UnsortedList() {
-		if err := oc.cleanupNodeResources(staleNode); err != nil {
-			return fmt.Errorf("failed to cleanup node resources:%s, err:%w", staleNode, err)
+	for _, staleSwitch := range staleSwitches.UnsortedList() {
+		if err := oc.cleanupNodeResources(staleSwitch); err != nil {
+			return fmt.Errorf("failed to cleanup node resources:%s, err:%w", staleSwitch, err)
 		}
 	}
 

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -281,6 +281,11 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 			if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
 				em.isInterconnectCluster && ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
 				transitSwitchName := ocInfo.bnc.GetNetworkName() + "_transit_switch"
+				extIDs := map[string]string{
+					ovntypes.NetworkExternalID:     ocInfo.bnc.GetNetworkName(),
+					ovntypes.NetworkRoleExternalID: util.GetUserDefinedNetworkRole(ocInfo.bnc.IsPrimaryNetwork()),
+					ovntypes.TopologyExternalID:    ocInfo.bnc.TopologyType(),
+				}
 				data = append(data, &nbdb.LogicalSwitch{
 					UUID: transitSwitchName + "-UUID",
 					Name: transitSwitchName,
@@ -291,6 +296,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 						"requested-tnl-key":        "16711685",
 						"mcast_snoop":              "true",
 					},
+					ExternalIDs: extIDs,
 				})
 			}
 			if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -15,7 +15,6 @@ import (
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
-
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1475,6 +1474,91 @@ spec:
 			}
 			Expect(found).To(BeTrue(), "should have found an event for invalid protocol")
 		})
+	})
+
+	Context("Sync", func() {
+		DescribeTable(
+			"perform east/west traffic between nodes following OVN Kube node pod restart",
+			func(
+				netConfig networkAttachmentConfigParams,
+				clientPodConfig podConfiguration,
+				serverPodConfig podConfiguration,
+			) {
+				if netConfig.topology == "layer2" && !isInterconnectEnabled() {
+					const upstreamIssue = "https://github.com/ovn-kubernetes/ovn-kubernetes/issues/4958"
+					e2eskipper.Skipf(
+						"Test skipped for layer2 topology due to known issue for non-IC deployments. Upstream issue: %s", upstreamIssue,
+					)
+				}
+				By("creating the network")
+				netConfig.namespace = f.Namespace.Name
+				udnManifest := generateUserDefinedNetworkManifest(&netConfig)
+				cleanup, err := createManifest(netConfig.namespace, udnManifest)
+				Expect(err).ShouldNot(HaveOccurred(), "creating manifest must succeed")
+				DeferCleanup(cleanup)
+				Expect(waitForUserDefinedNetworkReady(netConfig.namespace, netConfig.name, 5*time.Second)).To(Succeed())
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.Background(), f.ClientSet, 2)
+				Expect(err).ShouldNot(HaveOccurred(), "test requires at least two schedulable nodes")
+				Expect(len(nodes.Items)).Should(BeNumerically(">=", 2), "test requires >= 2 Ready nodes")
+				serverPodConfig.namespace = f.Namespace.Name
+				clientPodConfig.namespace = f.Namespace.Name
+				runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
+				runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
+				serverIP, err := podIPsForUserDefinedPrimaryNetwork(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name), 0)
+				Expect(err).ShouldNot(HaveOccurred(), "UDN pod IP must be retrieved")
+				By("restart OVNKube node pods on client and server Nodes and ensure connectivity")
+				serverPod := getPod(f, serverPodConfig.name)
+				clientPod := getPod(f, clientPodConfig.name)
+				for _, testPod := range []*v1.Pod{clientPod, serverPod} {
+					By(fmt.Sprintf("asserting the server pod IP %v is reachable from client before restart of OVNKube node pod on Node %s", serverIP, testPod.Spec.Hostname))
+					Expect(reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)).ShouldNot(HaveOccurred(), "must have connectivity to server pre OVN Kube node Pod restart")
+					By(fmt.Sprintf("restarting OVNKube node Pod located on Node %s which hosts test Pod %s/%s", testPod.Spec.NodeName, testPod.Namespace, testPod.Name))
+					Expect(restartOVNKubeNodePod(cs, ovnNamespace, testPod.Spec.NodeName)).ShouldNot(HaveOccurred(), "restart of OVNKube node pod must succeed")
+					By(fmt.Sprintf("asserting the server pod IP %v is reachable from client post restart", serverIP))
+					Expect(reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)).ShouldNot(HaveOccurred(), "must have connectivity to server post restart")
+				}
+			},
+			Entry(
+				"L3",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					role:     "primary",
+				},
+				*podConfig(
+					"client-pod",
+					withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
+				),
+				*podConfig(
+					"server-pod",
+					withCommand(func() []string {
+						return httpServerContainerCmd(port)
+					}),
+					withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
+				),
+			),
+			Entry(
+				"L2",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer2",
+					cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					role:     "primary",
+				},
+				*podConfig(
+					"client-pod",
+					withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
+				),
+				*podConfig(
+					"server-pod",
+					withCommand(func() []string {
+						return httpServerContainerCmd(port)
+					}),
+					withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
+				),
+			),
+		)
 	})
 })
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
When default network controller (DNC) restarts and a sync is invoked, it may not exclude transit switches that support different L3 networks when attempting to cleanup stale Node switches.

Therefore, connectivity between Nodes will be impacted for Pods attached to L3 networks because its transit switch maybe removed during DNC sync.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://issues.redhat.com/browse/OCPBUGS-44487

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
