### PR TITLE
Set network ID on netInfo even when already annotated

### DIFF
--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -620,6 +620,7 @@ func (c *nadController) handleNetworkID(old util.NetInfo, new util.MutableNetInf
 		delete(annotations, types.OvnNetworkIDAnnotation)
 	}
 	if len(annotations) == 0 {
+		new.SetNetworkID(id)
 		return nil
 	}
 

--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -184,11 +184,11 @@ func TestSetAdvertisements(t *testing.T) {
 
 			namespace, name, err := cache.SplitMetaNamespaceKey(testNADName)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
-			nad, err := buildNAD(name, namespace, tt.network)
-			g.Expect(err).ToNot(gomega.HaveOccurred())
-			nad.Annotations = map[string]string{
+			nadAnnotations := map[string]string{
 				types.OvnRouteAdvertisementsKey: "[\"" + tt.ra.Name + "\"]",
 			}
+			nad, err := buildNADWithAnnotations(name, namespace, tt.network, nadAnnotations)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
 			_, err = fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), &tt.node, v1.CreateOptions{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -286,6 +286,8 @@ func (l *mutableNetInfo) copyFrom(r *mutableNetInfo) {
 }
 
 func (nInfo *mutableNetInfo) GetNetworkID() int {
+	nInfo.RLock()
+	defer nInfo.RUnlock()
 	return nInfo.id
 }
 


### PR DESCRIPTION
On cluster manager restart, there wouldn't be a need to update the network ID annotation of existing networks but we were not setting the annotated ID on NetInfo. This failed to ensure the network and in turn made the controller believe the network was stale, cleaning up the annotated ID on the nodes causing the network to definitely not start and a crash-loop.
