### PR TITLE
Refactor and fix UDN/CUDN readiness checks

### DIFF
--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -167,7 +167,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 				udnManifest := generateUserDefinedNetworkManifest(&c)
 				cleanup, err := createManifest(f.Namespace.Name, udnManifest)
 				DeferCleanup(cleanup)
-				Expect(waitForUserDefinedNetworkReady(f.Namespace.Name, c.name, 5*time.Second)).To(Succeed())
+				Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, f.Namespace.Name, c.name), 5*time.Second, time.Second).Should(Succeed())
 				return err
 			}),
 		)
@@ -253,7 +253,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 				udnManifest := generateUserDefinedNetworkManifest(&c)
 				cleanup, err := createManifest(fmt.Sprintf("%s-default", f.Namespace.Name), udnManifest)
 				DeferCleanup(cleanup)
-				Expect(waitForUserDefinedNetworkReady(fmt.Sprintf("%s-default", f.Namespace.Name), c.name, 5*time.Second)).To(Succeed())
+				Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, fmt.Sprintf("%s-default", f.Namespace.Name), c.name), 5*time.Second, time.Second).Should(Succeed())
 				return err
 			}),
 		)


### PR DESCRIPTION
This should fix a flake where the cluster UDN status was expected to be updated straight after creating a namespace:
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/acc803c79e4517975f70f7e315a3f09002c739b2/test/e2e/network_segmentation.go#L1138-L1151

The PR includes an alternative solution to: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4967.

Refactored the code to use a dynamic client instead of parsing raw kubectl output. I opted not to use udn/cudn client as this makes the tests more generic and portable.