### PR TITLE
Fixes 1 minute delay for primary UDN controllers to start

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -589,6 +589,13 @@ func (bsnc *BaseSecondaryNetworkController) syncPodsForSecondaryNetwork(pods []i
 		if bsnc.IsPrimaryNetwork() {
 			activeNetwork, err = bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// namespace is gone after we listed this pod, that means the pod no longer exists
+					// we don't need to preserve it's previously allocated IP address or logical switch port
+					klog.Infof("%s network controller pod sync: pod %s/%s namespace has been deleted, ignoring pod",
+						bsnc.GetNetworkName(), pod.Namespace, pod.Name)
+					continue
+				}
 				return fmt.Errorf("failed looking for the active network at namespace '%s': %w", pod.Namespace, err)
 			}
 		}


### PR DESCRIPTION
In our add handler code we process existing items. A long time ago a retry loop was added to retry processing failed existing items. 

https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/factory/factory.go#L1308

However, during the retry we never re-list and get the existing items in the cluster. This retry will last up to a minute. This becomes a problem when for UDN, because now with UDN we spin up these controllers dynamically at runtime, not just at OVNK start up.

Therefore, failures in the sync can cause a potential delay of a minute to start a controller, potentially backing up other controllers waiting their turn to start.

As a more general fix, we should examine eliminating this retry loop. However, due to the risk of regression and uncovering some issue that the retry loop was actually circumventing, a more precise fix is needed.

In this particular failure case, a primary UDN controller tries to sync all pods by listing them in the cluster. In order for a primary UDN to determine if the pod belongs to it, it needs to call GetActiveNetworkForNamespace, which will try to list the namespace. If the namespace and pod have since been deleted, this action will fail, causing the retry loop to run for a minute before timing out.

To fix this specific issue...if the namespace does not exist, then there is no point in processing the pod, so ignore it.

Reported downstream: https://issues.redhat.com/browse/OCPBUGS-49727

