### PR TITLE
crd, cudn: Ensure matching topology and topology-configuration

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -329,6 +329,14 @@ spec:
                 - topology
                 type: object
                 x-kubernetes-validations:
+                - message: spec.layer3 is required when topology is Layer3 and forbidden
+                    otherwise
+                  rule: 'has(self.topology) && self.topology == ''Layer3'' ? has(self.layer3):
+                    !has(self.layer3)'
+                - message: spec.layer2 is required when topology is Layer2 and forbidden
+                    otherwise
+                  rule: 'has(self.topology) && self.topology == ''Layer2'' ? has(self.layer2):
+                    !has(self.layer2)'
                 - message: Network spec is immutable
                   rule: self == oldSelf
             required:

--- a/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
@@ -30,6 +30,8 @@ type ClusterUserDefinedNetworkSpec struct {
 
 	// Network is the user-defined-network spec
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="has(self.topology) && self.topology == 'Layer3' ? has(self.layer3): !has(self.layer3)", message="spec.layer3 is required when topology is Layer3 and forbidden otherwise"
+	// +kubebuilder:validation:XValidation:rule="has(self.topology) && self.topology == 'Layer2' ? has(self.layer2): !has(self.layer2)", message="spec.layer2 is required when topology is Layer2 and forbidden otherwise"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Network spec is immutable"
 	// +required
 	Network NetworkSpec `json:"network"`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Add missing API validations to ensure the topology and the topology configuration are matching.
Similar to the validation rules on UserDefiendNetwork CRD [[1]](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/crd/userdefinednetwork/v1/udn.go#L18-L19).

For example: the following spec is invalid and should be blocked by the cluster API:
```
apiVersion: k8s.ovn.org/v1
kind: ClusterUserDefinedNetwork
...
spec
  network:
    topology: Layer2
    layer3:
    ...
```

[1] https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/crd/userdefinednetwork/v1/udn.go#L18-L19
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
