### PR TITLE
Fix race between NAD and NetPol deletions

### DIFF
--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -402,6 +402,11 @@ func NewInvalidPrimaryNetworkError(namespace string) *InvalidPrimaryNetworkError
 	return &InvalidPrimaryNetworkError{namespace: namespace}
 }
 
+func IsInvalidPrimaryNetworkError(err error) bool {
+	var invalidPrimaryNetworkError *InvalidPrimaryNetworkError
+	return errors.As(err, &invalidPrimaryNetworkError)
+}
+
 func GetUserDefinedNetworkRole(isPrimary bool) string {
 	networkRole := types.NetworkRoleSecondary
 	if isPrimary {


### PR DESCRIPTION
It's noticed NAD is deleted even before handling NetPol delete event which causes NetPol deletion never happened and error is always thrown upon retries. This skips such primary network error and proceeds with deleting netpol object.