### PR TITLE
Fix getting active network secondary udn

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -698,15 +698,26 @@ var _ = Describe("User Defined Network Controller", func() {
 						cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudnName, metav1.GetOptions{})
 						Expect(err).NotTo(HaveOccurred())
 						return normalizeConditions(cudn.Status.Conditions)
-					}).Should(Equal([]metav1.Condition{{
-						Type:   "NetworkCreated",
-						Status: "False",
-						Reason: "NetworkAttachmentDefinitionSyncError",
-						Message: "invalid primary network state for namespace \"black\": a valid primary user defined network or network attachment definition " +
-							"custom resource, and required namespace label \"k8s.ovn.org/primary-user-defined-network\" must both be present\ninvalid primary " +
-							"network state for namespace \"gray\": a valid primary user defined network or network attachment definition custom resource, and " +
-							"required namespace label \"k8s.ovn.org/primary-user-defined-network\" must both be present",
-					}}), "status should report NAD failed in existing and new test namespaces")
+					}).Should(Or(
+						Equal([]metav1.Condition{{
+							Type:   "NetworkCreated",
+							Status: "False",
+							Reason: "NetworkAttachmentDefinitionSyncError",
+							Message: "invalid primary network state for namespace \"black\": a valid primary user defined network or network attachment definition " +
+								"custom resource, and required namespace label \"k8s.ovn.org/primary-user-defined-network\" must both be present\ninvalid primary " +
+								"network state for namespace \"gray\": a valid primary user defined network or network attachment definition custom resource, and " +
+								"required namespace label \"k8s.ovn.org/primary-user-defined-network\" must both be present",
+						}}),
+						Equal([]metav1.Condition{{
+							Type:   "NetworkCreated",
+							Status: "False",
+							Reason: "NetworkAttachmentDefinitionSyncError",
+							Message: "invalid primary network state for namespace \"gray\": a valid primary user defined network or network attachment definition " +
+								"custom resource, and required namespace label \"k8s.ovn.org/primary-user-defined-network\" must both be present\ninvalid primary " +
+								"network state for namespace \"black\": a valid primary user defined network or network attachment definition custom resource, and " +
+								"required namespace label \"k8s.ovn.org/primary-user-defined-network\" must both be present",
+						}})),
+						"status should report NAD failed in existing and new test namespaces")
 					for _, nsName := range newNsNames {
 						nads, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nsName).List(context.Background(), metav1.ListOptions{})
 						Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -874,56 +874,18 @@ func (bnc *BaseNetworkController) isLocalZoneNode(node *kapi.Node) bool {
 	return util.GetNodeZone(node) == bnc.zone
 }
 
-// GetNetworkRole returns the role of this controller's
-// network for the given pod
-// Expected values are:
-// (1) "primary" if this network is the primary network of the pod.
-//
-//	The "default" network is the primary network of any pod usually
-//	unless user-defined-network-segmentation feature has been activated.
-//	If network segmentation feature is enabled then any user defined
-//	network can be the primary network of the pod.
-//
-// (2) "secondary" if this network is the secondary network of the pod.
-//
-//	Only user defined networks can be secondary networks for a pod.
-//
-// (3) "infrastructure-locked" is applicable only to "default" network if
-//
-//	a user defined network is the "primary" network for this pod. This
-//	signifies the "default" network is only used for probing and
-//	is otherwise locked for all intents and purposes.
-//
-// NOTE: Like in other places, expectation is this function is always called
-// from controller's that have some relation to the given pod, unrelated
-// networks are treated as secondary networks so caller has to be careful
+// GetNetworkRole returns the role of this controller's network for the given pod
 func (bnc *BaseNetworkController) GetNetworkRole(pod *kapi.Pod) (string, error) {
-	if !util.IsNetworkSegmentationSupportEnabled() {
-		// if user defined network segmentation is not enabled
-		// then we know pod's primary network is "default" and
-		// pod's secondary network is not its NOT primary network
-		if bnc.IsDefault() {
-			return types.NetworkRolePrimary, nil
-		}
-		return types.NetworkRoleSecondary, nil
-	}
-	activeNetwork, err := bnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
+
+	role, err := util.GetNetworkRole(bnc.GetNetInfo(), bnc.networkManager.GetActiveNetworkForNamespace, pod)
 	if err != nil {
 		if util.IsUnprocessedActiveNetworkError(err) {
 			bnc.recordPodErrorEvent(pod, err)
 		}
 		return "", err
 	}
-	if activeNetwork.GetNetworkName() == bnc.GetNetworkName() {
-		return types.NetworkRolePrimary, nil
-	}
-	if bnc.IsDefault() {
-		// if default network was not the primary network,
-		// then when UDN is turned on, default network is the
-		// infrastructure-locked network forthis pod
-		return types.NetworkRoleInfrastructure, nil
-	}
-	return types.NetworkRoleSecondary, nil
+
+	return role, nil
 }
 
 func (bnc *BaseNetworkController) isLayer2Interconnect() bool {

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -544,6 +544,11 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		return nil, nil, nil, false, err
 	}
 
+	if networkRole == ovntypes.NetworkRoleNone {
+		// pod not on this controller, nothing to do
+		return nil, nil, nil, false, nil
+	}
+
 	// Although we have different code to allocate the pod annotation for the
 	// default network and secondary networks, at the time of this writing they
 	// are functionally equivalent and the only reason to keep them separated is

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -257,9 +257,12 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *co
 		return err
 	}
 
-	activeNetwork, err := bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
-	if err != nil {
-		return fmt.Errorf("failed looking for the active network at namespace '%s': %w", pod.Namespace, err)
+	var activeNetwork util.NetInfo
+	if bsnc.IsPrimaryNetwork() {
+		activeNetwork, err = bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
+		if err != nil {
+			return fmt.Errorf("failed looking for the active network at namespace '%s': %w", pod.Namespace, err)
+		}
 	}
 
 	on, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, bsnc.GetNetInfo(), activeNetwork)
@@ -581,9 +584,13 @@ func (bsnc *BaseSecondaryNetworkController) syncPodsForSecondaryNetwork(pods []i
 			return fmt.Errorf("spurious object in syncPods: %v", podInterface)
 		}
 
-		activeNetwork, err := bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
-		if err != nil {
-			return fmt.Errorf("failed looking for the active network at namespace '%s': %w", pod.Namespace, err)
+		var activeNetwork util.NetInfo
+		var err error
+		if bsnc.IsPrimaryNetwork() {
+			activeNetwork, err = bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
+			if err != nil {
+				return fmt.Errorf("failed looking for the active network at namespace '%s': %w", pod.Namespace, err)
+			}
 		}
 
 		on, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, bsnc.GetNetInfo(), activeNetwork)

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -104,7 +104,7 @@ func (oc *BaseSecondaryLayer2NetworkController) run() error {
 		return err
 	}
 
-	if util.IsMultiNetworkPoliciesSupportEnabled() {
+	if util.IsMultiNetworkPoliciesSupportEnabled() && !oc.IsPrimaryNetwork() {
 		// WatchMultiNetworkPolicy depends on WatchPods and WatchNamespaces
 		if err := oc.WatchMultiNetworkPolicy(); err != nil {
 			return err

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -184,7 +184,7 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *kapi.Pod, ad
 		if err != nil {
 			return err
 		}
-		if networkRole != ovntypes.NetworkRolePrimary {
+		if networkRole == ovntypes.NetworkRoleInfrastructure {
 			// only update for non-default network pods
 			portName := oc.GetLogicalPortName(pod, oc.GetNetworkName())
 			err := oc.setUDNPodOpenPorts(pod.Namespace+"/"+pod.Name, pod.Annotations, portName)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -264,7 +264,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 	if err != nil {
 		return err
 	}
-	if networkRole != ovntypes.NetworkRolePrimary && util.IsNetworkSegmentationSupportEnabled() {
+	if networkRole == ovntypes.NetworkRoleInfrastructure && util.IsNetworkSegmentationSupportEnabled() {
 		pgName := libovsdbutil.GetPortGroupName(oc.getSecondaryPodsPortGroupDbIDs())
 		if ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, pgName, lsp.UUID); err != nil {
 			return err

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -318,7 +318,7 @@ func NewSecondaryLayer2NetworkController(
 		oc.zoneICHandler = zoneinterconnect.NewZoneInterconnectHandler(oc.GetNetInfo(), oc.nbClient, oc.sbClient, oc.watchFactory)
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() {
+	if util.IsNetworkSegmentationSupportEnabled() && netInfo.IsPrimaryNetwork() {
 		var err error
 		oc.svcController, err = svccontroller.NewController(
 			cnci.client, cnci.nbClient,

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -579,7 +579,7 @@ func (oc *SecondaryLayer3NetworkController) Run() error {
 		return err
 	}
 
-	if util.IsMultiNetworkPoliciesSupportEnabled() {
+	if util.IsMultiNetworkPoliciesSupportEnabled() && !oc.IsPrimaryNetwork() {
 		// WatchMultiNetworkPolicy depends on WatchPods and WatchNamespaces
 		if err := oc.WatchMultiNetworkPolicy(); err != nil {
 			return err

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -228,10 +228,10 @@ const (
 	NetworkRolePrimary   = "primary"
 	NetworkRoleSecondary = "secondary"
 	NetworkRoleDefault   = "default"
-	// defined internally by ovnkube to recognize "default"
-	// network's role as a "infrastructure-locked" network
-	// when user defined network is the primary network for
-	// the pod which makes "default" network niether primary
+	// NetworkRoleInfrastructure is defined internally by ovnkube to recognize "default"
+	// network's role as an "infrastructure-locked" network
+	// when a user defined network is the primary network for
+	// the pod which makes "default" network neither primary
 	// nor secondary
 	NetworkRoleInfrastructure = "infrastructure-locked"
 	NetworkRoleNone           = "none"

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -234,6 +234,7 @@ const (
 	// the pod which makes "default" network niether primary
 	// nor secondary
 	NetworkRoleInfrastructure = "infrastructure-locked"
+	NetworkRoleNone           = "none"
 
 	// db index keys
 	// PrimaryIDKey is used as a primary client index


### PR DESCRIPTION
Fixes issues where we are calling getActiveNetworkForNamespace on secondary UDN controllers. There is no point in doing this and can cause errors for resources like pods if we are handling pods slowly and the namespace has already been deleted. Remember secondary UDN/NAD can use other namespaces, so NAD/network controller may still be functional trying to add pods for another namespace and that namespace may no longer exist.

Fixes issues where we are starting services and multinetworkpolicy controllers when we shouldn't be.

There were duplicate functions for GetNetworkRole, with ambiguous logic that needed a note to caution developers against when to use it. Consolidated the function into a single util, and made the logic more explicit. Now if a GetNetworkRole is called on a pod that the controller is not serving, it will return "none", indicating to the caller that this  pod is not served by this controller and can be ignored.