### PR TITLE
UDN EIP IP: change scope from link to global

### DIFF
--- a/go-controller/pkg/node/gateway_egressip.go
+++ b/go-controller/pkg/node/gateway_egressip.go
@@ -518,7 +518,7 @@ func getEIPBridgeNetlinkAddress(ip net.IP, ifindex int) netlink.Addr {
 	return netlink.Addr{
 		IPNet:     &net.IPNet{IP: ip, Mask: util.GetIPFullMask(ip)},
 		Flags:     getEIPNetlinkAddressFlag(ip),
-		Scope:     int(netlink.SCOPE_LINK),
+		Scope:     int(netlink.SCOPE_UNIVERSE),
 		ValidLft:  getEIPNetlinkAddressValidLft(ip),
 		LinkIndex: ifindex,
 	}


### PR DESCRIPTION
When making a call to netlink to retrieve a links
addresses, netlink will return the addresses
and group them by at least the addresses scope.

It will return addresses grouped by scope - host, link and global scope.

Therefore if the EIP address assigned to the ext bridge to support EIP for UDN is scope host, and OVN Kube restarts, it may select the EIP address as the primary IP address.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
