### PR TITLE
multi-homing, tests: do not use OVN provided IPAM in L3 nets

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -505,22 +505,11 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 	logicalSwitch.OtherConfig = map[string]string{}
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := bnc.GetNodeGatewayIP(hostSubnet)
-		mgmtIfAddr := bnc.GetNodeManagementIP(hostSubnet)
 
 		if utilnet.IsIPv6CIDR(hostSubnet) {
 			v6Gateway = gwIfAddr.IP
-
-			logicalSwitch.OtherConfig["ipv6_prefix"] =
-				hostSubnet.IP.String()
 		} else {
 			v4Gateway = gwIfAddr.IP
-			excludeIPs := mgmtIfAddr.IP.String()
-			if config.HybridOverlay.Enabled {
-				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)
-				excludeIPs += ".." + hybridOverlayIfAddr.IP.String()
-			}
-			logicalSwitch.OtherConfig["subnet"] = hostSubnet.String()
-			logicalSwitch.OtherConfig["exclude_ips"] = excludeIPs
 		}
 	}
 

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -857,14 +857,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-					// check switch subnet is not set
-					newNodeLS := &nbdb.LogicalSwitch{Name: node.Name}
-					gomega.Consistently(func() bool {
-						sw, err := libovsdbops.GetLogicalSwitch(fakeOVN.nbClient, newNodeLS)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						return sw.OtherConfig["subnet"] == v4NodeSubnet
-					}).WithTimeout(500 * time.Millisecond).Should(gomega.BeFalse())
-
 					ginkgo.By("Updating node network and labels")
 					// update the node to match the selector and to fix node-subnets
 					// fixing node-subnets will cause switch add
@@ -875,14 +867,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), newNode, metav1.UpdateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-					ginkgo.By("Check node handler was called on update")
-					// check switch subnet is set, meaning the node handler was called
-					gomega.Eventually(func() bool {
-						sw, err := libovsdbops.GetLogicalSwitch(fakeOVN.nbClient, newNodeLS)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						return sw.OtherConfig["subnet"] == v4NodeSubnet
-					}).WithTimeout(500 * time.Millisecond).Should(gomega.BeTrue())
 
 					// make sure egress firewall acl was not updated as we are still holding a lock
 					getACLs := func() int {

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -1439,11 +1439,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Ports:       []string{"k8s-" + networkName1_ + node1Name + "-UUID", "stor-" + networkName1_ + node1Name + "-UUID"},
 						ExternalIDs: map[string]string{ovntypes.NetworkExternalID: netInfo.GetNetworkName(), ovntypes.TopologyExternalID: ovntypes.Layer3Topology},
 						QOSRules:    []string{fmt.Sprintf("%s-QoS-UUID", netInfo.GetNetworkName())},
-						OtherConfig: map[string]string{
-							"exclude_ips": util.GetNodeManagementIfAddr(node1UDNSubnet).IP.String(),
-							"subnet":      node1UDNSubnet.String(),
-						},
-						ACLs: []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
+						ACLs:        []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      netInfo.GetNetworkScopedName(ovntypes.TransitSwitchToRouterPrefix+node1.Name) + "-UUID",
@@ -1688,11 +1684,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Ports:       []string{"k8s-" + networkName1_ + node1Name + "-UUID", "stor-" + networkName1_ + node1Name + "-UUID"},
 						ExternalIDs: map[string]string{ovntypes.NetworkExternalID: netInfo.GetNetworkName(), ovntypes.TopologyExternalID: ovntypes.Layer3Topology},
 						QOSRules:    []string{fmt.Sprintf("%s-QoS-UUID", netInfo.GetNetworkName())},
-						OtherConfig: map[string]string{
-							"exclude_ips": util.GetNodeManagementIfAddr(node1UDNSubnet).IP.String(),
-							"subnet":      node1UDNSubnet.String(),
-						},
-						ACLs: []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
+						ACLs:        []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      netInfo.GetNetworkScopedName(ovntypes.TransitSwitchToRouterPrefix+node1.Name) + "-UUID",
@@ -2913,11 +2905,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Ports:       []string{"k8s-" + networkName1_ + node1Name + "-UUID", "stor-" + networkName1_ + node1Name + "-UUID"},
 						ExternalIDs: map[string]string{ovntypes.NetworkExternalID: netInfo.GetNetworkName(), ovntypes.TopologyExternalID: ovntypes.Layer3Topology},
 						QOSRules:    []string{fmt.Sprintf("%s-QoS-UUID", netInfo.GetNetworkName())},
-						OtherConfig: map[string]string{
-							"exclude_ips": util.GetNodeManagementIfAddr(node1UDNSubnet).IP.String(),
-							"subnet":      node1UDNSubnet.String(),
-						},
-						ACLs: []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
+						ACLs:        []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      netInfo.GetNetworkScopedName(ovntypes.TransitSwitchToRouterPrefix+node1.Name) + "-UUID",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -121,7 +121,6 @@ func (n tNode) logicalSwitch(loadBalancerGroupUUIDs []string) *nbdb.LogicalSwitc
 	return &nbdb.LogicalSwitch{
 		UUID:              n.Name + "-UUID",
 		Name:              n.Name,
-		OtherConfig:       map[string]string{"subnet": n.NodeSubnet},
 		LoadBalancerGroup: loadBalancerGroupUUIDs,
 	}
 }
@@ -1816,17 +1815,8 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			// Ensure that the node's switch is eventually created once the annotations
 			// are reconciled by the network cluster controller
 			gomega.Eventually(func() bool {
-				newNodeLS, err := libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: newNode.Name})
-				if err != nil {
-					return false
-				}
-				if newNodeLS.OtherConfig["subnet"] != newNodeIpv4Subnet {
-					return false
-				}
-				if newNodeLS.OtherConfig["ipv6_prefix"] != newNodeIpv6SubnetPrefix {
-					return false
-				}
-				return true
+				_, err = libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: newNode.Name})
+				return err == nil
 			}, 10).Should(gomega.BeTrue())
 
 			return nil

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -137,12 +137,10 @@ func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPortsW
 			}
 			subnets := podInfo.nodeSubnet
 			var (
-				subnet     *net.IPNet
-				hasSubnets bool
+				subnet *net.IPNet
 			)
 			if len(subnets) > 0 {
 				subnet = testing.MustParseIPNet(subnets)
-				hasSubnets = true
 			}
 
 			for nad, portInfo := range podInfo.allportInfo {
@@ -237,28 +235,6 @@ func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPortsW
 				nodeslsps[switchName] = append(nodeslsps[switchName], lspUUID)
 			}
 
-			var otherConfig map[string]string
-			if hasSubnets {
-				otherConfig = map[string]string{
-					"subnet": subnet.String(),
-				}
-				if !ocInfo.bnc.IsPrimaryNetwork() {
-					// FIXME: This is weird that for secondary networks that don't have
-					// management ports these tests are expecting managementportIP to be
-					// excluded for no reason.
-					// FIXME2: Why are we setting exclude_ips on OVN switches when we don't
-					// even use OVN IPAMs.
-					otherConfig["exclude_ips"] = managementPortIP(subnet).String()
-				}
-			}
-
-			// TODO: once we start the "full" Layer2UserDefinedNetworkController (instead of just Base)
-			// we can drop this, and compare all objects created by the controller (right now we're
-			// missing all the meters, and the COPP)
-			if ocInfo.bnc.TopologyType() == ovntypes.Layer2Topology {
-				otherConfig = nil
-			}
-
 			switchNodeMap[switchName] = &nbdb.LogicalSwitch{
 				UUID:  switchName + "-UUID",
 				Name:  switchName,
@@ -267,8 +243,7 @@ func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPortsW
 					ovntypes.NetworkExternalID:     ocInfo.bnc.GetNetworkName(),
 					ovntypes.NetworkRoleExternalID: util.GetUserDefinedNetworkRole(isPrimary),
 				},
-				OtherConfig: otherConfig,
-				ACLs:        acls[switchName],
+				ACLs: acls[switchName],
 			}
 
 			if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Do not configure OVN IPAM for secondary layer3 networks; since we configure the interface in the pods via CNI, it doesn't make sense to configure OVN IPAM.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4764 

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Refactor
  - Simplified per-node logical switch configuration by removing per-host management IP usage and related switch-level subnet/ipv6/exclude settings; switch creation, multicast, ports, and ACL behavior remain unchanged.
- Tests
  - Updated tests and test data to stop asserting switch-level subnet/ipv6_prefix/OtherConfig values and to reflect the simplified switch configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->