### PR TITLE
EgressService: add additionalPrinterColumn for .status.host

### DIFF
--- a/dist/templates/k8s.ovn.org_egressservices.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressservices.yaml.j2
@@ -14,7 +14,11 @@ spec:
     singular: egressservice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.host
+      name: Assigned Host
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-

--- a/go-controller/pkg/crd/egressservice/v1/types.go
+++ b/go-controller/pkg/crd/egressservice/v1/types.go
@@ -26,6 +26,7 @@ import (
 // +kubebuilder::singular=egressservice
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Assigned Host",type=string,JSONPath=".status.host"
 // EgressService is a CRD that allows the user to request that the source
 // IP of egress packets originating from all of the pods that are endpoints
 // of the corresponding LoadBalancer Service would be its ingress IP.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
We add the current host as a printerColumn to have a nicer way to understand which node is hosting the service:
```
$ kubectl get egressservice
NAME              ASSIGNED HOST
example-service   ovn-worker
```


## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
