### PR TITLE
[release-1.0] Add manual chart-releaser workflow

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,0 +1,33 @@
+name: Chart Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    permissions:
+      contents: write  # Needed so the action can push to gh-pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Required so chart-releaser can detect tags properly
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,9 @@
 name: ovn-docker-images
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ master,release-1.0 ]
+    branches: [ master, release-1.0 ]
 
 permissions:
   contents: read
@@ -10,9 +11,9 @@ permissions:
 
 env:
   GO_VERSION: 1.21
-  REGISTRY: ghcr.io 
-  OWNER: ovn-kubernetes
-  REPOSITORY: ovn-kubernetes
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+  REPOSITORY: ${{ github.event.repository.name }}
   FEDORA_IMAGE_NAME: ovn-kube-fedora
   UBUNTU_IMAGE_NAME: ovn-kube-ubuntu
 
@@ -36,8 +37,8 @@ jobs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}    
-   
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
@@ -57,7 +58,7 @@ jobs:
     - name: Generate git-info to write to image
       run: | 
         BRANCH=$(git rev-parse --short "$GITHUB_SHA")
-        COMMIT=$(git rev-parse  HEAD)
+        COMMIT=$(git rev-parse HEAD)
         pushd dist/images
           echo "ref: ${BRANCH}  commit: ${COMMIT}" > git_info
         popd 

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -24,7 +24,7 @@ set_default_params() {
   export KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
   export KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
   export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
-  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:helm'}
+  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:helm'}
 
   # Setup KUBECONFIG patch based on cluster-name
   export KUBECONFIG=${KUBECONFIG:-${HOME}/${KIND_CLUSTER_NAME}.conf}

--- a/docs/developer-guide/image-build.md
+++ b/docs/developer-guide/image-build.md
@@ -4,20 +4,20 @@ This file covers the container images available for OVN-Kubernetes and how to bu
 
 ## Images / Packages
 
-There are Ubuntu and Fedora-based images available in [GitHub's Registry](https://github.com/orgs/ovn-org/packages?repo_name=ovn-kubernetes). They are automatically generated upon merges via [a workflow](https://github.com/ovn-org/ovn-kubernetes/blob/9f1f3f2866fc566ffbe582ae9adf77d60d838484/.github/workflows/docker.yml#L5).
+There are Ubuntu and Fedora-based images available in [GitHub's Registry](https://github.com/orgs/ovn-kubernetes/packages?repo_name=ovn-kubernetes). They are automatically generated upon merges via [a workflow](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/.github/workflows/docker.yml).
 Prior to release-1.0, they were called ovn-kube-f (for the Fedora-based image) and ovnkube-u (for the Ubuntu-based image). From release 1.0 and beyond, these have been renamed to ovn-kube-fedora and ovn-kube-ubuntu, respectively.
 
 Therefore, use the following images and tags to obtain these images:
 
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:release-1.0
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:master
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:release-1.0
 
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:release-1.0
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:release-1.0
 
 ## Building Images
 
-To build images locally, use the following [Makefile](https://github.com/ovn-org/ovn-kubernetes/blob/master/dist/images/Makefile) and their respective Dockerfiles from the [dist/images](https://github.com/ovn-org/ovn-kubernetes/tree/master/dist/images) folder in this repository.
+To build images locally, use the following [Makefile](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/dist/images/Makefile) and their respective Dockerfiles from the [dist/images](https://github.com/ovn-kubernetes/ovn-kubernetes/tree/master/dist/images) folder in this repository.
 
 ```bash
 $ cd dist/images
@@ -26,5 +26,5 @@ $ make ubuntu
 ```
 
 The build will create an image called ovn-kube-fedora:latest or ovn-kube-ubuntu:latest, which can be re-tagged.
-For example: `${OCI_BIN} tag ovn-kube-fedora:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master`
+For example: `${OCI_BIN} tag ovn-kube-fedora:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:master`
 

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -70,14 +70,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:
@@ -389,7 +389,7 @@ true
 			<td>global.image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu"
+"ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu"
 </pre>
 </td>
 			<td>Image repository for ovn-kubernetes components</td>

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -8,7 +8,7 @@
 
 ## Source Code
 
-* <https://github.com/ovn-org/ovn-kubernetes>
+* <https://github.com/ovn-kubernetes/ovn-kubernetes>
 * <https://github.com/ovn-org/ovn>
 
 ## Introduction
@@ -81,14 +81,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:
@@ -422,7 +422,7 @@ true
 			<td>global.image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu"
+"ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu"
 </pre>
 </td>
 			<td>Image repository for ovn-kubernetes components</td>

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -79,14 +79,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:


### PR DESCRIPTION
This change takes advantage of the "Helm Chart Releaser" in GitHub. Information about this feature is located at: https://github.com/marketplace/actions/helm-chart-releaser

This is a backport of https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4971 to release-1.0 branch.