### PR TITLE
Use annotations in mirrored EndpointSlices for potentially long values

### DIFF
--- a/docs/features/multiple-networks/mirrored-endpointslices.md
+++ b/docs/features/multiple-networks/mirrored-endpointslices.md
@@ -17,9 +17,12 @@ The EndpointSlices mirror controller uses a separate set of labels:
 
 - `endpointslice.kubernetes.io/managed-by:endpointslice-mirror-controller.k8s.ovn.org` -  Indicates that the EndpointSlice is managed by the mirror controller.
 - `k8s.ovn.org/service-name:<service-name>` - The service that this mirrored EndpointSlice belongs to, used by the user-defined network service controller. Note that the label key is different from the default EndpointSlice.
+- `k8s.ovn.org/source-endpointslice-version:<default-endpointslice-resourceversion>` - The last reconciled resource version from the default EndpointSlice.
+
+and annotations (Label values have a length limit of 63 characters):
 - `k8s.ovn.org/endpointslice-network:<udn-network-name>` - The user-defined network that the IP addresses in the mirrored EndpointSlice belong to.
 - `k8s.ovn.org/source-endpointslice:<default-endpointslice>` -  The name of the default EndpointSlice that was the source of the mirrored EndpointSlice.
-- `k8s.ovn.org/source-endpointslice-version:<default-endpointslice-resourceversion>` - The last reconciled resource version from the default EndpointSlice.
+
 
 ### Example
 
@@ -99,10 +102,11 @@ metadata:
   generateName: l3-network-sample-deployment-
   labels:
     endpointslice.kubernetes.io/managed-by: endpointslice-mirror-controller.k8s.ovn.org
-    k8s.ovn.org/endpointslice-network: l3-network
     k8s.ovn.org/service-name: sample-deployment
-    k8s.ovn.org/source-endpointslice: sample-deployment-rkk4n
     k8s.ovn.org/source-endpointslice-version: "31533"
+  annotations:
+    k8s.ovn.org/endpointslice-network: l3-network
+    k8s.ovn.org/source-endpointslice: sample-deployment-rkk4n
   namespace: nad-l3
   resourceVersion: "31535"
 addressType: IPv4

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
@@ -3,6 +3,7 @@ package endpointslicemirror
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -109,7 +110,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					},
 				}
 				staleEndpointSlice := testing.MirrorEndpointSlice(&defaultEndpointSlice, "l3-network", false)
-				staleEndpointSlice.Labels[types.LabelSourceEndpointSlice] = "non-existing-endpointslice"
+				staleEndpointSlice.Annotations[types.SourceEndpointSliceAnnotation] = "non-existing-endpointslice"
 
 				objs := []runtime.Object{
 					&v1.PodList{
@@ -140,7 +141,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				var mirroredEndpointSlices *discovery.EndpointSliceList
+				var mirroredEndpointSlices []*discovery.EndpointSlice
 				gomega.Eventually(func() error {
 					// defaultEndpointSlice should exist
 					_, err := fakeClient.KubeClient.DiscoveryV1().EndpointSlices(namespaceT.Name).Get(context.TODO(), defaultEndpointSlice.Name, metav1.GetOptions{})
@@ -158,26 +159,21 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					}
 
 					// new mirrored EndpointSlice should get created
-					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
-						discovery.LabelManagedBy:       types.EndpointSliceMirrorControllerName,
-					}).AsSelectorPreValidated()
-
-					mirroredEndpointSlices, err = fakeClient.KubeClient.DiscoveryV1().EndpointSlices(namespaceT.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: mirrorEndpointSliceSelector.String()})
+					mirroredEndpointSlices, err = util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSlice.Name, namespaceT.Name, controller.endpointSliceLister)
 					if err != nil {
 						return err
 					}
 
-					if len(mirroredEndpointSlices.Items) == 0 {
+					if len(mirroredEndpointSlices) == 0 {
 						return fmt.Errorf("expected one mirrored EndpointSlices")
 					}
 					return nil
 				}).WithTimeout(5 * time.Second).ShouldNot(gomega.HaveOccurred())
 
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints).To(gomega.HaveLen(1))
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints[0].Addresses).To(gomega.HaveLen(1))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints).To(gomega.HaveLen(1))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.HaveLen(1))
 				// check if the Address is set to the primary IP
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints[0].Addresses[0]).To(gomega.BeEquivalentTo("10.132.2.4"))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses[0]).To(gomega.BeEquivalentTo("10.132.2.4"))
 
 				return nil
 			}
@@ -344,7 +340,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				var mirroredEndpointSlices *discovery.EndpointSliceList
+				var mirroredEndpointSlices []*discovery.EndpointSlice
 				gomega.Eventually(func() error {
 					// nad should exist
 					_, err := fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespaceT.Name).Get(context.TODO(), "l3-network", metav1.GetOptions{})
@@ -359,25 +355,20 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					}
 
 					// mirrored EndpointSlices should exist
-					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
-						discovery.LabelManagedBy:       types.EndpointSliceMirrorControllerName,
-					}).AsSelectorPreValidated()
-
-					mirroredEndpointSlices, err = fakeClient.KubeClient.DiscoveryV1().EndpointSlices(namespaceT.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: mirrorEndpointSliceSelector.String()})
+					mirroredEndpointSlices, err = util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSlice.Name, namespaceT.Name, controller.endpointSliceLister)
 					if err != nil {
 						return err
 					}
-					if len(mirroredEndpointSlices.Items) != 1 {
+					if len(mirroredEndpointSlices) != 1 {
 						return fmt.Errorf("expected one mirrored EndpointSlice")
 					}
-					if len(mirroredEndpointSlices.Items[0].Endpoints) != 1 {
+					if len(mirroredEndpointSlices[0].Endpoints) != 1 {
 						return fmt.Errorf("expected one Endpoint")
 					}
 					return nil
 				}).WithTimeout(5 * time.Second).ShouldNot(gomega.HaveOccurred())
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints[0].Addresses).To(gomega.HaveLen(1))
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints[0].Addresses).To(gomega.BeEquivalentTo([]string{"10.132.2.4"}))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.HaveLen(1))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.BeEquivalentTo([]string{"10.132.2.4"}))
 
 				ginkgo.By("when the EndpointSlice changes the mirrored one gets updated")
 				newPod := v1.Pod{
@@ -416,43 +407,33 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 						return err
 					}
 
-					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
-						discovery.LabelManagedBy:       types.EndpointSliceMirrorControllerName,
-					}).AsSelectorPreValidated()
-
-					mirroredEndpointSlices, err = fakeClient.KubeClient.DiscoveryV1().EndpointSlices(namespaceT.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: mirrorEndpointSliceSelector.String()})
+					mirroredEndpointSlices, err = util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSlice.Name, namespaceT.Name, controller.endpointSliceLister)
 					if err != nil {
 						return err
 					}
-					if len(mirroredEndpointSlices.Items) != 1 {
+					if len(mirroredEndpointSlices) != 1 {
 						return fmt.Errorf("expected one mirrored EndpointSlice")
 					}
-					if len(mirroredEndpointSlices.Items[0].Endpoints) != 2 {
-						return fmt.Errorf("expected two addresses, got: %d", len(mirroredEndpointSlices.Items[0].Endpoints))
+					if len(mirroredEndpointSlices[0].Endpoints) != 2 {
+						return fmt.Errorf("expected two addresses, got: %d", len(mirroredEndpointSlices[0].Endpoints))
 					}
 
 					return nil
 				}).WithTimeout(5 * time.Second).ShouldNot(gomega.HaveOccurred())
 
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints[0].Addresses[0]).To(gomega.BeEquivalentTo("10.132.2.4"))
-				gomega.Expect(mirroredEndpointSlices.Items[0].Endpoints[1].Addresses[0]).To(gomega.BeEquivalentTo("10.132.2.5"))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses[0]).To(gomega.BeEquivalentTo("10.132.2.4"))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[1].Addresses[0]).To(gomega.BeEquivalentTo("10.132.2.5"))
 
 				ginkgo.By("when the default EndpointSlice is removed the mirrored one follows")
 				err = fakeClient.KubeClient.DiscoveryV1().EndpointSlices(newPod.Namespace).Delete(context.TODO(), defaultEndpointSlice.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				gomega.Eventually(func() error {
-					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
-						discovery.LabelManagedBy:       types.EndpointSliceMirrorControllerName,
-					}).AsSelectorPreValidated()
-
-					mirroredEndpointSlices, err = fakeClient.KubeClient.DiscoveryV1().EndpointSlices(namespaceT.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: mirrorEndpointSliceSelector.String()})
+					mirroredEndpointSlices, err = util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSlice.Name, namespaceT.Name, controller.endpointSliceLister)
 					if err != nil {
 						return err
 					}
-					if len(mirroredEndpointSlices.Items) != 0 {
+					if len(mirroredEndpointSlices) != 0 {
 						return fmt.Errorf("expected no mirrored EndpointSlices")
 					}
 					return nil
@@ -464,5 +445,108 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("should create mirrored EndpointSlices for long endpointslice and network names", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *util.NewNamespace("testns")
+				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
+
+				pod := v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   namespaceT.Name,
+						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
+					},
+					Status: v1.PodStatus{Phase: v1.PodRunning},
+				}
+				longName := strings.Repeat("a", 253)
+
+				defaultEndpointSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      longName,
+						Namespace: namespaceT.Name,
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc2",
+							discovery.LabelManagedBy:   types.EndpointSliceDefaultControllerName,
+						},
+						ResourceVersion: "1",
+					},
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.244.2.3"},
+							TargetRef: &v1.ObjectReference{
+								Kind:      "Pod",
+								Namespace: namespaceT.Name,
+								Name:      pod.Name,
+							},
+						},
+					},
+				}
+				// make sure that really long network names work too
+				longNetName := "network" + longName
+				mirroredEndpointSlice := testing.MirrorEndpointSlice(&defaultEndpointSlice, longNetName, false)
+				objs := []runtime.Object{
+					&v1.PodList{
+						Items: []v1.Pod{
+							pod,
+						},
+					},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&discovery.EndpointSliceList{
+						Items: []discovery.EndpointSlice{
+							defaultEndpointSlice,
+							*mirroredEndpointSlice,
+						},
+					},
+				}
+
+				start(objs...)
+
+				nad := testing.GenerateNAD("l3-network", "l3-network", namespaceT.Name, types.Layer3Topology, "10.132.2.0/16/24", types.NetworkRolePrimary)
+				_, err := fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespaceT.Name).Create(
+					context.TODO(),
+					nad,
+					metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				var mirroredEndpointSlices []*discovery.EndpointSlice
+				gomega.Eventually(func() error {
+					// nad should exist
+					_, err := fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespaceT.Name).Get(context.TODO(), "l3-network", metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					// defaultEndpointSlice should exist
+					_, err = fakeClient.KubeClient.DiscoveryV1().EndpointSlices(namespaceT.Name).Get(context.TODO(), defaultEndpointSlice.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					// mirrored EndpointSlices should exist
+					mirroredEndpointSlices, err = util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSlice.Name, namespaceT.Name, controller.endpointSliceLister)
+					if err != nil {
+						return err
+					}
+					if len(mirroredEndpointSlices) != 1 {
+						return fmt.Errorf("expected one mirrored EndpointSlice")
+					}
+					if len(mirroredEndpointSlices[0].Endpoints) != 1 {
+						return fmt.Errorf("expected one Endpoint")
+					}
+					return nil
+				}).WithTimeout(5 * time.Second).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.HaveLen(1))
+				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.BeEquivalentTo([]string{"10.132.2.4"}))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
 	})
 })

--- a/go-controller/pkg/testing/kube.go
+++ b/go-controller/pkg/testing/kube.go
@@ -1,9 +1,10 @@
 package testing
 
 import (
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // USED ONLY FOR TESTING
@@ -55,9 +56,12 @@ func MirrorEndpointSlice(defaultEndpointSlice *discovery.EndpointSlice, network 
 	mirror := defaultEndpointSlice.DeepCopy()
 	mirror.Name = defaultEndpointSlice.Name + "-mirrored"
 	mirror.Labels[discovery.LabelManagedBy] = types.EndpointSliceMirrorControllerName
-	mirror.Labels[types.LabelSourceEndpointSlice] = defaultEndpointSlice.Name
-	mirror.Labels[types.LabelUserDefinedEndpointSliceNetwork] = network
 	mirror.Labels[types.LabelUserDefinedServiceName] = defaultEndpointSlice.Labels[discovery.LabelServiceName]
+	if mirror.Annotations == nil {
+		mirror.Annotations = make(map[string]string)
+	}
+	mirror.Annotations[types.SourceEndpointSliceAnnotation] = defaultEndpointSlice.Name
+	mirror.Annotations[types.UserDefinedNetworkEndpointSliceAnnotation] = network
 
 	if !keepEndpoints {
 		mirror.Endpoints = nil

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -123,14 +123,14 @@ const (
 	EndpointSliceMirrorControllerName = "endpointslice-mirror-controller.k8s.ovn.org"
 	// EndpointSliceDefaultControllerName default kubernetes EndpointSlice controller name (used as a value for the "endpointslice.kubernetes.io/managed-by" label)
 	EndpointSliceDefaultControllerName = "endpointslice-controller.k8s.io"
-	// LabelSourceEndpointSlice label key used in mirrored EndpointSlice
+	// SourceEndpointSliceAnnotation key used in mirrored EndpointSlice
 	// that has the value of the default EndpointSlice name
-	LabelSourceEndpointSlice = "k8s.ovn.org/source-endpointslice"
+	SourceEndpointSliceAnnotation = "k8s.ovn.org/source-endpointslice"
 	// LabelSourceEndpointSliceVersion label key used in mirrored EndpointSlice
 	// that has the value of the last known default EndpointSlice ResourceVersion
 	LabelSourceEndpointSliceVersion = "k8s.ovn.org/source-endpointslice-version"
-	// LabelUserDefinedEndpointSliceNetwork label key used in mirrored EndpointSlices that contains the current primary user defined network name
-	LabelUserDefinedEndpointSliceNetwork = "k8s.ovn.org/endpointslice-network"
+	// UserDefinedNetworkEndpointSliceAnnotation key used in mirrored EndpointSlices that contains the current primary user defined network name
+	UserDefinedNetworkEndpointSliceAnnotation = "k8s.ovn.org/endpointslice-network"
 	// LabelUserDefinedServiceName label key used in mirrored EndpointSlices that contains the service name matching the EndpointSlice
 	LabelUserDefinedServiceName = "k8s.ovn.org/service-name"
 

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -289,9 +289,11 @@ func TestServiceFromEndpointSlice(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test-namespace",
 						Name:      "test-eps",
+						Annotations: map[string]string{
+							types.UserDefinedNetworkEndpointSliceAnnotation: "primary-network",
+						},
 						Labels: map[string]string{
-							types.LabelUserDefinedEndpointSliceNetwork: "primary-network",
-							types.LabelUserDefinedServiceName:          "test-service",
+							types.LabelUserDefinedServiceName: "test-service",
 						},
 					},
 				},
@@ -310,9 +312,11 @@ func TestServiceFromEndpointSlice(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test-namespace",
 						Name:      "test-eps",
+						Annotations: map[string]string{
+							types.UserDefinedNetworkEndpointSliceAnnotation: "wrong-network",
+						},
 						Labels: map[string]string{
-							types.LabelUserDefinedEndpointSliceNetwork: "wrong-network",
-							types.LabelUserDefinedServiceName:          "test-service",
+							types.LabelUserDefinedServiceName: "test-service",
 						},
 					},
 				},
@@ -328,8 +332,8 @@ func TestServiceFromEndpointSlice(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test-namespace",
 						Name:      "test-eps",
-						Labels: map[string]string{
-							types.LabelUserDefinedEndpointSliceNetwork: "primary-network",
+						Annotations: map[string]string{
+							types.UserDefinedNetworkEndpointSliceAnnotation: "primary-network",
 						},
 					},
 				},


### PR DESCRIPTION
Label values have a length limit of 63 characters.
Use annotations for 'k8s.ovn.org/source-endpointslice' and 'k8s.ovn.org/endpointslice-network'.
Keep using labels where possible to enable labelselector logic. 
