### PR TITLE
fix flaky VM live migration e2e case

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -887,7 +887,7 @@ passwd:
 			Eventually(func() error {
 				endpoints, err = dialServiceNodePort(svc)
 				return err
-			}).WithPolling(time.Second).WithTimeout(20*time.Second).Should(Succeed(), "Should dial service port once service settled")
+			}).WithPolling(3*time.Second).WithTimeout(60*time.Second).Should(Succeed(), "Should dial service port once service settled")
 
 			checkConnectivityAndNetworkPolicies(vm.Name, endpoints, "before live migration")
 			// Do just one migration that will fail


### PR DESCRIPTION

## 📑 Description
Some time echoserver in VM could take more than 20s to start up, so increase timeout to 60 seconds to avoid flakiness.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->
