### PR TITLE
UDN: Rename NetworkReady condition to NetworkCreated

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -84,9 +84,9 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "True",
-					Reason:  "NetworkAttachmentDefinitionReady",
+					Reason:  "NetworkAttachmentDefinitionCreated",
 					Message: "NetworkAttachmentDefinition has been created",
 				}}))
 
@@ -107,7 +107,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: "failed to generate NetworkAttachmentDefinition: " + renderErr.Error(),
@@ -132,7 +132,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: "failed to create NetworkAttachmentDefinition: create NAD error",
@@ -154,7 +154,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: "foreign NetworkAttachmentDefinition with the desired name already exist [test/test]",
@@ -171,9 +171,9 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "True",
-					Reason:  "NetworkAttachmentDefinitionReady",
+					Reason:  "NetworkAttachmentDefinitionCreated",
 					Message: "NetworkAttachmentDefinition has been created",
 				}}))
 
@@ -210,9 +210,9 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "True",
-					Reason:  "NetworkAttachmentDefinitionReady",
+					Reason:  "NetworkAttachmentDefinitionCreated",
 					Message: "NetworkAttachmentDefinition has been created",
 				}}))
 				actualNAD, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Get(context.Background(), udn.Name, metav1.GetOptions{})
@@ -229,7 +229,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(udn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: "failed to update NetworkAttachmentDefinition: " + expectedErr.Error(),
@@ -256,7 +256,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(updatedUDN.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: `primary network already exist in namespace "test": "primary-net-1"`,
@@ -278,7 +278,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(updatedUDN.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: `failed to validate no primary network exist: unmarshal failed [test/another-primary-net]: invalid character '!' looking for beginning of value`,
@@ -314,7 +314,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(updatedUDN.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "SyncError",
 					Message: `failed to add finalizer to UserDefinedNetwork: ` + expectedErr.Error(),
@@ -384,9 +384,9 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(cudn.Status.Conditions)
 				}).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "True",
-					Reason:  "NetworkAttachmentDefinitionReady",
+					Reason:  "NetworkAttachmentDefinitionCreated",
 					Message: "NetworkAttachmentDefinition has been created in following namespaces: [blue, red]",
 				}}), "status should reflect NAD exist in test namespaces")
 				for testNamespace, expectedNAD := range expectedNsNADs {
@@ -441,9 +441,9 @@ var _ = Describe("User Defined Network Controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
 					}).Should(Equal([]metav1.Condition{{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "True",
-						Reason:  "NetworkAttachmentDefinitionReady",
+						Reason:  "NetworkAttachmentDefinitionCreated",
 						Message: "NetworkAttachmentDefinition has been created in following namespaces: [green, yellow]",
 					}}), "status should report NAD created in test labeled namespaces")
 					for _, nsName := range connectedNsNames {
@@ -500,9 +500,9 @@ var _ = Describe("User Defined Network Controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
 					}).Should(Equal([]metav1.Condition{{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "True",
-						Reason:  "NetworkAttachmentDefinitionReady",
+						Reason:  "NetworkAttachmentDefinitionCreated",
 						Message: "NetworkAttachmentDefinition has been created in following namespaces: [black, gray, green, yellow]",
 					}}), "status should report NAD exist in existing and new labeled namespaces")
 					for _, nsName := range append(connectedNsNames, newNsNames...) {
@@ -529,9 +529,9 @@ var _ = Describe("User Defined Network Controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
 					}).Should(Equal([]metav1.Condition{{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "True",
-						Reason:  "NetworkAttachmentDefinitionReady",
+						Reason:  "NetworkAttachmentDefinitionCreated",
 						Message: "NetworkAttachmentDefinition has been created in following namespaces: []",
 					}}))
 					for _, nsName := range connectedNsNames {
@@ -621,9 +621,9 @@ var _ = Describe("User Defined Network Controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
 					}).Should(Equal([]metav1.Condition{{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "True",
-						Reason:  "NetworkAttachmentDefinitionReady",
+						Reason:  "NetworkAttachmentDefinitionCreated",
 						Message: "NetworkAttachmentDefinition has been created in following namespaces: [black, gray, green, yellow]",
 					}}), "status should report NAD created in existing and new test namespaces")
 					for _, nsName := range append(connectedNsNames, newNsNames...) {
@@ -647,9 +647,9 @@ var _ = Describe("User Defined Network Controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
 					}).Should(Equal([]metav1.Condition{{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "True",
-						Reason:  "NetworkAttachmentDefinitionReady",
+						Reason:  "NetworkAttachmentDefinitionCreated",
 						Message: "NetworkAttachmentDefinition has been created in following namespaces: [blue, green, red, yellow]",
 					}}), "status should report NAD created in existing and new test namespaces")
 					for _, nsName := range append(connectedNsNames, disconnectedNsNames...) {
@@ -676,9 +676,9 @@ var _ = Describe("User Defined Network Controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
 					}).Should(Equal([]metav1.Condition{{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "True",
-						Reason:  "NetworkAttachmentDefinitionReady",
+						Reason:  "NetworkAttachmentDefinitionCreated",
 						Message: "NetworkAttachmentDefinition has been created in following namespaces: [" + connectedNsName + "]",
 					}}), "status should report NAD created in label namespace only")
 
@@ -728,9 +728,9 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					return normalizeConditions(cudn.Status.Conditions)
 				}, 50*time.Millisecond).Should(Equal([]metav1.Condition{{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "True",
-					Reason:  "NetworkAttachmentDefinitionReady",
+					Reason:  "NetworkAttachmentDefinitionCreated",
 					Message: "NetworkAttachmentDefinition has been created in following namespaces: [green, yellow]",
 				}}), "status should report NAD created in test labeled namespaces")
 
@@ -922,9 +922,9 @@ var _ = Describe("User Defined Network Controller", func() {
 				&udnv1.UserDefinedNetworkStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:    "NetworkReady",
+							Type:    "NetworkCreated",
 							Status:  "True",
-							Reason:  "NetworkAttachmentDefinitionReady",
+							Reason:  "NetworkAttachmentDefinitionCreated",
 							Message: "NetworkAttachmentDefinition has been created",
 						},
 					},
@@ -936,7 +936,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				&udnv1.UserDefinedNetworkStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:    "NetworkReady",
+							Type:    "NetworkCreated",
 							Status:  "False",
 							Reason:  "NetworkAttachmentDefinitionDeleted",
 							Message: "NetworkAttachmentDefinition is being deleted",
@@ -950,7 +950,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				&udnv1.UserDefinedNetworkStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:    "NetworkReady",
+							Type:    "NetworkCreated",
 							Status:  "False",
 							Reason:  "SyncError",
 							Message: "sync error",
@@ -971,7 +971,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			expectedStatus := &udnv1.UserDefinedNetworkStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "False",
 						Reason:  "SyncError",
 						Message: syncErr.Error(),
@@ -986,7 +986,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			expectedUpdatedStatus := &udnv1.UserDefinedNetworkStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:    "NetworkReady",
+						Type:    "NetworkCreated",
 						Status:  "False",
 						Reason:  "SyncError",
 						Message: anotherSyncErr.Error(),
@@ -1153,9 +1153,9 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(normalizeConditions(cudn.Status.Conditions)).To(ConsistOf([]metav1.Condition{
 				{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "True",
-					Reason:  "NetworkAttachmentDefinitionReady",
+					Reason:  "NetworkAttachmentDefinitionCreated",
 					Message: "NetworkAttachmentDefinition has been created in following namespaces: [green, red]",
 				},
 			}))
@@ -1179,7 +1179,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(normalizeConditions(cudn.Status.Conditions)).To(ConsistOf([]metav1.Condition{
 				{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "NetworkAttachmentDefinitionDeleted",
 					Message: "NetworkAttachmentDefinition are being deleted: [green/test]",
@@ -1204,7 +1204,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(normalizeConditions(cudn.Status.Conditions)).To(ConsistOf([]metav1.Condition{
 				{
-					Type:    "NetworkReady",
+					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "NetworkAttachmentDefinitionSyncError",
 					Message: "test sync NAD error",
@@ -1225,7 +1225,7 @@ func assertConditionReportNetworkInUse(conditions []metav1.Condition, messageNAD
 	}
 
 	c := conditions[0]
-	if c.Type != "NetworkReady" ||
+	if c.Type != "NetworkCreated" ||
 		c.Status != metav1.ConditionFalse ||
 		c.Reason != "NetworkAttachmentDefinitionSyncError" {
 
@@ -1273,7 +1273,7 @@ func assertFinalizersPresent(
 		Expect(err).NotTo(HaveOccurred())
 		return normalizeConditions(updatedUDN.Status.Conditions)
 	}).Should(Equal([]metav1.Condition{{
-		Type:    "NetworkReady",
+		Type:    "NetworkCreated",
 		Status:  "False",
 		Reason:  "SyncError",
 		Message: expectedConditionMsg,

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -956,7 +956,7 @@ spec:
 		var actualConditions []metav1.Condition
 		Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
 
-		Expect(actualConditions[0].Type).To(Equal("NetworkReady"))
+		Expect(actualConditions[0].Type).To(Equal("NetworkCreated"))
 		Expect(actualConditions[0].Status).To(Equal(metav1.ConditionFalse))
 		Expect(actualConditions[0].Reason).To(Equal("SyncError"))
 		expectedMessage := fmt.Sprintf("primary network already exist in namespace %q: %q", f.Namespace.Name, primaryNadName)
@@ -1223,7 +1223,7 @@ spec:
 			g.Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
 			return normalizeConditions(actualConditions)
 		}, 5*time.Second, 1*time.Second).Should(ConsistOf(metav1.Condition{
-			Type:    "NetworkReady",
+			Type:    "NetworkCreated",
 			Status:  metav1.ConditionFalse,
 			Reason:  "NetworkAttachmentDefinitionSyncError",
 			Message: expectedMessage,
@@ -1555,12 +1555,12 @@ func generateLayer3Subnets(cidrs string) []string {
 }
 
 func waitForUserDefinedNetworkReady(namespace, name string, timeout time.Duration) error {
-	_, err := e2ekubectl.RunKubectl(namespace, "wait", "userdefinednetwork", name, "--for", "condition=NetworkReady=True", "--timeout", timeout.String())
+	_, err := e2ekubectl.RunKubectl(namespace, "wait", "userdefinednetwork", name, "--for", "condition=NetworkCreated=True", "--timeout", timeout.String())
 	return err
 }
 
 func waitForClusterUserDefinedNetworkReady(name string, timeout time.Duration) error {
-	_, err := e2ekubectl.RunKubectl("", "wait", "clusteruserdefinednetwork", name, "--for", "condition=NetworkReady=True", "--timeout", timeout.String())
+	_, err := e2ekubectl.RunKubectl("", "wait", "clusteruserdefinednetwork", name, "--for", "condition=NetworkCreated=True", "--timeout", timeout.String())
 	return err
 }
 
@@ -1621,7 +1621,7 @@ func assertUDNStatusReportsConsumers(udnNamesapce, udnName, expectedPodName stri
 	found := false
 	for _, condition := range conditions {
 		if found, _ = Equal(metav1.Condition{
-			Type:    "NetworkReady",
+			Type:    "NetworkCreated",
 			Status:  "False",
 			Reason:  "SyncError",
 			Message: expectedMsg,
@@ -1680,9 +1680,9 @@ func assertClusterUDNStatusReportsActiveNamespaces(cudnName string, expectedActi
 
 	c := conditions[0]
 	// equality matcher cannot be used since condition message namespaces order is inconsistent
-	ExpectWithOffset(1, c.Type).Should(Equal("NetworkReady"))
+	ExpectWithOffset(1, c.Type).Should(Equal("NetworkCreated"))
 	ExpectWithOffset(1, c.Status).Should(Equal(metav1.ConditionTrue))
-	ExpectWithOffset(1, c.Reason).Should(Equal("NetworkAttachmentDefinitionReady"))
+	ExpectWithOffset(1, c.Reason).Should(Equal("NetworkAttachmentDefinitionCreated"))
 
 	ExpectWithOffset(1, c.Message).To(ContainSubstring("NetworkAttachmentDefinition has been created in following namespaces:"))
 	for _, ns := range expectedActiveNsNames {
@@ -1701,7 +1701,7 @@ func assertClusterUDNStatusReportConsumers(conditionsJSON, udnName, udnNamespace
 		udnNamespace, udnName, expectedPodName)
 	ExpectWithOffset(1, conditions).To(Equal([]metav1.Condition{
 		{
-			Type:    "NetworkReady",
+			Type:    "NetworkCreated",
 			Status:  "False",
 			Reason:  "NetworkAttachmentDefinitionSyncError",
 			Message: expectedMsg,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
As of today the `NetworkReady` condition indicated a NAD has been created.
And not necessarily that the underlying network is ready to work with,
because it require other internal components to act (e.g.: set ovs ports,
ovn flows, etc..).

Rename the `NetworkReady` condition type to `NetworkCreated` so it describe
better what it indicates.

This change enable introducing alternative `NetworkReady` condition that
provider actual indication a UDN network is ready, and that other
internal component acted successfully.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
