### PR TITLE
Add missing host-cidrs annotation for DPU Host

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -62,7 +62,34 @@ func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtConfig *ma
 		syncPeriod:     30 * time.Second,
 	}
 	mgr.nodeAnnotator = kube.NewNodeAnnotator(k, nodeName)
-	mgr.sync()
+	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		var ifAddrs []*net.IPNet
+
+		// update k8s.ovn.org/host-cidrs
+		node, err := watchFactory.GetNode(nodeName)
+		if err != nil {
+			klog.Errorf("Failed to get node %s: %v", nodeName, err)
+			return nil
+		}
+		if useNetlink {
+			// get updated interface IP addresses for the gateway bridge
+			ifAddrs, err = gwBridge.updateInterfaceIPAddresses(node)
+			if err != nil {
+				klog.Errorf("Failed to obtain interface IP addresses for node %s: %v", nodeName, err)
+				return nil
+			}
+		}
+		if err = mgr.updateHostCIDRs(node, ifAddrs); err != nil {
+			klog.Errorf("Failed to update host-cidrs annotations on node %s: %v", nodeName, err)
+			return nil
+		}
+		if err = mgr.nodeAnnotator.Run(); err != nil {
+			klog.Errorf("Failed to set host-cidrs annotations on node %s: %v", nodeName, err)
+			return nil
+		}
+	} else {
+		mgr.sync()
+	}
 
 	return mgr
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR fixes the issue of host-cidrs annotation missing from DPU Hosts. This is set during ovnkube-node-dpu initialization

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
