### PR TITLE
Change dynamic_neigh_routers to false for the Interconnect topology.

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -277,6 +277,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				UUID: node1.Name + "-UUID",
 				Name: node1.Name,
 			}
+			dynamicNeighRouters := "true"
+			if config.OVNKubernetesFeature.EnableInterconnect {
+				dynamicNeighRouters = "false"
+			}
+
+			logicalRouterOptions := map[string]string{
+				"dynamic_neigh_routers": dynamicNeighRouters,
+			}
+
 			fakeOvn.startWithDBSetup(
 				libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
@@ -290,9 +299,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							UUID: types.OVNClusterRouter + "-UUID",
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -392,10 +402,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					},
 				},
 				&nbdb.LogicalRouter{
-					Name:  types.GWRouterPrefix + node1.Name,
-					UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-					Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
-					Nat:   []string{"egressip-nat-UUID"},
+					Name:    types.GWRouterPrefix + node1.Name,
+					UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+					Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+					Nat:     []string{"egressip-nat-UUID"},
+					Options: logicalRouterOptions,
 				},
 				&nbdb.LogicalRouter{
 					Name:     types.OVNClusterRouter,
@@ -477,6 +488,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				Name:  node1.Name,
 				Ports: []string{"k8s-" + node1.Name + "-UUID"},
 			}
+			dynamicNeighRouters := "true"
+			if config.OVNKubernetesFeature.EnableInterconnect {
+				dynamicNeighRouters = "false"
+			}
+
+			logicalRouterOptions := map[string]string{
+				"dynamic_neigh_routers": dynamicNeighRouters,
+			}
 			fakeOvn.startWithDBSetup(
 				libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
@@ -490,9 +509,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							UUID: types.OVNClusterRouter + "-UUID",
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -587,9 +607,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					ExternalIDs: getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 				},
 				&nbdb.LogicalRouter{
-					Name:  types.GWRouterPrefix + node1.Name,
-					UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-					Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+					Name:    types.GWRouterPrefix + node1.Name,
+					UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+					Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+					Options: logicalRouterOptions,
 				},
 				&nbdb.LogicalRouter{
 					Name:     types.OVNClusterRouter,
@@ -690,6 +711,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						UUID: node2.Name + "-UUID",
 						Name: node2.Name,
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -708,14 +737,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1.Name,
-									UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1.Name,
+									UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2.Name,
-									UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node2.Name,
+									UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -853,15 +884,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							},
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
@@ -990,6 +1023,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						UUID: node3.Name + "-UUID",
 						Name: node3.Name,
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					initialDB := libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1012,19 +1053,22 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								UUID: types.OVNClusterRouter + "-UUID",
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node1.Name,
-								UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node1.Name,
+								UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node2.Name,
-								UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node2.Name,
+								UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node3.Name,
-								UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node3.Name,
+								UUID:    types.GWRouterPrefix + node3.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalSwitchPort{
 								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -1213,20 +1257,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							},
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node3.Name,
-							UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node3.Name,
+							UUID:    types.GWRouterPrefix + node3.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name: types.OVNClusterRouter,
@@ -1384,6 +1431,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Name:  node3.Name,
 						Ports: []string{"k8s-" + node3.Name + "-UUID"},
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					initialDB := libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1406,19 +1461,22 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								UUID: types.OVNClusterRouter + "-UUID",
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node1.Name,
-								UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node1.Name,
+								UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node2.Name,
-								UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node2.Name,
+								UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node3.Name,
-								UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node3.Name,
+								UUID:    types.GWRouterPrefix + node3.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalSwitchPort{
 								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -1612,20 +1670,23 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-							Nat:   []string{},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Nat:     []string{},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node3.Name,
-							UUID:  types.GWRouterPrefix + node3.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node3.Name,
+							UUID:    types.GWRouterPrefix + node3.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
@@ -1792,6 +1853,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Name:  node2.Name,
 						Ports: []string{"k8s-" + node2.Name + "-UUID"},
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
@@ -1811,15 +1880,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1.Name,
-									UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1.Name,
+									UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2.Name,
-									UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2.Name,
+									UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -1956,14 +2027,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
@@ -2158,7 +2231,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Name:  node2.Name,
 						Ports: []string{"k8s-" + node2.Name + "-UUID"},
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
 
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -2177,15 +2257,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1.Name,
-									UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1.Name,
+									UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2.Name,
-									UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2.Name,
+									UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -2390,15 +2472,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
-							Nat:   []string{},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Nat:     []string{},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name:         types.OVNClusterRouter,
@@ -2591,6 +2675,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Name:  node2.Name,
 						Ports: []string{"k8s-" + node2.Name + "-UUID"},
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
+
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -2609,9 +2702,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1.Name,
-									UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1.Name,
+									UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitch{
 									UUID:  types.ExternalSwitchPrefix + node1.Name + "-UUID",
@@ -2619,9 +2713,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2.Name,
-									UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node2.Name,
+									UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitch{
 									UUID:  types.ExternalSwitchPrefix + node2.Name + "-UUID",
@@ -2746,16 +2841,18 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
-							Nat:   []string{"egressip-nat1-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Nat:     []string{"egressip-nat1-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-							Nat:   []string{},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Nat:     []string{},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
@@ -2898,9 +2995,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
@@ -3035,7 +3133,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Name:  node2.Name,
 						Ports: []string{"k8s-" + node2.Name + "-UUID"},
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
 
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -3054,15 +3159,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1.Name,
-									UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1.Name,
+									UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2.Name,
-									UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2.Name,
+									UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -3202,14 +3309,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1.Name,
-							UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2.Name,
-							UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name: types.OVNClusterRouter,
@@ -3360,7 +3469,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						annotations["k8s.ovn.org/remote-zone-migrated"] = "remote" // used only for ic=true test
 					}
 					node2 := getNodeObj(node2Name, annotations, map[string]string{}) // add node to avoid errori-ing out on transit switch IP fetch
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
 
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -3379,15 +3495,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1Name,
-									UUID:  types.GWRouterPrefix + node1Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1Name,
+									UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2Name,
-									UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2Name,
+									UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID: "k8s-" + node1.Name + "-UUID",
@@ -3489,15 +3607,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6, node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1Name,
-							UUID:  types.GWRouterPrefix + node1Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID: "k8s-" + node1.Name + "-UUID",
@@ -3564,15 +3684,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6, node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1Name,
-							UUID:  types.GWRouterPrefix + node1Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   nil,
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     nil,
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID: "k8s-" + node1.Name + "-UUID",
@@ -3628,7 +3750,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 					node2 := nodes[1]
 					_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
 
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -3647,15 +3776,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1Name,
-									UUID:  types.GWRouterPrefix + node1Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1Name,
+									UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2Name,
-									UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2Name,
+									UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID:      "k8s-" + node1.Name + "-UUID",
@@ -3749,15 +3880,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node1Name,
-							UUID:  types.GWRouterPrefix + node1Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1.Name + "-UUID",
@@ -3846,7 +3979,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				egressNamespace := newNamespace(eipNamespace)
 				_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 				_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
+				dynamicNeighRouters := "true"
+				if config.OVNKubernetesFeature.EnableInterconnect {
+					dynamicNeighRouters = "false"
+				}
 
+				logicalRouterOptions := map[string]string{
+					"dynamic_neigh_routers": dynamicNeighRouters,
+				}
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
@@ -3860,13 +4000,15 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								UUID: types.OVNClusterRouter + "-UUID",
 							},
 							&nbdb.LogicalRouter{
-								Name: types.GWRouterPrefix + node1Name,
-								UUID: types.GWRouterPrefix + node1Name + "-UUID",
+								Name:    types.GWRouterPrefix + node1Name,
+								UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node2Name,
-								UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node2Name,
+								UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalSwitchPort{
 								UUID:      "k8s-" + node1Name + "-UUID",
@@ -3969,14 +4111,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						},
 					},
 					&nbdb.LogicalRouter{
-						Name: types.GWRouterPrefix + node1Name,
-						UUID: types.GWRouterPrefix + node1Name + "-UUID",
+						Name:    types.GWRouterPrefix + node1Name,
+						UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + node2Name,
-						UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-						Nat:   []string{"egressip-nat-UUID"},
+						Name:    types.GWRouterPrefix + node2Name,
+						UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+						Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+						Nat:     []string{"egressip-nat-UUID"},
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      "k8s-" + node1Name + "-UUID",
@@ -4205,6 +4349,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					egressNamespace := newNamespace(eipNamespace)
 					_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -4218,14 +4370,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name: types.GWRouterPrefix + node1Name,
-									UUID: types.GWRouterPrefix + node1Name + "-UUID",
+									Name:    types.GWRouterPrefix + node1Name,
+									UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2Name,
-									UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2Name,
+									UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID:      "k8s-" + node1Name + "-UUID",
@@ -4328,14 +4482,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -4456,6 +4612,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					}
 					_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -4469,14 +4633,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name: types.GWRouterPrefix + node1Name,
-									UUID: types.GWRouterPrefix + node1Name + "-UUID",
+									Name:    types.GWRouterPrefix + node1Name,
+									UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2Name,
-									UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2Name,
+									UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID:      "k8s-" + node1Name + "-UUID",
@@ -4565,14 +4731,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -4621,14 +4789,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   nil,
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     nil,
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -4680,6 +4850,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					}
 					_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -4693,14 +4871,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name: types.GWRouterPrefix + node1Name,
-									UUID: types.GWRouterPrefix + node1Name + "-UUID",
+									Name:    types.GWRouterPrefix + node1Name,
+									UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2Name,
-									UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2Name,
+									UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID:      "k8s-" + node1Name + "-UUID",
@@ -4810,14 +4990,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{nodeLogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -4864,14 +5046,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{nodeLogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   nil,
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     nil,
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -4924,6 +5108,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
 					egressIPServedPodsASv4, _ := buildEgressIPServedPodsAddressSets(nil, types.DefaultNetworkName, DefaultNetworkControllerName)
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -4937,14 +5129,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name: types.GWRouterPrefix + node1Name,
-									UUID: types.GWRouterPrefix + node1Name + "-UUID",
+									Name:    types.GWRouterPrefix + node1Name,
+									UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2Name,
-									UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-									Nat:   nil,
+									Name:    types.GWRouterPrefix + node2Name,
+									UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+									Nat:     nil,
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID:      "k8s-" + node1Name + "-UUID",
@@ -5044,14 +5238,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   []string{"egressip-nat-UUID"},
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     []string{"egressip-nat-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -5103,14 +5299,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Networks: []string{node2LogicalRouterIfAddrV6},
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1Name,
-							UUID: types.GWRouterPrefix + node1Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1Name,
+							UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + node2Name,
-							UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-							Nat:   nil,
+							Name:    types.GWRouterPrefix + node2Name,
+							UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+							Nat:     nil,
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -5280,6 +5478,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Name:  node2Name,
 						Ports: []string{"k8s-" + node2Name + "-UUID"},
 					}
+					dynamicNeighRouters := "true"
+					if config.OVNKubernetesFeature.EnableInterconnect {
+						dynamicNeighRouters = "false"
+					}
+
+					logicalRouterOptions := map[string]string{
+						"dynamic_neigh_routers": dynamicNeighRouters,
+					}
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
@@ -5298,14 +5504,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									UUID: types.OVNClusterRouter + "-UUID",
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node1.Name,
-									UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node1.Name,
+									UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalRouter{
-									Name:  types.GWRouterPrefix + node2.Name,
-									UUID:  types.GWRouterPrefix + node2.Name + "-UUID",
-									Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Name:    types.GWRouterPrefix + node2.Name,
+									UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+									Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+									Options: logicalRouterOptions,
 								},
 								&nbdb.LogicalSwitchPort{
 									UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -5452,14 +5660,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + assignmentNode1,
-							UUID:  types.GWRouterPrefix + assignmentNode1 + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + assignmentNode1,
+							UUID:    types.GWRouterPrefix + assignmentNode1 + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + assignmentNode2,
-							UUID:  types.GWRouterPrefix + assignmentNode2 + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + assignmentNode2,
+							UUID:    types.GWRouterPrefix + assignmentNode2 + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name: types.OVNClusterRouter,
@@ -5615,14 +5825,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + assignmentNode1,
-							UUID:  types.GWRouterPrefix + assignmentNode1 + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + assignmentNode1,
+							UUID:    types.GWRouterPrefix + assignmentNode1 + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name:  types.GWRouterPrefix + assignmentNode2,
-							UUID:  types.GWRouterPrefix + assignmentNode2 + "-UUID",
-							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Name:    types.GWRouterPrefix + assignmentNode2,
+							UUID:    types.GWRouterPrefix + assignmentNode2 + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
 							Name: types.OVNClusterRouter,
@@ -5755,7 +5967,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 				_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
 				egressIPServedPodsASv4, _ := buildEgressIPServedPodsAddressSets(nil, types.DefaultNetworkName, DefaultNetworkControllerName)
+				dynamicNeighRouters := "true"
+				if config.OVNKubernetesFeature.EnableInterconnect {
+					dynamicNeighRouters = "false"
+				}
 
+				logicalRouterOptions := map[string]string{
+					"dynamic_neigh_routers": dynamicNeighRouters,
+				}
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
@@ -5769,14 +5988,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								UUID: types.OVNClusterRouter + "-UUID",
 							},
 							&nbdb.LogicalRouter{
-								Name: types.GWRouterPrefix + node1Name,
-								UUID: types.GWRouterPrefix + node1Name + "-UUID",
+								Name:    types.GWRouterPrefix + node1Name,
+								UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node2Name,
-								UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-								Nat:   nil,
+								Name:    types.GWRouterPrefix + node2Name,
+								UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+								Nat:     nil,
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalSwitchPort{
 								UUID:      "k8s-" + node1Name + "-UUID",
@@ -5882,14 +6103,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					},
 					expectedNAT,
 					&nbdb.LogicalRouter{
-						Name: types.GWRouterPrefix + node1Name,
-						UUID: types.GWRouterPrefix + node1Name + "-UUID",
+						Name:    types.GWRouterPrefix + node1Name,
+						UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + node2Name,
-						UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-						Nat:   []string{"egressip-nat-UUID"},
+						Name:    types.GWRouterPrefix + node2Name,
+						UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+						Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+						Nat:     []string{"egressip-nat-UUID"},
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      "k8s-" + node1Name + "-UUID",
@@ -5978,14 +6201,16 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Networks: []string{node2LogicalRouterIfAddrV6},
 					},
 					&nbdb.LogicalRouter{
-						Name: types.GWRouterPrefix + node1Name,
-						UUID: types.GWRouterPrefix + node1Name + "-UUID",
+						Name:    types.GWRouterPrefix + node1Name,
+						UUID:    types.GWRouterPrefix + node1Name + "-UUID",
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + node2Name,
-						UUID:  types.GWRouterPrefix + node2Name + "-UUID",
-						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
-						Nat:   []string{},
+						Name:    types.GWRouterPrefix + node2Name,
+						UUID:    types.GWRouterPrefix + node2Name + "-UUID",
+						Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
+						Nat:     []string{},
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      "k8s-" + node1Name + "-UUID",
@@ -6078,6 +6303,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Name:  node2Name,
 					Ports: []string{"k8s-" + node2Name + "-UUID"},
 				}
+				dynamicNeighRouters := "true"
+				if config.OVNKubernetesFeature.EnableInterconnect {
+					dynamicNeighRouters = "false"
+				}
+
+				logicalRouterOptions := map[string]string{
+					"dynamic_neigh_routers": dynamicNeighRouters,
+				}
 				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
 						&nbdb.LogicalRouter{
@@ -6085,12 +6318,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							UUID: types.OVNClusterRouter + "-UUID",
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node1.Name,
-							UUID: types.GWRouterPrefix + node1.Name + "-UUID",
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node2.Name,
-							UUID: types.GWRouterPrefix + node2.Name + "-UUID",
+							Name:    types.GWRouterPrefix + node2.Name,
+							UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -6204,12 +6439,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					},
 					&nbdb.LogicalRouter{
-						Name: types.GWRouterPrefix + node1.Name,
-						UUID: types.GWRouterPrefix + node1.Name + "-UUID",
+						Name:    types.GWRouterPrefix + node1.Name,
+						UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalRouter{
-						Name: types.GWRouterPrefix + node2.Name,
-						UUID: types.GWRouterPrefix + node2.Name + "-UUID",
+						Name:    types.GWRouterPrefix + node2.Name,
+						UUID:    types.GWRouterPrefix + node2.Name + "-UUID",
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -6279,7 +6516,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", nodeIPv4),
 				}
 				node := getNodeObj("node", annotations, map[string]string{})
+				dynamicNeighRouters := "true"
+				if config.OVNKubernetesFeature.EnableInterconnect {
+					dynamicNeighRouters = "false"
+				}
 
+				logicalRouterOptions := map[string]string{
+					"dynamic_neigh_routers": dynamicNeighRouters,
+				}
 				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
 						&nbdb.LogicalRouter{
@@ -6287,8 +6531,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							UUID: types.OVNClusterRouter + "-UUID",
 						},
 						&nbdb.LogicalRouter{
-							Name: types.GWRouterPrefix + node.Name,
-							UUID: types.GWRouterPrefix + node.Name + "-UUID",
+							Name:    types.GWRouterPrefix + node.Name,
+							UUID:    types.GWRouterPrefix + node.Name + "-UUID",
+							Options: logicalRouterOptions,
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + nodeName + "UUID",
@@ -6380,8 +6625,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						ExternalIDs: getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					},
 					&nbdb.LogicalRouter{
-						Name: types.GWRouterPrefix + node.Name,
-						UUID: types.GWRouterPrefix + node.Name + "-UUID",
+						Name:    types.GWRouterPrefix + node.Name,
+						UUID:    types.GWRouterPrefix + node.Name + "-UUID",
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + nodeName + "UUID",
@@ -6468,7 +6714,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Name:  node1.Name,
 					Ports: []string{"k8s-" + node1.Name + "-UUID"},
 				}
+				dynamicNeighRouters := "true"
+				if config.OVNKubernetesFeature.EnableInterconnect {
+					dynamicNeighRouters = "false"
+				}
 
+				logicalRouterOptions := map[string]string{
+					"dynamic_neigh_routers": dynamicNeighRouters,
+				}
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
@@ -6477,9 +6730,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								UUID: types.OVNClusterRouter + "-UUID",
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node1.Name,
-								UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node1.Name,
+								UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouterPort{
 								UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -6591,10 +6845,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							"default-no-reroute-node-UUID", "default-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + node1.Name,
-						UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
-						Nat:   []string{"egressip-nat-UUID1"},
+						Name:    types.GWRouterPrefix + node1.Name,
+						UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+						Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+						Nat:     []string{"egressip-nat-UUID1"},
+						Options: logicalRouterOptions,
 					},
 					&nbdb.NAT{
 						UUID:        "egressip-nat-UUID1",
@@ -6699,10 +6954,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + node1.Name,
-						UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-						Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
-						Nat:   []string{},
+						Name:    types.GWRouterPrefix + node1.Name,
+						UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+						Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+						Nat:     []string{},
+						Options: logicalRouterOptions,
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
@@ -6813,7 +7069,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Name:  node1.Name,
 					Ports: []string{"k8s-" + node1.Name + "-UUID"},
 				}
+				dynamicNeighRouters := "true"
+				if config.OVNKubernetesFeature.EnableInterconnect {
+					dynamicNeighRouters = "false"
+				}
 
+				logicalRouterOptions := map[string]string{
+					"dynamic_neigh_routers": dynamicNeighRouters,
+				}
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
@@ -6822,9 +7085,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								UUID: types.OVNClusterRouter + "-UUID",
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + node1.Name,
-								UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-								Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Name:    types.GWRouterPrefix + node1.Name,
+								UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+								Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+								Options: logicalRouterOptions,
 							},
 							&nbdb.LogicalRouterPort{
 								UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -6903,10 +7167,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					UUID:        "reroute-UUID1",
 				}
 				node1GR := &nbdb.LogicalRouter{
-					Name:  types.GWRouterPrefix + node1.Name,
-					UUID:  types.GWRouterPrefix + node1.Name + "-UUID",
-					Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
-					Nat:   []string{"egressip-nat-UUID1"},
+					Name:    types.GWRouterPrefix + node1.Name,
+					UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+					Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+					Nat:     []string{"egressip-nat-UUID1"},
+					Options: logicalRouterOptions,
 				}
 				nodeSwitch.QOSRules = []string{"default-QoS-UUID"}
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -276,9 +276,14 @@ func (gw *GatewayManager) GatewayInit(
 		physicalIPs[i] = ip.IP.String()
 	}
 
+	dynamicNeighRouters := "true"
+	if config.OVNKubernetesFeature.EnableInterconnect {
+		dynamicNeighRouters = "false"
+	}
+
 	logicalRouterOptions := map[string]string{
 		"always_learn_from_arp_request": "false",
-		"dynamic_neigh_routers":         "true",
+		"dynamic_neigh_routers":         dynamicNeighRouters,
 		"chassis":                       l3GatewayConfig.ChassisID,
 		"lb_force_snat_ip":              "router_ip",
 		"mac_binding_age_threshold":     types.GRMACBindingAgeThreshold,

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -248,6 +248,11 @@ func generateGatewayInitExpectedNB(testData []libovsdbtest.TestData, expectedOVN
 	}
 	testData = append(testData, copp)
 
+	dynamicNeighRouters := "true"
+	if config.OVNKubernetesFeature.EnableInterconnect {
+		dynamicNeighRouters = "false"
+	}
+
 	testData = append(testData, &nbdb.LogicalRouter{
 		UUID: GRName + "-UUID",
 		Name: GRName,
@@ -255,7 +260,7 @@ func generateGatewayInitExpectedNB(testData []libovsdbtest.TestData, expectedOVN
 			"lb_force_snat_ip":              "router_ip",
 			"snat-ct-zone":                  "0",
 			"always_learn_from_arp_request": "false",
-			"dynamic_neigh_routers":         "true",
+			"dynamic_neigh_routers":         dynamicNeighRouters,
 			"chassis":                       l3GatewayConfig.ChassisID,
 			"mac_binding_age_threshold":     types.GRMACBindingAgeThreshold,
 		},
@@ -465,6 +470,13 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				LogicalPort: types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName,
 			}
 			GRName := "GR_" + nodeName
+
+			dynamicNeighRouters := "true"
+
+			if config.OVNKubernetesFeature.EnableInterconnect {
+				dynamicNeighRouters = "false"
+			}
+
 			expectedOVNGatewayRouter := &nbdb.LogicalRouter{
 				UUID: GRName + "-UUID",
 				Name: GRName,
@@ -472,7 +484,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					"lb_force_snat_ip":              "router_ip",
 					"snat-ct-zone":                  "0",
 					"always_learn_from_arp_request": "false",
-					"dynamic_neigh_routers":         "true",
+					"dynamic_neigh_routers":         dynamicNeighRouters,
 					"mac_binding_age_threshold":     types.GRMACBindingAgeThreshold,
 				},
 				StaticRoutes: []string{routeUUID},
@@ -573,6 +585,12 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				LogicalPort: types.GWRouterToExtSwitchPrefix + types.GWRouterPrefix + nodeName,
 			}
 			GRName := "GR_" + nodeName
+
+			dynamicNeighRouters := "true"
+			if config.OVNKubernetesFeature.EnableInterconnect {
+				dynamicNeighRouters = "false"
+			}
+
 			expectedOVNGatewayRouter := &nbdb.LogicalRouter{
 				UUID: GRName + "-UUID",
 				Name: GRName,
@@ -580,7 +598,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					"lb_force_snat_ip":              "router_ip",
 					"snat-ct-zone":                  "0",
 					"always_learn_from_arp_request": "false",
-					"dynamic_neigh_routers":         "true",
+					"dynamic_neigh_routers":         dynamicNeighRouters,
 					"mac_binding_age_threshold":     types.GRMACBindingAgeThreshold,
 				},
 				StaticRoutes: []string{routeUUID},

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -1015,12 +1015,18 @@ func gwRouterJoinIPAddress() *net.IPNet {
 }
 
 func gwRouterOptions(gwConfig util.L3GatewayConfig) map[string]string {
+
+	dynamicNeighRouters := "true"
+	if config.OVNKubernetesFeature.EnableInterconnect {
+		dynamicNeighRouters = "false"
+	}
+
 	return map[string]string{
 		"lb_force_snat_ip":              "router_ip",
 		"mac_binding_age_threshold":     "300",
 		"chassis":                       gwConfig.ChassisID,
 		"always_learn_from_arp_request": "false",
-		"dynamic_neigh_routers":         "true",
+		"dynamic_neigh_routers":         dynamicNeighRouters,
 	}
 }
 


### PR DESCRIPTION
In OVN Interconnect topology having dynamic_neigh_routers option on the gateway router will cause mac bindings to expire toward the join switch port. This change disables that option for IC.
