### PR TITLE
factory/handler: avoid deadlock on shutdown.

### DIFF
--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -430,12 +430,12 @@ func (i *informer) newFederatedQueuedHandler(internalInformerIndex int) cache.Re
 func (inf *informer) removeAllHandlers() {
 	for _, intInf := range inf.internalInformers {
 		intInf.Lock()
-		defer intInf.Unlock()
 		for _, handlers := range intInf.handlers {
 			for _, handler := range handlers {
 				inf.removeHandler(handler)
 			}
 		}
+		intInf.Unlock()
 	}
 }
 


### PR DESCRIPTION
Calling unlock in defer will only be executed before return, thus holding all informer locks at the same time.

e.g. if you try to execute Shutdown from 2 threads in parallel, and informers are not iterated in the same order, you get a deadlock.

```
thread1

for inf := [inf1, inf2]
  inf.Lock() // locks inf1
```

```
thread2

for inf := [inf2, inf1]
  inf.Lock() //locks inf2
```