### PR TITLE
Perf improvement: egress ip/qos reroute rules

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -468,6 +468,7 @@ type nodeSyncs struct {
 	syncGw                bool
 	syncHo                bool
 	syncZoneIC            bool
+	syncReroute           bool
 }
 
 func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) error {
@@ -540,7 +541,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 			}
 		}
 
-		// If we succcessfully discovered the host subnets then add the management port.
+		// If we successfully discovered the host subnets then add the management port.
 		if hostSubnets != nil {
 			if err = oc.syncNodeManagementPortDefault(node, oc.GetNetworkScopedSwitchName(node.Name), hostSubnets); err != nil {
 				errs = append(errs, err)

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -113,9 +113,18 @@ func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface
 			if fromRetryLoop {
 				_, syncMgmtPort := h.oc.mgmtPortFailed.Load(node.Name)
 				_, syncGw := h.oc.gatewaysFailed.Load(node.Name)
-				nodeParams = &nodeSyncs{syncMgmtPort: syncMgmtPort, syncGw: syncGw}
+				_, syncReroute := h.oc.syncEIPNodeRerouteFailed.Load(node.Name)
+				nodeParams = &nodeSyncs{
+					syncMgmtPort: syncMgmtPort,
+					syncGw:       syncGw,
+					syncReroute:  syncReroute,
+				}
 			} else {
-				nodeParams = &nodeSyncs{syncMgmtPort: true, syncGw: true}
+				nodeParams = &nodeSyncs{
+					syncMgmtPort: true,
+					syncGw:       true,
+					syncReroute:  true,
+				}
 			}
 			return h.oc.addUpdateLocalNodeEvent(node, nodeParams)
 		}
@@ -171,13 +180,22 @@ func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, ne
 					gatewayChanged(oldNode, newNode) ||
 					hostCIDRsChanged(oldNode, newNode) ||
 					nodeGatewayMTUSupportChanged(oldNode, newNode)
-
-				nodeSyncsParam = &nodeSyncs{syncMgmtPort: shouldSyncMgmtPort, syncGw: shouldSyncGW}
+				_, syncRerouteFailed := h.oc.syncEIPNodeRerouteFailed.Load(newNode.Name)
+				shouldSyncReroute := syncRerouteFailed || util.NodeHostCIDRsAnnotationChanged(oldNode, newNode)
+				nodeSyncsParam = &nodeSyncs{
+					syncMgmtPort: shouldSyncMgmtPort,
+					syncGw:       shouldSyncGW,
+					syncReroute:  shouldSyncReroute,
+				}
 			} else {
 				klog.Infof("Node %s moved from the remote zone %s to local zone %s.",
 					newNode.Name, util.GetNodeZone(oldNode), util.GetNodeZone(newNode))
 				// The node is now a local zone node. Trigger a full node sync.
-				nodeSyncsParam = &nodeSyncs{syncMgmtPort: true, syncGw: true}
+				nodeSyncsParam = &nodeSyncs{
+					syncMgmtPort: true,
+					syncGw:       true,
+					syncReroute:  true,
+				}
 			}
 
 			return h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam)
@@ -249,9 +267,10 @@ type SecondaryLayer2NetworkController struct {
 	BaseSecondaryLayer2NetworkController
 
 	// Node-specific syncMaps used by node event handler
-	mgmtPortFailed   sync.Map
-	gatewaysFailed   sync.Map
-	syncZoneICFailed sync.Map
+	mgmtPortFailed           sync.Map
+	gatewaysFailed           sync.Map
+	syncZoneICFailed         sync.Map
+	syncEIPNodeRerouteFailed sync.Map
 
 	// Cluster-wide router default Control Plane Protection (COPP) UUID
 	defaultCOPPUUID string
@@ -591,12 +610,20 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 			}
 		}
 
-		if config.OVNKubernetesFeature.EnableEgressIP {
+		if config.OVNKubernetesFeature.EnableEgressIP && nSyncs.syncReroute {
+			rerouteFailed := false
 			if err := oc.eIPController.ensureRouterPoliciesForNetwork(oc.GetNetInfo()); err != nil {
 				errs = append(errs, fmt.Errorf("failed to ensure EgressIP router policies for network %s: %v", oc.GetNetworkName(), err))
+				rerouteFailed = true
 			}
 			if err := oc.eIPController.ensureSwitchPoliciesForNode(oc.GetNetInfo(), node.Name); err != nil {
 				errs = append(errs, fmt.Errorf("failed to ensure EgressIP switch policies for network %s: %v", oc.GetNetworkName(), err))
+				rerouteFailed = true
+			}
+			if rerouteFailed {
+				oc.syncEIPNodeRerouteFailed.Store(node.Name, true)
+			} else {
+				oc.syncEIPNodeRerouteFailed.Delete(node.Name)
 			}
 		}
 	}
@@ -694,6 +721,7 @@ func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) e
 	oc.gatewayManagers.Delete(node.Name)
 	oc.localZoneNodes.Delete(node.Name)
 	oc.mgmtPortFailed.Delete(node.Name)
+	oc.syncEIPNodeRerouteFailed.Delete(node.Name)
 	return nil
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -115,12 +115,14 @@ func (h *secondaryLayer3NetworkControllerEventHandler) AddResource(obj interface
 				_, syncMgmtPort := h.oc.mgmtPortFailed.Load(node.Name)
 				_, syncGw := h.oc.gatewaysFailed.Load(node.Name)
 				_, syncZoneIC := h.oc.syncZoneICFailed.Load(node.Name)
+				_, syncReRoute := h.oc.syncEIPNodeRerouteFailed.Load(node.Name)
 				nodeParams = &nodeSyncs{
 					syncNode:              nodeSync,
 					syncClusterRouterPort: clusterRtrSync,
 					syncMgmtPort:          syncMgmtPort,
 					syncZoneIC:            syncZoneIC,
 					syncGw:                syncGw,
+					syncReroute:           syncReRoute,
 				}
 			} else {
 				nodeParams = &nodeSyncs{
@@ -129,6 +131,7 @@ func (h *secondaryLayer3NetworkControllerEventHandler) AddResource(obj interface
 					syncMgmtPort:          true,
 					syncZoneIC:            config.OVNKubernetesFeature.EnableInterconnect,
 					syncGw:                true,
+					syncReroute:           true,
 				}
 			}
 			if err := h.oc.addUpdateLocalNodeEvent(node, nodeParams); err != nil {
@@ -182,12 +185,15 @@ func (h *secondaryLayer3NetworkControllerEventHandler) UpdateResource(oldObj, ne
 					nodeSubnetChanged ||
 					hostCIDRsChanged(oldNode, newNode) ||
 					nodeGatewayMTUSupportChanged(oldNode, newNode)
+				_, failed = h.oc.syncEIPNodeRerouteFailed.Load(newNode.Name)
+				syncReroute := failed || util.NodeHostCIDRsAnnotationChanged(oldNode, newNode)
 				nodeSyncsParam = &nodeSyncs{
 					syncNode:              nodeSync,
 					syncClusterRouterPort: clusterRtrSync,
 					syncMgmtPort:          syncMgmtPort,
 					syncZoneIC:            syncZoneIC,
 					syncGw:                syncGw,
+					syncReroute:           syncReroute,
 				}
 			} else {
 				klog.Infof("Node %s moved from the remote zone %s to local zone %s.",
@@ -199,6 +205,7 @@ func (h *secondaryLayer3NetworkControllerEventHandler) UpdateResource(oldObj, ne
 					syncMgmtPort:          true,
 					syncZoneIC:            config.OVNKubernetesFeature.EnableInterconnect,
 					syncGw:                true,
+					syncReroute:           true,
 				}
 			}
 
@@ -287,6 +294,7 @@ type SecondaryLayer3NetworkController struct {
 	nodeClusterRouterPortFailed sync.Map
 	syncZoneICFailed            sync.Map
 	gatewaysFailed              sync.Map
+	syncEIPNodeRerouteFailed    sync.Map
 
 	gatewayManagers        sync.Map
 	gatewayTopologyFactory *topology.GatewayTopologyFactory
@@ -682,6 +690,7 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.N
 			oc.mgmtPortFailed.Store(node.Name, true)
 			oc.syncZoneICFailed.Store(node.Name, true)
 			oc.gatewaysFailed.Store(node.Name, true)
+			oc.syncEIPNodeRerouteFailed.Store(node.Name, true)
 			err = fmt.Errorf("nodeAdd: error adding node %q for network %s: %w", node.Name, oc.GetNetworkName(), err)
 			oc.recordNodeErrorEvent(node, err)
 			return err
@@ -774,12 +783,20 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.N
 		}
 	}
 
-	if config.OVNKubernetesFeature.EnableEgressIP && util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+	if config.OVNKubernetesFeature.EnableEgressIP && util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() && nSyncs.syncReroute {
+		rerouteFailed := false
 		if err = oc.eIPController.ensureRouterPoliciesForNetwork(oc.GetNetInfo()); err != nil {
 			errs = append(errs, fmt.Errorf("failed to ensure EgressIP router polices for network %s: %v", oc.GetNetworkName(), err))
+			rerouteFailed = true
 		}
 		if err = oc.eIPController.ensureSwitchPoliciesForNode(oc.GetNetInfo(), node.Name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to ensure EgressIP switch policies for network %s: %v", oc.GetNetworkName(), err))
+			rerouteFailed = true
+		}
+		if rerouteFailed {
+			oc.syncEIPNodeRerouteFailed.Store(node.Name, true)
+		} else {
+			oc.syncEIPNodeRerouteFailed.Delete(node.Name)
 		}
 	}
 
@@ -886,6 +903,7 @@ func (oc *SecondaryLayer3NetworkController) deleteNodeEvent(node *kapi.Node) err
 		}
 		oc.syncZoneICFailed.Delete(node.Name)
 	}
+	oc.syncEIPNodeRerouteFailed.Delete(node.Name)
 	return nil
 }
 


### PR DESCRIPTION
These things were constantly being executed on every node update. Bring them inline with what we do for other node syncs, keep a cache of what needs to be sync'ed. The impact of this was especially bad for UDN.

![image](https://github.com/user-attachments/assets/5fd7ffbd-e406-4557-95d6-94ae046f5158)
