### PR TITLE
l2, udpn: Add ipv6 lla gateway field to the ovn pod annotation

### DIFF
--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -54,6 +54,7 @@ func NewPodAnnotationAllocator(
 // false.
 func (allocator *PodAnnotationAllocator) AllocatePodAnnotation(
 	ipAllocator subnet.NamedAllocator,
+	node *corev1.Node,
 	pod *corev1.Pod,
 	network *nadapi.NetworkSelectionElement,
 	reallocateIP bool,
@@ -67,6 +68,7 @@ func (allocator *PodAnnotationAllocator) AllocatePodAnnotation(
 		allocator.kube,
 		ipAllocator,
 		allocator.netInfo,
+		node,
 		pod,
 		network,
 		allocator.ipamClaimsReconciler,
@@ -80,6 +82,7 @@ func allocatePodAnnotation(
 	kube kube.Interface,
 	ipAllocator subnet.NamedAllocator,
 	netInfo util.NetInfo,
+	node *corev1.Node,
 	pod *corev1.Pod,
 	network *nadapi.NetworkSelectionElement,
 	claimsReconciler persistentips.PersistentAllocations,
@@ -98,6 +101,7 @@ func allocatePodAnnotation(
 			ipAllocator,
 			idAllocator,
 			netInfo,
+			node,
 			pod,
 			network,
 			claimsReconciler,
@@ -133,6 +137,7 @@ func allocatePodAnnotation(
 func (allocator *PodAnnotationAllocator) AllocatePodAnnotationWithTunnelID(
 	ipAllocator subnet.NamedAllocator,
 	idAllocator id.NamedAllocator,
+	node *corev1.Node,
 	pod *corev1.Pod,
 	network *nadapi.NetworkSelectionElement,
 	reallocateIP bool,
@@ -147,6 +152,7 @@ func (allocator *PodAnnotationAllocator) AllocatePodAnnotationWithTunnelID(
 		ipAllocator,
 		idAllocator,
 		allocator.netInfo,
+		node,
 		pod,
 		network,
 		allocator.ipamClaimsReconciler,
@@ -161,6 +167,7 @@ func allocatePodAnnotationWithTunnelID(
 	ipAllocator subnet.NamedAllocator,
 	idAllocator id.NamedAllocator,
 	netInfo util.NetInfo,
+	node *corev1.Node,
 	pod *corev1.Pod,
 	network *nadapi.NetworkSelectionElement,
 	claimsReconciler persistentips.PersistentAllocations,
@@ -176,6 +183,7 @@ func allocatePodAnnotationWithTunnelID(
 			ipAllocator,
 			idAllocator,
 			netInfo,
+			node,
 			pod,
 			network,
 			claimsReconciler,
@@ -220,6 +228,7 @@ func allocatePodAnnotationWithRollback(
 	ipAllocator subnet.NamedAllocator,
 	idAllocator id.NamedAllocator,
 	netInfo util.NetInfo,
+	node *corev1.Node,
 	pod *corev1.Pod,
 	network *nadapi.NetworkSelectionElement,
 	claimsReconciler persistentips.PersistentAllocations,
@@ -397,7 +406,7 @@ func allocatePodAnnotationWithRollback(
 		}
 
 		// handle routes & gateways
-		err = util.AddRoutesGatewayIP(netInfo, pod, tentative, network)
+		err = util.AddRoutesGatewayIP(netInfo, node, pod, tentative, network)
 		if err != nil {
 			return
 		}

--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -124,6 +126,8 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 		wantReleaseID             bool
 		wantRelasedIDOnRollback   bool
 		wantErr                   bool
+		isSingleStackIPv4         bool
+		isSingleStackIPv6         bool
 		multiNetworkDisabled      bool
 	}{
 		{
@@ -232,6 +236,113 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				},
 				Role: types.NetworkRolePrimary,
 			},
+			wantReleasedIPsOnRollback: ovntest.MustParseIPNets("192.168.0.3/24"),
+			role:                      types.NetworkRolePrimary,
+		},
+		{
+			name:                   "expect new IP and ipv6 gateway LLA for primary udn layer2 with dual stack",
+			ipam:                   true,
+			idAllocation:           true,
+			persistentIPAllocation: true,
+			args: args{
+				ipAllocator: &ipAllocatorStub{
+					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24", "2010:100:200::3/60"),
+				},
+				idAllocator: &idAllocatorStub{
+					nextID: 100,
+				},
+			},
+			wantUpdatedPod: true,
+			wantPodAnnotation: &util.PodAnnotation{
+				IPs:            ovntest.MustParseIPNets("192.168.0.3/24", "2010:100:200::3/60"),
+				MAC:            util.IPAddrToHWAddr(ovntest.MustParseIPNets("192.168.0.3/24")[0].IP),
+				Gateways:       []net.IP{ovntest.MustParseIP("192.168.0.1").To4(), ovntest.MustParseIP("2010:100:200::1")},
+				GatewayIPv6LLA: util.HWAddrToIPv6LLA(util.IPAddrToHWAddr(ovntest.MustParseIP("100.65.0.4"))),
+				Routes: []util.PodRoute{
+					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("100.65.0.0").To4(),
+							Mask: net.CIDRMask(16, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+					{
+						Dest:    ovntest.MustParseIPNet("fd99::/64"),
+						NextHop: ovntest.MustParseIP("2010:100:200::1"),
+					},
+				},
+				Role:     types.NetworkRolePrimary,
+				TunnelID: 100,
+			},
+			wantRelasedIDOnRollback:   true,
+			wantReleasedIPsOnRollback: ovntest.MustParseIPNets("192.168.0.3/24", "2010:100:200::3/60"),
+			role:                      types.NetworkRolePrimary,
+		},
+		{
+			name:                   "expect new IP and ipv6 gateway LLA for primary udn layer2 with single stack IPv6",
+			isSingleStackIPv6:      true,
+			ipam:                   true,
+			idAllocation:           true,
+			persistentIPAllocation: true,
+			args: args{
+				ipAllocator: &ipAllocatorStub{
+					netxtIPs: ovntest.MustParseIPNets("2010:100:200::3/60"),
+				},
+				idAllocator: &idAllocatorStub{
+					nextID: 100,
+				},
+			},
+			wantUpdatedPod: true,
+			wantPodAnnotation: &util.PodAnnotation{
+				IPs:            ovntest.MustParseIPNets("2010:100:200::3/60"),
+				MAC:            util.IPAddrToHWAddr(ovntest.MustParseIPNets("2010:100:200::3/60")[0].IP),
+				Gateways:       []net.IP{ovntest.MustParseIP("2010:100:200::1")},
+				GatewayIPv6LLA: util.HWAddrToIPv6LLA(util.IPAddrToHWAddr(ovntest.MustParseIP("fd99::4"))),
+				Routes: []util.PodRoute{
+					{
+						Dest:    ovntest.MustParseIPNet("fd99::/64"),
+						NextHop: ovntest.MustParseIP("2010:100:200::1"),
+					},
+				},
+				Role:     types.NetworkRolePrimary,
+				TunnelID: 100,
+			},
+			wantRelasedIDOnRollback:   true,
+			wantReleasedIPsOnRollback: ovntest.MustParseIPNets("2010:100:200::3/60"),
+			role:                      types.NetworkRolePrimary,
+		},
+		{
+			name:                   "expect new IP but no ipv6 gateway LLA for primary udn layer2 with single stack IPv4",
+			isSingleStackIPv4:      true,
+			ipam:                   true,
+			idAllocation:           true,
+			persistentIPAllocation: true,
+			args: args{
+				ipAllocator: &ipAllocatorStub{
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+				},
+				idAllocator: &idAllocatorStub{
+					nextID: 100,
+				},
+			},
+			wantUpdatedPod: true,
+			wantPodAnnotation: &util.PodAnnotation{
+				IPs:      ovntest.MustParseIPNets("192.168.0.3/24"),
+				MAC:      util.IPAddrToHWAddr(ovntest.MustParseIPNets("192.168.0.3/24")[0].IP),
+				Gateways: []net.IP{ovntest.MustParseIP("192.168.0.1").To4()},
+				Routes: []util.PodRoute{
+					{
+						Dest: &net.IPNet{
+							IP:   ovntest.MustParseIP("100.65.0.0").To4(),
+							Mask: net.CIDRMask(16, 32),
+						},
+						NextHop: ovntest.MustParseIP("192.168.0.1").To4(),
+					},
+				},
+				Role:     types.NetworkRolePrimary,
+				TunnelID: 100,
+			},
+			wantRelasedIDOnRollback:   true,
 			wantReleasedIPsOnRollback: ovntest.MustParseIPNets("192.168.0.3/24"),
 			role:                      types.NetworkRolePrimary,
 		},
@@ -668,8 +779,13 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 			config.OVNKubernetesFeature.EnableMultiNetwork = !tt.multiNetworkDisabled
 			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 			config.IPv4Mode = true
+			if tt.isSingleStackIPv6 {
+				config.IPv4Mode = false
+			}
 			config.IPv6Mode = true
-
+			if tt.isSingleStackIPv4 {
+				config.IPv6Mode = false
+			}
 			var netInfo util.NetInfo
 			netInfo = &util.DefaultNetInfo{}
 			nadName := types.DefaultNetworkName
@@ -677,7 +793,12 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				nadName = util.GetNADName(network.Namespace, network.Name)
 				var subnets string
 				if tt.ipam {
-					subnets = "192.168.0.0/24"
+					subnets = "192.168.0.0/24,2001:db8::/64"
+					if tt.isSingleStackIPv4 {
+						subnets = "192.168.0.0/24"
+					} else if tt.isSingleStackIPv6 {
+						subnets = "2001:db8::/64"
+					}
 				}
 				netInfo, err = util.NewNetInfo(&ovncnitypes.NetConf{
 					Topology: types.Layer2Topology,
@@ -694,6 +815,20 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				}
 			}
 
+			ifaddrs := `{"network":{"ipv4":"100.65.0.4/16","ipv6":"fd99::4/64"}}`
+			if tt.isSingleStackIPv4 {
+				ifaddrs = `{"network":{"ipv4":"100.65.0.4/16"}}`
+			} else if tt.isSingleStackIPv6 {
+				ifaddrs = `{"network":{"ipv6":"fd99::4/64"}}`
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-gateway-router-lrp-ifaddrs": ifaddrs,
+					},
+				},
+			}
 
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -729,6 +864,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				tt.args.ipAllocator,
 				tt.args.idAllocator,
 				netInfo,
+				node,
 				pod,
 				network,
 				claimsReconciler,
@@ -774,7 +910,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 				g.Expect(podAnnotation.MAC[0]&2).To(gomega.BeEquivalentTo(2), "Expected local MAC")
 				return
 			}
-			g.Expect(podAnnotation).To(gomega.Equal(tt.wantPodAnnotation))
+			g.Expect(podAnnotation).To(gomega.Equal(tt.wantPodAnnotation), "diff: %s", cmp.Diff(tt.wantPodAnnotation, podAnnotation))
 
 			if tt.wantUpdatedPod {
 				g.Expect(pod).NotTo(gomega.BeNil(), "Expected an updated pod")

--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -6,9 +6,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/google/go-cmp/cmp"
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/onsi/gomega"
@@ -28,7 +27,7 @@ import (
 )
 
 type ipAllocatorStub struct {
-	netxtIPs         []*net.IPNet
+	nextIPs          []*net.IPNet
 	allocateIPsError error
 	releasedIPs      []*net.IPNet
 }
@@ -38,7 +37,7 @@ func (a *ipAllocatorStub) AllocateIPs([]*net.IPNet) error {
 }
 
 func (a *ipAllocatorStub) AllocateNextIPs() ([]*net.IPNet, error) {
-	return a.netxtIPs, nil
+	return a.nextIPs, nil
 }
 
 func (a *ipAllocatorStub) ReleaseIPs(ips []*net.IPNet) error {
@@ -159,7 +158,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					IPRequest: []string{"192.168.0.4/24"},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,
@@ -181,7 +180,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					GatewayRequest: ovntest.MustParseIPs("192.168.0.1"),
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,
@@ -213,7 +212,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 			ipam: true,
 			args: args{
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,
@@ -246,7 +245,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 			persistentIPAllocation: true,
 			args: args{
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24", "2010:100:200::3/60"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24", "2010:100:200::3/60"),
 				},
 				idAllocator: &idAllocatorStub{
 					nextID: 100,
@@ -286,7 +285,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 			persistentIPAllocation: true,
 			args: args{
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("2010:100:200::3/60"),
+					nextIPs: ovntest.MustParseIPNets("2010:100:200::3/60"),
 				},
 				idAllocator: &idAllocatorStub{
 					nextID: 100,
@@ -410,7 +409,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					IPRequest: []string{"192.168.0.4/24"},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,
@@ -447,7 +446,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					IPRequest: []string{"192.168.0.4/24"},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs:         ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs:          ovntest.MustParseIPNets("192.168.0.3/24"),
 					allocateIPsError: ipam.ErrAllocated,
 				},
 			},
@@ -484,7 +483,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					IPRequest: []string{"192.168.0.4/24"},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs:         ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs:          ovntest.MustParseIPNets("192.168.0.3/24"),
 					allocateIPsError: errors.New("Allocate IPs failed"),
 				},
 			},
@@ -520,7 +519,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					IPRequest: []string{"ivalid"},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantErr: true,
@@ -534,7 +533,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					MacRequest: "ivalid",
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantErr:         true,
@@ -550,7 +549,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					MacRequest: requestedMAC,
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,
@@ -586,7 +585,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					MacRequest: "invalid",
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			invalidNetworkAnnotation: true,
@@ -612,7 +611,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,
@@ -640,7 +639,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod:            true,
@@ -667,7 +666,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 					Status: ipamclaimsapi.IPAMClaimStatus{},
 				},
 				ipAllocator: &ipAllocatorStub{
-					netxtIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
+					nextIPs: ovntest.MustParseIPNets("192.168.0.3/24"),
 				},
 			},
 			wantUpdatedPod: true,

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -253,6 +253,7 @@ func (ncc *networkClusterController) init() error {
 			ncc.networkManager,
 			ncc.recorder,
 			ncc.tunnelIDAllocator,
+			ncc.watchFactory.NodeCoreInformer().Lister(),
 		)
 		if err := ncc.podAllocator.Init(); err != nil {
 			return fmt.Errorf("failed to initialize pod ip allocator: %w", err)

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
@@ -52,6 +53,8 @@ type PodAllocator struct {
 	// release more than once
 	releasedPods      map[string]sets.Set[string]
 	releasedPodsMutex sync.Mutex
+
+	nodeLister corev1listers.NodeLister
 }
 
 // NewPodAllocator builds a new PodAllocator
@@ -63,6 +66,7 @@ func NewPodAllocator(
 	networkManager networkmanager.Interface,
 	recorder record.EventRecorder,
 	idAllocator id.Allocator,
+	nodeLister corev1listers.NodeLister,
 ) *PodAllocator {
 	podAllocator := &PodAllocator{
 		netInfo:                netInfo,
@@ -72,6 +76,7 @@ func NewPodAllocator(
 		networkManager:         networkManager,
 		recorder:               recorder,
 		idAllocator:            idAllocator,
+		nodeLister:             nodeLister,
 	}
 
 	// this network might not have IPAM, we will just allocate MAC addresses
@@ -343,9 +348,15 @@ func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nad string, network *ne
 		return nil
 	}
 
+	node, err := a.nodeLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		return fmt.Errorf("failed to get node %q: %w", pod.Spec.NodeName, err)
+	}
+
 	updatedPod, podAnnotation, err := a.podAnnotationAllocator.AllocatePodAnnotationWithTunnelID(
 		ipAllocator,
 		idAllocator,
+		node,
 		pod,
 		network,
 		reallocate,

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -549,6 +549,7 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 			idallocator := &idAllocatorStub{}
 
 			podListerMock := &v1mocks.PodLister{}
+			nodeListerMock := &v1mocks.NodeLister{}
 			kubeMock := &kubemocks.InterfaceOVN{}
 			podNamespaceLister := &v1mocks.PodNamespaceLister{}
 
@@ -565,6 +566,8 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				"UpdateIPAMClaimIPs",
 				mock.AnythingOfType(fmt.Sprintf("%T", &ipamclaimsapi.IPAMClaim{})),
 			).Return(nil)
+
+			nodeListerMock.On("Get", mock.AnythingOfType("string")).Return(&corev1.Node{}, nil)
 
 			netConf := &ovncnitypes.NetConf{
 				Topology:           types.Layer2Topology,
@@ -640,6 +643,7 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				ipamClaimsReconciler:   ipamClaimsReconciler,
 				networkManager:         fakeNetworkManager,
 				recorder:               fakeRecorder,
+				nodeLister:             nodeListerMock,
 			}
 
 			var old, new *corev1.Pod

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -909,7 +909,13 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 		return nil, false, fmt.Errorf("cannot retrieve subnet for assigning gateway routes for pod %s, switch: %s",
 			podDesc, switchName)
 	}
-	err = util.AddRoutesGatewayIP(bnc.GetNetInfo(), pod, podAnnotation, network)
+
+	node, err := bnc.watchFactory.GetNode(pod.Spec.NodeName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	err = util.AddRoutesGatewayIP(bnc.GetNetInfo(), node, pod, podAnnotation, network)
 	if err != nil {
 		return nil, false, err
 	}
@@ -973,9 +979,14 @@ func (bnc *BaseNetworkController) allocatePodAnnotationForSecondaryNetwork(pod *
 	if bnc.doesNetworkRequireIPAM() {
 		ipAllocator = bnc.lsManager.ForSwitch(switchName)
 	}
-
+	node, err := bnc.watchFactory.GetNode(pod.Spec.NodeName)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get pod %s/%s/%s node %q: %w",
+			nadName, pod.Namespace, pod.Name, pod.Spec.NodeName, err)
+	}
 	updatedPod, podAnnotation, err := bnc.podAnnotationAllocator.AllocatePodAnnotation(
 		ipAllocator,
+		node,
 		pod,
 		network,
 		reallocate,

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -112,6 +112,13 @@ func TestMarshalPodAnnotation(t *testing.T) {
 			},
 			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","routes":[{"dest":"192.168.1.0/24","nextHop":""}]}}`},
 		},
+		{
+			desc: "ipv6 LLA gateway ip is set",
+			inpPodAnnot: PodAnnotation{
+				GatewayIPv6LLA: ovntest.MustParseIP("fe80::"),
+			},
+			expectedOutput: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"","ipv6_lla_gateway_ip":"fe80::"}}`},
+		},
 	}
 
 	for i, tc := range tests {
@@ -137,6 +144,7 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 		inpAnnotMap map[string]string
 		errAssert   bool
 		errMatch    error
+		nadName     string
 	}{
 		{
 			desc:        "verify `OVN pod annotation not found` error thrown",
@@ -147,76 +155,108 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 			desc:        "verify json unmarshal error",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"}}`}, //removed a quote to force json unmarshal error
 			errMatch:    fmt.Errorf("failed to unmarshal ovn pod annotation"),
+			nadName:     "default",
 		},
 		{
 			desc:        "verify MAC error parse error",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":""}}`},
 			errMatch:    fmt.Errorf("failed to parse pod MAC"),
+			nadName:     "default",
 		},
 		{
 			desc:        "test path when ip_addresses is empty and ip_address is set",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"0a:58:fd:98:00:01", "ip_address":"192.168.0.11/24"}}`},
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when ip_address and ip_addresses are conflicted",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0.11/24"}}`},
 			errMatch:    fmt.Errorf("bad annotation data (ip_address and ip_addresses conflict)"),
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when failed to parse pod IP",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0./24"],"mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0./24"}}`},
 			errMatch:    fmt.Errorf("failed to parse pod IP"),
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when gateway_ip and gateway_ips are conflicted",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"gateway_ips":["192.168.0.1"], "gateway_ip":"192.168.1.1","mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0.5/24"}}`},
 			errMatch:    fmt.Errorf("bad annotation data (gateway_ip and gateway_ips conflict)"),
+			nadName:     "default",
 		},
 		{
 			desc:        "test path when gateway_ips list is empty but gateway_ip is present",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"gateway_ips":[], "gateway_ip":"192.168.0.1","mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0.5/24"}}`},
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when failed to parse pod gateway",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"gateway_ips":["192.168.0."], "gateway_ip":"192.168.0.","mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0.5/24"}}`},
 			errMatch:    fmt.Errorf("failed to parse pod gateway"),
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when failed to parse pod route destination",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"192.168.1./24"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
 			errMatch:    fmt.Errorf("failed to parse pod route dest"),
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when default Route not specified as gateway",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"0.0.0.0/0"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
 			errAssert:   true,
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown when failed to parse pod route next hop",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1."}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
 			errMatch:    fmt.Errorf("failed to parse pod route next hop"),
+			nadName:     "default",
 		},
 		{
 			desc:        "verify error thrown where pod route has next hop of different family",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"fd01::1234/64","nextHop":"192.168.1.1"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
 			errAssert:   true,
+			nadName:     "default",
 		},
 		{
 			desc:        "verify successful unmarshal of pod annotation",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
+			nadName:     "default",
 		},
 		{
 			desc:        "verify successful unmarshal of pod annotation when role field is set",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1","role":"primary"}}`},
+			nadName:     "default",
 		},
 		{
 			desc:        "verify successful unmarshal of pod annotation when *only* the MAC address is present",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"mac_address":"0a:58:fd:98:00:01"}}`},
+			nadName:     "default",
+		},
+		{
+			desc:        "verify successful unmarshal of pod annotation with ipv6 lla gateway ip",
+			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"test_ns/l2":{"mac_address":"0a:58:fd:98:00:01","ipv6_lla_gateway_ip":"fe80::858:fdff:fe98:1"}}`},
+			nadName:     "test_ns/l2",
+		},
+		{
+			desc:        "verify error thrown when failed to unmarshal of pod annotation with non ipv6 lla gateway ip",
+			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"test_ns/l2":{"mac_address":"0a:58:fd:98:00:01","ipv6_lla_gateway_ip":"2001:0db8::1"}}`},
+			errMatch:    fmt.Errorf(`failed to parse pod ipv6 lla gateway, or non ipv6 lla "2001:0db8::1"`),
+			nadName:     "test_ns/l2",
+		},
+		{
+			desc:        "verify error thrown when failed to unmarshal of pod annotation with ipv4 instead ipv6 lla gateway ip",
+			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"test_ns/l2":{"mac_address":"0a:58:fd:98:00:01","ipv6_lla_gateway_ip":"192.168.0.5"}}`},
+			errMatch:    fmt.Errorf(`failed to parse pod ipv6 lla gateway, or non ipv6 lla "192.168.0.5"`),
+			nadName:     "test_ns/l2",
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			res, e := UnmarshalPodAnnotation(tc.inpAnnotMap, types.DefaultNetworkName)
+			res, e := UnmarshalPodAnnotation(tc.inpAnnotMap, tc.nadName)
 			t.Log(res, e)
 			if tc.errAssert {
 				assert.Error(t, e)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

For primary UDN layer2 the proper IPv6 gateway that should be configured
with received router advertisements is the one from the local GR IPv6
LLA, this change add field to the ovn pod annotations with that
information so it can be consumed by follow up PRs that will ensure
remove GRs are ignore as layer2 ipv6 gateways.

This is related to the following PRs that remove multipath ipv6 gateway for l2 primary UDNs:
https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4852
https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4847

Based on https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4866, just finalizing it.
Thanks @qinqon

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
