### PR TITLE
Statically set GH runner image to ubuntu 22.04 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
   # separate job for parallelism
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   build-release-1_0:
     name: Build-release-1.0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     # Create a cache for the built release-1.0 image
     - name: Restore release-1.0 image cache
@@ -146,7 +146,7 @@ jobs:
 
   build-pr:
     name: Build-PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     # Create a cache for the build PR image
     - name: Restore PR image cache
@@ -248,7 +248,7 @@ jobs:
   ovn-upgrade-e2e:
     name: Upgrade OVN from Release-1.0 to PR branch based image
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     needs:
       - build-release-1_0
@@ -379,7 +379,7 @@ jobs:
   e2e:
     name: e2e
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # 30 mins for kind, 180 mins for control-plane tests, 10 minutes for all other steps
     timeout-minutes: 220
     strategy:
@@ -551,7 +551,7 @@ jobs:
   e2e-dual-conversion:
     name: e2e-dual-conversion
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -664,7 +664,7 @@ jobs:
   e2e-periodic:
     name: e2e-periodic
     if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
'ubuntu-latest' now references ubuntu 24.04.
Previously, it referenced 22.04.

(cherry picked from commit bae7288368a66b642aaac2969f44d8d85004875e)
