### PR TITLE
UDN Gateway: Ignore EndpointSlices without a service label

### DIFF
--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -9,10 +9,18 @@ import (
 	"strconv"
 	"testing"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/stretchr/testify/assert"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetLegacyK8sMgmtIntfName(t *testing.T) {
@@ -249,4 +257,126 @@ func TestGenerateId(t *testing.T) {
 func TestGetNetworkScopedK8sMgmtHostIntfName(t *testing.T) {
 	intfName := GetNetworkScopedK8sMgmtHostIntfName(1245678)
 	assert.Equal(t, "ovn-k8s-mp12456", intfName)
+}
+
+func TestServiceFromEndpointSlice(t *testing.T) {
+	config.IPv4Mode = true
+	type args struct {
+		eps     *discovery.EndpointSlice
+		netInfo NetInfo
+	}
+	netInfo, _ := NewNetInfo(
+		&ovncnitypes.NetConf{
+			NetConf:  cnitypes.NetConf{Name: "primary-network"},
+			Topology: types.Layer3Topology,
+			Subnets:  "10.1.130.0/16/24",
+			Role:     types.NetworkRolePrimary,
+		})
+	defaultNetInfo, _ := NewNetInfo(
+		&ovncnitypes.NetConf{
+			NetConf: cnitypes.NetConf{Name: types.DefaultNetworkName},
+		})
+	var tests = []struct {
+		name    string
+		args    args
+		want    *k8stypes.NamespacedName
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Primary network with matching label",
+			args: args{
+				eps: &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-eps",
+						Labels: map[string]string{
+							types.LabelUserDefinedEndpointSliceNetwork: "primary-network",
+							types.LabelUserDefinedServiceName:          "test-service",
+						},
+					},
+				},
+				netInfo: netInfo,
+			},
+			want: &k8stypes.NamespacedName{
+				Namespace: "test-namespace",
+				Name:      "test-service",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Wrong primary network with matching label",
+			args: args{
+				eps: &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-eps",
+						Labels: map[string]string{
+							types.LabelUserDefinedEndpointSliceNetwork: "wrong-network",
+							types.LabelUserDefinedServiceName:          "test-service",
+						},
+					},
+				},
+				netInfo: netInfo,
+			},
+			want:    nil,
+			wantErr: assert.Error,
+		},
+		{
+			name: "Primary network with no service label set",
+			args: args{
+				eps: &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-eps",
+						Labels: map[string]string{
+							types.LabelUserDefinedEndpointSliceNetwork: "primary-network",
+						},
+					},
+				},
+				netInfo: netInfo,
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "default network with a service label set",
+			args: args{
+				eps: &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-eps",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "test-service",
+						},
+					},
+				},
+				netInfo: defaultNetInfo,
+			},
+			want:    &k8stypes.NamespacedName{Namespace: "test-namespace", Name: "test-service"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "default network with no service label set",
+			args: args{
+				eps: &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-eps",
+					},
+				},
+				netInfo: defaultNetInfo,
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ServiceFromEndpointSlice(tt.args.eps, tt.args.netInfo)
+			if !tt.wantErr(t, err, fmt.Sprintf("ServiceFromEndpointSlice(%v, %v)", tt.args.eps, tt.args.netInfo)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "ServiceFromEndpointSlice(%v, %v)", tt.args.eps, tt.args.netInfo)
+		})
+	}
 }


### PR DESCRIPTION
Instead of failing ignore EndpointSlices without a service label set.
These custom, user created slices should be ignored.