### PR TITLE
OCPBUGS-49621: Fix UDN and CUDN subnet validation

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -291,7 +291,7 @@ spec:
                               self.hostSubnet > cidr(self.cidr).prefixLength()'
                           - message: HostSubnet must < 32 for ipv4 CIDR
                             rule: '!has(self.hostSubnet) || !isCIDR(self.cidr) ||
-                              (cidr(self.cidr).ip().family() == 4 && self.hostSubnet
+                              (cidr(self.cidr).ip().family() != 4 || self.hostSubnet
                               < 32)'
                         maxItems: 2
                         minItems: 1

--- a/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
@@ -238,7 +238,7 @@ spec:
                           > cidr(self.cidr).prefixLength()'
                       - message: HostSubnet must < 32 for ipv4 CIDR
                         rule: '!has(self.hostSubnet) || !isCIDR(self.cidr) || (cidr(self.cidr).ip().family()
-                          == 4 && self.hostSubnet < 32)'
+                          != 4 || self.hostSubnet < 32)'
                     maxItems: 2
                     minItems: 1
                     type: array

--- a/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
@@ -69,7 +69,7 @@ type Layer3Config struct {
 }
 
 // +kubebuilder:validation:XValidation:rule="!has(self.hostSubnet) || !isCIDR(self.cidr) || self.hostSubnet > cidr(self.cidr).prefixLength()", message="HostSubnet must be smaller than CIDR subnet"
-// +kubebuilder:validation:XValidation:rule="!has(self.hostSubnet) || !isCIDR(self.cidr) || (cidr(self.cidr).ip().family() == 4 && self.hostSubnet < 32)", message="HostSubnet must < 32 for ipv4 CIDR"
+// +kubebuilder:validation:XValidation:rule="!has(self.hostSubnet) || !isCIDR(self.cidr) || (cidr(self.cidr).ip().family() != 4 || self.hostSubnet < 32)", message="HostSubnet must < 32 for ipv4 CIDR"
 type Layer3Subnet struct {
 	// CIDR specifies L3Subnet, which is split into smaller subnets for every node.
 	//


### PR DESCRIPTION
Fix UDN and CUDN subnet validation

In the previous validation rule, IPv6 subnets would mistakenly invalidate the CR.

I couldn't find any tests for this in the PR that introduced the changes (https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4933), I'm not sure if that was intended.