### PR TITLE
Migrate EgressService rules from iptables to nftables

### DIFF
--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -11,7 +11,7 @@ import (
 	egressserviceapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
-	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
+	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
@@ -19,14 +19,23 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/knftables"
 )
+
+const nftablesRulesEgressServicesBase = `
+add table inet ovn-kubernetes
+add chain inet ovn-kubernetes egress-services { type nat hook postrouting priority 100 ; }
+add map inet ovn-kubernetes egress-service-snat-v4 { type ipv4_addr : ipv4_addr ; }
+add rule inet ovn-kubernetes egress-services mark == 0x3f0 return comment "DoNotSNAT"
+add rule inet ovn-kubernetes egress-services snat to ip saddr map @egress-service-snat-v4
+`
 
 var _ = Describe("Egress Service Operations", func() {
 	var (
 		app         *cli.App
 		fakeOvnNode *FakeOVNNode
 		fExec       *ovntest.FakeExec
-		iptV4       util.IPTablesHelper
+		nft         *knftables.Fake
 		netlinkMock *mocks.NetLinkOps
 	)
 
@@ -51,7 +60,7 @@ var _ = Describe("Egress Service Operations", func() {
 		_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
 		config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 24}}
 
-		iptV4, _ = util.SetFakeIPTablesHelpers()
+		nft = nodenft.SetFakeNFTablesHelper()
 	})
 
 	AfterEach(func() {
@@ -61,7 +70,7 @@ var _ = Describe("Egress Service Operations", func() {
 	})
 
 	Context("on egress service resource changes", func() {
-		It("repairs iptables and ip rules when stale entries are present", func() {
+		It("repairs nftables and ip rules when stale entries are present", func() {
 			app.Action = func(ctx *cli.Context) error {
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 --json rule show",
@@ -86,73 +95,43 @@ var _ = Describe("Egress Service Operations", func() {
 					Err: nil,
 				})
 
-				fakeRules := []nodeipt.Rule{
-					{
-						Table: "nat",
-						Chain: "OVN-KUBE-EGRESS-SVC",
-						Args: []string{
-							"-m", "mark", "--mark", "0x3f0",
-							"-m", "comment", "--comment", "DoNotSNAT",
-							"-j", "RETURN",
-						},
-					},
-					{
-						Table: "nat",
-						Chain: "OVN-KUBE-EGRESS-SVC",
-						Args: []string{
-							"-s", "10.128.0.3",
-							"-m", "comment", "--comment", "namespace1/service1",
-							"-j", "SNAT",
-							"--to-source", "5.5.5.5",
-						},
-						Protocol: getIPTablesProtocol("5.5.5.5"),
-					},
-					{
-						Table: "nat",
-						Chain: "OVN-KUBE-EGRESS-SVC",
-						Args: []string{
-							"-s", "10.128.0.88", // gone ep
-							"-m", "comment", "--comment", "namespace1/service1",
-							"-j", "SNAT",
-							"--to-source", "5.5.5.5",
-						},
-						Protocol: getIPTablesProtocol("5.5.5.5"),
-					},
-					{
-						Table: "nat",
-						Chain: "OVN-KUBE-EGRESS-SVC",
-						Args: []string{
-							"-s", "10.128.0.4",
-							"-m", "comment", "--comment", "namespace1/service3",
-							"-j", "SNAT",
-							"--to-source", "5.200.5.12", // wrong lb
-						},
-						Protocol: getIPTablesProtocol("5.5.5.5"),
-					},
-					{
-						Table: "nat",
-						Chain: "OVN-KUBE-EGRESS-SVC",
-						Args: []string{
-							"-s", "10.128.0.5",
-							"-m", "comment", "--comment", "namespace13service6", // gone service
-							"-j", "SNAT",
-							"--to-source", "1.2.3.4",
-						},
-						Protocol: getIPTablesProtocol("5.5.5.5"),
-					},
-					{
-						Table: "nat",
-						Chain: "OVN-KUBE-EGRESS-SVC",
-						Args: []string{
-							"-s", "10.128.0.33",
-							"-m", "comment", "--comment", "namespace1/service2", // service with host=ALL
-							"-j", "SNAT",
-							"--to-source", "1.2.3.4",
-						},
-						Protocol: getIPTablesProtocol("5.5.5.5"),
-					},
-				}
-				Expect(appendIptRules(fakeRules)).To(Succeed())
+				tx := nft.NewTransaction()
+				tx.Add(&knftables.Map{
+					Name: egressservice.NFTablesMapV4,
+					Type: "ipv4_addr : ipv4_addr",
+				})
+				tx.Add(&knftables.Element{
+					Map:     egressservice.NFTablesMapV4,
+					Key:     []string{"10.128.0.3"},
+					Value:   []string{"5.5.5.5"},
+					Comment: knftables.PtrTo("namespace1/service1"),
+				})
+				tx.Add(&knftables.Element{
+					Map:     egressservice.NFTablesMapV4,
+					Key:     []string{"10.128.0.88"}, // gone ep
+					Value:   []string{"5.5.5.5"},
+					Comment: knftables.PtrTo("namespace1/service1"),
+				})
+				tx.Add(&knftables.Element{
+					Map:     egressservice.NFTablesMapV4,
+					Key:     []string{"10.128.0.4"},
+					Value:   []string{"5.200.5.12"}, // wrong lb
+					Comment: knftables.PtrTo("namespace1/service3"),
+				})
+				tx.Add(&knftables.Element{
+					Map:     egressservice.NFTablesMapV4,
+					Key:     []string{"10.128.0.5"},
+					Value:   []string{"1.2.3.4"},
+					Comment: knftables.PtrTo("namespace13service6"), // gone service
+				})
+				tx.Add(&knftables.Element{
+					Map:     egressservice.NFTablesMapV4,
+					Key:     []string{"10.128.0.33"},
+					Value:   []string{"1.2.3.4"},
+					Comment: knftables.PtrTo("namespace1/service2"), // service with host=ALL
+				})
+
+				Expect(nft.Run(context.Background(), tx)).To(Succeed())
 				epPortName := "https"
 				epPortValue := int32(443)
 
@@ -323,21 +302,12 @@ var _ = Describe("Egress Service Operations", func() {
 				err = c.Run(fakeOvnNode.wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
-							"-s 10.128.0.4 -m comment --comment namespace1/service3 -j SNAT --to-source 6.6.6.6",
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
+				expectedNFT := nftablesRulesEgressServicesBase + `
+add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "namespace1/service1" : 5.5.5.5 }
+add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.4 comment "namespace1/service3" : 6.6.6.6 }
+`
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
@@ -433,35 +403,19 @@ var _ = Describe("Egress Service Operations", func() {
 				err = c.Run(fakeOvnNode.wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-
-				f4 := iptV4.(*util.FakeIPTables)
+				expectedNFT := nftablesRulesEgressServicesBase + `
+add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "namespace1/service1" : 5.5.5.5 }
+`
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN"},
-					},
-					"filter": {},
-					"mangle": {},
-				}
 
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				expectedNFT = nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
@@ -649,46 +603,13 @@ var _ = Describe("Egress Service Operations", func() {
 				err = c.Run(fakeOvnNode.wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
-							"-s 10.128.0.11 -m comment --comment namespace1/service2 -j SNAT --to-source 5.5.5.6",
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-				// The order of the rules is determined by the order the services are processed.
-				// We check if one of the two tables match to not flake on ordering.
-				expectedTables2 := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-							"-s 10.128.0.11 -m comment --comment namespace1/service2 -j SNAT --to-source 5.5.5.6",
-							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
+				expectedNFT := nftablesRulesEgressServicesBase + `
+add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "namespace1/service1" : 5.5.5.5 }
+add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "namespace1/service2" : 5.5.5.6 }
+`
 				Eventually(func() error {
-					err := f4.MatchState(expectedTables, nil)
-					if err == nil {
-						return nil
-					}
-					return f4.MatchState(expectedTables2, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN"},
-					},
-					"filter": {},
-					"mangle": {},
-				}
 
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -696,8 +617,9 @@ var _ = Describe("Egress Service Operations", func() {
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				expectedNFT = nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
@@ -871,18 +793,9 @@ var _ = Describe("Egress Service Operations", func() {
 				err = c.Run(fakeOvnNode.wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
+				expectedNFT := nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -916,8 +829,9 @@ var _ = Describe("Egress Service Operations", func() {
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				expectedNFT = nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1034,18 +948,9 @@ var _ = Describe("Egress Service Operations", func() {
 				err = c.Run(fakeOvnNode.wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-						},
-					},
-					"filter": {},
-					"mangle": {},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
+				expectedNFT := nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1062,8 +967,9 @@ var _ = Describe("Egress Service Operations", func() {
 				_, err = fakeOvnNode.fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				expectedNFT = nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1080,8 +986,9 @@ var _ = Describe("Egress Service Operations", func() {
 				_, err = fakeOvnNode.fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				expectedNFT = nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
@@ -1101,8 +1008,9 @@ var _ = Describe("Egress Service Operations", func() {
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				expectedNFT = nftablesRulesEgressServicesBase
 				Eventually(func() error {
-					return f4.MatchState(expectedTables, nil)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -453,14 +453,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 					"-j OVN-KUBE-NODEPORT",
 					"-j OVN-KUBE-ITP",
 				},
-				"POSTROUTING": []string{
-					"-j OVN-KUBE-EGRESS-SVC",
-				},
 				"OVN-KUBE-NODEPORT":   []string{},
 				"OVN-KUBE-EXTERNALIP": []string{},
 				"OVN-KUBE-ETP":        []string{},
 				"OVN-KUBE-ITP":        []string{},
-				"OVN-KUBE-EGRESS-SVC": []string{},
 			},
 			"filter": {},
 			"mangle": {
@@ -1300,13 +1296,11 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 				},
 				"POSTROUTING": []string{
-					"-j OVN-KUBE-EGRESS-SVC",
 					"-s 169.254.169.1 -j MASQUERADE",
 					"-s 10.1.1.0/24 -j MASQUERADE",
 				},
-				"OVN-KUBE-ETP":        []string{},
-				"OVN-KUBE-ITP":        []string{},
-				"OVN-KUBE-EGRESS-SVC": []string{},
+				"OVN-KUBE-ETP": []string{},
+				"OVN-KUBE-ITP": []string{},
 			},
 			"filter": {
 				"FORWARD": []string{

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
 	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -94,16 +93,6 @@ func ensureChain(table, chain string) error {
 
 func getGatewayInitRules(chain string, proto iptables.Protocol) []nodeipt.Rule {
 	iptRules := []nodeipt.Rule{}
-	if chain == egressservice.Chain {
-		return []nodeipt.Rule{
-			{
-				Table:    "nat",
-				Chain:    "POSTROUTING",
-				Args:     []string{"-j", chain},
-				Protocol: proto,
-			},
-		}
-	}
 	if chain == iptableITPChain {
 		iptRules = append(iptRules,
 			nodeipt.Rule{
@@ -564,7 +553,7 @@ func addChaintoTable(ipt util.IPTablesHelper, tableName, chain string) {
 func handleGatewayIPTables(iptCallback func(rules []nodeipt.Rule) error, genGatewayChainRules func(chain string, proto iptables.Protocol) []nodeipt.Rule) error {
 	rules := make([]nodeipt.Rule, 0)
 	// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-	for _, chain := range []string{iptableITPChain, egressservice.Chain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
+	for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
 		for _, proto := range clusterIPTablesProtocols() {
 			ipt, err := util.GetIPTablesHelper(proto)
 			if err != nil {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -414,16 +414,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -494,16 +490,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -576,16 +568,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -668,9 +656,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -678,8 +663,7 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -768,9 +752,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -778,9 +759,8 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -869,9 +849,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -884,8 +861,7 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1011,9 +987,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1025,8 +998,7 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 0.5000000000", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, ep1.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%d -m statistic --mode random --probability 1.0000000000", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, ep2.Addresses[0], int32(service.Spec.Ports[0].TargetPort.IntValue())),
 						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1124,9 +1096,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -1134,9 +1103,8 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1239,9 +1207,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -1253,8 +1218,7 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1359,16 +1323,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1458,16 +1418,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIPv4, service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port),
 						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-NODEPORT": []string{},
+						"OVN-KUBE-ETP":      []string{},
+						"OVN-KUBE-ITP":      []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1556,14 +1512,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1641,14 +1593,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1730,18 +1678,14 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v",
 								service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port,
 								service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-NODEPORT": []string{},
+						"OVN-KUBE-ETP":      []string{},
+						"OVN-KUBE-ITP":      []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1777,12 +1721,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -1964,14 +1904,10 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2066,16 +2002,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2111,12 +2043,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2199,9 +2127,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -2209,8 +2134,7 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String(), service.Spec.Ports[0].NodePort),
 						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2250,12 +2174,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2342,16 +2262,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2398,12 +2314,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2496,16 +2408,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2550,12 +2458,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2641,16 +2545,12 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-EXTERNALIP": []string{},
 						"OVN-KUBE-ITP":        []string{},
 						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2700,11 +2600,7 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2794,9 +2690,6 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
@@ -2804,8 +2697,7 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, int32(service.Spec.Ports[0].TargetPort.IntValue())),
 						},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ETP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2850,12 +2742,8 @@ var _ = Describe("Node Operations", func() {
 							"-j OVN-KUBE-NODEPORT",
 							"-j OVN-KUBE-ITP",
 						},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
-						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
+						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP": []string{},
 					},
 					"filter": {},
 					"mangle": {
@@ -2904,12 +2792,8 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {
 						"FORWARD": []string{
@@ -2963,12 +2847,8 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-NODEPORT":   []string{},
 						"OVN-KUBE-EXTERNALIP": []string{},
-						"POSTROUTING": []string{
-							"-j OVN-KUBE-EGRESS-SVC",
-						},
 						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
-						"OVN-KUBE-EGRESS-SVC": []string{},
 					},
 					"filter": {
 						"FORWARD": []string{},

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
 	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/linkmanager"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
@@ -1044,7 +1043,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 	// sync netfilter rules once only for Full mode
 	if !npw.dpuMode {
 		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
-		for _, chain := range []string{iptableITPChain, egressservice.Chain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
+		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain} {
 			if err = recreateIPTRules("nat", chain, keepIPTRules); err != nil {
 				errors = append(errors, err)
 			}


### PR DESCRIPTION
Switch Egress Services over to nftables. This code is mostly separate from all the other iptables code. (Actually... I'm pretty sure the existing reference to `egresservice.Chain` in `gateway_shared_intf.go:SyncServices` was incorrect, and would just cause it to flush all rules in `egressservice.Chain`. That only runs at startup, and I guess the ordering must have been such that it ran before the egressservice startup repair code, which I guess explains why #4868 wasn't a problem...)

(includes one commit from #4890, which can merge either here or there...)