### PR TITLE
Skip session affinity conformance test

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -39,6 +39,9 @@ service.kubernetes.io/headless
 # TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/95351
 should resolve connection reset issue #74839
 
+# TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/129049
+Services should be able to switch session affinity for NodePort service
+
 # api flakes
 sig-api-machinery
 


### PR DESCRIPTION
Test has been flaking and timing out jobs. Already fixed in k8s upstream. See #4965

