### PR TITLE
Calculates mgmt port MAC rather than storing

### DIFF
--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -113,10 +113,6 @@ func (mp *managementPortRepresentor) Create(_ *routemanager.Controller, node *v1
 		link:   link,
 	}
 
-	mgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(mp.hostSubnets[0]).IP)
-	if err := util.UpdateNodeManagementPortMACAddressesWithRetry(node, nodeLister, kubeInterface, mgmtPortMac, types.DefaultNetworkName); err != nil {
-		return nil, err
-	}
 	waiter.AddWait(managementPortReady, nil)
 	return mpcfg, nil
 }

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -883,9 +883,10 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// make sure egress firewall acl was not updated as we are still holding a lock
 					getACLs := func() int {
-						acls, err := libovsdbops.FindACLsWithPredicate(fakeOVN.nbClient, func(acl *nbdb.ACL) bool {
-							return true
-						})
+						// find all existing egress firewall ACLs
+						predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLEgressFirewall, "default-network-controller", nil)
+						aclP := libovsdbops.GetPredicate[*nbdb.ACL](predicateIDs, nil)
+						acls, err := libovsdbops.FindACLsWithPredicate(fakeOVN.nbClient, aclP)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						return len(acls)
 					}

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -169,7 +169,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(is
 					if em.gatewayConfig != nil {
 						mgmtPortName := managementPortName(switchName)
 						mgmtPortUUID := mgmtPortName + "-UUID"
-						mgmtPort := expectedManagementPort(mgmtPortName, managementIP.String())
+						mgmtPort := expectedManagementPort(mgmtPortName, managementIP)
 						data = append(data, mgmtPort)
 						nodeslsps[switchName] = append(nodeslsps[switchName], mgmtPortUUID)
 						const aclUUID = "acl1-UUID"
@@ -187,7 +187,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(is
 						// there are multiple mgmt ports in the cluster, thus the ports must be scoped with the node name
 						mgmtPortName := managementPortName(ocInfo.bnc.GetNetworkScopedName(nodeName))
 						mgmtPortUUID := mgmtPortName + "-UUID"
-						mgmtPort := expectedManagementPort(mgmtPortName, managementIP.String())
+						mgmtPort := expectedManagementPort(mgmtPortName, managementIP)
 						data = append(data, mgmtPort)
 						nodeslsps[switchName] = append(nodeslsps[switchName], mgmtPortUUID)
 
@@ -333,10 +333,10 @@ func managementPortName(switchName string) string {
 	return fmt.Sprintf("k8s-%s", switchName)
 }
 
-func expectedManagementPort(portName string, ip string) *nbdb.LogicalSwitchPort {
+func expectedManagementPort(portName string, ip net.IP) *nbdb.LogicalSwitchPort {
 	return &nbdb.LogicalSwitchPort{
 		UUID:      portName + "-UUID",
-		Addresses: []string{fmt.Sprintf("02:03:04:05:06:07 %s", ip)},
+		Addresses: []string{fmt.Sprintf("%s %s", util.IPAddrToHWAddr(ip).String(), ip.String())},
 		Name:      portName,
 	}
 }

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -45,7 +45,6 @@ type secondaryNetInfo struct {
 }
 
 const (
-	dummyMACAddr         = "02:03:04:05:06:07"
 	nadName              = "blue-net"
 	ns                   = "namespace1"
 	secondaryNetworkName = "isolatednet"
@@ -630,7 +629,6 @@ func newNodeWithSecondaryNets(nodeName string, nodeIPv4CIDR string, netInfos ...
 				"k8s.ovn.org/l3-gateway-config":                             fmt.Sprintf("{\"default\":{\"mode\":\"shared\",\"bridge-id\":\"breth0\",\"interface-id\":\"breth0_ovn-worker\",\"mac-address\":%q,\"ip-addresses\":[%[2]q],\"ip-address\":%[2]q,\"next-hops\":[%[3]q],\"next-hop\":%[3]q,\"node-port-enable\":\"true\",\"vlan-id\":\"0\"}}", util.IPAddrToHWAddr(nodeIP), nodeCIDR, nextHopIP),
 				util.OvnNodeChassisID:                                       "abdcef",
 				"k8s.ovn.org/network-ids":                                   "{\"default\":\"0\",\"isolatednet\":\"2\"}",
-				util.OvnNodeManagementPortMacAddresses:                      fmt.Sprintf("{\"isolatednet\":%q}", dummyMACAddr),
 				util.OVNNodeGRLRPAddrs:                                      fmt.Sprintf("{\"isolatednet\":{\"ipv4\":%q}}", gwRouterJoinIPAddress()),
 				"k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids": "{\"isolatednet\":\"25\"}",
 			},
@@ -807,7 +805,7 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	rtosLRPUUID := rtosLRPName + "-UUID"
 	nodeIP := gwConfig.IPAddresses[0].IP.String()
 	masqSNAT := newNATEntry(masqSNATUUID1, "169.254.169.14", nodeSubnet.String(), standardNonDefaultNetworkExtIDs(netInfo), "")
-	masqSNAT.Match = getMasqueradeManagementIPSNATMatch(dummyMACAddr)
+	masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
 	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName))
 	if !config.OVNKubernetesFeature.EnableInterconnect {
 		masqSNAT.GatewayPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName) + "-UUID")
@@ -905,7 +903,8 @@ func udnGWSNATAddress() *net.IPNet {
 }
 
 func newMasqueradeManagementNATEntry(uuid string, externalIP string, logicalIP string, netInfo util.NetInfo) *nbdb.NAT {
-	masqSNAT := newNATEntry(uuid, "169.254.169.14", layer2Subnet().String(), standardNonDefaultNetworkExtIDs(netInfo), getMasqueradeManagementIPSNATMatch(dummyMACAddr))
+	masqSNAT := newNATEntry(uuid, "169.254.169.14", layer2Subnet().String(), standardNonDefaultNetworkExtIDs(netInfo),
+		getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(layer2Subnet())).String()))
 	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtoj-GR_%s_%s", netInfo.GetNetworkName(), nodeName))
 	return masqSNAT
 }


### PR DESCRIPTION
Today ovnkube-controller relies on ovnkube-node to annotate the mac address so that it can properly program the OVN mgmt port. In practice with UDN, this means cluster manager creates the node and allocates some subnet info to the node, both the node and the ovnkube-controller side get updates, but ovnkube-controller fails to program the first time because it is waiting for the node side to configure the mac address.

This patch changes the behavior of ovn-kubernetes to calculate the MAC address for the management port from the mgmt port IP address of the first subnet for the network. For backwards compatibility (on default network), it will first attempt to read the node annotation, and if it no mgmt MAC exists, it will derive it from the mgmt IP of the subnet.

Note the DPU code already uses the mgmt IP to derive the MAC.

