### PR TITLE
Increase scalability of secondary network controllers by multiplexing informers.

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -67,6 +67,7 @@ type ClusterManager struct {
 func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory,
 	identity string, wg *sync.WaitGroup, recorder record.EventRecorder) (*ClusterManager, error) {
 
+	wf = wf.ShallowClone()
 	defaultNetClusterController := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, ovnClient, wf, recorder)
 
 	zoneClusterController, err := newZoneClusterController(ovnClient, wf)

--- a/go-controller/pkg/clustermanager/node/subnet_allocator.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator.go
@@ -44,6 +44,9 @@ func NewSubnetAllocator() SubnetAllocator {
 
 // Usage returns the number of used/allocated v4 and v6 subnets
 func (sna *BaseSubnetAllocator) Usage() (uint64, uint64) {
+	sna.Lock()
+	defer sna.Unlock()
+
 	var v4used, v6used uint64
 	for _, snr := range sna.v4ranges {
 		v4used = v4used + snr.usage()
@@ -56,6 +59,9 @@ func (sna *BaseSubnetAllocator) Usage() (uint64, uint64) {
 
 // Count returns the number of available (both used and unused) v4 and v6 subnets
 func (sna *BaseSubnetAllocator) Count() (uint64, uint64) {
+	sna.Lock()
+	defer sna.Unlock()
+
 	var v4count, v6count uint64
 	for _, snr := range sna.v4ranges {
 		v4count = v4count + snr.count()

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -64,7 +64,7 @@ func (sncm *secondaryNetworkClusterManager) NewNetworkController(nInfo util.NetI
 	sncc := newNetworkClusterController(
 		nInfo,
 		sncm.ovnClient,
-		sncm.watchFactory,
+		sncm.watchFactory.ShallowClone(),
 		sncm.recorder,
 		sncm.networkManager,
 		sncm.errorReporter,

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -65,7 +65,9 @@ type ControllerManager struct {
 }
 
 func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkmanager.NetworkController, error) {
-	cnci, err := cm.newCommonNetworkControllerInfo()
+	// Pass a shallow clone of the watch factory, this allows multiplexing
+	// informers for secondary networks.
+	cnci, err := cm.newCommonNetworkControllerInfo(cm.watchFactory.ShallowClone())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network controller info %w", err)
 	}
@@ -83,7 +85,9 @@ func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkma
 
 // newDummyNetworkController creates a dummy network controller used to clean up specific network
 func (cm *ControllerManager) newDummyNetworkController(topoType, netName string) (networkmanager.NetworkController, error) {
-	cnci, err := cm.newCommonNetworkControllerInfo()
+	// Pass a shallow clone of the watch factory, this allows multiplexing
+	// informers for secondary networks.
+	cnci, err := cm.newCommonNetworkControllerInfo(cm.watchFactory.ShallowClone())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network controller info %w", err)
 	}
@@ -301,14 +305,14 @@ func (cm *ControllerManager) createACLLoggingMeter() error {
 }
 
 // newCommonNetworkControllerInfo creates and returns the common networkController info
-func (cm *ControllerManager) newCommonNetworkControllerInfo() (*ovn.CommonNetworkControllerInfo, error) {
-	return ovn.NewCommonNetworkControllerInfo(cm.client, cm.kube, cm.watchFactory, cm.recorder, cm.nbClient,
+func (cm *ControllerManager) newCommonNetworkControllerInfo(wf *factory.WatchFactory) (*ovn.CommonNetworkControllerInfo, error) {
+	return ovn.NewCommonNetworkControllerInfo(cm.client, cm.kube, wf, cm.recorder, cm.nbClient,
 		cm.sbClient, cm.podRecorder, cm.SCTPSupport, cm.multicastSupport, cm.svcTemplateSupport)
 }
 
 // initDefaultNetworkController creates the controller for default network
 func (cm *ControllerManager) initDefaultNetworkController(observManager *observability.Manager) error {
-	cnci, err := cm.newCommonNetworkControllerInfo()
+	cnci, err := cm.newCommonNetworkControllerInfo(cm.watchFactory)
 	if err != nil {
 		return fmt.Errorf("failed to create common network controller info: %w", err)
 	}

--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -53,7 +53,9 @@ func (ncm *NodeControllerManager) NewNetworkController(nInfo util.NetInfo) (netw
 	topoType := nInfo.TopologyType()
 	switch topoType {
 	case ovntypes.Layer3Topology, ovntypes.Layer2Topology, ovntypes.LocalnetTopology:
-		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(),
+		// Pass a shallow clone of the watch factory, this allows multiplexing
+		// informers for secondary networks.
+		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(ncm.watchFactory.(*factory.WatchFactory).ShallowClone()),
 			nInfo, ncm.vrfManager, ncm.ruleManager, ncm.defaultNodeNetworkController.Gateway)
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
@@ -79,8 +81,8 @@ func (ncm *NodeControllerManager) CleanupStaleNetworks(validNetworks ...util.Net
 }
 
 // newCommonNetworkControllerInfo creates and returns the base node network controller info
-func (ncm *NodeControllerManager) newCommonNetworkControllerInfo() *node.CommonNodeNetworkControllerInfo {
-	return node.NewCommonNodeNetworkControllerInfo(ncm.ovnNodeClient.KubeClient, ncm.ovnNodeClient.AdminPolicyRouteClient, ncm.watchFactory, ncm.recorder, ncm.name, ncm.routeManager)
+func (ncm *NodeControllerManager) newCommonNetworkControllerInfo(wf factory.NodeWatchFactory) *node.CommonNodeNetworkControllerInfo {
+	return node.NewCommonNodeNetworkControllerInfo(ncm.ovnNodeClient.KubeClient, ncm.ovnNodeClient.AdminPolicyRouteClient, wf, ncm.recorder, ncm.name, ncm.routeManager)
 }
 
 // isNetworkManagerRequiredForNode checks if network manager should be started
@@ -127,7 +129,7 @@ func NewNodeControllerManager(ovnClient *util.OVNClientset, wf factory.NodeWatch
 
 // initDefaultNodeNetworkController creates the controller for default network
 func (ncm *NodeControllerManager) initDefaultNodeNetworkController() error {
-	defaultNodeNetworkController, err := node.NewDefaultNodeNetworkController(ncm.newCommonNetworkControllerInfo(), ncm.networkManager.Interface())
+	defaultNodeNetworkController, err := node.NewDefaultNodeNetworkController(ncm.newCommonNetworkControllerInfo(ncm.watchFactory), ncm.networkManager.Interface())
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"reflect"
 	"sync/atomic"
 	"time"
@@ -105,11 +106,15 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// WatchFactory initializes and manages common kube watches
-type WatchFactory struct {
+type handlerCounter struct {
 	// Must be first member in the struct due to Golang ARM/x86 32-bit
 	// requirements with atomic accesses
-	handlerCounter uint64
+	counter uint64
+}
+
+// WatchFactory initializes and manages common kube watches
+type WatchFactory struct {
+	handlerCounter *handlerCounter
 
 	iFactory             informerfactory.SharedInformerFactory
 	anpFactory           anpinformerfactory.SharedInformerFactory
@@ -129,10 +134,39 @@ type WatchFactory struct {
 	informers            map[reflect.Type]*informer
 
 	stopChan chan struct{}
+
+	// Shallow watch factory clones potentially use different internal
+	// informers (to allow multiplexing and load sharing).
+	internalInformerIndex int
+}
+
+func (wf *WatchFactory) ShallowClone() *WatchFactory {
+	return &WatchFactory{
+		handlerCounter:       wf.handlerCounter,
+		iFactory:             wf.iFactory,
+		anpFactory:           wf.anpFactory,
+		eipFactory:           wf.eipFactory,
+		efFactory:            wf.efFactory,
+		dnsFactory:           wf.dnsFactory,
+		cpipcFactory:         wf.cpipcFactory,
+		egressQoSFactory:     wf.egressQoSFactory,
+		mnpFactory:           wf.mnpFactory,
+		egressServiceFactory: wf.egressServiceFactory,
+		apbRouteFactory:      wf.apbRouteFactory,
+		ipamClaimsFactory:    wf.ipamClaimsFactory,
+		nadFactory:           wf.nadFactory,
+		udnFactory:           wf.udnFactory,
+		informers:            wf.informers,
+		stopChan:             wf.stopChan,
+
+		// Choose a random internalInformer to use for this clone of the
+		// factory.  Reserve index 0 for default network handlers.
+		internalInformerIndex: rand.IntN(internalInformerPoolSize-1) + 1,
+	}
 }
 
 // WatchFactory implements the ObjectCacheInterface interface.
-var _ ObjectCacheInterface = &WatchFactory{}
+var _ ObjectCacheInterface = &WatchFactory{handlerCounter: &handlerCounter{}}
 
 const (
 	// resync time is 0, none of the resources being watched in ovn-kubernetes have
@@ -258,6 +292,7 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 	// the downside of making it tight (like 10 minutes) is needless spinning on all resources
 	// However, AddEventHandlerWithResyncPeriod can specify a per handler resync period
 	wf := &WatchFactory{
+		handlerCounter:       &handlerCounter{},
 		iFactory:             informerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.KubeClient, resyncInterval, informerfactory.WithTransform(informerObjectTrim)),
 		anpFactory:           anpinformerfactory.NewSharedInformerFactory(ovnClientset.ANPClient, resyncInterval),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
@@ -654,6 +689,7 @@ func (wf *WatchFactory) Stop() {
 // of the localPodSelector or figure out how to deal with selecting all pods everywhere.
 func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (*WatchFactory, error) {
 	wf := &WatchFactory{
+		handlerCounter:       &handlerCounter{},
 		iFactory:             informerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.KubeClient, resyncInterval, informerfactory.WithTransform(informerObjectTrim)),
 		egressServiceFactory: egressserviceinformerfactory.NewSharedInformerFactory(ovnClientset.EgressServiceClient, resyncInterval),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
@@ -815,6 +851,7 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 // mode process.
 func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset) (*WatchFactory, error) {
 	wf := &WatchFactory{
+		handlerCounter:       &handlerCounter{},
 		iFactory:             informerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.KubeClient, resyncInterval, informerfactory.WithTransform(informerObjectTrim)),
 		efFactory:            egressfirewallinformerfactory.NewSharedInformerFactory(ovnClientset.EgressFirewallClient, resyncInterval),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
@@ -1218,8 +1255,10 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel l
 		return true
 	}
 
-	inf.Lock()
-	defer inf.Unlock()
+	intInf := inf.internalInformers[wf.internalInformerIndex]
+
+	intInf.Lock()
+	defer intInf.Unlock()
 
 	items := make([]interface{}, 0)
 	for _, obj := range inf.inf.GetStore().List() {
@@ -1243,8 +1282,8 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel l
 		}
 	}
 
-	handlerID := atomic.AddUint64(&wf.handlerCounter, 1)
-	handler := inf.addHandler(handlerID, priority, filterFunc, funcs, items)
+	handlerID := atomic.AddUint64(&wf.handlerCounter.counter, 1)
+	handler := inf.addHandler(wf.internalInformerIndex, handlerID, priority, filterFunc, funcs, items)
 	klog.V(5).Infof("Added %v event handler %d", objType, handler.id)
 	return handler, nil
 }

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -147,6 +147,8 @@ const (
 
 	// namespace, node, and pod handlers
 	defaultNumEventQueues uint32 = 15
+	// rest of handlers
+	minNumEventQueues = 1
 
 	// default priorities for various handlers (also the highest priority)
 	defaultHandlerPriority int = 0
@@ -220,7 +222,8 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 	}
 	wf.cpipcFactory = ocpcloudnetworkinformerfactory.NewSharedInformerFactory(ovnClientset.CloudNetworkClient, resyncInterval)
 	if util.PlatformTypeIsEgressIPCloudProvider() {
-		wf.informers[CloudPrivateIPConfigType], err = newInformer(CloudPrivateIPConfigType, wf.cpipcFactory.Cloud().V1().CloudPrivateIPConfigs().Informer())
+		wf.informers[CloudPrivateIPConfigType], err = newQueuedInformer(CloudPrivateIPConfigType,
+			wf.cpipcFactory.Cloud().V1().CloudPrivateIPConfigs().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -336,11 +339,13 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[ServiceType], err = newInformer(ServiceType, wf.iFactory.Core().V1().Services().Informer())
+	wf.informers[ServiceType], err = newQueuedInformer(ServiceType, wf.iFactory.Core().V1().Services().Informer(),
+		wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[PolicyType], err = newInformer(PolicyType, wf.iFactory.Networking().V1().NetworkPolicies().Informer())
+	wf.informers[PolicyType], err = newQueuedInformer(PolicyType, wf.iFactory.Networking().V1().NetworkPolicies().Informer(),
+		wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
@@ -354,28 +359,33 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[EndpointSliceType], err = newInformer(EndpointSliceType, wf.iFactory.Discovery().V1().EndpointSlices().Informer())
+	wf.informers[EndpointSliceType], err = newQueuedInformer(EndpointSliceType, wf.iFactory.Discovery().V1().EndpointSlices().Informer(),
+		wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
 	if config.OVNKubernetesFeature.EnableAdminNetworkPolicy {
-		wf.informers[AdminNetworkPolicyType], err = newInformer(AdminNetworkPolicyType, wf.anpFactory.Policy().V1alpha1().AdminNetworkPolicies().Informer())
+		wf.informers[AdminNetworkPolicyType], err = newQueuedInformer(AdminNetworkPolicyType,
+			wf.anpFactory.Policy().V1alpha1().AdminNetworkPolicies().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
-		wf.informers[BaselineAdminNetworkPolicyType], err = newInformer(BaselineAdminNetworkPolicyType, wf.anpFactory.Policy().V1alpha1().BaselineAdminNetworkPolicies().Informer())
+		wf.informers[BaselineAdminNetworkPolicyType], err = newQueuedInformer(BaselineAdminNetworkPolicyType,
+			wf.anpFactory.Policy().V1alpha1().BaselineAdminNetworkPolicies().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if config.OVNKubernetesFeature.EnableEgressIP {
-		wf.informers[EgressIPType], err = newInformer(EgressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer())
+		wf.informers[EgressIPType], err = newQueuedInformer(EgressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer(), wf.stopChan,
+			minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if config.OVNKubernetesFeature.EnableEgressFirewall {
-		wf.informers[EgressFirewallType], err = newInformer(EgressFirewallType, wf.efFactory.K8s().V1().EgressFirewalls().Informer())
+		wf.informers[EgressFirewallType], err = newQueuedInformer(EgressFirewallType, wf.efFactory.K8s().V1().EgressFirewalls().Informer(),
+			wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -386,13 +396,15 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 		}
 	}
 	if config.OVNKubernetesFeature.EnableEgressQoS {
-		wf.informers[EgressQoSType], err = newInformer(EgressQoSType, wf.egressQoSFactory.K8s().V1().EgressQoSes().Informer())
+		wf.informers[EgressQoSType], err = newQueuedInformer(EgressQoSType, wf.egressQoSFactory.K8s().V1().EgressQoSes().Informer(),
+			wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if config.OVNKubernetesFeature.EnableEgressService {
-		wf.informers[EgressServiceType], err = newInformer(EgressServiceType, wf.egressServiceFactory.K8s().V1().EgressServices().Informer())
+		wf.informers[EgressServiceType], err = newQueuedInformer(EgressServiceType,
+			wf.egressServiceFactory.K8s().V1().EgressServices().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -400,14 +412,16 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 
 	if config.OVNKubernetesFeature.EnableMultiNetwork {
 		wf.nadFactory = nadinformerfactory.NewSharedInformerFactory(ovnClientset.NetworkAttchDefClient, resyncInterval)
-		wf.informers[NetworkAttachmentDefinitionType], err = newInformer(NetworkAttachmentDefinitionType, wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer())
+		wf.informers[NetworkAttachmentDefinitionType], err = newQueuedInformer(NetworkAttachmentDefinitionType,
+			wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 
 		if config.OVNKubernetesFeature.EnablePersistentIPs && !config.OVNKubernetesFeature.EnableInterconnect {
 			wf.ipamClaimsFactory = ipamclaimsfactory.NewSharedInformerFactory(ovnClientset.IPAMClaimsClient, resyncInterval)
-			wf.informers[IPAMClaimsType], err = newInformer(IPAMClaimsType, wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer())
+			wf.informers[IPAMClaimsType], err = newQueuedInformer(IPAMClaimsType,
+				wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer(), wf.stopChan, minNumEventQueues)
 			if err != nil {
 				return nil, err
 			}
@@ -416,19 +430,22 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 
 	if util.IsNetworkSegmentationSupportEnabled() {
 		wf.udnFactory = userdefinednetworkapiinformerfactory.NewSharedInformerFactory(ovnClientset.UserDefinedNetworkClient, resyncInterval)
-		wf.informers[UserDefinedNetworkType], err = newInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer())
+		wf.informers[UserDefinedNetworkType], err = newQueuedInformer(UserDefinedNetworkType,
+			wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 
-		wf.informers[ClusterUserDefinedNetworkType], err = newInformer(ClusterUserDefinedNetworkType, wf.udnFactory.K8s().V1().ClusterUserDefinedNetworks().Informer())
+		wf.informers[ClusterUserDefinedNetworkType], err = newQueuedInformer(ClusterUserDefinedNetworkType,
+			wf.udnFactory.K8s().V1().ClusterUserDefinedNetworks().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if util.IsMultiNetworkPoliciesSupportEnabled() {
-		wf.informers[MultiNetworkPolicyType], err = newInformer(MultiNetworkPolicyType, wf.mnpFactory.K8sCniCncfIo().V1beta1().MultiNetworkPolicies().Informer())
+		wf.informers[MultiNetworkPolicyType], err = newQueuedInformer(MultiNetworkPolicyType,
+			wf.mnpFactory.K8sCniCncfIo().V1beta1().MultiNetworkPolicies().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -708,7 +725,8 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 			getEndpointSliceSelector())
 	})
 
-	wf.informers[NamespaceType], err = newInformer(NamespaceType, wf.iFactory.Core().V1().Namespaces().Informer())
+	wf.informers[NamespaceType], err = newQueuedInformer(NamespaceType, wf.iFactory.Core().V1().Namespaces().Informer(),
+		wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
@@ -717,32 +735,35 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[ServiceType], err = newInformer(
+	wf.informers[ServiceType], err = newQueuedInformer(
 		ServiceType,
-		wf.iFactory.Core().V1().Services().Informer())
+		wf.iFactory.Core().V1().Services().Informer(), wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[EndpointSliceType], err = newInformer(
+	wf.informers[EndpointSliceType], err = newQueuedInformer(
 		EndpointSliceType,
-		wf.iFactory.Discovery().V1().EndpointSlices().Informer())
+		wf.iFactory.Discovery().V1().EndpointSlices().Informer(), wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
 
-	wf.informers[NodeType], err = newInformer(NodeType, wf.iFactory.Core().V1().Nodes().Informer())
+	wf.informers[NodeType], err = newQueuedInformer(NodeType, wf.iFactory.Core().V1().Nodes().Informer(), wf.stopChan,
+		minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
 
 	if config.OVNKubernetesFeature.EnableEgressService {
-		wf.informers[EgressServiceType], err = newInformer(EgressServiceType, wf.egressServiceFactory.K8s().V1().EgressServices().Informer())
+		wf.informers[EgressServiceType], err = newQueuedInformer(EgressServiceType,
+			wf.egressServiceFactory.K8s().V1().EgressServices().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if config.OVNKubernetesFeature.EnableEgressIP {
-		wf.informers[EgressIPType], err = newInformer(EgressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer())
+		wf.informers[EgressIPType], err = newQueuedInformer(EgressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer(),
+			wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -764,7 +785,8 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 	// needs the NAD factory whenever the UDN feature is used.
 	if config.OVNKubernetesFeature.EnableMultiNetwork && (config.OVNKubernetesFeature.EnableNetworkSegmentation || config.OvnKubeNode.Mode == types.NodeModeDPU) {
 		wf.nadFactory = nadinformerfactory.NewSharedInformerFactory(ovnClientset.NetworkAttchDefClient, resyncInterval)
-		wf.informers[NetworkAttachmentDefinitionType], err = newInformer(NetworkAttachmentDefinitionType, wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer())
+		wf.informers[NetworkAttachmentDefinitionType], err = newQueuedInformer(NetworkAttachmentDefinitionType,
+			wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -772,12 +794,14 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 
 	if util.IsNetworkSegmentationSupportEnabled() {
 		wf.udnFactory = userdefinednetworkapiinformerfactory.NewSharedInformerFactory(ovnClientset.UserDefinedNetworkClient, resyncInterval)
-		wf.informers[UserDefinedNetworkType], err = newInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer())
+		wf.informers[UserDefinedNetworkType], err = newQueuedInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer(),
+			wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 
-		wf.informers[ClusterUserDefinedNetworkType], err = newInformer(ClusterUserDefinedNetworkType, wf.udnFactory.K8s().V1().ClusterUserDefinedNetworks().Informer())
+		wf.informers[ClusterUserDefinedNetworkType], err = newQueuedInformer(ClusterUserDefinedNetworkType,
+			wf.udnFactory.K8s().V1().ClusterUserDefinedNetworks().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -854,37 +878,42 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 
 	var err error
 	// Create our informer-wrapper informer (and underlying shared informer) for types we need
-	wf.informers[ServiceType], err = newInformer(ServiceType, wf.iFactory.Core().V1().Services().Informer())
+	wf.informers[ServiceType], err = newQueuedInformer(ServiceType, wf.iFactory.Core().V1().Services().Informer(),
+		wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
 
-	wf.informers[EndpointSliceType], err = newInformer(
+	wf.informers[EndpointSliceType], err = newQueuedInformer(
 		EndpointSliceType,
-		wf.iFactory.Discovery().V1().EndpointSlices().Informer())
+		wf.iFactory.Discovery().V1().EndpointSlices().Informer(), wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
 
-	wf.informers[NodeType], err = newInformer(NodeType, wf.iFactory.Core().V1().Nodes().Informer())
+	wf.informers[NodeType], err = newQueuedInformer(NodeType, wf.iFactory.Core().V1().Nodes().Informer(),
+		wf.stopChan, minNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
 	if config.OVNKubernetesFeature.EnableEgressIP {
-		wf.informers[EgressIPType], err = newInformer(EgressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer())
+		wf.informers[EgressIPType], err = newQueuedInformer(EgressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer(),
+			wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if util.PlatformTypeIsEgressIPCloudProvider() {
-		wf.informers[CloudPrivateIPConfigType], err = newInformer(CloudPrivateIPConfigType, wf.cpipcFactory.Cloud().V1().CloudPrivateIPConfigs().Informer())
+		wf.informers[CloudPrivateIPConfigType], err = newQueuedInformer(CloudPrivateIPConfigType,
+			wf.cpipcFactory.Cloud().V1().CloudPrivateIPConfigs().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if config.OVNKubernetesFeature.EnableEgressService {
-		wf.informers[EgressServiceType], err = newInformer(EgressServiceType, wf.egressServiceFactory.K8s().V1().EgressServices().Informer())
+		wf.informers[EgressServiceType], err = newQueuedInformer(EgressServiceType,
+			wf.egressServiceFactory.K8s().V1().EgressServices().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -892,20 +921,23 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 
 	if config.OVNKubernetesFeature.EnableMultiNetwork {
 		wf.nadFactory = nadinformerfactory.NewSharedInformerFactory(ovnClientset.NetworkAttchDefClient, resyncInterval)
-		wf.informers[NetworkAttachmentDefinitionType], err = newInformer(NetworkAttachmentDefinitionType, wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer())
+		wf.informers[NetworkAttachmentDefinitionType], err = newQueuedInformer(NetworkAttachmentDefinitionType,
+			wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
 
 		if config.OVNKubernetesFeature.EnableInterconnect {
-			wf.informers[PodType], err = newQueuedInformer(PodType, wf.iFactory.Core().V1().Pods().Informer(), wf.stopChan, defaultNumEventQueues)
+			wf.informers[PodType], err = newQueuedInformer(PodType, wf.iFactory.Core().V1().Pods().Informer(),
+				wf.stopChan, defaultNumEventQueues)
 			if err != nil {
 				return nil, err
 			}
 
 			if config.OVNKubernetesFeature.EnablePersistentIPs {
 				wf.ipamClaimsFactory = ipamclaimsfactory.NewSharedInformerFactory(ovnClientset.IPAMClaimsClient, resyncInterval)
-				wf.informers[IPAMClaimsType], err = newInformer(IPAMClaimsType, wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer())
+				wf.informers[IPAMClaimsType], err = newQueuedInformer(IPAMClaimsType,
+					wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer(), wf.stopChan, minNumEventQueues)
 				if err != nil {
 					return nil, err
 				}
@@ -930,11 +962,13 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 
 	if util.IsNetworkSegmentationSupportEnabled() {
 		wf.udnFactory = userdefinednetworkapiinformerfactory.NewSharedInformerFactory(ovnClientset.UserDefinedNetworkClient, resyncInterval)
-		wf.informers[UserDefinedNetworkType], err = newInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer())
+		wf.informers[UserDefinedNetworkType], err = newQueuedInformer(UserDefinedNetworkType,
+			wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
-		wf.informers[ClusterUserDefinedNetworkType], err = newInformer(ClusterUserDefinedNetworkType, wf.udnFactory.K8s().V1().ClusterUserDefinedNetworks().Informer())
+		wf.informers[ClusterUserDefinedNetworkType], err = newQueuedInformer(ClusterUserDefinedNetworkType,
+			wf.udnFactory.K8s().V1().ClusterUserDefinedNetworks().Informer(), wf.stopChan, minNumEventQueues)
 		if err != nil {
 			return nil, err
 		}
@@ -1027,6 +1061,22 @@ func getObjectMeta(objType reflect.Type, obj interface{}) (*metav1.ObjectMeta, e
 	case IPAMClaimsType:
 		if persistentips, ok := obj.(*ipamclaimsapi.IPAMClaim); ok {
 			return &persistentips.ObjectMeta, nil
+		}
+	case EgressQoSType:
+		if egressQoS, ok := obj.(*egressqosapi.EgressQoS); ok {
+			return &egressQoS.ObjectMeta, nil
+		}
+	case EgressServiceType:
+		if egressService, ok := obj.(*egressserviceapi.EgressService); ok {
+			return &egressService.ObjectMeta, nil
+		}
+	case UserDefinedNetworkType:
+		if udn, ok := obj.(*userdefinednetworkapi.UserDefinedNetwork); ok {
+			return &udn.ObjectMeta, nil
+		}
+	case ClusterUserDefinedNetworkType:
+		if cudn, ok := obj.(*userdefinednetworkapi.ClusterUserDefinedNetwork); ok {
+			return &cudn.ObjectMeta, nil
 		}
 	}
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -188,11 +188,18 @@ const (
 	defaultHandlerPriority int = 0
 	// lowest priority among various handlers (See GetHandlerPriority for more information)
 	minHandlerPriority int = 4
+)
 
+var (
 	// Use a larger queue for incoming events to avoid bottlenecks
 	// due to handlers being slow.
 	eventQueueSize uint32 = 1000
 )
+
+// Override default event queue configuration.  Used only for tests.
+func SetEventQueueSize(newEventQueueSize uint32) {
+	eventQueueSize = newEventQueueSize
+}
 
 // types for dynamic handlers created when adding a network policy
 type addressSetNamespaceAndPodSelector struct{}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -726,7 +726,7 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 	})
 
 	wf.informers[NamespaceType], err = newQueuedInformer(NamespaceType, wf.iFactory.Core().V1().Namespaces().Informer(),
-		wf.stopChan, minNumEventQueues)
+		wf.stopChan, defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +749,7 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 	}
 
 	wf.informers[NodeType], err = newQueuedInformer(NodeType, wf.iFactory.Core().V1().Nodes().Informer(), wf.stopChan,
-		minNumEventQueues)
+		defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
@@ -892,7 +892,7 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 	}
 
 	wf.informers[NodeType], err = newQueuedInformer(NodeType, wf.iFactory.Core().V1().Nodes().Informer(),
-		wf.stopChan, minNumEventQueues)
+		wf.stopChan, defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -210,7 +210,7 @@ func (i *informer) removeHandler(handler *Handler) {
 	}()
 }
 
-func newQueueMap(numEventQueues uint32, wg *sync.WaitGroup, stopChan chan struct{}) *queueMap {
+func newQueueMap(qSize uint32, numEventQueues uint32, wg *sync.WaitGroup, stopChan chan struct{}) *queueMap {
 	qm := &queueMap{
 		entries:  make(map[ktypes.NamespacedName]*queueMapEntry),
 		queues:   make([]chan *event, numEventQueues),
@@ -218,7 +218,7 @@ func newQueueMap(numEventQueues uint32, wg *sync.WaitGroup, stopChan chan struct
 		stopChan: stopChan,
 	}
 	for j := 0; j < int(numEventQueues); j++ {
-		qm.queues[j] = make(chan *event, 10)
+		qm.queues[j] = make(chan *event, qSize)
 	}
 	return qm
 }
@@ -512,7 +512,7 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 	}, nil
 }
 
-func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInformer,
+func newQueuedInformer(queueSize uint32, oType reflect.Type, sharedInformer cache.SharedIndexInformer,
 	stopChan chan struct{}, numEventQueues uint32) (*informer, error) {
 	informer, err := newBaseInformer(oType, sharedInformer)
 	if err != nil {
@@ -525,7 +525,8 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		// is added, only that handler should receive events for all
 		// existing objects.
 		addsWg := &sync.WaitGroup{}
-		addsMap := newQueueMap(numEventQueues, addsWg, stopChan)
+
+		addsMap := newQueueMap(queueSize, numEventQueues, addsWg, stopChan)
 		addsMap.start()
 
 		// Distribute the existing items into the handler-specific
@@ -542,7 +543,7 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 	}
 
 	for i := 0; i < internalInformerPoolSize; i++ {
-		informer.internalInformers[i].queueMap = newQueueMap(numEventQueues, &informer.shutdownWg, stopChan)
+		informer.internalInformers[i].queueMap = newQueueMap(queueSize, numEventQueues, &informer.shutdownWg, stopChan)
 		informer.internalInformers[i].queueMap.start()
 
 		_, err = informer.inf.AddEventHandler(informer.newFederatedQueuedHandler(i))

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -33,6 +33,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Use a pool of internal informers to allow multiplexing of events
+// between multiple internal informers.  This reduces lock contention
+// when adding/removing event handlers by distributing them between
+// internal informers.
+const internalInformerPoolSize int = 201
+
 // Handler represents an event handler and is private to the factory module
 type Handler struct {
 	base cache.FilteringResourceEventHandler
@@ -48,6 +54,10 @@ type Handler struct {
 	// example: a handler with priority 0 will process the received event first
 	// before a handler with priority 1.
 	priority int
+
+	// indicates which informer.internalInformers index to use
+	// clients are distributed between internal informers
+	internalInformerIndex int
 }
 
 func (h *Handler) OnAdd(obj interface{}, isInInitialList bool) {
@@ -95,8 +105,15 @@ type queueMapEntry struct {
 	refcount int32
 }
 
-type informer struct {
+type internalInformer struct {
 	sync.RWMutex
+	oType    reflect.Type
+	handlers map[int]map[uint64]*Handler
+	// queueMap handles distributing events across a queued handler's queues
+	queueMap *queueMap
+}
+
+type informer struct {
 	oType reflect.Type
 	inf   cache.SharedIndexInformer
 	// keyed by priority - used to track the handler's priority of being invoked.
@@ -104,40 +121,37 @@ type informer struct {
 	// before a handler with priority 1, 0 being the higest priority.
 	// NOTE: we can have multiple handlers with the same priority hence the value
 	// is a map of handlers keyed by its unique id.
-	handlers map[int]map[uint64]*Handler
-	lister   listerInterface
+	lister listerInterface
 	// initialAddFunc will be called to deliver the initial list of objects
 	// when a handler is added
 	initialAddFunc initialAddFn
 	shutdownWg     sync.WaitGroup
 
-	// queueMap handles distributing events across a queued handler's queues
-	queueMap *queueMap
+	internalInformers []*internalInformer
 }
 
-func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
-	i.RLock()
-	defer i.RUnlock()
-
+func (inf *internalInformer) forEachQueuedHandler(f func(h *Handler)) {
+	inf.RLock()
+	defer inf.RUnlock()
 	for priority := 0; priority <= minHandlerPriority; priority++ { // loop over priority higest to lowest
-		for _, handler := range i.handlers[priority] {
+		for _, handler := range inf.handlers[priority] {
 			f(handler)
 		}
 	}
 }
 
-func (i *informer) forEachQueuedHandlerReversed(f func(h *Handler)) {
-	i.RLock()
-	defer i.RUnlock()
+func (inf *internalInformer) forEachQueuedHandlerReversed(f func(h *Handler)) {
+	inf.RLock()
+	defer inf.RUnlock()
 
 	for priority := minHandlerPriority; priority >= 0; priority-- { // loop over priority lowest to highest
-		for _, handler := range i.handlers[priority] {
+		for _, handler := range inf.handlers[priority] {
 			f(handler)
 		}
 	}
 }
 
-func (i *informer) addHandler(id uint64, priority int, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
+func (i *informer) addHandler(internalInformerIndex int, id uint64, priority int, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
 	handler := &Handler{
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterFunc,
@@ -146,6 +160,7 @@ func (i *informer) addHandler(id uint64, priority int, filterFunc func(obj inter
 		id,
 		handlerAlive,
 		priority,
+		internalInformerIndex,
 	}
 
 	// Send existing items to the handler's add function; informers usually
@@ -153,11 +168,13 @@ func (i *informer) addHandler(id uint64, priority int, filterFunc func(obj inter
 	// we must emulate that here
 	i.initialAddFunc(handler, existingItems)
 
-	_, ok := i.handlers[priority]
+	intInf := i.internalInformers[internalInformerIndex]
+
+	_, ok := intInf.handlers[priority]
 	if !ok {
-		i.handlers[priority] = make(map[uint64]*Handler)
+		intInf.handlers[priority] = make(map[uint64]*Handler)
 	}
-	i.handlers[priority][id] = handler
+	intInf.handlers[priority][id] = handler
 
 	return handler
 }
@@ -171,16 +188,18 @@ func (i *informer) removeHandler(handler *Handler) {
 	klog.V(5).Infof("Sending %v event handler %d for removal", i.oType, handler.id)
 
 	go func() {
-		i.Lock()
-		defer i.Unlock()
+		intInf := i.internalInformers[handler.internalInformerIndex]
+
+		intInf.Lock()
+		defer intInf.Unlock()
 		removed := 0
-		for priority := range i.handlers { // loop over priority
-			if _, ok := i.handlers[priority]; !ok {
+		for priority := range intInf.handlers { // loop over priority
+			if _, ok := intInf.handlers[priority]; !ok {
 				continue // protection against nil map as value
 			}
-			if _, ok := i.handlers[priority][handler.id]; ok {
+			if _, ok := intInf.handlers[priority][handler.id]; ok {
 				// Remove the handler
-				delete(i.handlers[priority], handler.id)
+				delete(intInf.handlers[priority], handler.id)
 				removed = 1
 				klog.V(5).Infof("Removed %v event handler %d", i.oType, handler.id)
 			}
@@ -357,24 +376,25 @@ func ensureObjectOnDelete(obj interface{}, expectedType reflect.Type) (interface
 	return obj, nil
 }
 
-func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
+func (i *informer) newFederatedQueuedHandler(internalInformerIndex int) cache.ResourceEventHandlerFuncs {
 	name := i.oType.Elem().Name()
+	intInf := i.internalInformers[internalInformerIndex]
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			i.queueMap.enqueueEvent(nil, obj, i.oType, false, func(e *event) {
+			intInf.queueMap.enqueueEvent(nil, obj, i.oType, false, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "add").Inc()
 				start := time.Now()
-				i.forEachQueuedHandler(func(h *Handler) {
+				intInf.forEachQueuedHandler(func(h *Handler) {
 					h.OnAdd(e.obj, false)
 				})
 				metrics.MetricResourceAddLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			i.queueMap.enqueueEvent(oldObj, newObj, i.oType, false, func(e *event) {
+			intInf.queueMap.enqueueEvent(oldObj, newObj, i.oType, false, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
 				start := time.Now()
-				i.forEachQueuedHandler(func(h *Handler) {
+				intInf.forEachQueuedHandler(func(h *Handler) {
 					old := oldObj.(metav1.Object)
 					new := newObj.(metav1.Object)
 					if old.GetUID() != new.GetUID() {
@@ -395,10 +415,10 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				klog.Errorf(err.Error())
 				return
 			}
-			i.queueMap.enqueueEvent(nil, realObj, i.oType, true, func(e *event) {
+			intInf.queueMap.enqueueEvent(nil, realObj, i.oType, true, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 				start := time.Now()
-				i.forEachQueuedHandlerReversed(func(h *Handler) {
+				intInf.forEachQueuedHandlerReversed(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
 				metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
@@ -407,12 +427,14 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 	}
 }
 
-func (i *informer) removeAllHandlers() {
-	i.Lock()
-	defer i.Unlock()
-	for _, handlers := range i.handlers {
-		for _, handler := range handlers {
-			i.removeHandler(handler)
+func (inf *informer) removeAllHandlers() {
+	for _, intInf := range inf.internalInformers {
+		intInf.Lock()
+		defer intInf.Unlock()
+		for _, handlers := range intInf.handlers {
+			for _, handler := range handlers {
+				inf.removeHandler(handler)
+			}
 		}
 	}
 }
@@ -474,24 +496,30 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 		return nil, err
 	}
 
+	internalInformers := make([]*internalInformer, 0, internalInformerPoolSize)
+	for i := 0; i < internalInformerPoolSize; i++ {
+		internalInformers = append(internalInformers, &internalInformer{
+			oType:    oType,
+			handlers: make(map[int]map[uint64]*Handler),
+		})
+	}
+
 	return &informer{
-		oType:    oType,
-		inf:      sharedInformer,
-		lister:   lister,
-		handlers: make(map[int]map[uint64]*Handler),
+		oType:             oType,
+		inf:               sharedInformer,
+		lister:            lister,
+		internalInformers: internalInformers,
 	}, nil
 }
 
 func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInformer,
 	stopChan chan struct{}, numEventQueues uint32) (*informer, error) {
-	i, err := newBaseInformer(oType, sharedInformer)
+	informer, err := newBaseInformer(oType, sharedInformer)
 	if err != nil {
 		return nil, err
 	}
-	i.queueMap = newQueueMap(numEventQueues, &i.shutdownWg, stopChan)
-	i.queueMap.start()
 
-	i.initialAddFunc = func(h *Handler, items []interface{}) {
+	informer.initialAddFunc = func(h *Handler, items []interface{}) {
 		// Make a handler-specific channel array across which the
 		// initial add events will be distributed. When a new handler
 		// is added, only that handler should receive events for all
@@ -503,7 +531,7 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		// Distribute the existing items into the handler-specific
 		// channel array.
 		for _, obj := range items {
-			addsMap.enqueueEvent(nil, obj, i.oType, false, func(e *event) {
+			addsMap.enqueueEvent(nil, obj, informer.oType, false, func(e *event) {
 				h.OnAdd(e.obj, false)
 			})
 		}
@@ -513,11 +541,16 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		addsWg.Wait()
 	}
 
-	_, err = i.inf.AddEventHandler(i.newFederatedQueuedHandler())
-	if err != nil {
-		return nil, err
+	for i := 0; i < internalInformerPoolSize; i++ {
+		informer.internalInformers[i].queueMap = newQueueMap(numEventQueues, &informer.shutdownWg, stopChan)
+		informer.internalInformers[i].queueMap.start()
+
+		_, err = informer.inf.AddEventHandler(informer.newFederatedQueuedHandler(i))
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return i, nil
+	return informer, nil
 
 }

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -683,7 +683,7 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				return nil
@@ -887,11 +887,11 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
 				Expect(flows).To(Equal(expectedLBIngressFlows))
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
 
 				return nil
@@ -1024,8 +1024,8 @@ var _ = Describe("Node Operations", func() {
 				err := nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_80"]).To(Equal(expectedLBIngressFlows))
-				Expect(fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_80"]).To(Equal(expectedLBExternalIPFlows))
+				Expect(fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_80")).To(Equal(expectedLBIngressFlows))
+				Expect(fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_80")).To(Equal(expectedLBExternalIPFlows))
 				return nil
 			}
 			Expect(app.Run([]string{app.Name})).To(Succeed())
@@ -1129,11 +1129,11 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
 				Expect(flows).To(Equal(expectedLBIngressFlows))
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
 
 				return nil
@@ -1257,11 +1257,11 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedNodePortFlows))
-				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
 				Expect(flows).To(Equal(expectedLBIngressFlows))
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
 
 				return nil
@@ -1816,13 +1816,13 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				Expect(err).NotTo(HaveOccurred())
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
 				Expect(flows).To(Equal(expectedLBIngressFlows))
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
 				Expect(flows).To(Equal(expectedLBExternalIPFlows1))
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.2_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.2_8080")
 				Expect(flows).To(Equal(expectedLBExternalIPFlows2))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{
@@ -1834,13 +1834,13 @@ var _ = Describe("Node Operations", func() {
 				})
 				err = fNPW.DeleteService(&service)
 				Expect(err).NotTo(HaveOccurred())
-				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.flowCache["Ingress_namespace1_service1_5.5.5.5_8080"]
+				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
 				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
 				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.2_8080"]
+				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.2_8080")
 				Expect(flows).To(BeNil())
 
 				return nil
@@ -2153,7 +2153,7 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
@@ -2193,7 +2193,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				return nil
@@ -2293,7 +2293,7 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
@@ -2333,7 +2333,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				return nil
@@ -2437,7 +2437,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
@@ -2477,7 +2477,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				return nil
@@ -2578,7 +2578,7 @@ var _ = Describe("Node Operations", func() {
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
@@ -2618,7 +2618,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				return nil
@@ -2721,7 +2721,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
@@ -2761,7 +2761,7 @@ var _ = Describe("Node Operations", func() {
 				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 
-				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				return nil

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -113,16 +113,16 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset,
 	_, err := n.watchFactory.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
-			n.AddService(svc)
+			Expect(n.AddService(svc)).To(Succeed())
 		},
 		UpdateFunc: func(old, new interface{}) {
 			oldSvc := old.(*kapi.Service)
 			newSvc := new.(*kapi.Service)
-			n.UpdateService(oldSvc, newSvc)
+			Expect(n.UpdateService(oldSvc, newSvc)).To(Succeed())
 		},
 		DeleteFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
-			n.DeleteService(svc)
+			Expect(n.DeleteService(svc)).To(Succeed())
 		},
 	}, n.SyncServices)
 
@@ -268,6 +268,8 @@ var _ = Describe("Node Operations", func() {
 		fNPW               *nodePortWatcher
 		fakeMgmtPortConfig managementPortConfig
 		netlinkMock        *mocks.NetLinkOps
+
+		nInitialFakeCommands int
 	)
 
 	origNetlinkInst := util.GetNetLinkOps()
@@ -286,6 +288,7 @@ var _ = Describe("Node Operations", func() {
 		fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-vsctl --timeout=15 --no-heading --data=bare --format=csv --columns name list interface",
 		})
+		nInitialFakeCommands = 1
 
 		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
 		nft = nodenft.SetFakeNFTablesHelper()
@@ -318,14 +321,15 @@ var _ = Describe("Node Operations", func() {
 	Context("on startup", func() {
 		It("removes stale iptables/nftables rules while keeping remaining intact", func() {
 			app.Action = func(ctx *cli.Context) error {
+				// Depending on the order of informer event processing the initial
+				// Service might be "added" once or twice.  Take that into account.
+				minNFakeCommands := nInitialFakeCommands + 2
+				fakeOvnNode.fakeExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+				}, 3)
+
 				externalIP := "1.1.1.1"
 				externalIPPort := int32(8032)
-				for i := 0; i < 2; i++ {
-					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: "ovs-ofctl show ",
-					})
-				}
-
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -399,7 +403,9 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
+				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 				Expect(setupManagementPortNFTables(&fakeMgmtPortConfig)).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
@@ -435,10 +441,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
-
-				return nil
+				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
@@ -475,8 +478,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -507,13 +508,11 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-
-				return nil
+				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
@@ -552,8 +551,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables := map[string]util.FakeTable{
@@ -585,13 +582,11 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-
-				return nil
+				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
@@ -641,8 +636,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -675,7 +668,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
@@ -694,12 +687,14 @@ var _ = Describe("Node Operations", func() {
 
 		It("inits iptables rules with LoadBalancer", func() {
 			app.Action = func(ctx *cli.Context) error {
+				// Depending on the order of informer event processing the initial
+				// Service might be "added" once or twice.  Take that into account.
+				minNFakeCommands := nInitialFakeCommands + 2
+				fakeOvnNode.fakeExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+				}, 3)
+
 				externalIP := "1.1.1.1"
-				for i := 0; i < 3; i++ {
-					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: "ovs-ofctl show ",
-					})
-				}
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -736,9 +731,9 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
+				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -772,13 +767,11 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-
-				return nil
+				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
@@ -834,8 +827,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -879,7 +870,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
@@ -973,7 +964,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				fNPW.AddService(&service)
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -1081,8 +1071,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -1123,7 +1111,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
@@ -1192,8 +1180,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -1249,7 +1235,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				err := f4.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
@@ -1307,8 +1293,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables4 := map[string]util.FakeTable{
@@ -1340,7 +1324,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4, nil)
+				err := f4.MatchState(expectedTables4, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
@@ -1368,16 +1352,18 @@ var _ = Describe("Node Operations", func() {
 		It("inits iptables rules for ExternalIP with DualStack", func() {
 			app.Action = func(ctx *cli.Context) error {
 
+				// Depending on the order of informer event processing the initial
+				// Service might be "added" once or twice.  Take that into account.
+				minNFakeCommands := nInitialFakeCommands + 2
+				fakeOvnNode.fakeExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+				}, 3)
+
 				externalIPv4 := "10.10.10.1"
 				externalIPv6 := "fd00:96:1::1"
 				clusterIPv4 := "10.129.0.2"
 				clusterIPv6 := "fd00:10:96::10"
 				fNPW.gatewayIPv6 = v6localnetGatewayIP
-				for i := 0; i < 3; i++ {
-					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: "ovs-ofctl show ",
-					})
-				}
 
 				service := *newService("service1", "namespace1", clusterIPv4,
 					[]v1.ServicePort{
@@ -1402,9 +1388,9 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
+				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables4 := map[string]util.FakeTable{
 					"nat": {
@@ -1435,7 +1421,7 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables4, nil)
+				err := f4.MatchState(expectedTables4, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables6 := map[string]util.FakeTable{
@@ -1453,9 +1439,7 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-
-				return nil
+				return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
@@ -1465,12 +1449,14 @@ var _ = Describe("Node Operations", func() {
 	Context("on delete", func() {
 		It("deletes iptables rules with ExternalIP", func() {
 			app.Action = func(ctx *cli.Context) error {
+				// Depending on the order of informer event processing the initial
+				// Service might be "added" once or twice.  Take that into account.
+				minNFakeCommands := nInitialFakeCommands + 2
+				fakeOvnNode.fakeExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+				}, 3)
+
 				externalIP := "1.1.1.1"
-				for i := 0; i < 2; i++ {
-					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: "ovs-ofctl show ",
-					})
-				}
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -1496,9 +1482,11 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"1.1.1.1", 8032}, {"10.129.0.2", 8032}})
-				err := fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
+				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -1526,21 +1514,25 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
 					"filter": {},
 					"mangle": {},
 				}
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f6 := iptV6.(*util.FakeIPTables)
+					return f6.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
 				return nil
 			}
@@ -1577,9 +1569,9 @@ var _ = Describe("Node Operations", func() {
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 0}, {"192.168.18.15", 31111}})
-				err := fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
+				Eventually(fakeOvnNode.fakeExec.CalledMatchesExpected, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -1607,9 +1599,10 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
@@ -1617,12 +1610,15 @@ var _ = Describe("Node Operations", func() {
 					"mangle": {},
 				}
 
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f6 := iptV6.(*util.FakeIPTables)
+					return f6.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
 				return nil
 			}
@@ -1634,12 +1630,14 @@ var _ = Describe("Node Operations", func() {
 	Context("on add and delete", func() {
 		It("manages iptables rules with ExternalIP", func() {
 			app.Action = func(ctx *cli.Context) error {
+				// Depending on the order of informer event processing the initial
+				// Service might be "added" once or twice.  Take that into account.
+				minNFakeCommands := nInitialFakeCommands + 2
+				fakeOvnNode.fakeExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+				}, 3)
+
 				externalIP := "10.10.10.1"
-				for i := 0; i < 3; i++ {
-					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: "ovs-ofctl show ",
-					})
-				}
 				externalIPPort := int32(8034)
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
@@ -1662,9 +1660,9 @@ var _ = Describe("Node Operations", func() {
 				)
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpectedAtLeastN(minNFakeCommands)
+				}, "2s").Should(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -1696,16 +1694,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}).Should(Succeed())
 
-				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}).Should(Succeed())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.10.10.1", 8034}, {"10.129.0.2", 8034}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -1733,18 +1734,20 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
 				return nil
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 
 		It("check openflows for LoadBalancer and external ip are correctly added and removed where ETP=local, LGW mode", func() {
@@ -1802,8 +1805,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
@@ -1815,15 +1816,18 @@ var _ = Describe("Node Operations", func() {
 					"cookie=0x77df6d2c74c0a658, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.2, actions=output:LOCAL",
 				}
 
-				Expect(err).NotTo(HaveOccurred())
-				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
-				Expect(flows).To(Equal(expectedLBIngressFlows))
-				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
-				Expect(flows).To(Equal(expectedLBExternalIPFlows1))
-				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.2_8080")
-				Expect(flows).To(Equal(expectedLBExternalIPFlows2))
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}).Should(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
+				}).Should(Equal(expectedLBIngressFlows))
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
+				}).Should(Equal(expectedLBExternalIPFlows1))
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.2_8080")
+				}).Should(Equal(expectedLBExternalIPFlows2))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{
 					{"1.1.1.1", 8080},
@@ -1832,16 +1836,22 @@ var _ = Describe("Node Operations", func() {
 					{"192.168.18.15", 31111},
 					{"10.129.0.2", 8080},
 				})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
-				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
-				Expect(flows).To(BeNil())
-				flows = fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.2_8080")
-				Expect(flows).To(BeNil())
+
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
+
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}, "2s").Should(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("Ingress_namespace1_service1_5.5.5.5_8080")
+				}, "2s").Should(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.1_8080")
+				}, "2s").Should(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("External_namespace1_service1_1.1.1.2_8080")
+				}, "2s").Should(BeNil())
 
 				return nil
 			}
@@ -1986,9 +1996,7 @@ var _ = Describe("Node Operations", func() {
 				)
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+				Eventually(fakeOvnNode.fakeExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -2018,16 +2026,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}).Should(Succeed())
 
-				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}).Should(Succeed())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 38034}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2055,12 +2066,15 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
 				return nil
 			}
@@ -2112,8 +2126,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -2146,19 +2158,18 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
+				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(BeNil())
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2186,15 +2197,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
-				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}, "2s").Should(BeNil())
 
 				return nil
 			}
@@ -2247,8 +2262,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -2285,20 +2298,18 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2326,15 +2337,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 = iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
-				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}, "2s").Should(BeNil())
 
 				return nil
 			}
@@ -2393,8 +2408,6 @@ var _ = Describe("Node Operations", func() {
 				// to ensure the endpoint is local-host-networked
 				res := fNPW.nodeIPManager.cidrs.Has(fmt.Sprintf("%s/32", ep1.Addresses[0]))
 				Expect(res).To(BeTrue())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -2431,18 +2444,17 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2470,15 +2482,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 = iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
-				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}, "2s").Should(BeNil())
 
 				return nil
 			}
@@ -2530,8 +2546,6 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -2570,20 +2584,18 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
 				expectedNFT += fmt.Sprintf("add element inet ovn-kubernetes mgmtport-no-snat-nodeports { tcp . %v }\n", service.Spec.Ports[0].NodePort)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
-				Expect(err).NotTo(HaveOccurred())
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
 				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
 				Expect(flows).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2611,15 +2623,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 = iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
-				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}, "2s").Should(BeNil())
 
 				return nil
 			}
@@ -2676,8 +2692,6 @@ var _ = Describe("Node Operations", func() {
 				// to ensure the endpoint is local-host-networked
 				res := fNPW.nodeIPManager.cidrs.Has(fmt.Sprintf("%s/32", endpointSlice.Endpoints[0].Addresses[0]))
 				Expect(res).To(BeTrue())
-				err := fNPW.AddService(&service)
-				Expect(err).NotTo(HaveOccurred())
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"PREROUTING": []string{
@@ -2715,18 +2729,16 @@ var _ = Describe("Node Operations", func() {
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(f4.MatchState(expectedTables, nil)).To(Succeed())
 
 				expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Expect(nodenft.MatchNFTRules(expectedNFT, nft.Dump())).To(Succeed())
 
-				flows := fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(Equal(expectedFlows))
+				Expect(fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")).To(Equal(expectedFlows))
 
 				addConntrackMocks(netlinkMock, []ctFilterDesc{{"10.129.0.2", 8080}, {"192.168.18.15", 31111}})
-				err = fNPW.DeleteService(&service)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeOvnNode.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Delete(
+					context.Background(), service.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
@@ -2754,15 +2766,19 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					f4 := iptV4.(*util.FakeIPTables)
+					return f4.MatchState(expectedTables, nil)
+				}, "2s").Should(Succeed())
 
-				expectedNFT = getBaseNFTRules(fakeMgmtPortConfig.ifName)
-				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				Eventually(func() error {
+					expectedNFT := getBaseNFTRules(fakeMgmtPortConfig.ifName)
+					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
+				}, "2s").Should(Succeed())
 
-				flows = fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
-				Expect(flows).To(BeNil())
+				Eventually(func() []string {
+					return fNPW.ofm.getFlowsByKey("NodePort_namespace1_service1_tcp_31111")
+				}, "2s").Should(BeNil())
 
 				return nil
 			}

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -90,6 +90,12 @@ func (c *openflowManager) deleteFlowsByKey(key string) {
 	delete(c.flowCache, key)
 }
 
+func (c *openflowManager) getFlowsByKey(key string) []string {
+	c.flowMutex.Lock()
+	defer c.flowMutex.Unlock()
+	return c.flowCache[key]
+}
+
 func (c *openflowManager) updateExBridgeFlowCacheEntry(key string, flows []string) {
 	c.exGWFlowMutex.Lock()
 	defer c.exGWFlowMutex.Unlock()

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -73,6 +73,7 @@ func (o *FakeOVNNode) restart() {
 func (o *FakeOVNNode) shutdown() {
 	close(o.stopChan)
 	o.wg.Wait()
+	o.watcher.Shutdown()
 }
 
 func (o *FakeOVNNode) init() {

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -202,6 +202,11 @@ func (o *FakeOVN) shutdown() {
 
 func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 	var err error
+	// Use shorter event queues for unit tests (reduce to 10 from the default)
+	// to avoid running out of resources in constrained CI environments
+	// (e.g., on GitHub).
+	factory.SetEventQueueSize(10)
+
 	o.watcher, err = factory.NewMasterWatchFactory(o.fakeClient)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/go-controller/pkg/testing/exec.go
+++ b/go-controller/pkg/testing/exec.go
@@ -127,6 +127,18 @@ func (f *FakeExec) CalledMatchesExpected() bool {
 	return len(f.executedCommands) == len(f.expectedCommands)
 }
 
+// CalledMatchesExpectedAtLeastN returns true if the number of commands the code under
+// test called is at least 'minNumberOfMatches' and less than or equal to the number of
+// expected commands in the FakeExec's list
+func (f *FakeExec) CalledMatchesExpectedAtLeastN(minNumberOfMatches int) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.receivedUnexpected {
+		return false
+	}
+	return len(f.executedCommands) >= minNumberOfMatches && len(f.executedCommands) <= len(f.expectedCommands)
+}
+
 // ExpectedCmd contains properties that the testcase expects a called command
 // to have as well as the output that the fake command should return
 type ExpectedCmd struct {
@@ -296,6 +308,15 @@ func (f *FakeExec) AddFakeCmd(expected *ExpectedCmd) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.expectedCommands = append(f.expectedCommands, expected)
+}
+
+// AddRepeatedFakeCmd takes the ExpectedCmd and appends its runner function to
+// a fake command action list of the FakeExec repeatCount times
+func (f *FakeExec) AddRepeatedFakeCmd(expected *ExpectedCmd, repeatCount int) {
+	for i := 0; i < repeatCount; i++ {
+		cmdCopy := *expected
+		f.AddFakeCmd(&cmdCopy)
+	}
 }
 
 // AddFakeCmdsNoOutputNoError appends a list of commands to the expected


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Instead of using a single (federated) event handler for the shared kubernetes index informer create a pool of handlers.  Ensures that all secondary network controllers register their object event handlers with the same entry in the pool.  This allows load sharing between secondary network controllers.

## Additional Information for reviewers
The change is mostly limited to the `factory` package but requires shallow cloning of the watch factory when secondary network controllers are created.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
All existing tests must pass.  The change should be transparent from a functionality point of view.
