### PR TITLE
Fix doc: Replace ovn-org with ovn-kubernetes to reflect repo move

### DIFF
--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -27,7 +27,7 @@ set_default_params() {
   export ENABLE_MULTI_NET=${ENABLE_MULTI_NET:-false}
   export KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
   export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
-  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:helm'}
+  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:helm'}
 
   # Setup KUBECONFIG patch based on cluster-name
   export KUBECONFIG=${KUBECONFIG:-${HOME}/${KIND_CLUSTER_NAME}.conf}

--- a/docs/developer-guide/image-build.md
+++ b/docs/developer-guide/image-build.md
@@ -4,20 +4,20 @@ This file covers the container images available for OVN-Kubernetes and how to bu
 
 ## Images / Packages
 
-There are Ubuntu and Fedora-based images available in [GitHub's Registry](https://github.com/orgs/ovn-org/packages?repo_name=ovn-kubernetes). They are automatically generated upon merges via [a workflow](https://github.com/ovn-org/ovn-kubernetes/blob/9f1f3f2866fc566ffbe582ae9adf77d60d838484/.github/workflows/docker.yml#L5).
+There are Ubuntu and Fedora-based images available in [GitHub's Registry](https://github.com/orgs/ovn-kubernetes/packages?repo_name=ovn-kubernetes). They are automatically generated upon merges via [a workflow](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/.github/workflows/docker.yml).
 Prior to release-1.0, they were called ovn-kube-f (for the Fedora-based image) and ovnkube-u (for the Ubuntu-based image). From release 1.0 and beyond, these have been renamed to ovn-kube-fedora and ovn-kube-ubuntu, respectively.
 
 Therefore, use the following images and tags to obtain these images:
 
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:release-1.0
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:master
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:release-1.0
 
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:release-1.0
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+- ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:release-1.0
 
 ## Building Images
 
-To build images locally, use the following [Makefile](https://github.com/ovn-org/ovn-kubernetes/blob/master/dist/images/Makefile) and their respective Dockerfiles from the [dist/images](https://github.com/ovn-org/ovn-kubernetes/tree/master/dist/images) folder in this repository.
+To build images locally, use the following [Makefile](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/dist/images/Makefile) and their respective Dockerfiles from the [dist/images](https://github.com/ovn-kubernetes/ovn-kubernetes/tree/master/dist/images) folder in this repository.
 
 ```bash
 $ cd dist/images
@@ -26,5 +26,5 @@ $ make ubuntu
 ```
 
 The build will create an image called ovn-kube-fedora:latest or ovn-kube-ubuntu:latest, which can be re-tagged.
-For example: `${OCI_BIN} tag ovn-kube-fedora:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master`
+For example: `${OCI_BIN} tag ovn-kube-fedora:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:master`
 

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -70,14 +70,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:
@@ -389,7 +389,7 @@ true
 			<td>global.image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu"
+"ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu"
 </pre>
 </td>
 			<td>Image repository for ovn-kubernetes components</td>

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -48,11 +48,6 @@ CNI features, this can be done by editing `tags` section in values.yaml file.
 Run script `helm/basic-deploy.sh` to set up a basic OVN/Kubernetes cluster.
 
 ## Manual steps:
-- Disable IPv6 of `kind` docker network, otherwise ovnkube-node will fail to start
-```
-# docker network rm kind (delete `kind` network if it already exists)
-# docker network create kind -o "com.docker.network.bridge.enable_ip_masquerade"="true" -o "com.docker.network.driver.mtu"="1500"
-```
 
 - Launch a Kind cluster without CNI and kubeproxy (additional controle-plane or worker nodes can be added)
 ```
@@ -74,16 +69,26 @@ networking:
 # kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
+This chart does not use a `values.yaml` by default. You must specify a values file during installation.
+
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values-no-ic.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
-## Notes:
-- Only following scenarios were tested with Kind cluster
-  - ovs-node + ovnkube-node + ovnkube-db + ovnkube-master, with/without ovnkube-identity
-  - ovs-node + ovnkube-node + ovnkube-db-raft + ovnkube-master, with/without ovnkube-identity
+## Alternative Configurations
+
+To deploy ovn-kubernetes in interconnect mode, use `-f values-single-node-zone.yaml` instead of `-f values-no-ic.yaml`.
+Additionally, you must set the zone annotation on each node before deploying.
+
+Here is an example of how to set the annotation in a Kind cluster:
+
+```
+for n in $(kind get nodes --name "${kind_cluster_name}"); do
+  kubectl label node "${n}" k8s.ovn.org/zone-name=${n} --overwrite
+done
+```
 
 Following section describes the meaning of the values.
 

--- a/helm/ovn-kubernetes/Chart.yaml
+++ b/helm/ovn-kubernetes/Chart.yaml
@@ -6,6 +6,8 @@ version: 1.0.0
 appVersion: "1.0.0"
 home: https://ovn-kubernetes.io/
 icon: https://www.ovn.org/images/ovn-logo.png
+annotations:
+  default-values: "values-no-ic.yaml"
 sources:
   - https://github.com/ovn-org/ovn-kubernetes
   - https://github.com/ovn-org/ovn

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -68,11 +68,6 @@ CNI features, this can be done by editing `tags` section in values.yaml file.
   ```
 
 ## Manual steps:
-- Disable IPv6 of `kind` docker network, otherwise ovnkube-node will fail to start
-```
-# docker network rm kind (delete `kind` network if it already exists)
-# docker network create kind -o "com.docker.network.bridge.enable_ip_masquerade"="true" -o "com.docker.network.driver.mtu"="1500"
-```
 
 - Launch a Kind cluster without CNI and kubeproxy (additional controle-plane or worker nodes can be added)
 ```
@@ -94,16 +89,26 @@ networking:
 # kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
-- Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
+This chart does not use a `values.yaml` by default. You must specify a values file during installation.
+
+- Run `helm install` with the appropriate `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values-no-ic.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
-## Notes:
-- Only following scenarios were tested with Kind cluster
-  - ovs-node + ovnkube-node + ovnkube-db + ovnkube-master, with/without ovnkube-identity
-  - ovs-node + ovnkube-node + ovnkube-db-raft + ovnkube-master, with/without ovnkube-identity
+## Alternative Configurations
+
+To deploy ovn-kubernetes in interconnect mode, use `-f values-single-node-zone.yaml` instead of `-f values-no-ic.yaml`.
+Additionally, you must set the zone annotation on each node before deploying.
+
+Here is an example of how to set the annotation in a Kind cluster:
+
+```
+for n in $(kind get nodes --name "${kind_cluster_name}"); do
+  kubectl label node "${n}" k8s.ovn.org/zone-name=${n} --overwrite
+done
+```
 
 Following section describes the meaning of the values.
 

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -8,7 +8,7 @@
 
 ## Source Code
 
-* <https://github.com/ovn-org/ovn-kubernetes>
+* <https://github.com/ovn-kubernetes/ovn-kubernetes>
 * <https://github.com/ovn-org/ovn>
 
 ## Introduction
@@ -90,14 +90,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:
@@ -440,7 +440,7 @@ true
 			<td>global.image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu"
+"ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu"
 </pre>
 </td>
 			<td>Image repository for ovn-kubernetes components</td>

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -88,14 +88,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:

--- a/helm/ovn-kubernetes/values-multi-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-multi-node-zone.yaml
@@ -146,7 +146,7 @@ global:
   libovsdbClientLogFile: ""
   image:
     # -- Image repository for ovn-kubernetes components
-    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
+    repository: ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu
     # -- Specify image tag to run
     tag: master
     # -- Image pull policy

--- a/helm/ovn-kubernetes/values-no-ic.yaml
+++ b/helm/ovn-kubernetes/values-no-ic.yaml
@@ -144,7 +144,7 @@ global:
   noHostSubnetLabel: ""
   image:
     # -- Image repository for ovn-kubernetes components
-    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
+    repository: ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu
     # -- Specify image tag to run
     tag: master
     # -- Image pull policy
@@ -152,7 +152,7 @@ global:
   # -- Image for DPUs
   dpuImage:
     # -- Image repository for ovn-kubernetes components
-    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
+    repository: ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu
     # -- Specify image tag to run
     tag: master
     # -- Image pull policy

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -149,7 +149,7 @@ global:
   libovsdbClientLogFile: ""
   image:
     # -- Image repository for ovn-kubernetes components
-    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
+    repository: ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu
     # -- Specify image tag to run
     tag: master
     # -- Image pull policy


### PR DESCRIPTION
Update documentation to replace a bunch of ovn-org to ovn-kubernetes.
