### PR TITLE
Fixes pkt larger dispatch flows for UDNs

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2043,6 +2043,16 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=10, table=11, reg0=0x1, "+
 					"actions=output:%s", defaultOpenFlowCookie, ofPortHost))
+
+			// Send UDN destined traffic to right patch port
+			for _, netConfig := range bridge.patchedNetConfigs() {
+				if netConfig.masqCTMark != ctMarkOVN {
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=5, table=11, ct_mark=%s"+
+							"actions=output:%s", defaultOpenFlowCookie, netConfig.masqCTMark, netConfig.ofPortPatch))
+				}
+			}
+
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=1, table=11, "+
 					"actions=output:%s", defaultOpenFlowCookie, defaultNetConfig.ofPortPatch))


### PR DESCRIPTION
Looks like this path was missed and causes egress IP with UDNs on local gateway mode to not function correctly. Reply traffic was being sent to default cluster network patch port rather than the correct UDN patch port.

@martinkennelly FYI