### PR TITLE
kubevirt, l2, pudn: reconcile ipv4 gateway mac after live migration

### DIFF
--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -2,8 +2,6 @@ package linkmanager
 
 import (
 	"fmt"
-	"net"
-	"net/netip"
 	"sync"
 	"time"
 
@@ -12,7 +10,6 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
-	"github.com/mdlayher/arp"
 	"github.com/vishvananda/netlink"
 )
 
@@ -198,7 +195,7 @@ func (c *Controller) syncLink(link netlink.Link) error {
 		// For IPv4, use arping to try to update other hosts ARP caches, in case this IP was
 		// previously active on another node
 		if addressWanted.IP.To4() != nil {
-			if err = gratuitousArpOverIfaceByName(addressWanted.IP, linkName); err != nil {
+			if err = util.BroadcastGARP(linkName, util.GARP{IP: addressWanted.IP}); err != nil {
 				klog.Errorf("Failed to send a GARP for IP %s over interface %s: %v", addressWanted.IP.String(),
 					linkName, err)
 			}
@@ -306,30 +303,4 @@ func containsAddress(addresses []netlink.Addr, candidate netlink.Addr) bool {
 		}
 	}
 	return false
-}
-
-func gratuitousArpOverIfaceByName(srcIP net.IP, ifaceName string) error {
-	iface, err := net.InterfaceByName(ifaceName)
-	if err != nil {
-		return fmt.Errorf("failed finding interface '%s': %w", ifaceName, err)
-	}
-
-	c, err := arp.Dial(iface)
-	if err != nil {
-		return fmt.Errorf("failed dialing logical switch interface '%s': %w", ifaceName, err)
-	}
-	defer c.Close()
-	addr, err := netip.ParseAddr(srcIP.String())
-	if err != nil {
-		return fmt.Errorf("failed converting net.IP to netip.Addr: %w", err)
-	}
-	p, err := arp.NewPacket(arp.OperationRequest, iface.HardwareAddr, addr, net.HardwareAddr{0, 0, 0, 0, 0, 0}, addr)
-	if err != nil {
-		return fmt.Errorf("failed create GARP: %w", err)
-	}
-	err = c.WriteTo(p, net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
-	if err != nil {
-		return fmt.Errorf("failed sending GARP: %w", err)
-	}
-	return nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -111,7 +111,7 @@ func (bsnc *BaseSecondaryNetworkController) UpdateSecondaryNetworkResourceCommon
 		oldPod := oldObj.(*corev1.Pod)
 		newPod := newObj.(*corev1.Pod)
 
-		return bsnc.ensurePodForSecondaryNetwork(newPod, inRetryCache || util.PodScheduled(oldPod) != util.PodScheduled(newPod))
+		return bsnc.ensurePodForSecondaryNetwork(newPod, shouldAddPort(oldPod, newPod, inRetryCache))
 
 	case factory.NamespaceType:
 		oldNs, newNs := oldObj.(*corev1.Namespace), newObj.(*corev1.Namespace)
@@ -941,4 +941,8 @@ func (bsnc *BaseSecondaryNetworkController) enableSourceLSPFailedLiveMigration(p
 	}
 
 	return nil
+}
+
+func shouldAddPort(oldPod, newPod *corev1.Pod, inRetryCache bool) bool {
+	return inRetryCache || util.PodScheduled(oldPod) != util.PodScheduled(newPod)
 }

--- a/go-controller/pkg/util/arp.go
+++ b/go-controller/pkg/util/arp.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/mdlayher/arp"
+)
+
+type GARP struct {
+	// IP to advertise the MAC address
+	IP net.IP
+	// MAC to advertise (optional), default: link mac address
+	MAC *net.HardwareAddr
+}
+
+// BroadcastGARP send a pair of GARPs with "request" and "reply" operations
+// since some system response to request and others to reply.
+// If "garp.MAC" is not passed the link form "interfaceName" mac will be
+// advertise
+func BroadcastGARP(interfaceName string, garp GARP) error {
+	srcIP := netip.AddrFrom4([4]byte(garp.IP))
+
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed finding interface %s: %v", interfaceName, err)
+	}
+
+	if garp.MAC == nil {
+		garp.MAC = &iface.HardwareAddr
+	}
+
+	c, err := arp.Dial(iface)
+	if err != nil {
+		return fmt.Errorf("failed dialing %q: %v", interfaceName, err)
+	}
+	defer c.Close()
+
+	// Note that some devices will respond to the gratuitous request and some
+	// will respond to the gratuitous reply. If one is trying to write
+	// software for moving IP addresses around that works with all routers,
+	// switches and IP stacks, it is best to send both the request and the reply.
+	// These are documented by [RFC 2002](https://tools.ietf.org/html/rfc2002)
+	// and [RFC 826](https://tools.ietf.org/html/rfc826). Software implementing
+	// the gratuitious ARP function can be found
+	// [in the Linux-HA source tree](http://hg.linux-ha.org/lha-2.1/file/1d5b54f0a2e0/heartbeat/libnet_util/send_arp.c).
+	//
+	// ref: https://wiki.wireshark.org/Gratuitous_ARP
+	for _, op := range []arp.Operation{arp.OperationRequest, arp.OperationReply} {
+		// At at GARP the source and target IP should be the same and point to the
+		// the IP we want to reconcile -> https://wiki.wireshark.org/Gratuitous_ARP
+		p, err := arp.NewPacket(op, *garp.MAC /* srcHw */, srcIP, net.HardwareAddr{0, 0, 0, 0, 0, 0}, srcIP)
+		if err != nil {
+			return fmt.Errorf("failed creating %q GARP %+v: %w", op, garp, err)
+		}
+
+		if err := c.WriteTo(p, net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}); err != nil {
+			return fmt.Errorf("failed sending %q GARP %+v:  %w", op, garp, err)
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/kubevirt/net.go
+++ b/test/e2e/kubevirt/net.go
@@ -2,10 +2,63 @@ package kubevirt
 
 import (
 	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func GenerateAddressDiscoveryConfigurationCommand(iface string) string {
 	return fmt.Sprintf(`
 nmcli c mod %[1]s ipv4.addresses "" ipv6.addresses "" ipv4.gateway "" ipv6.gateway "" ipv6.method auto ipv4.method auto ipv6.addr-gen-mode eui64
 nmcli d reapply %[1]s`, iface)
+}
+
+func RetrieveCachedGatewayMAC(vmi *kubevirtv1.VirtualMachineInstance, dev, cidr string) (string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	gatewayIP := util.GetNodeGatewayIfAddr(ipNet).IP.String()
+
+	output, err := RunCommand(vmi, fmt.Sprintf("ip neigh get %s dev %s", gatewayIP, dev), 2*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("%s: %v", output, err)
+	}
+	outputSplit := strings.Split(output, " ")
+	if len(outputSplit) < 5 {
+		return "", fmt.Errorf("unexpected 'ip neigh' output %q", output)
+	}
+	return outputSplit[4], nil
+}
+
+func GenerateGatewayMAC(node *corev1.Node, networkName string) (string, error) {
+	config.IPv4Mode = true
+	lrpJoinAddress, err := util.ParseNodeGatewayRouterJoinNetwork(node, networkName)
+	if err != nil {
+		return "", err
+	}
+
+	lrpJoinIPString := lrpJoinAddress.IPv4
+	if lrpJoinIPString == "" {
+		lrpJoinIPString = lrpJoinAddress.IPv6
+	}
+
+	if lrpJoinIPString == "" {
+		return "", fmt.Errorf("missing lrp join ip at node %q with network %q", node.Name)
+	}
+
+	lrpJoinIP, _, err := net.ParseCIDR(lrpJoinIPString)
+	if err != nil {
+		return "", err
+	}
+
+	return util.IPAddrToHWAddr(lrpJoinIP).String(), nil
 }


### PR DESCRIPTION
## 📑 Description
After a L2 primary UDN virtual machine is live migrated its ipv4 gateway mac cache is still pointing to the previous node gateway mac from the gateway router LRP.

This PR send a GARP after live migration to update the VM's gateway mac to the new node GR LRP mac address.

## Additional Information for reviewers
This created some utils under pkg/kubevirt to send the GARP and reconcile the gateway and wired up at the layer2 controller so only this controller has code for it.

Closes https://issues.redhat.com/browse/OCPBUGS-48337

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI 

## How to verify it
It includes tests.
