### PR TITLE
Ensure UDN peer namespace address sets added on the gress policy ACL

### DIFF
--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -76,6 +76,10 @@ func (h *Handler) OnDelete(obj interface{}) {
 	}
 }
 
+func (h *Handler) FilterFunc(obj interface{}) bool {
+	return h.base.FilterFunc(obj)
+}
+
 func (h *Handler) kill() bool {
 	return atomic.CompareAndSwapUint32(&h.tombstone, handlerAlive, handlerDead)
 }

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -260,6 +260,10 @@ func (oc *BaseNetworkController) doReconcile(reconcileRoutes, reconcilePendingPo
 		}
 	}
 
+	// reconciles namespaces that were added to the network, this will trigger namespace add event and
+	// network controller creates the address set for the namespace.
+	// To update gress policy ACLs with peer namespace address set, invoke requeuePeerNamespace method after
+	// address set is created for the namespace.
 	namespaceAdded := false
 	for _, ns := range reconcileNamespaces {
 		namespace, err := oc.watchFactory.GetNamespace(ns)
@@ -276,11 +280,6 @@ func (oc *BaseNetworkController) doReconcile(reconcileRoutes, reconcilePendingPo
 	}
 	if namespaceAdded {
 		oc.retryNamespaces.RequestRetryObjs()
-	}
-
-	err := oc.requeuePeerNamespaces(reconcileNamespaces)
-	if err != nil {
-		klog.Infof("Failed to retry network policy peer namespaces for network %s: %v", oc.GetNetworkName(), err)
 	}
 }
 

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -191,8 +191,7 @@ type BaseNetworkController struct {
 
 func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed func(string)) error {
 	// gather some information first
-	var err error
-	var retryNodes []*corev1.Node
+	var reconcileNodes []string
 	oc.localZoneNodes.Range(func(key, _ any) bool {
 		nodeName := key.(string)
 		wasAdvertised := util.IsPodNetworkAdvertisedAtNode(oc, nodeName)
@@ -201,41 +200,57 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 			// noop
 			return true
 		}
-		var node *corev1.Node
-		node, err = oc.watchFactory.GetNode(nodeName)
-		if err != nil {
-			return false
-		}
-		retryNodes = append(retryNodes, node)
+		reconcileNodes = append(reconcileNodes, nodeName)
 		return true
 	})
-	if err != nil {
-		return fmt.Errorf("failed to reconcile network %s: %w", oc.GetNetworkName(), err)
-	}
 	reconcileRoutes := oc.routeImportManager != nil && oc.routeImportManager.NeedsReconciliation(netInfo)
 	reconcilePendingPods := !oc.IsDefault() && !oc.ReconcilableNetInfo.EqualNADs(netInfo.GetNADs()...)
+	reconcileNamespaces := sets.NewString()
+	if oc.IsPrimaryNetwork() {
+		// since CanServeNamespace filters out namespace events for namespaces unknown
+		// to be served by this primary network, we need to reconcile namespaces once
+		// the network is reconfigured to serve a namespace.
+		reconcileNamespaces = sets.NewString(netInfo.GetNADNamespaces()...).Difference(
+			sets.NewString(oc.GetNADNamespaces()...))
+	}
 
 	// set the new NetInfo, point of no return
-	err = util.ReconcileNetInfo(oc.ReconcilableNetInfo, netInfo)
+	err := util.ReconcileNetInfo(oc.ReconcilableNetInfo, netInfo)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile network information for network %s: %v", oc.GetNetworkName(), err)
 	}
 
+	oc.doReconcile(reconcileRoutes, reconcilePendingPods, reconcileNodes, setNodeFailed, reconcileNamespaces.List())
+
+	return nil
+}
+
+// doReconcile performs the reconciliation after the controller NetInfo has already being
+// updated with the changes. What needs to be reconciled should already be known and
+// provided on the arguments of the method. This method returns no error and logs them
+// instead since once the controller NetInfo has been updated there is no point in retrying.
+func (oc *BaseNetworkController) doReconcile(reconcileRoutes, reconcilePendingPods bool,
+	reconcileNodes []string, setNodeFailed func(string), reconcileNamespaces []string) {
 	if reconcileRoutes {
-		err = oc.routeImportManager.ReconcileNetwork(oc.GetNetworkName())
+		err := oc.routeImportManager.ReconcileNetwork(oc.GetNetworkName())
 		if err != nil {
 			klog.Errorf("Failed to reconcile network %s on route import controller: %v", oc.GetNetworkName(), err)
 		}
 	}
 
-	for _, node := range retryNodes {
-		setNodeFailed(node.Name)
+	for _, nodeName := range reconcileNodes {
+		setNodeFailed(nodeName)
+		node, err := oc.watchFactory.GetNode(nodeName)
+		if err != nil {
+			klog.Infof("Failed to get node %s for reconciling network %s: %v", nodeName, oc.GetNetworkName(), err)
+			continue
+		}
 		err = oc.retryNodes.AddRetryObjWithAddNoBackoff(node)
 		if err != nil {
-			klog.Errorf("Failed to retry node %s for network %s: %v", node.Name, oc.GetNetworkName(), err)
+			klog.Errorf("Failed to retry node %s for network %s: %v", nodeName, oc.GetNetworkName(), err)
 		}
 	}
-	if len(retryNodes) > 0 {
+	if len(reconcileNodes) > 0 {
 		oc.retryNodes.RequestRetryObjs()
 	}
 
@@ -245,7 +260,28 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 		}
 	}
 
-	return nil
+	namespaceAdded := false
+	for _, ns := range reconcileNamespaces {
+		namespace, err := oc.watchFactory.GetNamespace(ns)
+		if err != nil {
+			klog.Infof("Failed to get namespace %s for reconciling network %s: %v", ns, oc.GetNetworkName(), err)
+			continue
+		}
+		err = oc.retryNamespaces.AddRetryObjWithAddNoBackoff(namespace)
+		if err != nil {
+			klog.Infof("Failed to retry namespace %s for network %s: %v", ns, oc.GetNetworkName(), err)
+			continue
+		}
+		namespaceAdded = true
+	}
+	if namespaceAdded {
+		oc.retryNamespaces.RequestRetryObjs()
+	}
+
+	err := oc.requeuePeerNamespaces(reconcileNamespaces)
+	if err != nil {
+		klog.Infof("Failed to retry network policy peer namespaces for network %s: %v", oc.GetNetworkName(), err)
+	}
 }
 
 // BaseSecondaryNetworkController structure holds per-network fields and network specific

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -679,7 +679,15 @@ func (bsnc *BaseSecondaryNetworkController) AddNamespaceForSecondaryNetwork(ns *
 	if err != nil {
 		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
-	defer nsUnlock()
+	nsUnlock()
+	// Enqueue the UDN namespace into network policy controller if it needs to be
+	// processed by network policy peer namespace handlers.
+	if bsnc.IsPrimaryNetwork() {
+		err = bsnc.requeuePeerNamespace(ns)
+		if err != nil {
+			return fmt.Errorf("failed to requeue peer namespace %s: %v", ns.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -209,6 +209,10 @@ func (gp *gressPolicy) addNamespaceAddressSet(name string, asf addressset.Addres
 		return false, fmt.Errorf("cannot add peer namespace %s: failed to get address set: %v", name, err)
 	}
 	v4HashName, v6HashName := as.GetASHashNames()
+	if v4HashName == "" && v6HashName == "" {
+		// This would happen when a namespace is not yet reconciled with UDN network.
+		return false, fmt.Errorf("cannot add peer namespace %s: address set has empty hashed name", name)
+	}
 	v4HashName = "$" + v4HashName
 	v6HashName = "$" + v6HashName
 
@@ -234,6 +238,9 @@ func (gp *gressPolicy) addNamespaceAddressSet(name string, asf addressset.Addres
 func (gp *gressPolicy) delNamespaceAddressSet(name string) bool {
 	dbIDs := getNamespaceAddrSetDbIDs(name, gp.controllerName)
 	v4HashName, v6HashName := addressset.GetHashNamesForAS(dbIDs)
+	if v4HashName == "" && v6HashName == "" {
+		return false
+	}
 	v4HashName = "$" + v4HashName
 	v6HashName = "$" + v6HashName
 

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -298,6 +298,8 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					return updatedPod.Status.Phase
 				}, 1*time.Minute, 6*time.Second).Should(gomega.Equal(v1.PodPending))
 
+				// The pod won't run and the namespace address set won't be created until the NAD for the network is added
+				// to the namespace and we test here that once that happens the policy is reconciled to account for it.
 				ginkgo.By("creating NAD for red and orange namespaces and check pod moves into running state")
 				for _, namespace := range []string{namespaceRed, namespaceOrange} {
 					ginkgo.By("creating the attachment configuration for " + netConfName + " in namespace " + namespace)

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -35,6 +35,8 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 			randomStringLength           = 5
 			nameSpaceYellowSuffix        = "yellow"
 			namespaceBlueSuffix          = "blue"
+			namespaceRedSuffix           = "red"
+			namespaceOrangeSuffix        = "orange"
 		)
 
 		var (
@@ -57,7 +59,10 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 
 			namespaceYellow := getNamespaceName(f, nameSpaceYellowSuffix)
 			namespaceBlue := getNamespaceName(f, namespaceBlueSuffix)
-			for _, namespace := range []string{namespaceYellow, namespaceBlue} {
+			namespaceRed := getNamespaceName(f, namespaceRedSuffix)
+			namespaceOrange := getNamespaceName(f, namespaceOrangeSuffix)
+			for _, namespace := range []string{namespaceYellow, namespaceBlue,
+				namespaceRed, namespaceOrange} {
 				ginkgo.By("Creating namespace " + namespace)
 				ns, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
@@ -180,11 +185,13 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 
 				namespaceYellow := getNamespaceName(f, nameSpaceYellowSuffix)
 				namespaceBlue := getNamespaceName(f, namespaceBlueSuffix)
+				namespaceRed := getNamespaceName(f, namespaceRedSuffix)
+				namespaceOrange := getNamespaceName(f, namespaceOrangeSuffix)
 
 				nad := networkAttachmentConfigParams{
 					topology: topology,
 					cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
-					// Both yellow and blue namespaces are going to served by green network.
+					// The yellow, blue and red namespaces are going to served by green network.
 					// Use random suffix for the network name to avoid race between tests.
 					networkName: fmt.Sprintf("%s-%s", "green", rand.String(randomStringLength)),
 					role:        "primary",
@@ -258,8 +265,8 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
 				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 
-				ginkgo.By("creating a \"allow-traffic-to-pod\" network policy")
-				_, err = allowTrafficToPodFromNamespacePolicy(f, namespaceYellow, namespaceBlue, "allow-traffic-to-pod", allowServerPodLabel)
+				ginkgo.By("creating a \"allow-traffic-to-pod\" network policy for blue and red namespace")
+				_, err = allowTrafficToPodFromNamespacePolicy(f, namespaceYellow, namespaceBlue, namespaceRed, "allow-traffic-to-pod", allowServerPodLabel)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("asserting the *client* pod can contact the allow server pod exposed endpoint")
@@ -272,6 +279,72 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
 				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 
+				// Create client pod in red namespace and check network policy is working.
+				ginkgo.By("creating client pod in red namespace and check if it is in pending state until NAD is created")
+				clientPodConfig.namespace = namespaceRed
+				podSpec := generatePodSpec(clientPodConfig)
+				_, err = cs.CoreV1().Pods(clientPodConfig.namespace).Create(
+					context.Background(),
+					podSpec,
+					metav1.CreateOptions{},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Consistently(func() v1.PodPhase {
+					updatedPod, err := cs.CoreV1().Pods(clientPodConfig.namespace).Get(context.Background(),
+						clientPodConfig.name, metav1.GetOptions{})
+					if err != nil {
+						return v1.PodFailed
+					}
+					return updatedPod.Status.Phase
+				}, 1*time.Minute, 6*time.Second).Should(gomega.Equal(v1.PodPending))
+
+				ginkgo.By("creating NAD for red and orange namespaces and check pod moves into running state")
+				for _, namespace := range []string{namespaceRed, namespaceOrange} {
+					ginkgo.By("creating the attachment configuration for " + netConfName + " in namespace " + namespace)
+					netConfig := newNetworkAttachmentConfig(nad)
+					netConfig.namespace = namespace
+					netConfig.name = netConfName
+
+					_, err := nadClient.NetworkAttachmentDefinitions(namespace).Create(
+						context.Background(),
+						generateNAD(netConfig),
+						metav1.CreateOptions{},
+					)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+				gomega.Eventually(func() v1.PodPhase {
+					updatedPod, err := cs.CoreV1().Pods(clientPodConfig.namespace).Get(context.Background(),
+						clientPodConfig.name, metav1.GetOptions{})
+					if err != nil {
+						return v1.PodFailed
+					}
+					return updatedPod.Status.Phase
+				}, 1*time.Minute, 6*time.Second).Should(gomega.Equal(v1.PodRunning))
+
+				ginkgo.By("asserting the *red client* pod can contact the allow server pod exposed endpoint")
+				gomega.Eventually(func() error {
+					return reachServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
+				}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+
+				ginkgo.By("asserting the *red client* pod can not contact deny server pod exposed endpoint")
+				gomega.Eventually(func() error {
+					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
+				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+
+				// Create client pod in orange namespace now and check network policy is working.
+				ginkgo.By("creating client pod in orange namespace")
+				clientPodConfig.namespace = namespaceOrange
+				runUDNPod(cs, namespaceOrange, clientPodConfig, nil)
+
+				ginkgo.By("asserting the *orange client* pod can not contact the allow server pod exposed endpoint")
+				gomega.Eventually(func() error {
+					return reachServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
+				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+
+				ginkgo.By("asserting the *orange client* pod can not contact deny server pod exposed endpoint")
+				gomega.Eventually(func() error {
+					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
+				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 			},
 			ginkgo.Entry(
 				"in L2 primary UDN",
@@ -328,7 +401,7 @@ func getNamespaceName(f *framework.Framework, nsSuffix string) string {
 	return fmt.Sprintf("%s-%s", f.Namespace.Name, nsSuffix)
 }
 
-func allowTrafficToPodFromNamespacePolicy(f *framework.Framework, namespace, fromNamespace, policyName string, podLabel map[string]string) (*knet.NetworkPolicy, error) {
+func allowTrafficToPodFromNamespacePolicy(f *framework.Framework, namespace, fromNamespace1, fromNamespace2, policyName string, podLabel map[string]string) (*knet.NetworkPolicy, error) {
 	policy := &knet.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: policyName,
@@ -337,7 +410,8 @@ func allowTrafficToPodFromNamespacePolicy(f *framework.Framework, namespace, fro
 			PodSelector: metav1.LabelSelector{MatchLabels: podLabel},
 			PolicyTypes: []knet.PolicyType{knet.PolicyTypeIngress},
 			Ingress: []knet.NetworkPolicyIngressRule{{From: []knet.NetworkPolicyPeer{
-				{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": fromNamespace}}}}}},
+				{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": fromNamespace1}}},
+				{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": fromNamespace2}}}}}},
 		},
 	}
 	return f.ClientSet.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})


### PR DESCRIPTION
The network policy controller previously added address sets for both default and UDN networks though target namespace is managed by primary UDN. With [PR](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4861) as an optimization, Address Set for default network is no longer available for UDN networked peer namespace, so needed to add a check while creating and deleting ACL for gress policy to skip empty hash when trying to query for AS for such peer namespace on default network (or it is being avoided with network check before updating ACL). Anyway this PR has checks for both.

The network policy controller used to populate corresponding peer UDN namespace address sets in its ACL which were always there for existing namespace because secondary network controllers created those address sets for the network beforehand though it can be associated with a different network later on. But this is no longer the case for UDN with [PR](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4861), it has an address set created only for the first namespace associated with the network, for the remaining namespaces belonging to the same network address set creation happens only at the time the first pod is created on it. Hence this PR hooks up peer namespace into gress ACL while setting up a network for a pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded network segmentation policy tests to include additional namespaces and more comprehensive connectivity scenarios.

* **Bug Fixes**
  * Improved validation in network policy address set management to prevent operations with incomplete or invalid namespace information.

* **Refactor**
  * Enhanced error handling and modularized reconciliation logic for network controllers, improving reliability and maintainability.
  * Refactored peer namespace handling in network policies to use retry frameworks for more robust reconciliation.
  * Updated namespace handling to support immediate requeueing for network policy processing in primary networks.

* **Tests**
  * Added new test cases covering more namespaces and network policy behaviors to ensure correct isolation and traffic allowance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->