### PR TITLE
stop adding events to NAD if the network type is not ovn-k

### DIFF
--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -120,10 +120,6 @@ func parseNetConfSingle(bytes []byte) (*ovncnitypes.NetConf, error) {
 }
 
 func parseNetConfList(confList *libcni.NetworkConfigList) (*ovncnitypes.NetConf, error) {
-	if len(confList.Plugins) > 1 {
-		return nil, ErrorChainingNotSupported
-	}
-
 	netconf := &ovncnitypes.NetConf{MTU: Default.MTU}
 	if err := json.Unmarshal(confList.Plugins[0].Bytes, netconf); err != nil {
 		return nil, err
@@ -132,6 +128,10 @@ func parseNetConfList(confList *libcni.NetworkConfigList) (*ovncnitypes.NetConf,
 	// skip non-OVN NAD
 	if netconf.Type != "ovn-k8s-cni-overlay" {
 		return nil, ErrorAttachDefNotOvnManaged
+	}
+
+	if len(confList.Plugins) > 1 {
+		return nil, ErrorChainingNotSupported
 	}
 
 	netconf.Name = confList.Name

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -274,6 +274,11 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 	if nad != nil {
 		nadNetwork, err = util.ParseNADInfo(nad)
 		if err != nil {
+			// in case the type for the NAD is not ovn-k we should not record the error event
+			if err.Error() == util.ErrorAttachDefNotOvnManaged.Error() {
+				return nil
+			}
+
 			if c.recorder != nil {
 				c.recorder.Eventf(&corev1.ObjectReference{Kind: nad.Kind, Namespace: nad.Namespace, Name: nad.Name}, corev1.EventTypeWarning,
 					"InvalidConfig", "Failed to parse network config: %v", err.Error())

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -469,6 +469,21 @@ func TestNADController(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "non ovn-k NAD added",
+			args: []args{
+				{
+					nad: "test/nad_1",
+					network: &ovncnitypes.NetConf{
+						NetConf: cnitypes.NetConf{
+							Name: "test",
+							Type: "sriov",
+						},
+					},
+					wantErr: false,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1151,6 +1151,9 @@ func ParseNADInfo(nad *nettypes.NetworkAttachmentDefinition) (NetInfo, error) {
 func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnitypes.NetConf, error) {
 	netconf, err := config.ParseNetConf([]byte(netattachdef.Spec.Config))
 	if err != nil {
+		if err.Error() == ErrorAttachDefNotOvnManaged.Error() {
+			return nil, err
+		}
 		return nil, fmt.Errorf("error parsing Network Attachment Definition %s/%s: %v", netattachdef.Namespace, netattachdef.Name, err)
 	}
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -180,7 +180,7 @@ func TestParseNetconf(t *testing.T) {
             "netAttachDefName": "default/tenantred"
     }
 `,
-			expectedError: fmt.Errorf("error parsing Network Attachment Definition ns1/nad1: net-attach-def not managed by OVN"),
+			expectedError: fmt.Errorf("net-attach-def not managed by OVN"),
 		},
 		{
 			desc: "attachment definition with IPAM key defined, using a wrong type",
@@ -1153,6 +1153,16 @@ func TestSubnetOverlapCheck(t *testing.T) {
                     "netAttachDefName": "ns1/nad1"
                 }
 			`,
+		},
+		{
+			desc: "return error when the network is not ovnk",
+			inputNetAttachDefConfigSpec: `
+                {
+                    "name": "test",
+                    "type": "sriov-cni"
+                }
+			`,
+			expectedError: ErrorAttachDefNotOvnManaged,
 		},
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

If NADs like bridge,macvlan or others exist we should not record an error event for it

Also in case the NAD is not ovn-k for example multus we support chain plugins.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
