### PR TITLE
Fixes SNAT removal with egress IP

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -3533,8 +3533,11 @@ func (e *EgressIPController) createNATRuleOps(ni util.NetInfo, ops []ovsdb.Opera
 func (e *EgressIPController) deleteNATRuleOps(ni util.NetInfo, ops []ovsdb.Operation, status egressipv1.EgressIPStatusItem,
 	egressIPName, podNamespace, podName string) ([]ovsdb.Operation, error) {
 	var err error
-	pV4 := libovsdbops.GetPredicate[*nbdb.NAT](getEgressIPNATDbIDs(egressIPName, podNamespace, podName, IPFamilyValueV4, e.controllerName), nil)
-	pV6 := libovsdbops.GetPredicate[*nbdb.NAT](getEgressIPNATDbIDs(egressIPName, podNamespace, podName, IPFamilyValueV6, e.controllerName), nil)
+	filterByIP := func(n *nbdb.NAT) bool {
+		return n.ExternalIP == status.EgressIP
+	}
+	pV4 := libovsdbops.GetPredicate[*nbdb.NAT](getEgressIPNATDbIDs(egressIPName, podNamespace, podName, IPFamilyValueV4, e.controllerName), filterByIP)
+	pV6 := libovsdbops.GetPredicate[*nbdb.NAT](getEgressIPNATDbIDs(egressIPName, podNamespace, podName, IPFamilyValueV6, e.controllerName), filterByIP)
 	router := &nbdb.LogicalRouter{
 		Name: ni.GetNetworkScopedGWRouterName(status.Node),
 	}


### PR DESCRIPTION
When a single ovnkube-controller manages the NBDB for multiple nodes, such as without IC or IC with multiple nodes per zone, the predicate search for NATs to remove would accidentally remove egress IP SNATs that were not part of the status being removed. For example in the test:

EgressIP UPDATE should update OVN on EgressIP .spec.egressips change interconnect disabled; non-ic - single zone setup

The test will:
1. create node 1 and 2, with egress ip .101 and .102, respectively
2. change the egress ip on node 1 to be .103

The test would flake because the SNAT for .102 would be missing for node 2. The reason this happens is because when the egress IP status is updated for .103 to be added on node1:

1. the code will call e.deletePreviousNetworkPodEgressIPAssignments
2. the code will then call e.addPodEgressIPAssignments

When the delete is called, it passes the status to remove any stale pod configuration for this status. However, it was searching for any SNAT for the egress IP name, which would in turn remove the SNAT for .102 as well.

This fixes it by passing a predicate to ensure the external IP in the SNAT matches the egress IP status.

