### PR TITLE
Use CNCF hosted DCO check

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,7 @@
+name: DCO
+on:
+  pull_request:
+  merge_group:
+jobs:
+  check:
+    uses: cncf/dcochecker/.github/workflows/dco.yml@main


### PR DESCRIPTION
The probot DCO app is unmaintained and does not support merge queue.

