### PR TITLE
Statically set GH runner image to ubuntu 22.04 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
   # separate job for parallelism
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
 
   build-master:
     name: Build-master
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     # Create a cache for the built master image
     - name: Restore master image cache
@@ -147,7 +147,7 @@ jobs:
 
   build-pr:
     name: Build-PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     # Create a cache for the build PR image
     - name: Restore PR image cache
@@ -256,7 +256,7 @@ jobs:
   ovn-upgrade-e2e:
     name: Upgrade OVN from Master to PR branch based image
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     needs:
       - build-master
@@ -386,7 +386,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # 30 mins for kind, 180 mins for control-plane tests, 10 minutes for all other steps
     timeout-minutes: 220
     strategy:
@@ -605,7 +605,7 @@ jobs:
   e2e-dual-conversion:
     name: e2e-dual-conversion
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
'ubuntu-latest' now references ubuntu 24.04.
Previously, it referenced 22.04.
Potential short term measure to unblock GH CI.
Failures for ubuntu 24.04 can be seen here: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4914