### PR TITLE
Check if cluster manager controller has retry pod framework

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -445,7 +445,7 @@ func (ncc *networkClusterController) Reconcile(netInfo util.NetInfo) error {
 	if err != nil {
 		klog.Errorf("Failed to reconcile network %s: %v", ncc.GetNetworkName(), err)
 	}
-	if reconcilePendingPods {
+	if reconcilePendingPods && ncc.retryPods != nil {
 		if err := objretry.RequeuePendingPods(ncc.kube, ncc.GetNetInfo(), ncc.retryPods); err != nil {
 			klog.Errorf("Failed to requeue pending pods for network %s: %v", ncc.GetNetworkName(), err)
 		}


### PR DESCRIPTION
Fixes NPE seen at:
https://github.com/openshift/ovn-kubernetes/pull/2427#issuecomment-2620375385

Certain network types may not have a pod handler or retry framework for cluster manager.

