### PR TITLE
[UDN: host isolation] check that node uses cgroup v2.

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/metallb/frr-k8s v0.0.15
 	github.com/miekg/dns v1.1.31
 	github.com/mitchellh/copystructure v1.2.0
+	github.com/moby/sys/userns v0.1.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift/api v0.0.0-20231120222239-b86761094ee3

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -581,6 +581,8 @@ github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVO
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
+github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
+github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -146,7 +146,7 @@ func newDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, sto
 	}
 	if util.IsNetworkSegmentationSupportEnabled() && !config.OVNKubernetesFeature.DisableUDNHostIsolation {
 		c.udnHostIsolationManager = NewUDNHostIsolationManager(config.IPv4Mode, config.IPv6Mode,
-			cnnci.watchFactory.PodCoreInformer())
+			cnnci.watchFactory.PodCoreInformer(), cnnci.name, cnnci.recorder)
 	}
 	c.linkManager = linkmanager.NewController(cnnci.name, config.IPv4Mode, config.IPv6Mode, c.updateGatewayMAC)
 	return c

--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -10,9 +10,12 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/moby/sys/userns"
+	"golang.org/x/sys/unix"
 
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,8 +24,10 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/controller"
@@ -52,6 +57,8 @@ type UDNHostIsolationManager struct {
 	podController     controller.Controller
 	podLister         corelisters.PodLister
 	kubeletCgroupPath string
+	nodeName          string
+	recorder          record.EventRecorder
 
 	udnPodIPsv4 *nftPodElementsSet
 	udnPodIPsv6 *nftPodElementsSet
@@ -63,11 +70,13 @@ type UDNHostIsolationManager struct {
 	udnOpenPortsICMPv6 *nftPodElementsSet
 }
 
-func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodInformer) *UDNHostIsolationManager {
+func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodInformer, nodeName string, recorder record.EventRecorder) *UDNHostIsolationManager {
 	m := &UDNHostIsolationManager{
 		podLister:          podInformer.Lister(),
 		ipv4:               ipv4,
 		ipv6:               ipv6,
+		nodeName:           nodeName,
+		recorder:           recorder,
 		udnPodIPsv4:        newNFTPodElementsSet(nftablesUDNPodIPsv4, false),
 		udnPodIPsv6:        newNFTPodElementsSet(nftablesUDNPodIPsv6, false),
 		udnOpenPortsv4:     newNFTPodElementsSet(nftablesUDNOpenPortsv4, true),
@@ -90,22 +99,34 @@ func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodIn
 // Start must be called on node setup.
 func (m *UDNHostIsolationManager) Start(ctx context.Context) error {
 	klog.Infof("Starting UDN host isolation manager")
-	// find kubelet cgroup path.
-	// kind cluster uses "kubelet.slice/kubelet.service", while OCP cluster uses "system.slice/kubelet.service".
-	// as long as ovn-k node is running as a privileged container, we can access the host cgroup directory.
-	err := filepath.WalkDir("/sys/fs/cgroup", func(path string, d os.DirEntry, err error) error {
-		if err != nil {
+	if hostUsesCgroupv2() {
+		// find kubelet cgroup path.
+		// kind cluster uses "kubelet.slice/kubelet.service", while OCP cluster uses "system.slice/kubelet.service".
+		// as long as ovn-k node is running as a privileged container, we can access the host cgroup directory.
+		err := filepath.WalkDir("/sys/fs/cgroup", func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.Name() == "kubelet.service" {
+				m.kubeletCgroupPath = strings.TrimPrefix(path, "/sys/fs/cgroup/")
+				klog.Infof("Found kubelet cgroup path: %s", m.kubeletCgroupPath)
+				return filepath.SkipAll
+			}
 			return nil
+		})
+		if err != nil || m.kubeletCgroupPath == "" {
+			return fmt.Errorf("failed to find kubelet cgroup path: %w", err)
 		}
-		if d.Name() == "kubelet.service" {
-			m.kubeletCgroupPath = strings.TrimPrefix(path, "/sys/fs/cgroup/")
-			klog.Infof("Found kubelet cgroup path: %s", m.kubeletCgroupPath)
-			return filepath.SkipAll
+	} else {
+		// We can't use cgroup v2 match, so m.kubeletCgroupPath will be empty.
+		// As a side effect, all kubelet probes will fail, but host isolation will still work.
+		message := fmt.Sprintf("Kubelet probes for UDN are not supported on the node %s as it uses cgroup v1.", m.nodeName)
+		klog.Warning(message)
+		nodeRef := &kapi.ObjectReference{
+			Kind: "Node",
+			Name: m.nodeName,
 		}
-		return nil
-	})
-	if err != nil || m.kubeletCgroupPath == "" {
-		return fmt.Errorf("failed to find kubelet cgroup path: %w", err)
+		m.recorder.Eventf(nodeRef, kapi.EventTypeWarning, "UDNKubeletProbesNotSupported", message)
 	}
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
@@ -231,12 +252,15 @@ func (m *UDNHostIsolationManager) addRules(tx *knftables.Transaction) {
 			),
 		})
 
-		tx.Add(&knftables.Rule{
-			Chain: UDNIsolationChain,
-			Rule: knftables.Concat(
-				"socket", "cgroupv2", "level 2", m.kubeletCgroupPath,
-				"ip", "daddr", "@", nftablesUDNPodIPsv4, "accept"),
-		})
+		if m.kubeletCgroupPath != "" {
+			tx.Add(&knftables.Rule{
+				Chain: UDNIsolationChain,
+				Rule: knftables.Concat(
+					"socket", "cgroupv2", "level 2", m.kubeletCgroupPath,
+					"ip", "daddr", "@", nftablesUDNPodIPsv4, "accept"),
+			})
+		}
+
 		tx.Add(&knftables.Rule{
 			Chain: UDNIsolationChain,
 			Rule: knftables.Concat(
@@ -258,12 +282,14 @@ func (m *UDNHostIsolationManager) addRules(tx *knftables.Transaction) {
 				"accept",
 			),
 		})
-		tx.Add(&knftables.Rule{
-			Chain: UDNIsolationChain,
-			Rule: knftables.Concat(
-				"socket", "cgroupv2", "level 2", m.kubeletCgroupPath,
-				"ip6", "daddr", "@", nftablesUDNPodIPsv6, "accept"),
-		})
+		if m.kubeletCgroupPath != "" {
+			tx.Add(&knftables.Rule{
+				Chain: UDNIsolationChain,
+				Rule: knftables.Concat(
+					"socket", "cgroupv2", "level 2", m.kubeletCgroupPath,
+					"ip6", "daddr", "@", nftablesUDNPodIPsv6, "accept"),
+			})
+		}
 		tx.Add(&knftables.Rule{
 			Chain: UDNIsolationChain,
 			Rule: knftables.Concat(
@@ -708,4 +734,37 @@ func joinNFTSlice(k []string) string {
 // splitNFTSlice converts nftElementStorage key or value string representation back to slice.
 func splitNFTSlice(k string) []string {
 	return strings.Split(k, " . ")
+}
+
+// hostUsesCgroupv2 returns true if host is using cgroup v2, which means we can match on kubelet cgroup path.
+// For cgroup v1, kubelet rule will be broken, but host isolation will stay.
+func hostUsesCgroupv2() bool {
+	return IsCgroup2UnifiedMode()
+}
+
+var (
+	isUnifiedOnce sync.Once
+	isUnified     bool
+)
+
+const (
+	unifiedMountpoint = "/sys/fs/cgroup"
+)
+
+// this function is copied from github.com/opencontainers/runc/libcontainer/cgroups to avoid extra dependencies.
+func IsCgroup2UnifiedMode() bool {
+	isUnifiedOnce.Do(func() {
+		var st unix.Statfs_t
+		err := unix.Statfs(unifiedMountpoint, &st)
+		if err != nil {
+			if os.IsNotExist(err) && userns.RunningInUserNS() {
+				// ignore the "not found" error if running in userns
+				isUnified = false
+				return
+			}
+			panic(fmt.Sprintf("cannot statfs cgroup root: %s", err))
+		}
+		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
+	})
+	return isUnified
 }

--- a/go-controller/pkg/node/udn_isolation_test.go
+++ b/go-controller/pkg/node/udn_isolation_test.go
@@ -279,7 +279,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		wf, err = factory.NewNodeWatchFactory(fakeClient, "node1")
 		Expect(err).NotTo(HaveOccurred())
 
-		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer())
+		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil)
 
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -335,7 +335,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		var err error
 		wf, err = factory.NewNodeWatchFactory(fakeClient, "node1")
 		Expect(err).NotTo(HaveOccurred())
-		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer())
+		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil)
 		nft = nodenft.SetFakeNFTablesHelper()
 		manager.nft = nft
 

--- a/go-controller/vendor/github.com/moby/sys/userns/LICENSE
+++ b/go-controller/vendor/github.com/moby/sys/userns/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go-controller/vendor/github.com/moby/sys/userns/userns.go
+++ b/go-controller/vendor/github.com/moby/sys/userns/userns.go
@@ -1,0 +1,16 @@
+// Package userns provides utilities to detect whether we are currently running
+// in a Linux user namespace.
+//
+// This code was migrated from [libcontainer/runc], which based its implementation
+// on code from [lcx/incus].
+//
+// [libcontainer/runc]: https://github.com/opencontainers/runc/blob/3778ae603c706494fd1e2c2faf83b406e38d687d/libcontainer/userns/userns_linux.go#L12-L49
+// [lcx/incus]: https://github.com/lxc/incus/blob/e45085dd42f826b3c8c3228e9733c0b6f998eafe/shared/util.go#L678-L700
+package userns
+
+// RunningInUserNS detects whether we are currently running in a Linux
+// user namespace and memoizes the result. It returns false on non-Linux
+// platforms.
+func RunningInUserNS() bool {
+	return inUserNS()
+}

--- a/go-controller/vendor/github.com/moby/sys/userns/userns_linux.go
+++ b/go-controller/vendor/github.com/moby/sys/userns/userns_linux.go
@@ -1,0 +1,53 @@
+package userns
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sync"
+)
+
+var inUserNS = sync.OnceValue(runningInUserNS)
+
+// runningInUserNS detects whether we are currently running in a user namespace.
+//
+// This code was migrated from [libcontainer/runc] and based on an implementation
+// from [lcx/incus].
+//
+// [libcontainer/runc]: https://github.com/opencontainers/runc/blob/3778ae603c706494fd1e2c2faf83b406e38d687d/libcontainer/userns/userns_linux.go#L12-L49
+// [lcx/incus]: https://github.com/lxc/incus/blob/e45085dd42f826b3c8c3228e9733c0b6f998eafe/shared/util.go#L678-L700
+func runningInUserNS() bool {
+	file, err := os.Open("/proc/self/uid_map")
+	if err != nil {
+		// This kernel-provided file only exists if user namespaces are supported.
+		return false
+	}
+	defer file.Close()
+
+	buf := bufio.NewReader(file)
+	l, _, err := buf.ReadLine()
+	if err != nil {
+		return false
+	}
+
+	return uidMapInUserNS(string(l))
+}
+
+func uidMapInUserNS(uidMap string) bool {
+	if uidMap == "" {
+		// File exist but empty (the initial state when userns is created,
+		// see user_namespaces(7)).
+		return true
+	}
+
+	var a, b, c int64
+	if _, err := fmt.Sscanf(uidMap, "%d %d %d", &a, &b, &c); err != nil {
+		// Assume we are in a regular, non user namespace.
+		return false
+	}
+
+	// As per user_namespaces(7), /proc/self/uid_map of
+	// the initial user namespace shows 0 0 4294967295.
+	initNS := a == 0 && b == 0 && c == 4294967295
+	return !initNS
+}

--- a/go-controller/vendor/github.com/moby/sys/userns/userns_linux_fuzzer.go
+++ b/go-controller/vendor/github.com/moby/sys/userns/userns_linux_fuzzer.go
@@ -1,0 +1,8 @@
+//go:build linux && gofuzz
+
+package userns
+
+func FuzzUIDMap(uidmap []byte) int {
+	_ = uidMapInUserNS(string(uidmap))
+	return 1
+}

--- a/go-controller/vendor/github.com/moby/sys/userns/userns_unsupported.go
+++ b/go-controller/vendor/github.com/moby/sys/userns/userns_unsupported.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package userns
+
+// inUserNS is a stub for non-Linux systems. Always returns false.
+func inUserNS() bool { return false }

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -288,6 +288,9 @@ github.com/mitchellh/reflectwalk
 ## explicit; go 1.13
 github.com/moby/spdystream
 github.com/moby/spdystream/spdy
+# github.com/moby/sys/userns v0.1.0
+## explicit; go 1.21
+github.com/moby/sys/userns
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 ## explicit
 github.com/modern-go/concurrent


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Cgroupv1 nodes won't be able to match on kubelet cgroup path, therefore kubelet checks won't work on such nodes

cgroup check is copied from https://github.com/kubernetes/kubernetes/blob/bfde2edba75c8c00370d0b1a7a82c0988d13f0c6/pkg/kubelet/cm/cgroup_manager_linux.go#L157
It brings quite a lot of dependencies for just 1 cgroup check function, but I am not sure if I want to copy its code and make sure it keeps working
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
