### PR TITLE
Do not update EncapIP if it is configured

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -228,9 +228,11 @@ type DefaultConfig struct {
 	// EncapType value defines the encapsulation protocol to use to transmit packets between
 	// hypervisors. By default the value is 'geneve'
 	EncapType string `gcfg:"encap-type"`
-	// The IP address of the encapsulation endpoint. If not specified, the IP address the
-	// NodeName resolves to will be used
+	// Configured IP address of the encapsulation endpoint.
 	EncapIP string `gcfg:"encap-ip"`
+	// Effective encap IP. It may be different from EncapIP if EncapIP meant to be
+	// the node's primary IP which can be updated when node's primary IP changes.
+	EffectiveEncapIP string
 	// The UDP Port of the encapsulation endpoint. If not specified, the IP default port
 	// of 6081 will be used
 	EncapPort uint `gcfg:"encap-port"`

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -270,22 +270,66 @@ func setOVSFlowTargets(node *kapi.Node) error {
 	return nil
 }
 
+// validateEncapIP returns false if there is an error or if the given IP is not known local IP address.
+func validateEncapIP(encapIP string) (bool, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return false, fmt.Errorf("failed to get all the links on the node: %v", err)
+	}
+	for _, link := range links {
+		addrs, err := util.GetFilteredInterfaceAddrs(link, config.IPv4Mode, config.IPv6Mode)
+		if err != nil {
+			return false, err
+		}
+		for _, addr := range addrs {
+			if addr.IP.String() == encapIP {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 func setupOVNNode(node *kapi.Node) error {
 	var err error
 
+	nodePrimaryIP, err := util.GetNodePrimaryIP(node)
+	if err != nil {
+		return fmt.Errorf("failed to obtain local primary IP from node %q: %v", node.Name, err)
+	}
+
 	encapIP := config.Default.EncapIP
 	if encapIP == "" {
-		encapIP, err = util.GetNodePrimaryIP(node)
-		if err != nil {
-			return fmt.Errorf("failed to obtain local IP from node %q: %v", node.Name, err)
-		}
-		config.Default.EncapIP = encapIP
+		config.Default.EffectiveEncapIP = nodePrimaryIP
 	} else {
 		// OVN allows `external_ids:ovn-encap-ip` to be a list of IPs separated by comma.
+		config.Default.EffectiveEncapIP = encapIP
 		ovnEncapIps := strings.Split(encapIP, ",")
 		for _, ovnEncapIp := range ovnEncapIps {
 			if ip := net.ParseIP(strings.TrimSpace(ovnEncapIp)); ip == nil {
 				return fmt.Errorf("invalid IP address %q in provided encap-ip setting %q", ovnEncapIp, encapIP)
+			}
+		}
+		// if there are more than one encap IPs, it must be configured explicitly. otherwise:
+		if len(ovnEncapIps) == 1 {
+			encapIP = ovnEncapIps[0]
+			if encapIP == nodePrimaryIP {
+				// the current encap IP is node primary IP, unset config.Default.EncapIP to indicate it is
+				// implicitly configured through the old external_ids:ovn-encap-ip value and needs to be updated
+				// if node primary IP changes.
+				config.Default.EncapIP = ""
+			} else {
+				// the encap IP may be incorrectly set or;
+				// previous implicitly set with the old primary node IP through the old external_ids:ovn-encap-ip value,
+				// that has changed when ovnkube-node is down.
+				// validate it to see if it is still a valid local IP address.
+				valid, err := validateEncapIP(encapIP)
+				if err != nil {
+					return fmt.Errorf("invalid encap IP %s: %v", encapIP, err)
+				}
+				if !valid {
+					return fmt.Errorf("invalid encap IP %s: does not exist", encapIP)
+				}
 			}
 		}
 	}
@@ -295,7 +339,7 @@ func setupOVNNode(node *kapi.Node) error {
 		"Open_vSwitch",
 		".",
 		fmt.Sprintf("external_ids:ovn-encap-type=%s", config.Default.EncapType),
-		fmt.Sprintf("external_ids:ovn-encap-ip=%s", encapIP),
+		fmt.Sprintf("external_ids:ovn-encap-ip=%s", config.Default.EffectiveEncapIP),
 		fmt.Sprintf("external_ids:ovn-remote-probe-interval=%d",
 			config.Default.InactivityProbe),
 		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
@@ -1285,11 +1329,11 @@ func (nc *DefaultNodeNetworkController) WatchNamespaces() error {
 // enough, it will return an error
 func (nc *DefaultNodeNetworkController) validateVTEPInterfaceMTU() error {
 	// OVN allows `external_ids:ovn-encap-ip` to be a list of IPs separated by comma
-	ovnEncapIps := strings.Split(config.Default.EncapIP, ",")
+	ovnEncapIps := strings.Split(config.Default.EffectiveEncapIP, ",")
 	for _, ip := range ovnEncapIps {
 		ovnEncapIP := net.ParseIP(strings.TrimSpace(ip))
 		if ovnEncapIP == nil {
-			return fmt.Errorf("invalid IP address %q in provided encap-ip setting %q", ovnEncapIP, config.Default.EncapIP)
+			return fmt.Errorf("invalid IP address %q in provided encap-ip setting %q", ovnEncapIP, config.Default.EffectiveEncapIP)
 		}
 		interfaceName, mtu, err := util.GetIFNameAndMTUForAddress(ovnEncapIP)
 		if err != nil {

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Node", func() {
 			}
 
 			config.Default.MTU = configDefaultMTU
-			config.Default.EncapIP = "10.1.0.40"
+			config.Default.EffectiveEncapIP = "10.1.0.40"
 
 		})
 
@@ -219,7 +219,7 @@ var _ = Describe("Node", func() {
 			BeforeEach(func() {
 				config.IPv4Mode = true
 				config.IPv6Mode = false
-				config.Default.EncapIP = "10.1.0.40,10.2.0.50"
+				config.Default.EffectiveEncapIP = "10.1.0.40,10.2.0.50"
 				netlinkOpsMock.On("LinkByIndex", 5).Return(netlinkLinkMock, nil)
 			})
 

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -255,7 +255,7 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
 		return
 	}
-	if nodePrimaryAddrChanged {
+	if nodePrimaryAddrChanged && config.Default.EncapIP == "" {
 		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
 		updateOVNEncapIPAndReconnect(c.nodePrimaryAddr)
 	}
@@ -519,6 +519,7 @@ func updateOVNEncapIPAndReconnect(newIP net.IP) {
 		}
 	}
 
+	config.Default.EffectiveEncapIP = newIP.String()
 	confCmd := []string{
 		"set",
 		"Open_vSwitch",


### PR DESCRIPTION
If EncapIP is configured, it means it is different from the node's primary address. Do not update EncapIP when node's primary address changes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Cherry picked from PR https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4680

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
