### PR TITLE
build, images: pass the OCI_BIN variable to the img building scripts

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -804,7 +804,7 @@ build_ovn_image() {
     make -C ${DIR}/../go-controller
 
     # Build image
-    make -C ${DIR}/../dist/images IMAGE="${OVN_IMAGE}" OVN_REPO="${OVN_REPO}" OVN_GITREF="${OVN_GITREF}" fedora-image
+    make -C ${DIR}/../dist/images IMAGE="${OVN_IMAGE}" OVN_REPO="${OVN_REPO}" OVN_GITREF="${OVN_GITREF}" OCI_BIN="${OCI_BIN}" fedora-image
 
     # store in local registry
     if [ "$KIND_LOCAL_REGISTRY" == true ];then


### PR DESCRIPTION
PR [0] broke podman users, with the following error:
```
find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f -exec cp -f {} . \;
echo "ref: refs/heads/master  commit: dd2a70c928d362a8d471352e7ec6e07164064e9f" > git_info
docker build \
	--build-arg OVN_FROM=koji \
	--build-arg OVN_REPO= \
	--build-arg OVN_GITREF= \
	-t localhost/ovn-daemonset-fedora:dev \
	-f Dockerfile.fedora .
make: docker: No such file or directory
```

By passing along the `OCI_BIN` variable, we make podman users happy again.

[0] - https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4899

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Using podman runtime, deploy a kind cluster. It should work with this PR, but fail without it.
