### PR TITLE
change slack url to point to the cloud-native workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We welcome many different types of contributions including:
 * Release management
 
 Not everything happens through a GitHub pull request. Please come to our
-[meetings](./MEETINGS.md) or [contact us](https://ovn-org.slack.com/archives/C010SQ5FSNL) and let's discuss how we can work
+[meetings](./MEETINGS.md) or [contact us](https://cloud-native.slack.com/archives/C08452HR8V6) and let's discuss how we can work
 together. 
 
 ### Come to Meetings
@@ -60,7 +60,7 @@ your first pull request.
 
 Sometimes there won’t be any issues with these labels. That’s ok! There is
 likely still something for you to work on. If you want to contribute but you
-don’t know where to start or can't find a suitable issue, you can you can reach out to us on [Slack](https://ovn-org.slack.com/) and we will be happy to help.
+don’t know where to start or can't find a suitable issue, you can reach out to us on [Slack](https://cloud-native.slack.com/archives/C08452HR8V6) and we will be happy to help.
 
 Once you see an issue that you'd like to work on, please post a comment saying
 that you want to work on it. Something like "I want to work on this" is fine.
@@ -71,7 +71,7 @@ The best way to reach us with a question when contributing is to ask on:
 
 * The original github issue
 * The developer mailing list (mailing-list: https://groups.google.com/g/ovn-kubernetes)
-* Our Slack channel (workspace: https://ovn-org.slack.com/, channel: #ovn-kubernetes)
+* Our Slack channel (workspace: https://cloud-native.slack.com/, channel: #ovn-kubernetes)
 
 ## Pull Request Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [go-doc-badge]: https://pkg.go.dev/badge/github.com/ovn-org/ovn-kubernetes
 [go-doc-url]: https://pkg.go.dev/github.com/ovn-org/ovn-kubernetes
 [slack-badge]: https://img.shields.io/badge/slack-ovn_kubernetes-blue
-[slack-url]: https://ovn-org.slack.com/
+[slack-url]: https://cloud-native.slack.com/archives/C08452HR8V6
 
 ## Welcome to ovn-kubernetes
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -23,7 +23,7 @@ Avoid burnout by enforcing healthy boundaries. Here are some examples of how a r
 * Authors should meet baseline expectations when submitting a pull request, such as writing tests and relevant documentation.
 * If your availability changes, you can step down from a pull request and have someone else assigned.
 * If interactions with an author are not following code of conduct, raise it up with your Code of Conduct committee or point of contact. It's not your job to coax people into behaving.
-  * The code of conduct committee for this project is the same as the maintainers list for this project. The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). If you face any issues please reach out to one of the maintainers on our slack channel (workspace: https://ovn-org.slack.com/, channel: #ovn-kubernetes)
+  * The code of conduct committee for this project is the same as the maintainers list for this project. The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). If you face any issues please reach out to one of the maintainers on our slack channel (workspace: https://cloud-native.slack.com/, channel: #ovn-kubernetes)
 
 ### Trust
 

--- a/docs/governance/CONTRIBUTING.md
+++ b/docs/governance/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We welcome many different types of contributions including:
 * Release management
 
 Not everything happens through a GitHub pull request. Please come to our
-[meetings](./MEETINGS.md) or [contact us](https://ovn-org.slack.com/archives/C010SQ5FSNL) and let's discuss how we can work
+[meetings](./MEETINGS.md) or [contact us](https://cloud-native.slack.com/archives/C08452HR8V6) and let's discuss how we can work
 together. 
 
 ### Come to Meetings
@@ -60,7 +60,7 @@ your first pull request.
 
 Sometimes there won’t be any issues with these labels. That’s ok! There is
 likely still something for you to work on. If you want to contribute but you
-don’t know where to start or can't find a suitable issue, you can you can reach out to us on [Slack](https://ovn-org.slack.com/) and we will be happy to help.
+don’t know where to start or can't find a suitable issue, you can reach out to us on [Slack](https://cloud-native.slack.com/archives/C08452HR8V6) and we will be happy to help.
 
 Once you see an issue that you'd like to work on, please post a comment saying
 that you want to work on it. Something like "I want to work on this" is fine.
@@ -71,7 +71,7 @@ The best way to reach us with a question when contributing is to ask on:
 
 * The original github issue
 * The developer mailing list (mailing-list: https://groups.google.com/g/ovn-kubernetes)
-* Our Slack channel (workspace: https://ovn-org.slack.com/, channel: #ovn-kubernetes)
+* Our Slack channel (workspace: https://cloud-native.slack.com/, channel: #ovn-kubernetes)
 
 ## Pull Request Lifecycle
 

--- a/docs/governance/REVIEWING.md
+++ b/docs/governance/REVIEWING.md
@@ -23,8 +23,8 @@ Avoid burnout by enforcing healthy boundaries. Here are some examples of how a r
 * Authors should meet baseline expectations when submitting a pull request, such as writing tests and relevant documentation.
 * If your availability changes, you can step down from a pull request and have someone else assigned.
 * If interactions with an author are not following code of conduct, raise it up with your Code of Conduct committee or point of contact. It's not your job to coax people into behaving.
-  * The code of conduct committee for this project is the same as the maintainers list for this project. The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). If you face any issues please reach out to one of the maintainers on our slack channel (workspace: https://ovn-org.slack.com/, channel: #ovn-kubernetes)
-
+  * The code of conduct committee for this project is the same as the maintainers list for this project. The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). If you face any issues please reach out to one of the maintainers on our slack channel (workspace: https://cloud-native.slack.com/, channel: #ovn-kubernetes)
+cnc
 ### Trust
 
 Be trustworthy. During a review, your actions both build and help maintain the trust that the community has placed in this project. Below are examples of ways that we build trust:


### PR DESCRIPTION
Currently all our documentation is pointing to an archived slack workspace and channel. We need to move it to the new slack_url: https://cloud-native.slack.com/archives/C08452HR8V6 
