### PR TITLE
docs/multi-homing: Add missing physicalNetworkName reference

### DIFF
--- a/docs/features/multiple-networks/multi-homing.md
+++ b/docs/features/multiple-networks/multi-homing.md
@@ -224,6 +224,9 @@ localnet network.
   IP addresses in a `ipamclaims.k8s.cni.cncf.io` object. This IP addresses will
   be reused by other pods if requested. Useful for KubeVirt VMs. Only makes
   sense if the `subnets` attribute is also defined.
+- `physicalNetworkName` (string, optional): the name of the physical network to
+  which the OVN overlay will connect. When omitted, it will default to the value
+  of the localnet network name on the NAD's `.spec.config.name`.
 
 > [!NOTE]
 > when the subnets attribute is omitted, the logical switch implementing the


### PR DESCRIPTION
## 📑 Description
This PR is adding a missing reference to the physicalNetworkName when configuring localnet topology.

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
