### PR TITLE
Remove per-pod-SNAT support for UDNs

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -460,6 +460,7 @@ type GatewayConfig struct {
 	// NodeportEnable sets whether to provide Kubernetes NodePort service or not
 	NodeportEnable bool `gcfg:"nodeport"`
 	// DisableSNATMultipleGws sets whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
+	// only applicable to the default network not for UDNs
 	DisableSNATMultipleGWs bool `gcfg:"disable-snat-multiple-gws"`
 	// V4JoinSubnet to be used in the cluster
 	V4JoinSubnet string `gcfg:"v4-join-subnet"`

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -381,18 +381,6 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *c
 		ops = append(ops, addOps...)
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork() && config.Gateway.DisableSNATMultipleGWs {
-		// we need to add per-pod SNATs for UDN networks
-		snatOps, err := bsnc.addPerPodSNATOps(pod, podAnnotation.IPs)
-		if err != nil {
-			return fmt.Errorf("failed to construct SNAT for pod %s/%s which is part of network %s, err: %v",
-				pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-		}
-		if snatOps != nil {
-			ops = append(ops, snatOps...)
-		}
-	}
-
 	recordOps, txOkCallBack, _, err := bsnc.AddConfigDurationRecord("pod", pod.Namespace, pod.Name)
 	if err != nil {
 		klog.Errorf("Config duration recorder: %v", err)
@@ -424,30 +412,6 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *c
 	}
 
 	return nil
-}
-
-// addPerPodSNATOps returns the ops that will add the SNAT towards masqueradeIP for this given pod
-func (bsnc *BaseSecondaryNetworkController) addPerPodSNATOps(pod *corev1.Pod, podIPs []*net.IPNet) ([]ovsdb.Operation, error) {
-	if !bsnc.isPodScheduledinLocalZone(pod) {
-		// nothing to do if its a remote zone pod
-		return nil, nil
-	}
-	// we need to add per-pod SNATs for UDN networks
-	networkID, err := bsnc.getNetworkID()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get networkID for network %q: %v", bsnc.GetNetworkName(), err)
-	}
-	masqIPs, err := udn.GetUDNGatewayMasqueradeIPs(networkID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", bsnc.GetNetworkName(), networkID, err)
-	}
-
-	ops, err := addOrUpdatePodSNATOps(bsnc.nbClient, bsnc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), masqIPs, podIPs, bsnc.GetNetworkScopedClusterSubnetSNATMatch(pod.Spec.NodeName), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct SNAT pods for pod %s/%s which is part of network %s, err: %v",
-			pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-	}
-	return ops, nil
 }
 
 // removePodForSecondaryNetwork tried to tear down a pod. It returns nil on success and error on failure;
@@ -512,15 +476,6 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *co
 		pInfo, err := bsnc.deletePodLogicalPort(pod, portInfoMap[nadName], nadName)
 		if err != nil {
 			return err
-		}
-
-		// Cleanup the SNAT entries before checking whether this controller handled the IP allocation
-		if util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork() && config.Gateway.DisableSNATMultipleGWs {
-			// we need to delete per-pod SNATs for UDN networks
-			if err := bsnc.delPerPodSNAT(pod, nadName); err != nil {
-				return fmt.Errorf("failed to delete SNAT for pod %s/%s which is part of network %s, err: %v",
-					pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-			}
 		}
 
 		// do not release IP address if this controller does not handle IP allocation
@@ -613,37 +568,6 @@ func (bsnc *BaseSecondaryNetworkController) hasIPAMClaim(pod *corev1.Pod, nadNam
 
 	hasIPAMClaim := ipamClaim != nil && len(ipamClaim.Status.IPs) > 0
 	return hasIPAMClaim, nil
-}
-
-// delPerPodSNAT will delete the SNAT towards masqueradeIP for this given pod
-func (bsnc *BaseSecondaryNetworkController) delPerPodSNAT(pod *corev1.Pod, nadName string) error {
-	if !bsnc.isPodScheduledinLocalZone(pod) {
-		// nothing to do if its a remote zone pod
-		return nil
-	}
-	// we need to add per-pod SNATs for UDN networks
-	networkID, err := bsnc.getNetworkID()
-	if err != nil {
-		return fmt.Errorf("failed to get networkID for network %q: %v", bsnc.GetNetworkName(), err)
-	}
-	masqIPs, err := udn.GetUDNGatewayMasqueradeIPs(networkID)
-	if err != nil {
-		return fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", bsnc.GetNetworkName(), networkID, err)
-	}
-	podNetAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
-	if err != nil {
-		return fmt.Errorf("failed to fetch annotations for pod %s/%s in network %s; err: %v", pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-	}
-	ops, err := deletePodSNATOps(bsnc.nbClient, nil, bsnc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), masqIPs, podNetAnnotation.IPs, bsnc.GetNetworkScopedClusterSubnetSNATMatch(pod.Spec.NodeName))
-	if err != nil {
-		return fmt.Errorf("failed to construct SNAT pods for pod %s/%s which is part of network %s, err: %v",
-			pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-	}
-	if _, err = libovsdbops.TransactAndCheck(bsnc.nbClient, ops); err != nil {
-		return fmt.Errorf("failed to delete SNAT rule for pod %s/%s in network %s on gateway router %s: %w",
-			pod.Namespace, pod.Name, bsnc.GetNetworkName(), bsnc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), err)
-	}
-	return nil
 }
 
 func (bsnc *BaseSecondaryNetworkController) syncPodsForSecondaryNetwork(pods []interface{}) error {

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -787,7 +787,7 @@ func (gw *GatewayManager) GatewayInit(
 
 	nats := make([]*nbdb.NAT, 0, len(clusterIPSubnet))
 	var nat *nbdb.NAT
-	if !config.Gateway.DisableSNATMultipleGWs && !gw.isRoutingAdvertised(nodeName) {
+	if (!config.Gateway.DisableSNATMultipleGWs || gw.netInfo.IsPrimaryNetwork()) && !gw.isRoutingAdvertised(nodeName) {
 		// Default SNAT rules. DisableSNATMultipleGWs=false in LGW (traffic egresses via mp0) always.
 		// We are not checking for gateway mode to be shared explicitly to reduce topology differences.
 		for _, entry := range clusterIPSubnet {

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -552,11 +552,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	masqSNAT := newMasqueradeManagementNATEntry(masqSNATUUID1, netInfo)
 
 	var nat []string
-	if config.Gateway.DisableSNATMultipleGWs {
-		nat = append(nat, nat1, nat3, perPodSNAT, masqSNATUUID1)
-	} else {
-		nat = append(nat, nat1, nat2, nat3, masqSNATUUID1)
-	}
+	nat = append(nat, nat1, nat2, nat3, masqSNATUUID1)
 	gr := &nbdb.LogicalRouter{
 		Name:         gwRouterName,
 		UUID:         gwRouterName + "-UUID",
@@ -593,15 +589,9 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	}
 
 	expectedEntities = append(expectedEntities, expectedExternalSwitchAndLSPs(netInfo, gwConfig, nodeName)...)
-	if config.Gateway.DisableSNATMultipleGWs {
-		expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-		expectedEntities = append(expectedEntities, newNATEntry(nat3, dummyMasqueradeIP().IP.String(), layer2SubnetGWAddr().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-		expectedEntities = append(expectedEntities, newNATEntry(perPodSNAT, dummyMasqueradeIP().IP.String(), dummyL2TestPodAdditionalNetworkIP(), nil, fmt.Sprintf("outport == %q", gwRouterToExtSwitchPortName)))
-	} else {
-		expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-		expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), layer2Subnet().String(), standardNonDefaultNetworkExtIDs(netInfo), fmt.Sprintf("outport == %q", gwRouterToExtSwitchPortName)))
-		expectedEntities = append(expectedEntities, newNATEntry(nat3, dummyMasqueradeIP().IP.String(), layer2SubnetGWAddr().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-	}
+	expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
+	expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), layer2Subnet().String(), standardNonDefaultNetworkExtIDs(netInfo), fmt.Sprintf("outport == %q", gwRouterToExtSwitchPortName)))
+	expectedEntities = append(expectedEntities, newNATEntry(nat3, dummyMasqueradeIP().IP.String(), layer2SubnetGWAddr().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
 	return expectedEntities
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -724,11 +724,7 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 	nextHopMasqIP := nextHopMasqueradeIP().String()
 	masqSubnet := config.Gateway.V4MasqueradeSubnet
 	var nat []string
-	if config.Gateway.DisableSNATMultipleGWs {
-		nat = append(nat, nat1, perPodSNAT)
-	} else {
-		nat = append(nat, nat1, nat2)
-	}
+	nat = append(nat, nat1, nat2)
 	expectedEntities := []libovsdbtest.TestData{
 		&nbdb.LogicalRouter{
 			Name:         gwRouterName,
@@ -743,13 +739,8 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 		expectedGRStaticRoute(staticRoute2, ipv4DefaultRoute, nextHopIP, nil, &staticRouteOutputPort, netInfo),
 		expectedGRStaticRoute(staticRoute3, masqSubnet, nextHopMasqIP, nil, &staticRouteOutputPort, netInfo),
 	}
-	if config.Gateway.DisableSNATMultipleGWs {
-		expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-		expectedEntities = append(expectedEntities, newNATEntry(perPodSNAT, dummyMasqueradeIP().IP.String(), dummyTestPodAdditionalNetworkIP(), nil, ""))
-	} else {
-		expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-		expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), netInfo.Subnets()[0].CIDR.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-	}
+	expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
+	expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), netInfo.Subnets()[0].CIDR.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
 	return expectedEntities
 }
 


### PR DESCRIPTION
disable-SNAT-Multiple-GWs means we use per pod SNATs
instead of subnet SNAT at the GR. This option is only
relevant to default network as of this PR. We are removing
the support for per pod SNAT due to two reasons:

1) VM Live migration on L2 UDNs needs the older SNAT for the
pod to the present on the older node which is hard to keep
around else some traffic will leave with podIP from the old
node immediately after live migration has finished
2) lots of SNATs cannot be good for scale, a SNAT per network
subnect sounds better.
3) ICNI is the only feature that uses per pod SNAT which is not
supported on UDNs so we don't need that anyways