### PR TITLE
Fixes CNI primary udn log message

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -151,7 +151,7 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 
 	primaryUDN := udn.NewPrimaryNetwork(networkManager)
 	if util.IsNetworkSegmentationSupportEnabled() {
-		annotCondFn = primaryUDN.WaitForPrimaryAnnotationFn(namespace, annotCondFn)
+		annotCondFn = primaryUDN.WaitForPrimaryAnnotationFn(podName, namespace, annotCondFn)
 	}
 	pod, annotations, podNADAnnotation, err := GetPodWithAnnotations(pr.ctx, clientset, namespace, podName, pr.nadName, annotCondFn)
 	if err != nil {

--- a/go-controller/pkg/cni/udn/primary_network_test.go
+++ b/go-controller/pkg/cni/udn/primary_network_test.go
@@ -204,7 +204,8 @@ func TestWaitForPrimaryAnnotationFn(t *testing.T) {
 			}
 
 			userDefinedPrimaryNetwork := NewPrimaryNetwork(fakeNetworkManager)
-			obtainedAnnotation, obtainedIsReady := userDefinedPrimaryNetwork.WaitForPrimaryAnnotationFn(tt.namespace, waitCond)(tt.annotations, tt.nadName)
+			obtainedAnnotation, obtainedIsReady := userDefinedPrimaryNetwork.WaitForPrimaryAnnotationFn(
+				"testPod", tt.namespace, waitCond)(tt.annotations, tt.nadName)
 			obtainedFound := userDefinedPrimaryNetwork.Found()
 			obtainedNetworkName := userDefinedPrimaryNetwork.NetworkName()
 			obtainedNADName := userDefinedPrimaryNetwork.NADName()


### PR DESCRIPTION
The log message looked like this:
2025-02-14T00:49:29.504280050Z E0214 00:49:29.504252 2349982 primary_network.go:77] Failed ensuring user defined primary network for nad 'default': failed looking for primary network annotation for nad 'default': missing network annotation with primary role 'map[k8s.ovn.org/pod-networks:{"default":{"ip_addresses":["10.131.6.22/23"],"mac_address":"0a:58:0a:83:06:16","routes":[{"dest":"10.128.0.0/14","nextHop":"10.131.6.1"},{"dest":"100.64.0.0/16","nextHop":"10.131.6.1"}],"ip_address":"10.131.6.22/23","role":"infrastructure-locked"}} openshift.io/scc:restricted-v2 seccomp.security.alpha.kubernetes.io/pod:runtime/default]'

The primary network is always going to be nad "default", so there is no point in printing that a bunch of times. Also the log was missing what pod this was referring to.

