### PR TITLE
[UDN: host isolation] Fix node event reporting.

### DIFF
--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -122,7 +122,7 @@ func (m *UDNHostIsolationManager) Start(ctx context.Context) error {
 		// As a side effect, all kubelet probes will fail, but host isolation will still work.
 		message := fmt.Sprintf("Kubelet probes for UDN are not supported on the node %s as it uses cgroup v1.", m.nodeName)
 		klog.Warning(message)
-		nodeRef := &kapi.ObjectReference{
+		nodeRef := &v1.ObjectReference{
 			Kind: "Node",
 			Name: m.nodeName,
 		}


### PR DESCRIPTION
We want to use "k8s.io/api/core/v1.ObjectReference" for event reporting. At the same time "k8s.io/kubernetes/pkg/apis/core.ObjectReference" exists.
The fun part is that in default_node_network_controller.go we import
```  
  kapi "k8s.io/api/core/v1"
```
and in udn_isolation.go
  ```
  v1 "k8s.io/api/core/v1"
  kapi "k8s.io/kubernetes/pkg/apis/core"
```

so when the tested code was moved to another file, it started using the wrong type.

Currently we get an error
"Could not construct reference, will not report event" err="object does not implement the common interface for accessing the SelfLink"