### PR TITLE
Fix WatchNamespaces for UDNs

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace_test.go
@@ -1,0 +1,84 @@
+package ovn
+
+import (
+	"testing"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/stretchr/testify/assert"
+
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
+	tests := []struct {
+		name                                                 string
+		netCfg                                               *ovntypes.NetConf
+		enableNetSeg, enableMultiNetPolicies, expectedReturn bool
+	}{
+		{
+			name: "should watch namespaces for default network",
+			netCfg: &ovntypes.NetConf{
+				NetConf: cnitypes.NetConf{Name: types.DefaultNetworkName},
+			},
+			expectedReturn: true,
+		},
+		{
+			name: "should watch namespaces for primary network when network segmentation is enabled",
+			netCfg: &ovntypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: "primary"},
+				Topology: types.Layer3Topology,
+				Role:     types.NetworkRolePrimary,
+			},
+			enableNetSeg:   true,
+			expectedReturn: true,
+		},
+		{
+			name: "should watch namespaces for secondary network when multi NetworkPolicies are enabled",
+			netCfg: &ovntypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: "secondary"},
+				Topology: types.Layer3Topology,
+				Role:     types.NetworkRoleSecondary,
+			},
+			enableMultiNetPolicies: true,
+			expectedReturn:         true,
+		},
+		{
+			name: "should not watch namespaces for primary network when network segmentation is disabled",
+			netCfg: &ovntypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: "primary"},
+				Topology: types.Layer3Topology,
+				Role:     types.NetworkRolePrimary,
+			},
+			expectedReturn: false,
+		},
+		{
+			name: "should not watch namespaces for secondary network when multi NetworkPolicies is disabled",
+			netCfg: &ovntypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: "secondary"},
+				Topology: types.Layer3Topology,
+				Role:     types.NetworkRoleSecondary,
+			},
+			expectedReturn: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			util.PrepareTestConfig()
+			config.OVNKubernetesFeature.EnableMultiNetwork = tt.enableNetSeg || tt.enableMultiNetPolicies
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = tt.enableNetSeg
+			config.OVNKubernetesFeature.EnableMultiNetworkPolicy = tt.enableMultiNetPolicies
+			netInfo, err := util.NewNetInfo(tt.netCfg)
+			assert.Nil(t, err, "failed to create network info")
+			bnc := &BaseNetworkController{
+				ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo),
+			}
+			if tt.expectedReturn != bnc.shouldWatchNamespaces() {
+				t.Fail()
+			}
+			assert.Equal(t, tt.expectedReturn, bnc.shouldWatchNamespaces())
+		})
+	}
+}


### PR DESCRIPTION
When multinetwork policies support is disabled WatchNamespaces should run to completion for primary UDNs.
This was not happening because a primary UDN is also a secondary network.

cc: @dceara 