### PR TITLE
cudn,crd: Block namespace-selector with zero-rules

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -88,6 +88,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: namespace selector must have at least one rule
+                  rule: has(self.matchLabels) && self.matchLabels.size() > 0 || has(self.matchExpressions)
+                    && self.matchExpressions.size() > 0
               network:
                 description: Network is the user-defined-network spec
                 properties:

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -617,6 +617,9 @@ func (c *Controller) getSelectedNamespaces(sel metav1.LabelSelector) (sets.Set[s
 	if err != nil {
 		return nil, fmt.Errorf("failed to create label-selector: %w", err)
 	}
+	if labelSelector.Empty() {
+		return nil, fmt.Errorf("namespace selector is invalid: selecting all namespaces is not allowed")
+	}
 	selectedNamespacesList, err := c.namespaceInformer.Lister().List(labelSelector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list namespaces: %w", err)

--- a/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
@@ -26,6 +26,7 @@ type ClusterUserDefinedNetworkSpec struct {
 	// NamespaceSelector Label selector for which namespace network should be available for.
 	// +kubebuilder:validation:Required
 	// +required
+	// +kubebuilder:validation:XValidation:rule="has(self.matchLabels) && self.matchLabels.size() > 0 || has(self.matchExpressions) && self.matchExpressions.size() > 0", message="namespace selector must have at least one rule"
 	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector"`
 
 	// Network is the user-defined-network spec


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Nothing prevents from creating one to create primary CUDN CR selecting all namespaces, unintentionally by specifying empty namespace-selector.
Such CUDN instance could affect all pod in the cluster including the system components (e.g.:kube-system pods, cluster API server, etcd).

Reverting this state is almost impossible w/o causing disruption to cluster components and workloads, because CUDN deletion will be blocked until all connected pods are deleted (pod created after the CUDN).

To avoid such scenarios,validate CUDN namespace-selector, rejecting CUDNs with empty namespace-selectors, at the controller and API level.

Having a CUDN that affects all namespaces in the cluster is still possible by labeling all namespaces with a common label, and specify that label in the CUDN namespace-selector.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
