### PR TITLE
EgressIP: add route policies for east-west traffic between networks

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2958,18 +2958,22 @@ func createDefaultNoRerouteReplyTrafficPolicy(nbClient libovsdbclient.Client, ne
 // createDefaultNoReroutePodPolicies ensures egress pods east<->west traffic with regular pods,
 // i.e: ensuring that an egress pod can still communicate with a regular pod / service backed by regular pods
 func createDefaultNoReroutePodPolicies(nbClient libovsdbclient.Client, network, controller, clusterRouter string, v4ClusterSubnet, v6ClusterSubnet []*net.IPNet) error {
-	for _, v4Subnet := range v4ClusterSubnet {
-		match := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", v4Subnet.String(), v4Subnet.String())
-		dbIDs := getEgressIPLRPNoReRoutePodToPodDbIDs(IPFamilyValueV4, network, controller)
-		if err := createLogicalRouterPolicy(nbClient, clusterRouter, match, types.DefaultNoRereoutePriority, nil, dbIDs); err != nil {
-			return fmt.Errorf("unable to create IPv4 no-reroute pod policies, err: %v", err)
+	for _, v4Subnet1 := range v4ClusterSubnet {
+		for _, v4Subnet2 := range v4ClusterSubnet {
+			match := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", v4Subnet1.String(), v4Subnet2.String())
+			dbIDs := getEgressIPLRPNoReRoutePodToPodDbIDs(IPFamilyValueV4, network, controller)
+			if err := createLogicalRouterPolicy(nbClient, clusterRouter, match, types.DefaultNoRereoutePriority, nil, dbIDs); err != nil {
+				return fmt.Errorf("unable to create IPv4 no-reroute pod policies, err: %v", err)
+			}
 		}
 	}
-	for _, v6Subnet := range v6ClusterSubnet {
-		match := fmt.Sprintf("ip6.src == %s && ip6.dst == %s", v6Subnet.String(), v6Subnet.String())
-		dbIDs := getEgressIPLRPNoReRoutePodToPodDbIDs(IPFamilyValueV6, network, controller)
-		if err := createLogicalRouterPolicy(nbClient, clusterRouter, match, types.DefaultNoRereoutePriority, nil, dbIDs); err != nil {
-			return fmt.Errorf("unable to create IPv6 no-reroute pod policies, err: %v", err)
+	for _, v6Subnet1 := range v6ClusterSubnet {
+		for _, v6Subnet2 := range v6ClusterSubnet {
+			match := fmt.Sprintf("ip6.src == %s && ip6.dst == %s", v6Subnet1.String(), v6Subnet2.String())
+			dbIDs := getEgressIPLRPNoReRoutePodToPodDbIDs(IPFamilyValueV6, network, controller)
+			if err := createLogicalRouterPolicy(nbClient, clusterRouter, match, types.DefaultNoRereoutePriority, nil, dbIDs); err != nil {
+				return fmt.Errorf("unable to create IPv6 no-reroute pod policies, err: %v", err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## 📑 Description

When primary network have multiple networks, the ovn_cluster_router only has route policies to allow east-west traffic within the individual network, e.g.:
```
    102 ip4.src == 10.1.0.0/16 && ip4.dst == 10.1.0.0/16    allow
    102 ip4.src == 10.2.0.0/16 && ip4.dst == 10.2.0.0/16    allow
```

This change adds the necessary route polices to allow east-west traffic across different CIDRs:
```
    102 ip4.src == 10.1.0.0/16 && ip4.dst == 10.2.0.0/16    allow
    102 ip4.src == 10.2.0.0/16 && ip4.dst == 10.1.0.0/16    allow
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI 

## How to verify it

This issue was found in our downstream with below scenario:
- cluster has two networks(net_cidr): 10.1.0.0/16 and 10.2.0.0/16
- two k8s nodes have subnet allocated from different networks

When a pod on node with network 10.1.0.0/16 sends a packet to another pod on node with network 10.2.0.0/16, the packet can  not be matched by:
```
    # 102 - DefaultNoRereoutePriority
   # DefaultNoRereoutePriority policies are added when EgressIP feature is enabled, they ensure that east-west traffic is not using egress IPs.
    102 ip4.src == 10.1.0.0/16 && ip4.dst == 10.1.0.0/16    allow
    102 ip4.src == 10.2.0.0/16 && ip4.dst == 10.2.0.0/16    allow
```

So it could be matched by egressIP reroute policy if the pod matching a EgressIP:
```
      # 100 - EgressIPReroutePriority
      # added for the pod matching egressip-prod EgressIP, and it redirects the traffic to one of the egress nodes
       100                              ip4.src == 10.1.0.3         reroute                100.64.0.3, 100.64.0.4
```

Our downstream has a in-house node subnet allocation mechanism based on the node's pod density(indicated by an annotation), so it's easier to allocate node subnet from different network. Upstream e2e test only has one cluster network, even it has multiple networks there are no way to allocate node subnet from different network.

It's not possible to cover this change in e2e for now, but this change is straightforward, please take a look if it can be merged.

