### PR TITLE
Small iptables/nftables fixes

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -942,6 +942,8 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	const mtu string = "1234"
 	const clusterCIDR string = "10.1.0.0/16"
 	config.Gateway.DisableForwarding = true
+	// Make this larger-than-default, so it makes sense for the UDN case
+	config.Gateway.V4MasqueradeSubnet = "169.254.169.0/24"
 
 	if len(eth0GWIP) > 0 {
 		// And a default route
@@ -1329,9 +1331,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				"-j OVN-KUBE-UDN-MASQUERADE",
 			)
 			expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"] = append(expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"],
-				"-s 169.254.169.2/29 -j RETURN",     // this guarantees we don't SNAT default network masqueradeIPs
+				"-s 169.254.169.0/29 -j RETURN",     // this guarantees we don't SNAT default network masqueradeIPs
 				"-d 172.16.1.0/24 -j RETURN",        // this guarantees we don't SNAT service traffic
-				"-s 169.254.169.0/29 -j MASQUERADE", // this guarantees we SNAT all UDN MasqueradeIPs traffic leaving the node
+				"-s 169.254.169.0/24 -j MASQUERADE", // this guarantees we SNAT all UDN MasqueradeIPs traffic leaving the node
 			)
 		}
 		f4 := iptV4.(*util.FakeIPTables)

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -427,15 +427,18 @@ func getUDNMasqueradeRules(protocol iptables.Protocol) []nodeipt.Rule {
 	// NOTE: Ordering is important here, the RETURN must come before
 	// the MASQUERADE rule. Please don't change the ordering.
 	srcUDNMasqueradePrefix := config.Gateway.V4MasqueradeSubnet
-	// defaultNetworkReservedMasqueradePrefix contains the first 6IPs in the masquerade
-	// range that shouldn't be MASQUERADED. Hence /29 and /125 is intentionally hardcoded here
-	defaultNetworkReservedMasqueradePrefix := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String() + "/29"
 	ipFamily := utilnet.IPv4
 	if protocol == iptables.ProtocolIPv6 {
 		srcUDNMasqueradePrefix = config.Gateway.V6MasqueradeSubnet
-		defaultNetworkReservedMasqueradePrefix = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String() + "/125"
 		ipFamily = utilnet.IPv6
 	}
+	// defaultNetworkReservedMasqueradePrefix contains the first 6 IPs in the
+	// masquerade range that shouldn't be masqueraded. Hence it's always 3 bits (8
+	// IPs) wide, regardless of IP family.
+	_, ipnet, _ := net.ParseCIDR(srcUDNMasqueradePrefix)
+	_, len := ipnet.Mask.Size()
+	defaultNetworkReservedMasqueradePrefix := fmt.Sprintf("%s/%d", ipnet.IP.String(), len-3)
+
 	rules := []nodeipt.Rule{
 		{
 			Table:    "nat",

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1116,6 +1116,7 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
@@ -1342,6 +1343,7 @@ var _ = Describe("Node Operations", func() {
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(err).NotTo(HaveOccurred())
 
 				return nil
 			}


### PR DESCRIPTION
Three fixes:
- ~`Improve egress service repair unit test`: adds a third Service to the test and adjusts the initial incorrect state to make use of it, because there wouldn't be any way to make the initial state have multiple incorrect rules _for the same endpoint_ in the upcoming nftables version.~ (EDIT: This got merged as part of #4893)
- `Fix some nftables checking in the unit tests`: in half of the tests we were doing `err = nodenft.MatchNFTRules(...)` but then not checking `err` afterward. (This fix didn't turn up any new bugs; presumably if the generated rules were wrong before, the e2es would have failed and we would have noticed that way.) (EDIT: most of this got fixed as part of #4939.)
- `Slightly fix UDN local gateway masquerade rules (and unit tests)`: don't depend on undocumented behavior of the iptables binary, and tweak the unit test config so that the generated output actually demonstrates that the code is using the smaller subnet in one rule and the larger subnet in the other (rather than using a `/29` for both of them).
