### PR TITLE
dist, udn: Fix validation MTU size when IPv6 subent is used

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -161,6 +161,10 @@ spec:
                     - message: IPAMLifecycle is only supported when subnets are set
                       rule: '!has(self.ipamLifecycle) || has(self.subnets) && size(self.subnets)
                         > 0'
+                    - message: MTU should be greater than or equal to 1280 when IPv6
+                        subent is used
+                      rule: '!has(self.mtu) || !has(self.subnets) || !self.subnets.exists_one(i,
+                        cidr(i).ip().family() == 6) || self.mtu >= 1280'
                   layer3:
                     description: Layer3 is the Layer3 topology configuration.
                     properties:
@@ -234,6 +238,10 @@ spec:
                     - message: JoinSubnets is only supported for Primary network
                       rule: '!has(self.joinSubnets) || has(self.role) && self.role
                         == ''Primary'''
+                    - message: MTU should be greater than or equal to 1280 when IPv6
+                        subent is used
+                      rule: '!has(self.mtu) || !has(self.subnets) || !self.subnets.exists_one(i,
+                        cidr(i.cidr).ip().family() == 6) || self.mtu >= 1280'
                   topology:
                     description: |-
                       Topology describes network configuration.

--- a/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
@@ -109,6 +109,10 @@ spec:
                 - message: IPAMLifecycle is only supported when subnets are set
                   rule: '!has(self.ipamLifecycle) || has(self.subnets) && size(self.subnets)
                     > 0'
+                - message: MTU should be greater than or equal to 1280 when IPv6 subent
+                    is used
+                  rule: '!has(self.mtu) || !has(self.subnets) || !self.subnets.exists_one(i,
+                    cidr(i).ip().family() == 6) || self.mtu >= 1280'
               layer3:
                 description: Layer3 is the Layer3 topology configuration.
                 properties:
@@ -182,6 +186,10 @@ spec:
                 - message: JoinSubnets is only supported for Primary network
                   rule: '!has(self.joinSubnets) || has(self.role) && self.role ==
                     ''Primary'''
+                - message: MTU should be greater than or equal to 1280 when IPv6 subent
+                    is used
+                  rule: '!has(self.mtu) || !has(self.subnets) || !self.subnets.exists_one(i,
+                    cidr(i.cidr).ip().family() == 6) || self.mtu >= 1280'
               topology:
                 description: |-
                   Topology describes network configuration.

--- a/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
@@ -26,8 +26,7 @@ const (
 
 // +kubebuilder:validation:XValidation:rule="has(self.subnets) && size(self.subnets) > 0", message="Subnets is required for Layer3 topology"
 // +kubebuilder:validation:XValidation:rule="!has(self.joinSubnets) || has(self.role) && self.role == 'Primary'", message="JoinSubnets is only supported for Primary network"
-// + TODO This validation does not work and needs to be fixed
-// + kubebuilder:validation:XValidation:rule="!has(self.subnets) || !self.subnets.exists_one(i, cidr(i.cidr).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subent is used"
+// +kubebuilder:validation:XValidation:rule="!has(self.mtu) || !has(self.subnets) || !self.subnets.exists_one(i, cidr(i.cidr).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subent is used"
 type Layer3Config struct {
 	// Role describes the network role in the pod.
 	//
@@ -95,8 +94,7 @@ type Layer3Subnet struct {
 // +kubebuilder:validation:XValidation:rule="self.role != 'Primary' || has(self.subnets) && size(self.subnets) > 0", message="Subnets is required for Primary Layer2 topology"
 // +kubebuilder:validation:XValidation:rule="!has(self.joinSubnets) || has(self.role) && self.role == 'Primary'", message="JoinSubnets is only supported for Primary network"
 // +kubebuilder:validation:XValidation:rule="!has(self.ipamLifecycle) || has(self.subnets) && size(self.subnets) > 0", message="IPAMLifecycle is only supported when subnets are set"
-// + TODO This validation does not work and needs to be fixed
-// + kubebuilder:validation:XValidation:rule="!has(self.subnets) || !self.subnets.exists_one(i, cidr(i).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subent is used"
+// +kubebuilder:validation:XValidation:rule="!has(self.mtu) || !has(self.subnets) || !self.subnets.exists_one(i, cidr(i).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subent is used"
 type Layer2Config struct {
 	// Role describes the network role in the pod.
 	//


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Fix UDN & CUDN CRDs CEL validation that checks MTU is valid when IPv6 subnet is used.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
