### PR TITLE
kubevirt, pudn: Keep SNAT after live migration

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -479,3 +479,17 @@ func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) 
 	}
 	return &status, nil
 }
+
+func IsVirtualMachineRunning(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {
+	vmKey := ExtractVMNameFromPod(pod)
+	if vmKey == nil {
+		return false, nil
+	}
+
+	vmPods, err := client.GetPodsBySelector(pod.Namespace, metav1.LabelSelector{MatchLabels: map[string]string{kubevirtv1.VirtualMachineNameLabel: vmKey.Name}})
+	if err != nil {
+		return false, err
+	}
+
+	return len(filterNotComplete(vmPods)) > 0, nil
+}


### PR DESCRIPTION
## 📑 Description
After kubevirt live migration the migration source pod is deleted and this end up deleting the per pod snat that allow north south traffic on that node also the migrated VM has still the default gw mac address pointing to the previous node and not to the node where the VM is running, that get updated after ip neigh reconciliation and that depends on the guest. This end up with VMs not being able to do north south traffic after live migration.

This change keep the SNAT at all he nodes where the VM is being migrated from so north south traffic works even if the VM default gw mac is pointing to previous nodes.


## Additional Information for reviewers
This will cover only IC since we don't support live migration with primary UDNs layer2 for non IC.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
TODO:
- [ ] unit test 

This should be tested with at snat per pod IC cluster and e2e at PR:
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4834
