### PR TITLE
factory: Set default event queue size to 100.

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -193,7 +193,7 @@ const (
 var (
 	// Use a larger queue for incoming events to avoid bottlenecks
 	// due to handlers being slow.
-	eventQueueSize uint32 = 1000
+	eventQueueSize uint32 = 100
 )
 
 // Override default event queue configuration.  Used only for tests.


### PR DESCRIPTION
Commit 6dda0b511d26 ("factory: Bump the event queue size to 1K.") increased the event queue size to 1K events.  However, in combination with fe17136cfd3a ("factory: Reduce contention on informer locks.") which configures 201 internal informers this might end up using too much memory in cases when controllers cannot consume events as fast as they're queued by the kube API.

For each kubernetes API object type we consume:
  N_internal_informers x N_queues x N_events x sizeof(event)
memory.

That currently translates to:
  N_internal_informers = 201
  N_queues = 15
  N_events = 1000
  sizeof(event) = 32B
  => ~92MB of memory per object type

Given that ovn-kubernetes processes need to be informed about multiple object types this can grow to a significantly large number when controllers that are supposed to consume events from the internal informer queues are slow.

Reduce the queue size, making it 100, in order to lower the worst case scenario memory usage:
  N_internal_informers = 201
  N_queues = 15
  N_events = 100
  sizeof(event) = 32B
  => ~9.2MB of memory per object type

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
