### PR TITLE
Handles unspecified protocol in network policy port

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	utilnet "k8s.io/utils/net"
 )
@@ -102,12 +103,16 @@ func (gp *gressPolicy) addPeerAddressSets(asHashNameV4, asHashNameV6 string) {
 // If the port is not specified, it implies all ports for that protocol
 func (gp *gressPolicy) addPortPolicy(portJSON *knet.NetworkPolicyPort) {
 	var pp *libovsdbutil.NetworkPolicyPort
+	protocol := v1.ProtocolTCP
+	if portJSON.Protocol != nil {
+		protocol = *portJSON.Protocol
+	}
 	if portJSON.Port != nil && portJSON.EndPort != nil {
-		pp = libovsdbutil.GetNetworkPolicyPort(*portJSON.Protocol, portJSON.Port.IntVal, *portJSON.EndPort)
+		pp = libovsdbutil.GetNetworkPolicyPort(protocol, portJSON.Port.IntVal, *portJSON.EndPort)
 	} else if portJSON.Port != nil {
-		pp = libovsdbutil.GetNetworkPolicyPort(*portJSON.Protocol, portJSON.Port.IntVal, 0)
+		pp = libovsdbutil.GetNetworkPolicyPort(protocol, portJSON.Port.IntVal, 0)
 	} else {
-		pp = libovsdbutil.GetNetworkPolicyPort(*portJSON.Protocol, 0, 0)
+		pp = libovsdbutil.GetNetworkPolicyPort(protocol, 0, 0)
 	}
 	gp.portPolicies = append(gp.portPolicies, pp)
 }

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -540,8 +540,7 @@ func getPortNetworkPolicy(policyName, namespace, labelName, labelVal string, tcp
 		},
 		[]knet.NetworkPolicyIngressRule{{
 			Ports: []knet.NetworkPolicyPort{{
-				Port:     &intstr.IntOrString{IntVal: tcpPort},
-				Protocol: &tcpProtocol,
+				Port: &intstr.IntOrString{IntVal: tcpPort},
 			}},
 		}},
 		[]knet.NetworkPolicyEgressRule{{


### PR DESCRIPTION
Fixes a null pointer exception when network policy port has no protocol. If the protocol is missing in the network policy port definition, it should be assumed to be TCP.

Hit the crash downstream in:
https://issues.redhat.com/browse/OCPBUGS-49393

