### PR TITLE
localnet: Change default MTU to 1500

### DIFF
--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -100,7 +100,7 @@ func ParseNetConf(bytes []byte) (*ovncnitypes.NetConf, error) {
 }
 
 func parseNetConfSingle(bytes []byte) (*ovncnitypes.NetConf, error) {
-	netconf := &ovncnitypes.NetConf{MTU: Default.MTU}
+	netconf := &ovncnitypes.NetConf{}
 	err := json.Unmarshal(bytes, &netconf)
 	if err != nil {
 		return nil, err
@@ -109,6 +109,13 @@ func parseNetConfSingle(bytes []byte) (*ovncnitypes.NetConf, error) {
 	// skip non-OVN NAD
 	if netconf.Type != "ovn-k8s-cni-overlay" {
 		return nil, ErrorAttachDefNotOvnManaged
+	}
+	if netconf.MTU == 0 {
+		if netconf.Topology != ovntypes.LocalnetTopology {
+			netconf.MTU = Default.MTU
+		} else {
+			netconf.MTU = DefaultLocalnet.MTU
+		}
 	}
 
 	err = ValidateNetConfNameFields(netconf)
@@ -124,7 +131,7 @@ func parseNetConfList(confList *libcni.NetworkConfigList) (*ovncnitypes.NetConf,
 		return nil, ErrorChainingNotSupported
 	}
 
-	netconf := &ovncnitypes.NetConf{MTU: Default.MTU}
+	netconf := &ovncnitypes.NetConf{}
 	if err := json.Unmarshal(confList.Plugins[0].Bytes, netconf); err != nil {
 		return nil, err
 	}
@@ -132,6 +139,13 @@ func parseNetConfList(confList *libcni.NetworkConfigList) (*ovncnitypes.NetConf,
 	// skip non-OVN NAD
 	if netconf.Type != "ovn-k8s-cni-overlay" {
 		return nil, ErrorAttachDefNotOvnManaged
+	}
+	if netconf.MTU == 0 {
+		if netconf.Topology != ovntypes.LocalnetTopology {
+			netconf.MTU = Default.MTU
+		} else {
+			netconf.MTU = DefaultLocalnet.MTU
+		}
 	}
 
 	netconf.Name = confList.Name

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -76,6 +76,10 @@ var (
 		RawUDNAllowedDefaultServices: "default/kubernetes,kube-system/kube-dns",
 	}
 
+	DefaultLocalnet = DefaultConfig{
+		MTU: 1500,
+	}
+
 	// Logging holds logging-related parsed config file parameters and command-line overrides
 	Logging = LoggingConfig{
 		File:                "", // do not log to a file by default

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -239,7 +239,7 @@ func TestParseNetconf(t *testing.T) {
 			expectedNetConf: &ovncnitypes.NetConf{
 				Topology: "localnet",
 				NADName:  "ns1/nad1",
-				MTU:      1400,
+				MTU:      1500,
 				VLANID:   10,
 				NetConf:  cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
 			},
@@ -278,7 +278,7 @@ func TestParseNetconf(t *testing.T) {
 			expectedNetConf: &ovncnitypes.NetConf{
 				Topology: "localnet",
 				NADName:  "ns1/nad1",
-				MTU:      1400,
+				MTU:      1500,
 				VLANID:   10,
 				NetConf:  cnitypes.NetConf{Name: "tenantred", CNIVersion: "1.0.0", Type: "ovn-k8s-cni-overlay"},
 			},
@@ -298,7 +298,7 @@ func TestParseNetconf(t *testing.T) {
 			expectedNetConf: &ovncnitypes.NetConf{
 				Topology:           "localnet",
 				NADName:            "ns1/nad1",
-				MTU:                1400,
+				MTU:                1500,
 				NetConf:            cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
 				AllowPersistentIPs: true,
 				Subnets:            "192.168.200.0/16",


### PR DESCRIPTION
## 📑 Description
In localnet there is no tunneling; thus, there is no point in accounting for tunnel overhead when setting the MTU.
This PR changes the localnet MTU default to kernel default (1500).

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
