### PR TITLE
ovspinning: Enable the feature at runtime

### DIFF
--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -68,7 +68,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 	}
 
 	// Disable the feature by making the enabler file empty
-	os.WriteFile(featureEnablerFile, []byte(""), 0)
+	err = os.WriteFile(featureEnablerFile, []byte(""), 0)
 	assert.NoError(t, err)
 
 	var tmpCPUset unix.CPUSet
@@ -78,6 +78,33 @@ func TestAlignCPUAffinity(t *testing.T) {
 
 	assertNeverPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
 	assertNeverPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
+
+	// Enable the feature back by putting contents in the enabler file
+	err = os.WriteFile(featureEnablerFile, []byte("1"), 0)
+	assert.NoError(t, err)
+
+	assertPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
+	assertPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
+
+	// Disable the feature by deleting the enabler file
+	klog.Infof("Remove the enabler file to disable the feature")
+	err = os.Remove(featureEnablerFile)
+	assert.NoError(t, err)
+
+	tmpCPUset.Set(1)
+	err = unix.SchedSetaffinity(os.Getpid(), &tmpCPUset)
+	assert.NoError(t, err)
+
+	assertNeverPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
+	assertNeverPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
+
+	// Re-enable the feature back by recreating the enabler file
+	klog.Infof("Re-enable the feature")
+	err = os.WriteFile(featureEnablerFile, []byte("1"), 0)
+	assert.NoError(t, err)
+
+	assertPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
+	assertPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
 }
 
 func TestIsFileNotEmpty(t *testing.T) {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
A configuration manager like the `machine-config-operator` is often used to enable the OVS CPU pinning feature. During reconciliation loop, the configurator might remove and recreate a file for a very short time. When it comes to the `/etc/openvswitch/enable_dynamic_cpu_affinity` file, it might disable the CPU pinning permanently and an ovnkube-controller restart is needed.

Make the OVS CPU pinning be enabled without restarting `ovnkube-controller` pod. Watch the parent folder instead of the enabler file because if the file gets deleted, the file watch will not emit any further fsevent.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
