### PR TITLE
kubevirt, e2e: Add localnet ipamless live migration

### DIFF
--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -31,18 +31,22 @@ func netCIDR(netCIDR string, netPrefixLengthPerNode int) string {
 
 // takes ipv4 and ipv6 cidrs and returns the correct type for the cluster under test
 func correctCIDRFamily(ipv4CIDR, ipv6CIDR string) string {
+	return strings.Join(selectCIDRs(ipv4CIDR, ipv6CIDR), ",")
+}
+
+// takes ipv4 and ipv6 cidrs and returns the correct type for the cluster under test
+func selectCIDRs(ipv4CIDR, ipv6CIDR string) []string {
 	// dual stack cluster
 	if isIPv6Supported() && isIPv4Supported() {
-		return strings.Join([]string{ipv4CIDR, ipv6CIDR}, ",")
+		return []string{ipv4CIDR, ipv6CIDR}
 	}
 	// is an ipv6 only cluster
 	if isIPv6Supported() {
-		return ipv6CIDR
+		return []string{ipv6CIDR}
 	}
 
 	//ipv4 only cluster
-	return ipv4CIDR
-
+	return []string{ipv4CIDR}
 }
 
 func getNetCIDRSubnet(netCIDR string) (string, error) {


### PR DESCRIPTION

## 📑 Description
The current localnet kubevirt live migration tests are implemented using persistent IPs, this change add similar version of those tests but for ipamless localnet where VMI and pod IPs are statically assigned.

