### PR TITLE
Allow default network pods to reach localnet on the same node

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -124,20 +124,22 @@ func (c *addressManager) delAddr(ipnet net.IPNet, linkIndex int) bool {
 }
 
 // ListAddresses returns all the addresses we know about
-func (c *addressManager) ListAddresses() []net.IP {
+func (c *addressManager) ListAddresses() ([]net.IP, []*net.IPNet) {
 	c.Lock()
 	defer c.Unlock()
 	addrs := sets.List(c.cidrs)
-	out := make([]net.IP, 0, len(addrs))
+	addresses := make([]net.IP, 0, len(addrs))
+	networkAddresses := make([]*net.IPNet, 0, len(addrs))
 	for _, addr := range addrs {
-		ip, _, err := net.ParseCIDR(addr)
+		ip, networkAddress, err := net.ParseCIDR(addr)
 		if err != nil {
 			klog.Errorf("Failed to parse %s: %v", addr, err)
 			continue
 		}
-		out = append(out, ip)
+		addresses = append(addresses, ip)
+		networkAddresses = append(networkAddresses, networkAddress)
 	}
-	return out
+	return addresses, networkAddresses
 }
 
 type subscribeFn func() (bool, chan netlink.AddrUpdate, error)

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -145,6 +145,7 @@ const (
 
 	// OpenFlow and Networking constants
 	RouteAdvertisementICMPType    = 134
+	NeighborSolicitationICMPType  = 135
 	NeighborAdvertisementICMPType = 136
 
 	// Meter constants

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1536,12 +1536,12 @@ runcmd:
 				DeferCleanup(func() {
 					if e2eframework.TestContext.DeleteNamespace && (e2eframework.TestContext.DeleteNamespaceOnFailure || !CurrentSpecReport().Failed()) {
 						By("tearing down the localnet underlay")
-						Expect(teardownUnderlay(nodes)).To(Succeed())
+						Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed())
 					}
 				})
 
 				const secondaryInterfaceName = "eth1"
-				Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+				Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed())
 			}
 
 			By("Creating NetworkAttachmentDefinition")

--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -13,27 +13,29 @@ import (
 )
 
 const (
-	bridgeName = "ovsbr1"
-	add        = "add-br"
-	del        = "del-br"
+	defaultOvsBridge = "breth0"
+	secondaryBridge  = "ovsbr1"
+	add              = "add-br"
+	del              = "del-br"
 )
 
-func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmentConfig) error {
+func setupUnderlay(ovsPods []v1.Pod, bridgeName, portName string, nadConfig networkAttachmentConfig) error {
 	for _, ovsPod := range ovsPods {
-		if err := addOVSBridge(ovsPod.Name, bridgeName); err != nil {
-			return err
-		}
-
-		if nadConfig.vlanID > 0 {
-			if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, nadConfig.vlanID); err != nil {
+		if bridgeName != defaultOvsBridge {
+			if err := addOVSBridge(ovsPod.Name, bridgeName); err != nil {
 				return err
 			}
-		} else {
-			if err := ovsAttachPortToBridge(ovsPod.Name, bridgeName, portName); err != nil {
-				return err
+
+			if nadConfig.vlanID > 0 {
+				if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, nadConfig.vlanID); err != nil {
+					return err
+				}
+			} else {
+				if err := ovsAttachPortToBridge(ovsPod.Name, bridgeName, portName); err != nil {
+					return err
+				}
 			}
 		}
-
 		if err := configureBridgeMappings(
 			ovsPod.Name,
 			defaultNetworkBridgeMapping(),
@@ -47,11 +49,11 @@ func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmen
 
 func ovsRemoveSwitchPort(ovsPods []v1.Pod, portName string, newVLANID int) error {
 	for _, ovsPod := range ovsPods {
-		if err := ovsRemoveVLANAccessPort(ovsPod.Name, bridgeName, portName); err != nil {
+		if err := ovsRemoveVLANAccessPort(ovsPod.Name, secondaryBridge, portName); err != nil {
 			return fmt.Errorf("failed to remove old VLAN port: %v", err)
 		}
 
-		if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, newVLANID); err != nil {
+		if err := ovsEnableVLANAccessPort(ovsPod.Name, secondaryBridge, portName, newVLANID); err != nil {
 			return fmt.Errorf("failed to add new VLAN port: %v", err)
 		}
 	}
@@ -59,9 +61,18 @@ func ovsRemoveSwitchPort(ovsPods []v1.Pod, portName string, newVLANID int) error
 	return nil
 }
 
-func teardownUnderlay(ovsPods []v1.Pod) error {
+func teardownUnderlay(ovsPods []v1.Pod, bridgeName string) error {
 	for _, ovsPod := range ovsPods {
-		if err := removeOVSBridge(ovsPod.Name, bridgeName); err != nil {
+		if bridgeName != defaultOvsBridge {
+			if err := removeOVSBridge(ovsPod.Name, bridgeName); err != nil {
+				return err
+			}
+		}
+		// restore default bridge mapping
+		if err := configureBridgeMappings(
+			ovsPod.Name,
+			defaultNetworkBridgeMapping(),
+		); err != nil {
 			return err
 		}
 	}
@@ -110,7 +121,6 @@ func ovsAttachPortToBridge(ovsNodeName string, bridgeName string, portName strin
 		"kubectl", "-n", ovnNamespace, "exec", ovsNodeName, "--",
 		"ovs-vsctl", "add-port", bridgeName, portName,
 	}
-
 	if _, err := runCommand(cmd...); err != nil {
 		return fmt.Errorf("failed to add port %s to OVS bridge %s: %v", portName, bridgeName, err)
 	}
@@ -121,9 +131,8 @@ func ovsAttachPortToBridge(ovsNodeName string, bridgeName string, portName strin
 func ovsEnableVLANAccessPort(ovsNodeName string, bridgeName string, portName string, vlanID int) error {
 	cmd := []string{
 		"kubectl", "-n", ovnNamespace, "exec", ovsNodeName, "--",
-		"ovs-vsctl", "add-port", bridgeName, portName, fmt.Sprintf("tag=%d", vlanID), "vlan_mode=access",
+		"ovs-vsctl", "--may-exist", "add-port", bridgeName, portName, fmt.Sprintf("tag=%d", vlanID), "vlan_mode=access",
 	}
-
 	if _, err := runCommand(cmd...); err != nil {
 		return fmt.Errorf("failed to add port %s to OVS bridge %s: %v", portName, bridgeName, err)
 	}

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"os/exec"
 	"strconv"
@@ -25,9 +26,15 @@ import (
 	mnpclient "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1beta1"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+
+	ipgenerator "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/ip"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-const PolicyForAnnotation = "k8s.v1.cni.cncf.io/policy-for"
+const (
+	PolicyForAnnotation = "k8s.v1.cni.cncf.io/policy-for"
+	nodeHostnameKey     = "kubernetes.io/hostname"
+)
 
 var _ = Describe("Multi Homing", func() {
 	const (
@@ -190,7 +197,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"when attaching to an localnet - switched - network",
+				"when attaching to a localnet - switched - network",
 				networkAttachmentConfigParams{
 					cidr:     secondaryLocalnetNetworkCIDR,
 					name:     secondaryNetworkName,
@@ -203,7 +210,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"when attaching to an Localnet - switched - network featuring `excludeCIDR`s",
+				"when attaching to a localnet - switched - network featuring `excludeCIDR`s",
 				networkAttachmentConfigParams{
 					cidr:         secondaryLocalnetNetworkCIDR,
 					name:         secondaryNetworkName,
@@ -217,7 +224,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"when attaching to an localnet - switched - network without IPAM",
+				"when attaching to a localnet - switched - network without IPAM",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -229,7 +236,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"when attaching to an localnet - switched - network with an IPv6 subnet",
+				"when attaching to a localnet - switched - network with an IPv6 subnet",
 				networkAttachmentConfigParams{
 					cidr:     secondaryIPv6CIDR,
 					name:     secondaryNetworkName,
@@ -255,12 +262,133 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 		)
+
+		const (
+			clientPodName     = "client-pod"
+			clientIPOffset    = 100
+			serverIPOffset    = 102
+			port              = 9000
+			workerOneNodeName = "ovn-worker"
+			workerTwoNodeName = "ovn-worker2"
+		)
+
+		ginkgo.DescribeTable("attached to a localnet network mapped to breth0",
+
+			func(netConfigParams networkAttachmentConfigParams, clientPodConfig, serverPodConfig podConfiguration) {
+
+				netConfig := newNetworkAttachmentConfig(networkAttachmentConfigParams{
+					name:      secondaryNetworkName,
+					namespace: f.Namespace.Name,
+					topology:  "localnet",
+				})
+				if clientPodConfig.namespace == "" {
+					clientPodConfig.namespace = f.Namespace.Name
+				}
+				if serverPodConfig.namespace == "" {
+					serverPodConfig.namespace = f.Namespace.Name
+				}
+
+				By("setting up the localnet underlay")
+				pods := ovsPods(cs)
+				Expect(pods).NotTo(BeEmpty())
+				defer func() {
+					By("tearing down the localnet underlay")
+					Expect(teardownUnderlay(pods, defaultOvsBridge)).To(Succeed())
+				}()
+				Expect(setupUnderlay(pods, defaultOvsBridge, "", netConfig)).To(Succeed())
+
+				nad := generateNAD(netConfig)
+				By(fmt.Sprintf("creating the attachment configuration: %v\n", nad))
+				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
+					context.Background(),
+					nad,
+					metav1.CreateOptions{},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				if serverPodConfig.attachments != nil && serverPodConfig.needsIPRequestFromHostSubnet {
+					By("finalizing the server pod IP configuration")
+					err = addIPRequestToPodConfig(cs, &serverPodConfig, serverIPOffset)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				if clientPodConfig.attachments != nil && clientPodConfig.needsIPRequestFromHostSubnet {
+					By("finalizing the client pod IP configuration")
+					err = addIPRequestToPodConfig(cs, &clientPodConfig, clientIPOffset)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				By("instantiating the server pod")
+				serverPod := kickstartPod(cs, serverPodConfig)
+
+				By("instantiating the client pod")
+				kickstartPod(cs, clientPodConfig)
+
+				// Check that the client pod can reach the server pod on the server localnet interface
+				serverIPs, err := podIPsForAttachment(cs, f.Namespace.Name, serverPod.GetName(), netConfig.name)
+				Expect(err).NotTo(HaveOccurred())
+				for _, serverIP := range serverIPs {
+					By(fmt.Sprintf("asserting the *client* can contact the server pod exposed endpoint: %q on port %q", serverIP, port))
+					Eventually(func() error {
+						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+					}, 2*time.Minute, 6*time.Second).Should(Succeed())
+
+					By(fmt.Sprintf("asserting the *client* can ping the server pod exposed endpoint: %q", serverIP))
+					Eventually(func() error {
+						return pingServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP)
+					}, 2*time.Minute, 6*time.Second).Should(Succeed())
+				}
+			},
+			ginkgo.Entry(
+				"can be reached by a client pod in the default network on a different node",
+				networkAttachmentConfigParams{
+					name:     secondaryNetworkName,
+					topology: "localnet",
+				},
+				podConfiguration{ // client on default network
+					name:         clientPodName,
+					nodeSelector: map[string]string{nodeHostnameKey: workerOneNodeName},
+					isPrivileged: true,
+				},
+				podConfiguration{ // server attached to localnet secondary network
+					attachments: []nadapi.NetworkSelectionElement{{
+						Name: secondaryNetworkName,
+					}},
+					name:                         podName,
+					containerCmd:                 httpServerContainerCmd(port),
+					nodeSelector:                 map[string]string{nodeHostnameKey: workerTwoNodeName},
+					needsIPRequestFromHostSubnet: true, // will override attachments above with an IPRequest
+				},
+				Label("BUG", "OCPBUGS-43004"),
+			),
+			ginkgo.Entry(
+				"can be reached by a client pod in the default network on the same node",
+				networkAttachmentConfigParams{
+					name:     secondaryNetworkName,
+					topology: "localnet",
+				},
+				podConfiguration{ // client on default network
+					name:         clientPodName + "-same-node",
+					nodeSelector: map[string]string{nodeHostnameKey: workerTwoNodeName},
+					isPrivileged: true,
+				},
+				podConfiguration{ // server attached to localnet secondary network
+					attachments: []nadapi.NetworkSelectionElement{{
+						Name: secondaryNetworkName,
+					}},
+					name:                         podName,
+					containerCmd:                 httpServerContainerCmd(port),
+					nodeSelector:                 map[string]string{nodeHostnameKey: workerTwoNodeName},
+					needsIPRequestFromHostSubnet: true,
+				},
+				Label("BUG", "OCPBUGS-43004"),
+			),
+		)
 	})
 
 	Context("multiple pods connected to the same OVN-K secondary network", func() {
 		const (
 			clientPodName     = "client-pod"
-			nodeHostnameKey   = "kubernetes.io/hostname"
 			port              = 9000
 			workerOneNodeName = "ovn-worker"
 			workerTwoNodeName = "ovn-worker2"
@@ -352,11 +480,11 @@ var _ = Describe("Multi Homing", func() {
 					Expect(nodes).NotTo(BeEmpty())
 					defer func() {
 						By("tearing down the localnet underlay")
-						Expect(teardownUnderlay(nodes)).To(Succeed())
+						Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed())
 					}()
 
 					const secondaryInterfaceName = "eth1"
-					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+					Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed())
 				}
 
 				By("creating the attachment configuration")
@@ -431,7 +559,7 @@ var _ = Describe("Multi Homing", func() {
 
 					By("asserting the *client* pod can contact the server pod exposed endpoint")
 					Eventually(func() error {
-						return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 					}, 2*time.Minute, 6*time.Second).Should(Succeed())
 				}
 			},
@@ -604,7 +732,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"can communicate over an localnet secondary network when the pods are scheduled on different nodes",
+				"can communicate over a localnet secondary network when the pods are scheduled on different nodes",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -624,7 +752,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"can communicate over an localnet secondary network without IPAM when the pods are scheduled on different nodes",
+				"can communicate over a localnet secondary network without IPAM when the pods are scheduled on different nodes",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -645,7 +773,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"can communicate over an localnet secondary network without IPAM when the pods are scheduled on different nodes, with static IPs configured via network selection elements",
+				"can communicate over a localnet secondary network without IPAM when the pods are scheduled on different nodes, with static IPs configured via network selection elements",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -670,7 +798,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"can communicate over an localnet secondary network with an IPv6 subnet when pods are scheduled on different nodes",
+				"can communicate over a localnet secondary network with an IPv6 subnet when pods are scheduled on different nodes",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -690,7 +818,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			ginkgo.Entry(
-				"can communicate over an localnet secondary network with a dual stack configuration when pods are scheduled on different nodes",
+				"can communicate over a localnet secondary network with a dual stack configuration when pods are scheduled on different nodes",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -744,7 +872,7 @@ var _ = Describe("Multi Homing", func() {
 					By("setting up the localnet underlay")
 					nodes = ovsPods(cs)
 					Expect(nodes).NotTo(BeEmpty())
-					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+					Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed())
 				})
 
 				BeforeEach(func() {
@@ -795,7 +923,7 @@ var _ = Describe("Multi Homing", func() {
 
 				AfterEach(func() {
 					By("tearing down the localnet underlay")
-					Expect(teardownUnderlay(nodes)).To(Succeed())
+					Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed())
 				})
 
 				It("correctly sets the MTU on the pod", func() {
@@ -1130,7 +1258,7 @@ var _ = Describe("Multi Homing", func() {
 						})
 
 					By("setting up the localnet underlay with a trunked configuration")
-					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed(), "configuring the OVS bridge")
+					Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed(), "configuring the OVS bridge")
 
 					By(fmt.Sprintf("creating a VLAN interface on top of the bridge connecting the cluster nodes with IP: %s", underlayIP))
 					cli, err := client.NewClientWithOpts(client.FromEnv)
@@ -1155,7 +1283,7 @@ var _ = Describe("Multi Homing", func() {
 				AfterEach(func() {
 					Expect(cmdWebServer.Process.Kill()).NotTo(HaveOccurred(), "kill the python webserver")
 					Expect(deleteVLANInterface(underlayBridgeName, strconv.Itoa(vlanID))).NotTo(HaveOccurred(), "remove the underlay physical configuration")
-					Expect(teardownUnderlay(nodes)).To(Succeed(), "tear down the localnet underlay")
+					Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed(), "tear down the localnet underlay")
 				})
 
 				It("the same bridge mapping can be shared by a separate VLAN by using the physical network name attribute", func() {
@@ -1239,11 +1367,11 @@ var _ = Describe("Multi Homing", func() {
 						Expect(nodes).NotTo(BeEmpty())
 						defer func() {
 							By("tearing down the localnet underlay")
-							Expect(teardownUnderlay(nodes)).To(Succeed())
+							Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed())
 						}()
 
 						const secondaryInterfaceName = "eth1"
-						Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+						Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed())
 					}
 
 					Expect(createNads(f, nadClient, extraNamespace, netConfig)).NotTo(HaveOccurred())
@@ -1268,7 +1396,7 @@ var _ = Describe("Multi Homing", func() {
 
 					By("asserting the *allowed-client* pod can contact the server pod exposed endpoint")
 					Eventually(func() error {
-						return reachToServerPodFromClient(cs, serverPodConfig, allowedClientPodConfig, serverIP, port)
+						return reachServerPodFromClient(cs, serverPodConfig, allowedClientPodConfig, serverIP, port)
 					}, 2*time.Minute, 6*time.Second).Should(Succeed())
 
 					By("asserting the *blocked-client* pod **cannot** contact the server pod exposed endpoint")
@@ -1666,10 +1794,10 @@ var _ = Describe("Multi Homing", func() {
 					Expect(nodes).NotTo(BeEmpty())
 					defer func() {
 						By("tearing down the localnet underlay")
-						Expect(teardownUnderlay(nodes)).To(Succeed())
+						Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed())
 					}()
 					const secondaryInterfaceName = "eth1"
-					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+					Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed())
 
 					Expect(createNads(f, nadClient, extraNamespace, netConfig)).NotTo(HaveOccurred())
 
@@ -1684,7 +1812,7 @@ var _ = Describe("Multi Homing", func() {
 
 					By("asserting the *client* pod can contact the server pod exposed endpoint")
 					Eventually(func() error {
-						return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 					}, 2*time.Minute, 6*time.Second).Should(Succeed())
 				},
 				ginkgo.Entry(
@@ -1798,10 +1926,10 @@ var _ = Describe("Multi Homing", func() {
 					Expect(nodes).NotTo(BeEmpty())
 					defer func() {
 						By("tearing down the localnet underlay")
-						Expect(teardownUnderlay(nodes)).To(Succeed())
+						Expect(teardownUnderlay(nodes, secondaryBridge)).To(Succeed())
 					}()
 					const secondaryInterfaceName = "eth1"
-					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+					Expect(setupUnderlay(nodes, secondaryBridge, secondaryInterfaceName, netConfig)).To(Succeed())
 
 					Expect(createNads(f, nadClient, extraNamespace, netConfig)).NotTo(HaveOccurred())
 
@@ -1816,7 +1944,7 @@ var _ = Describe("Multi Homing", func() {
 
 					By("asserting the *client* pod can't contact the server pod exposed endpoint when using ingress deny-all")
 					Eventually(func() error {
-						return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 					}, 2*time.Minute, 6*time.Second).Should(Not(Succeed()))
 				},
 				ginkgo.Entry(
@@ -1960,7 +2088,8 @@ var _ = Describe("Multi Homing", func() {
 })
 
 func kickstartPod(cs clientset.Interface, configuration podConfiguration) *v1.Pod {
-	By(fmt.Sprintf("instantiating the %q pod", fmt.Sprintf("%s/%s", configuration.namespace, configuration.name)))
+	podNamespacedName := fmt.Sprintf("%s/%s", configuration.namespace, configuration.name)
+	By(fmt.Sprintf("instantiating pod %q", podNamespacedName))
 	createdPod, err := cs.CoreV1().Pods(configuration.namespace).Create(
 		context.Background(),
 		generatePodSpec(configuration),
@@ -1968,7 +2097,7 @@ func kickstartPod(cs clientset.Interface, configuration podConfiguration) *v1.Po
 	)
 	Expect(err).WithOffset(1).NotTo(HaveOccurred())
 
-	By("asserting the pod reaches the `Ready` state")
+	By(fmt.Sprintf("asserting that pod %q reaches the `Ready` state", podNamespacedName))
 	EventuallyWithOffset(1, func() v1.PodPhase {
 		updatedPod, err := cs.CoreV1().Pods(configuration.namespace).Get(context.Background(), configuration.name, metav1.GetOptions{})
 		if err != nil {
@@ -2025,4 +2154,73 @@ func createMultiNetworkPolicy(mnpClient mnpclient.K8sCniCncfIoV1beta1Interface, 
 		metav1.CreateOptions{},
 	)
 	return err
+}
+
+func computeIPWithOffset(baseAddr string, increment int) (string, error) {
+	addr, err := netip.ParsePrefix(baseAddr)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse CIDR %v", err)
+	}
+
+	ip := addr.Addr()
+
+	for i := 0; i < increment; i++ {
+		ip = ip.Next()
+		if !ip.IsValid() {
+			return "", fmt.Errorf("overflow: IP address exceeds bounds")
+		}
+	}
+
+	return netip.PrefixFrom(ip, addr.Bits()).String(), nil
+}
+
+// Given a node name and an offset, generateIPsFromNodePrimaryIfAddr returns an IPv4 and an IPv6 address
+// at the provided offset from the primary interface addresses found on the node.
+func generateIPsFromNodePrimaryIfAddr(cs clientset.Interface, nodeName string, offset int) ([]string, error) {
+	var newAddresses []string
+
+	node, err := cs.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get node %s: %v", nodeName, err)
+	}
+
+	nodeIfAddr, err := util.GetNodeIfAddrAnnotation(node)
+	if err != nil {
+		return nil, err
+	}
+	nodeAddresses := []string{}
+	if nodeIfAddr.IPv4 != "" {
+		nodeAddresses = append(nodeAddresses, nodeIfAddr.IPv4)
+	}
+	if nodeIfAddr.IPv6 != "" {
+		nodeAddresses = append(nodeAddresses, nodeIfAddr.IPv6)
+	}
+	for _, nodeAddress := range nodeAddresses {
+		ipGen, err := ipgenerator.NewIPGenerator(nodeAddress)
+		if err != nil {
+			return nil, err
+		}
+		newIP, err := ipGen.GenerateIP(offset)
+		if err != nil {
+			return nil, err
+		}
+		newAddresses = append(newAddresses, newIP.String())
+	}
+	return newAddresses, nil
+}
+
+func addIPRequestToPodConfig(cs clientset.Interface, podConfig *podConfiguration, offset int) error {
+	nodeName, ok := podConfig.nodeSelector[nodeHostnameKey]
+	if !ok {
+		return fmt.Errorf("No node selector found on podConfig")
+	}
+
+	IPsToRequest, err := generateIPsFromNodePrimaryIfAddr(cs, nodeName, offset)
+	if err != nil {
+		return err
+	}
+	for i := range podConfig.attachments {
+		podConfig.attachments[i].IPRequest = IPsToRequest
+	}
+	return nil
 }

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -149,14 +149,15 @@ func patchNADSpec(nadClient nadclient.K8sCniCncfIoV1Interface, name, namespace s
 }
 
 type podConfiguration struct {
-	attachments            []nadapi.NetworkSelectionElement
-	containerCmd           []string
-	name                   string
-	namespace              string
-	nodeSelector           map[string]string
-	isPrivileged           bool
-	labels                 map[string]string
-	requiresExtraNamespace bool
+	attachments                  []nadapi.NetworkSelectionElement
+	containerCmd                 []string
+	name                         string
+	namespace                    string
+	nodeSelector                 map[string]string
+	isPrivileged                 bool
+	labels                       map[string]string
+	requiresExtraNamespace       bool
+	needsIPRequestFromHostSubnet bool
 }
 
 func generatePodSpec(config podConfiguration) *v1.Pod {
@@ -303,6 +304,19 @@ func getSecondaryInterfaceMTU(clientPodConfig podConfiguration) (int, error) {
 	return mtu, nil
 }
 
+func pingServer(clientPodConfig podConfiguration, serverIP string) error {
+	_, err := e2ekubectl.RunKubectl(
+		clientPodConfig.namespace,
+		"exec",
+		clientPodConfig.name,
+		"--",
+		"ping",
+		"-c", "1", // send one ICMP echo request
+		"-W", "2", // timeout after 2 seconds if no response
+		serverIP)
+	return err
+}
+
 func newAttachmentConfigWithOverriddenName(name, namespace, networkName, topology, cidr string) networkAttachmentConfig {
 	return newNetworkAttachmentConfig(
 		networkAttachmentConfigParams{
@@ -332,24 +346,35 @@ func areStaticIPsConfiguredViaCNI(podConfig podConfiguration) bool {
 	return false
 }
 
-func podIPForAttachment(k8sClient clientset.Interface, podNamespace string, podName string, attachmentName string, ipIndex int) (string, error) {
+func podIPsForAttachment(k8sClient clientset.Interface, podNamespace string, podName string, attachmentName string) ([]string, error) {
 	pod, err := k8sClient.CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
 		return status.Name == namespacedName(podNamespace, attachmentName)
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(netStatus) != 1 {
-		return "", fmt.Errorf("more than one status entry for attachment %s on pod %s", attachmentName, namespacedName(podNamespace, podName))
+		return nil, fmt.Errorf("more than one status entry for attachment %s on pod %s", attachmentName, namespacedName(podNamespace, podName))
 	}
 	if len(netStatus[0].IPs) == 0 {
-		return "", fmt.Errorf("no IPs for attachment %s on pod %s", attachmentName, namespacedName(podNamespace, podName))
+		return nil, fmt.Errorf("no IPs for attachment %s on pod %s", attachmentName, namespacedName(podNamespace, podName))
 	}
-	return netStatus[0].IPs[ipIndex], nil
+	return netStatus[0].IPs, nil
+}
+
+func podIPForAttachment(k8sClient clientset.Interface, podNamespace string, podName string, attachmentName string, ipIndex int) (string, error) {
+	ips, err := podIPsForAttachment(k8sClient, podNamespace, podName, attachmentName)
+	if err != nil {
+		return "", err
+	}
+	if ipIndex >= len(ips) {
+		return "", fmt.Errorf("no IP at index %d for attachment %s on pod %s", ipIndex, attachmentName, namespacedName(podNamespace, podName))
+	}
+	return ips[ipIndex], nil
 }
 
 func allowedClient(podName string) string {
@@ -581,7 +606,7 @@ func allowedTCPPortsForPolicy(allowPorts ...int) []mnpapi.MultiNetworkPolicyPort
 	return portAllowlist
 }
 
-func reachToServerPodFromClient(cs clientset.Interface, serverConfig podConfiguration, clientConfig podConfiguration, serverIP string, serverPort int) error {
+func reachServerPodFromClient(cs clientset.Interface, serverConfig podConfiguration, clientConfig podConfiguration, serverIP string, serverPort int) error {
 	updatedPod, err := cs.CoreV1().Pods(serverConfig.namespace).Get(context.Background(), serverConfig.name, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -589,6 +614,19 @@ func reachToServerPodFromClient(cs clientset.Interface, serverConfig podConfigur
 
 	if updatedPod.Status.Phase == v1.PodRunning {
 		return connectToServer(clientConfig, serverIP, serverPort)
+	}
+
+	return fmt.Errorf("pod not running. /me is sad")
+}
+
+func pingServerPodFromClient(cs clientset.Interface, serverConfig podConfiguration, clientConfig podConfiguration, serverIP string) error {
+	updatedPod, err := cs.CoreV1().Pods(serverConfig.namespace).Get(context.Background(), serverConfig.name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if updatedPod.Status.Phase == v1.PodRunning {
+		return pingServer(clientConfig, serverIP)
 	}
 
 	return fmt.Errorf("pod not running. /me is sad")

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -174,7 +174,7 @@ var _ = Describe("Network Segmentation", func() {
 
 							By("asserting the *client* pod can contact the server pod exposed endpoint")
 							Eventually(func() error {
-								return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+								return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 							}, 2*time.Minute, 6*time.Second).Should(Succeed())
 						}
 					},
@@ -764,7 +764,7 @@ var _ = Describe("Network Segmentation", func() {
 
 						By("asserting the *client* pod can contact the server pod exposed endpoint")
 						Eventually(func() error {
-							return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+							return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 						}, 2*time.Minute, 6*time.Second).Should(Succeed())
 					}
 				}
@@ -1702,11 +1702,11 @@ spec:
 				clientPod := getPod(f, clientPodConfig.name)
 				for _, testPod := range []*v1.Pod{clientPod, serverPod} {
 					By(fmt.Sprintf("asserting the server pod IP %v is reachable from client before restart of OVNKube node pod on Node %s", serverIP, testPod.Spec.Hostname))
-					Expect(reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)).ShouldNot(HaveOccurred(), "must have connectivity to server pre OVN Kube node Pod restart")
+					Expect(reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)).ShouldNot(HaveOccurred(), "must have connectivity to server pre OVN Kube node Pod restart")
 					By(fmt.Sprintf("restarting OVNKube node Pod located on Node %s which hosts test Pod %s/%s", testPod.Spec.NodeName, testPod.Namespace, testPod.Name))
 					Expect(restartOVNKubeNodePod(cs, ovnNamespace, testPod.Spec.NodeName)).ShouldNot(HaveOccurred(), "restart of OVNKube node pod must succeed")
 					By(fmt.Sprintf("asserting the server pod IP %v is reachable from client post restart", serverIP))
-					Expect(reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)).ShouldNot(HaveOccurred(), "must have connectivity to server post restart")
+					Expect(reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)).ShouldNot(HaveOccurred(), "must have connectivity to server post restart")
 				}
 			},
 			Entry(

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", func() {
 
 					ginkgo.By("asserting the *client* pod can contact the server pod exposed endpoint")
 					gomega.Eventually(func() error {
-						return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 					}, 2*time.Minute, 6*time.Second).Should(gomega.Succeed())
 				}
 
@@ -122,7 +122,7 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", func() {
 
 				ginkgo.By("asserting the *client* pod can not contact the server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+					return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
 				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 
 			},
@@ -235,12 +235,12 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", func() {
 
 				ginkgo.By("asserting the *client* pod can contact the allow server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
+					return reachServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
 				}, 2*time.Minute, 6*time.Second).Should(gomega.Succeed())
 
 				ginkgo.By("asserting the *client* pod can contact the deny server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
+					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
 				}, 2*time.Minute, 6*time.Second).Should(gomega.Succeed())
 
 				ginkgo.By("creating a \"default deny\" network policy")
@@ -249,12 +249,12 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", func() {
 
 				ginkgo.By("asserting the *client* pod can not contact the allow server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
+					return reachServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
 				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 
 				ginkgo.By("asserting the *client* pod can not contact the deny server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
+					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
 				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 
 				ginkgo.By("creating a \"allow-traffic-to-pod\" network policy")
@@ -263,12 +263,12 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", func() {
 
 				ginkgo.By("asserting the *client* pod can contact the allow server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
+					return reachServerPodFromClient(cs, allowServerPodConfig, clientPodConfig, allowServerPodIP, port)
 				}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
 
 				ginkgo.By("asserting the *client* pod can not contact deny server pod exposed endpoint")
 				gomega.Eventually(func() error {
-					return reachToServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
+					return reachServerPodFromClient(cs, denyServerPodConfig, clientPodConfig, denyServerPodIP, port)
 				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
 
 			},


### PR DESCRIPTION
Add flows at prio=102 to allow traffic from the OVN network to the host network to be handled normally by the bridge instead of forwarding it directly to the NIC (which would be done by the flow at prio=100). This allows pods in the default network to reach localnet pods on the same node.

Add e2e tests to check connections from default network to localnet on different nodes and on the same node.

Testing downstream here: https://github.com/openshift/ovn-kubernetes/pull/2467

Follow-up PR for localnet->host: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5093 

Fixes #OCPBUGS-43004 