### PR TITLE
Unit tests: set klog level explicitly

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -662,6 +662,12 @@ func PrepareTestConfig() error {
 		return err
 	}
 
+	// set klog level here as some tests will not call InitConfig
+	var level klog.Level
+	if err := level.Set(strconv.Itoa(Logging.Level)); err != nil {
+		return fmt.Errorf("failed to set klog log level %v", err)
+	}
+
 	// Don't pick up defaults from the environment
 	os.Unsetenv("KUBECONFIG")
 	os.Unsetenv("K8S_CACERT")


### PR DESCRIPTION
We use PrepareTestConfig to set the logging level to 5, however that was not taking effect for klog all the time. This results in some unit tests only printing libovsdb logs, and regular klog level lines. We miss a ton of debug logs required to investigate unit tests failures.

