### PR TITLE
Suppress layer 2 missing pod anno errors

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -931,8 +931,9 @@ func (bnc *BaseNetworkController) allocatePodAnnotationForSecondaryNetwork(pod *
 	if !bnc.allocatesPodAnnotation() {
 		podAnnotation, _ := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 		if !util.IsValidPodAnnotation(podAnnotation) {
-			return nil, false, fmt.Errorf("failed to get PodAnnotation for %s/%s/%s, cluster manager might have not allocated it yet",
-				nadName, pod.Namespace, pod.Name)
+			return nil, false, ovntypes.NewSuppressedError(fmt.Errorf(
+				"failed to get PodAnnotation for %s/%s/%s, cluster manager might have not allocated it yet",
+				nadName, pod.Namespace, pod.Name))
 		}
 
 		return podAnnotation, false, nil


### PR DESCRIPTION
For layer 2 UDNs it is expected that ovnkube-controller will process the pod with the annotation missing while waiting for cluster manager to allocate it. Suppress the error in that case.

