### PR TITLE
Introduce TEST_OVSDB_TXN_TIMEOUT environment variable.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ env:
   CI_IMAGE_PR_TAR: image-pr.tar
   CI_DIST_IMAGES_OUTPUT: dist/images/_output/
 
+  # Sets OVSDBTxnTimeout to reduce tests exection time
+  TEST_OVSDB_TXN_TIMEOUT: 1s
 
 jobs:
   # separate job for parallelism

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -61,7 +61,7 @@ windows:
 # tests in a container. Refer: https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/ for additional context
 check test:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	$(CONTAINER_RUNTIME) run -it --rm --security-opt label=disable ${C_ARGS} -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} PKGS="${PKGS}" hack/test-go.sh focus \"${GINKGO_FOCUS}\" "
+	$(CONTAINER_RUNTIME) run -it --rm --security-opt label=disable ${C_ARGS} -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e TEST_OVSDB_TXN_TIMEOUT=${TEST_OVSDB_TXN_TIMEOUT} -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} PKGS="${PKGS}" hack/test-go.sh focus \"${GINKGO_FOCUS}\" "
 else
 	RACE=1 hack/test-go.sh
 endif

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -653,7 +653,13 @@ func PrepareTestConfig() error {
 	ClusterManager = savedClusterManager
 	Kubernetes.DisableRequestedChassis = false
 	EnableMulticast = false
-	Default.OVSDBTxnTimeout = 5 * time.Second
+
+	// OVSDBTimeout can be overriden for test, reduce to reduce test exection time
+	// increase to reduce flakiness, if unset or parsing failed, defaults to 5s
+	Default.OVSDBTxnTimeout, _ = time.ParseDuration(os.Getenv("TEST_OVSDB_TXN_TIMEOUT"))
+	if Default.OVSDBTxnTimeout <= 0 {
+		Default.OVSDBTxnTimeout = 5 * time.Second
+	}
 
 	if err := completeConfig(); err != nil {
 		return err


### PR DESCRIPTION
Setting it  reduces  test exections time where TNX_TIMEOUT is expected. For ci environments it can be set at higher value, for local development it can be safely lowered to 500ms.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Expands on work by @npinaeva #4505, i experimented with different values and found what i can safely set to `500ms` in local dev. This speed whole make check suite by ~2:30 (from 19:57.47 to 17:26.73). This is most noticable on suites in `ovn` folder.

This change is aimed to help hunt flakes in `egressip` tests as well as improve CI time.

PR also sets env variable for CI in workflow file to 1s. But this part is experimental and can be tuned.
 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Exectute
`time make check`
`TEST_OVSDB_TXN_TIMEOUT=500ms time make check`
Both should pass (except for known flakes). Test launch with reduced timeout should take less time.
