### PR TITLE
udn host isolation: fix initialSync.

### DIFF
--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -91,6 +91,7 @@ func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodIn
 
 // Start must be called on node setup.
 func (m *UDNHostIsolationManager) Start(ctx context.Context) error {
+	klog.Infof("Starting UDN host isolation manager")
 	// find kubelet cgroup path.
 	// kind cluster uses "kubelet.slice/kubelet.service", while OCP cluster uses "system.slice/kubelet.service".
 	// as long as ovn-k node is running as a privileged container, we can access the host cgroup directory.
@@ -367,7 +368,10 @@ func (m *UDNHostIsolationManager) podInitialSync() error {
 		// ignore openPorts parse error in initial sync
 		pi, _, err := m.getPodInfo(podKey, pod)
 		if err != nil {
-			return err
+			// don't fail because of one pod error on initial sync as it may cause crashloop.
+			// expect pod event to come later with correct/updated annotations.
+			klog.Warningf("UDNHostIsolationManager failed to get pod info for pod %s/%s on initial sync: %v", pod.Name, pod.Namespace, err)
+			continue
 		}
 		if pi == nil {
 			// this pod doesn't need to be updated
@@ -455,6 +459,10 @@ func (m *UDNHostIsolationManager) getPodInfo(podKey string, pod *v1.Pod) (*podIn
 	pi := &podInfo{}
 	if pod == nil {
 		return pi, nil, nil
+	}
+	if util.PodWantsHostNetwork(pod) {
+		// host network pods can't be isolated by IP
+		return nil, nil, nil
 	}
 	// only add pods with primary UDN
 	primaryUDN, err := m.isPodPrimaryUDN(pod)

--- a/go-controller/pkg/node/udn_isolation_test.go
+++ b/go-controller/pkg/node/udn_isolation_test.go
@@ -327,6 +327,36 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		}
 	})
 
+	It("correctly handles host-network and not ready pods on initial sync", func() {
+		hostNetPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hostnet",
+				UID:       ktypes.UID("hostnet"),
+				Namespace: defaultNamespace,
+			},
+		}
+		hostNetPod.Spec.HostNetwork = true
+		notReadyPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notready",
+				UID:       ktypes.UID("notready"),
+				Namespace: defaultNamespace,
+			},
+		}
+
+		fakeClient = util.GetOVNClientset(hostNetPod, notReadyPod).GetNodeClientset()
+		var err error
+		wf, err = factory.NewNodeWatchFactory(fakeClient, "node1")
+		Expect(err).NotTo(HaveOccurred())
+		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), nadController)
+		nft = nodenft.SetFakeNFTablesHelper()
+		manager.nft = nft
+
+		Expect(wf.Start()).To(Succeed())
+		Expect(manager.setupUDNIsolationFromHost()).To(Succeed())
+		Expect(manager.podInitialSync()).To(Succeed())
+	})
+
 	It("correctly generates initial rules", func() {
 		start()
 		Expect(nft.Dump()).To(Equal(getExpectedDump(nil, nil)))


### PR DESCRIPTION
Handle host-network pods as default network.
Don't return per-pod errors on startup.
