### PR TITLE
update ovn-kube-util to use ovn-appctl when possible

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -25,13 +25,13 @@ var callbacks = map[string]readinessFunc{
 
 func ovnControllerReadiness(target string) error {
 	// Check if ovn-controller is connected to OVN SB
-	output, _, err := util.RunOVSAppctlWithTimeout(5, "-t", target, "connection-status")
+	output, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "connection-status")
 	if err != nil {
 		return fmt.Errorf("failed getting connection status of %q: (%v)", target, err)
 	} else if output != "connected" {
 		return fmt.Errorf("%q is not connected to OVN SB database, status: (%s)", target, output)
 	}
-	result, _, err := util.RunOVSAppctlWithTimeout(5, "-t", target, "coverage/read-counter", "lflow_run")
+	result, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "coverage/read-counter", "lflow_run")
 	if err != nil {
 		return fmt.Errorf("failed getting coverage/show of %q: (%v)", target, err)
 	} else if result == "0" {
@@ -45,7 +45,7 @@ func ovnControllerReadiness(target string) error {
 		return fmt.Errorf("failed to get pid for osvdb-server process: %v", err)
 	}
 	ctlFile := fmt.Sprintf("/var/run/openvswitch/ovsdb-server.%s.ctl", strings.Trim(string(ovsdbPid), " \n"))
-	_, _, err = util.RunOVSAppctlWithTimeout(5, "-t", ctlFile, "ovsdb-server/list-dbs")
+	_, _, err = util.RunOVNAppctlWithTimeout(5, "-t", ctlFile, "ovsdb-server/list-dbs")
 	if err != nil {
 		return fmt.Errorf("failed retrieving list of databases from ovsdb-server: %v", err)
 	}
@@ -55,7 +55,7 @@ func ovnControllerReadiness(target string) error {
 		return fmt.Errorf("failed to get pid for ovs-vswitchd process: %v", err)
 	}
 	ctlFile = fmt.Sprintf("/var/run/openvswitch/ovs-vswitchd.%s.ctl", strings.Trim(string(ovsPid), " \n"))
-	_, _, err = util.RunOVSAppctlWithTimeout(5, "-t", ctlFile, "ofproto/list")
+	_, _, err = util.RunOVNAppctlWithTimeout(5, "-t", ctlFile, "ofproto/list")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve ofproto instances from ovs-vswitchd: %v", err)
 	}
@@ -137,11 +137,11 @@ func ovnNorthdReadiness(target string) error {
 }
 
 func ovsDaemonsReadiness(target string) error {
-	_, _, err := util.RunOVSAppctlWithTimeout(5, "-t", "ovsdb-server", "ovsdb-server/list-dbs")
+	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovsdb-server", "ovsdb-server/list-dbs")
 	if err != nil {
 		return fmt.Errorf("failed retrieving list of databases from ovsdb-server: %v", err)
 	}
-	_, _, err = util.RunOVSAppctlWithTimeout(5, "-t", "ovs-vswitchd", "ofproto/list")
+	_, _, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovs-vswitchd", "ofproto/list")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve ofproto instances from ovs-vswitchd: %v", err)
 	}


### PR DESCRIPTION
RunOVNAppctlWithTimeout runs a command via ovn-appctl. If ovn-appctl is not present, then it falls back to using ovs-appctl

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
