### PR TITLE
Lint improvements for unit tests

### DIFF
--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - nosprintfhostport
     - revive
     - staticcheck
+    - testifylint
     - typecheck
     - unused
 

--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - revive
     - staticcheck
     - testifylint
+    - thelper
     - typecheck
     - unused
 

--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   enable:
     - errcheck
     - gci
+    - ginkgolinter
     - gofmt
     - gosimple
     - govet

--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -3,10 +3,6 @@ issues:
     - vendor
     - pkg/crd
 
-  exclude-files:
-    # TODO: lint test files as well
-    - ".*\\_test.go$"
-
 linters:
   disable-all: true
   enable:

--- a/go-controller/hybrid-overlay/pkg/controller/ho_node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ho_node_linux_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -34,7 +34,7 @@ const (
 func appHONRun(app *cli.App) {
 	err := app.Run([]string{
 		app.Name,
-		"-no-hostsubnet-nodes=" + v1.LabelOSStable + "=linux",
+		"-no-hostsubnet-nodes=" + corev1.LabelOSStable + "=linux",
 	})
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -109,8 +109,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				types.HybridOverlayNodeSubnet: hoNodeSubnet,
 			})
 
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{
+			fakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{
 					*testNode,
 				},
 			})
@@ -156,13 +156,13 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				types.HybridOverlayNodeSubnet: hoNodeSubnet,
 			})
 
-			fakeClient := fake.NewSimpleClientset(&v1.PodList{
-				Items: []v1.Pod{
+			fakeClient := fake.NewSimpleClientset(&corev1.PodList{
+				Items: []corev1.Pod{
 					*testPod1,
 					*testPod2,
 				},
-			}, &v1.NodeList{
-				Items: []v1.Node{
+			}, &corev1.NodeList{
+				Items: []corev1.Node{
 					*testNode,
 				},
 			})

--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux_test.go
@@ -524,7 +524,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// adding a remote pod should do nothing... we only care about directing traffic for pods on this node
 			_, err = fakeClient.CoreV1().Pods(remoteTestPod.Namespace).Create(context.TODO(), remoteTestPod, metav1.CreateOptions{})
@@ -533,7 +533,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			_, err = fakeClient.CoreV1().Pods(testPod.Namespace).Create(context.TODO(), testPod, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -548,7 +548,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
@@ -630,7 +630,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
@@ -703,7 +703,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			windowsAnnotation := createNodeAnnotationsForSubnet(node1Subnet)
 			windowsAnnotation[hotypes.HybridOverlayDRMAC] = node1DRMAC
@@ -726,7 +726,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 			return nil
 		}
 		appRun(app)
@@ -805,7 +805,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// setup windows node
 			windowsAnnotation := createNodeAnnotationsForSubnet(node1Subnet)
@@ -829,7 +829,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// setup local pod
 			testPod := createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC)
@@ -845,7 +845,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			//update Node DRIP
 			node.Annotations[hotypes.HybridOverlayDRIP] = updatedDRIP
@@ -865,7 +865,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			return nil
 		}
@@ -943,7 +943,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// setup windows node
 			windowsAnnotation := createNodeAnnotationsForSubnet(node1Subnet)
@@ -967,7 +967,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// setup local pod
 			testPod := createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC)
@@ -983,7 +983,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			//update Node DRIP
 			annotations[hotypes.HybridOverlayDRMAC] = updatedDRMAC
@@ -1000,7 +1000,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			return nil
 		}
@@ -1072,7 +1072,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// setup hybrid overlay node
 			windowsAnnotation := createNodeAnnotationsForSubnet(node1Subnet)
@@ -1096,7 +1096,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				linuxNode.flowMutex.Lock()
 				defer linuxNode.flowMutex.Unlock()
 				return compareFlowCache(linuxNode.flowCache, initialFlowCache)
-			}, 2).Should(BeNil())
+			}, 2).Should(Succeed())
 
 			// node is swiched to ovn node
 			_, err = fakeClient.CoreV1().Nodes().Update(context.TODO(), createNode(node1Name, "linux", node1IP, windowsAnnotation), metav1.UpdateOptions{})

--- a/go-controller/observability-lib/sampledecoder/sample_decoder_test.go
+++ b/go-controller/observability-lib/sampledecoder/sample_decoder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
@@ -19,7 +20,7 @@ func TestCreateOrUpdateACL(t *testing.T) {
 			libovsdbops.PolicyDirectionKey.String(): string(libovsdbutil.ACLIngress),
 		},
 	})
-	assert.ErrorContains(t, err, "expected format namespace:name for Object Name, but found: foo")
+	require.ErrorContains(t, err, "expected format namespace:name for Object Name, but found: foo")
 	assert.Nil(t, event)
 
 	event, err = newACLEvent(&nbdb.ACL{
@@ -30,7 +31,7 @@ func TestCreateOrUpdateACL(t *testing.T) {
 			libovsdbops.PolicyDirectionKey.String(): string(libovsdbutil.ACLIngress),
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Allowed by network policy foo in namespace bar, direction Ingress", event.String())
 
 	event, err = newACLEvent(&nbdb.ACL{
@@ -41,7 +42,7 @@ func TestCreateOrUpdateACL(t *testing.T) {
 			libovsdbops.PolicyDirectionKey.String(): string(libovsdbutil.ACLIngress),
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Allowed by admin network policy foo, direction Ingress", event.String())
 
 	event, err = newACLEvent(&nbdb.ACL{
@@ -51,7 +52,7 @@ func TestCreateOrUpdateACL(t *testing.T) {
 			libovsdbops.ObjectNameKey.String(): "foo",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Allowed by egress firewall in namespace foo", event.String())
 	assert.Equal(t, "Egress", event.Direction)
 
@@ -61,7 +62,7 @@ func TestCreateOrUpdateACL(t *testing.T) {
 			libovsdbops.OwnerTypeKey.String(): libovsdbops.NetpolNodeOwnerType,
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Allowed by default allow from local node policy, direction Ingress", event.String())
 	assert.Equal(t, "Ingress", event.Direction)
 }

--- a/go-controller/pkg/allocator/bitmap/bitmap_test.go
+++ b/go-controller/pkg/allocator/bitmap/bitmap_test.go
@@ -83,11 +83,11 @@ func TestRelease(t *testing.T) {
 }
 
 func TestForEach(t *testing.T) {
-	testCases := []sets.Int{
-		sets.NewInt(),
-		sets.NewInt(0),
-		sets.NewInt(0, 2, 5, 9),
-		sets.NewInt(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+	testCases := []sets.Set[int]{
+		sets.New[int](),
+		sets.New(0),
+		sets.New(0, 2, 5, 9),
+		sets.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
 	}
 
 	for i, tc := range testCases {
@@ -100,7 +100,7 @@ func TestForEach(t *testing.T) {
 				t.Errorf("[%d] expect offset %v allocated", i, offset)
 			}
 		}
-		calls := sets.NewInt()
+		calls := sets.New[int]()
 		m.ForEach(func(i int) {
 			calls.Insert(i)
 		})
@@ -108,7 +108,7 @@ func TestForEach(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List(calls), sets.List(tc))
 		}
 	}
 }
@@ -288,11 +288,11 @@ func TestRoundRobinWrapAround(t *testing.T) {
 }
 
 func TestRoundRobinForEach(t *testing.T) {
-	testCases := []sets.Int{
-		sets.NewInt(),
-		sets.NewInt(0),
-		sets.NewInt(0, 2, 5, 9),
-		sets.NewInt(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+	testCases := []sets.Set[int]{
+		sets.New[int](),
+		sets.New(0),
+		sets.New(0, 2, 5, 9),
+		sets.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
 	}
 
 	for i, tc := range testCases {
@@ -305,7 +305,7 @@ func TestRoundRobinForEach(t *testing.T) {
 				t.Fatalf("[%d] expect offset %d allocated", i, offset)
 			}
 		}
-		calls := sets.NewInt()
+		calls := sets.New[int]()
 		m.ForEach(func(j int) {
 			calls.Insert(j)
 		})
@@ -313,7 +313,7 @@ func TestRoundRobinForEach(t *testing.T) {
 			t.Fatalf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Fatalf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Fatalf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List(calls), sets.List(tc))
 		}
 	}
 }

--- a/go-controller/pkg/allocator/ip/allocator_test.go
+++ b/go-controller/pkg/allocator/ip/allocator_test.go
@@ -225,11 +225,11 @@ func TestForEach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testCases := []sets.String{
-		sets.NewString(),
-		sets.NewString("192.168.1.1"),
-		sets.NewString("192.168.1.1", "192.168.1.254"),
-		sets.NewString("192.168.1.1", "192.168.1.128", "192.168.1.254"),
+	testCases := []sets.Set[string]{
+		sets.New[string](),
+		sets.New("192.168.1.1"),
+		sets.New("192.168.1.1", "192.168.1.254"),
+		sets.New("192.168.1.1", "192.168.1.128", "192.168.1.254"),
 	}
 
 	for i, tc := range testCases {
@@ -246,7 +246,7 @@ func TestForEach(t *testing.T) {
 				t.Errorf("[%d] expected IP %v allocated", i, ip)
 			}
 		}
-		calls := sets.NewString()
+		calls := sets.New[string]()
 		r.ForEach(func(ip net.IP) {
 			calls.Insert(ip.String())
 		})
@@ -254,7 +254,7 @@ func TestForEach(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List(calls), sets.List(tc))
 		}
 	}
 }

--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -11,7 +11,7 @@ import (
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/id"
@@ -31,7 +31,7 @@ type ipAllocatorStub struct {
 	releasedIPs      []*net.IPNet
 }
 
-func (a *ipAllocatorStub) AllocateIPs(ips []*net.IPNet) error {
+func (a *ipAllocatorStub) AllocateIPs([]*net.IPNet) error {
 	return a.allocateIPsError
 }
 
@@ -58,7 +58,7 @@ func (a *idAllocatorStub) AllocateID() (int, error) {
 	return a.nextID, nil
 }
 
-func (a *idAllocatorStub) ReserveID(id int) error {
+func (a *idAllocatorStub) ReserveID(int) error {
 	return a.reserveIDError
 }
 
@@ -688,7 +688,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 
 			config.OVNKubernetesFeature.EnableInterconnect = tt.idAllocation
 
-			pod := &v1.Pod{
+			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod",
 					Namespace: "namespace",

--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -919,7 +919,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 						}
 
 						gomega.Expect(gwLRPAddrs).NotTo(gomega.BeNil())
-						gomega.Expect(len(gwLRPAddrs)).To(gomega.Equal(2))
+						gomega.Expect(gwLRPAddrs).To(gomega.HaveLen(2))
 						return nil
 					}).ShouldNot(gomega.HaveOccurred())
 				}
@@ -991,7 +991,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 							return err
 						}
 						gomega.Expect(gwLRPAddrs).NotTo(gomega.BeNil())
-						gomega.Expect(len(gwLRPAddrs)).To(gomega.Equal(2))
+						gomega.Expect(gwLRPAddrs).To(gomega.HaveLen(2))
 						nodeAddrs[n.Name] = updatedNode.Annotations[util.OVNNodeGRLRPAddrs]
 						return nil
 					}).ShouldNot(gomega.HaveOccurred())
@@ -1094,7 +1094,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 							return err
 						}
 						gomega.Expect(gwLRPAddrs).NotTo(gomega.BeNil())
-						gomega.Expect(len(gwLRPAddrs)).To(gomega.Equal(2))
+						gomega.Expect(gwLRPAddrs).To(gomega.HaveLen(2))
 
 						// Store the node 3's gw router port addresses
 						if updatedNode.Name == "node3" {
@@ -1154,7 +1154,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 						return err
 					}
 					gomega.Expect(gwLRPAddrs).NotTo(gomega.BeNil())
-					gomega.Expect(len(gwLRPAddrs)).To(gomega.Equal(2))
+					gomega.Expect(gwLRPAddrs).To(gomega.HaveLen(2))
 					return nil
 				}).ShouldNot(gomega.HaveOccurred())
 				return nil

--- a/go-controller/pkg/clustermanager/dnsnameresolver/controller_test.go
+++ b/go-controller/pkg/clustermanager/dnsnameresolver/controller_test.go
@@ -306,7 +306,7 @@ var _ = ginkgo.Describe("Cluster manager DNS Name Resolver Controller operations
 				dnsNameResolvers, err := dnsLister.DNSNameResolvers(config.Kubernetes.OVNConfigNamespace).List(labels.Everything())
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				gomega.Expect(len(dnsNameResolvers)).To(gomega.Equal(1))
+				gomega.Expect(dnsNameResolvers).To(gomega.HaveLen(1))
 
 				dnsNameResolver = checkDNSNameResolverExists(dnsName)
 

--- a/go-controller/pkg/clustermanager/dnsnameresolver/controller_test.go
+++ b/go-controller/pkg/clustermanager/dnsnameresolver/controller_test.go
@@ -9,7 +9,7 @@ import (
 	ocpnetworkapiv1alpha1 "github.com/openshift/api/network/v1alpha1"
 	ocpnetworklisterv1alpha1 "github.com/openshift/client-go/network/listers/network/v1alpha1"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("Cluster manager DNS Name Resolver Controller operations
 
 	checkDNSNameResolverExists := func(dnsName string) *ocpnetworkapiv1alpha1.DNSNameResolver {
 		var dnsNameResolvers []*ocpnetworkapiv1alpha1.DNSNameResolver
-		err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Second, true, func(context.Context) (done bool, err error) {
 			dnsNameResolvers, err = dnsLister.DNSNameResolvers(config.Kubernetes.OVNConfigNamespace).List(labels.Everything())
 			if err != nil {
 				return false, err
@@ -101,9 +101,9 @@ var _ = ginkgo.Describe("Cluster manager DNS Name Resolver Controller operations
 	}
 
 	checkDNSNameResolverRemoved := func(resolverName string) {
-		err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Second, true, func(context.Context) (done bool, err error) {
 			_, err = dnsLister.DNSNameResolvers(config.Kubernetes.OVNConfigNamespace).Get(resolverName)
-			if err == nil || !errors.IsNotFound(err) {
+			if err == nil || !apierrors.IsNotFound(err) {
 				return false, nil
 			}
 

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -1129,7 +1129,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 							gomega.Expect(prevProbes).To(gomega.Equal(hcc.ProbeCount), desc)
 						} else {
 							// Still connected and probe counters should be going up
-							gomega.Expect(prevProbes < hcc.ProbeCount).To(gomega.BeTrue(), desc)
+							gomega.Expect(prevProbes).To(gomega.BeNumerically("<", hcc.ProbeCount), desc)
 						}
 					}
 				}
@@ -1477,7 +1477,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				gomega.Expect(getEgressIPAllocatorSafely(node1.Name, false).Net).To(gomega.Equal(ip1V4Sub))
 				gomega.Expect(getEgressIPAllocatorSafely(node1.Name, true).Net).To(gomega.Equal(ip1V6Sub))
 				gomega.Expect(getEgressIPAllocatorSafely(node2.Name, false).Net).To(gomega.Equal(ip2V4Sub))
-				gomega.Eventually(eIP.Status.Items).Should(gomega.HaveLen(0))
+				gomega.Eventually(eIP.Status.Items).Should(gomega.BeEmpty())
 
 				node1.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
@@ -1695,9 +1695,9 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				node.Annotations["test"] = "dummy"
 				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(hcClient.IsConnected()).Should(gomega.Equal(true))
+				gomega.Eventually(hcClient.IsConnected).Should(gomega.BeTrue())
 				// the node should not be marked as reachable in the update handler as it is not getting added
-				gomega.Consistently(func() bool { return fakeClusterManagerOVN.eIPC.nodeAllocator.cache[node.Name].isReachable }).Should(gomega.Equal(false))
+				gomega.Consistently(func() bool { return fakeClusterManagerOVN.eIPC.nodeAllocator.cache[node.Name].isReachable }).Should(gomega.BeFalse())
 
 				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
 				// explicitly call check reachability, periodic checker is not active
@@ -2218,7 +2218,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
 				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
-				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 
 				return nil
 			}
@@ -2301,7 +2301,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node1)).To(gomega.Succeed())
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node2)).To(gomega.Succeed())
 				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
-				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 
 				return nil
 			}
@@ -2380,7 +2380,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
 				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
-				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
 
@@ -2459,7 +2459,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
 				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
-				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
 
@@ -2619,7 +2619,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
 				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
-				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
 
@@ -2694,7 +2694,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				assignedStatuses, err := fakeClusterManagerOVN.eIPC.validateEgressIPSpec(eIP.Name, eIP.Spec.EgressIPs)
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err.Error()).To(gomega.Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
-				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
 
@@ -2860,7 +2860,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				validatedIPs, err := fakeClusterManagerOVN.eIPC.validateEgressIPSpec(eIP.Name, eIP.Spec.EgressIPs)
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err.Error()).To(gomega.Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
-				gomega.Expect(validatedIPs).To(gomega.HaveLen(0))
+				gomega.Expect(validatedIPs).To(gomega.BeEmpty())
 				return nil
 			}
 

--- a/go-controller/pkg/clustermanager/egressservice_cluster_test.go
+++ b/go-controller/pkg/clustermanager/egressservice_cluster_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,13 +42,13 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		// disabling EgressIP to be sure we're creating the no reroute policies ourselves
 		config.OVNKubernetesFeature.EnableEgressIP = false
 		config.OVNKubernetesFeature.EnableEgressService = true
 		_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
 		_, cidr6, _ := net.ParseCIDR("fe00::/16")
-		config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{cidr4, 24}, {cidr6, 64}}
+		config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 24}, {CIDR: cidr6, HostSubnetLength: 64}}
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 	ginkgo.Context("on startup repair", func() {
 
 		ginkgo.It("should delete stale labels from nodes", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
 				node2 := nodeFor(node2Name, node2IPv4, node2IPv6, node2IPv4Subnet, node2IPv6Subnet)
@@ -176,19 +176,19 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 							*node2,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 							svc2,
 							srcIPNotByLBService,
@@ -256,7 +256,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 		})
 
 		ginkgo.It("should delete stale status from EgressServices", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
 
@@ -304,18 +304,18 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc2,
 						},
 					},
@@ -366,7 +366,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 
 	ginkgo.Context("on services changes", func() {
 		ginkgo.It("should create/update/delete EgressService host", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
 				node1.Labels = map[string]string{"firstName": "Albus"}
@@ -422,19 +422,19 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 							*node2,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 						},
 					},
@@ -488,7 +488,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				s2 := lbSvcFor("testns", "svc2")
 				svc2 := &s2
 
-				svc2, err = fakeCM.fakeClient.KubeClient.CoreV1().Services("testns").Create(context.TODO(), svc2, metav1.CreateOptions{})
+				_, err = fakeCM.fakeClient.KubeClient.CoreV1().Services("testns").Create(context.TODO(), svc2, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				ginkgo.By("creating an EgressService for the second service with a config that matches the second node its status will be updated")
@@ -551,7 +551,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 		})
 
 		ginkgo.It("should create/update/delete node labels", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
 				node1.Labels = map[string]string{"animal": "FlyingBison"}
@@ -591,19 +591,19 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 							*node2,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 						},
 					},
@@ -734,7 +734,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 		})
 
 		ginkgo.It("should do nothing when an invalid nodeSelector is specified", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
 
@@ -771,18 +771,18 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 						},
 					},
@@ -834,7 +834,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 	ginkgo.Context("on endpointslices changes", func() {
 
 		ginkgo.It("should create/update/delete status for ETP=Local Service", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				config.IPv6Mode = true
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
@@ -857,7 +857,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 					},
 				}
 				svc1 := lbSvcFor("testns", "svc1")
-				svc1.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+				svc1.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 
 				v4EpSlice := &discovery.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -878,18 +878,18 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 						},
 					},
@@ -1023,7 +1023,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 
 	ginkgo.Context("on nodes changes", func() {
 		ginkgo.It("should create/update/delete labels and status", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				config.IPv6Mode = true
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
@@ -1133,19 +1133,19 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 							*node2,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 							svc2,
 						},
@@ -1218,10 +1218,10 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}).ShouldNot(gomega.HaveOccurred())
 
 				ginkgo.By("updating the first node's to be not ready the resources of first service will be deleted")
-				node1.Status.Conditions = []v1.NodeCondition{
+				node1.Status.Conditions = []corev1.NodeCondition{
 					{
-						Type:   v1.NodeReady,
-						Status: v1.ConditionFalse,
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
 					},
 				}
 				node1.ResourceVersion = "2"
@@ -1368,7 +1368,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 		})
 
 		ginkgo.It("should update labels and status on reachability failure", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("testns")
 				config.IPv6Mode = true
 				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
@@ -1425,18 +1425,18 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
-					&v1.ServiceList{
-						Items: []v1.Service{
+					&corev1.ServiceList{
+						Items: []corev1.Service{
 							svc1,
 						},
 					},
@@ -1456,7 +1456,7 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 				ginkgo.By("modifying the controller's IsReachable func to return false on the first call and true for the second")
 				count := 0
 
-				isReachable = func(nodeName string, _ []net.IP, _ healthcheck.EgressIPHealthClient) bool {
+				isReachable = func(string, []net.IP, healthcheck.EgressIPHealthClient) bool {
 					count++
 					return count == 2
 				}
@@ -1555,19 +1555,19 @@ var _ = ginkgo.Describe("Cluster manager Egress Service operations", func() {
 
 })
 
-func lbSvcFor(namespace, name string) v1.Service {
-	return v1.Service{
+func lbSvcFor(namespace, name string) corev1.Service {
+	return corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
 			ResourceVersion: "1",
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
 		},
-		Status: v1.ServiceStatus{
-			LoadBalancer: v1.LoadBalancerStatus{
-				Ingress: []v1.LoadBalancerIngress{
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
 					{
 						IP: "1.1.1.1", // arbitrary ip, we don't care about it for the lrps as long as it's there
 					},
@@ -1577,8 +1577,8 @@ func lbSvcFor(namespace, name string) v1.Service {
 	}
 }
 
-func nodeFor(name, ipv4, ipv6, v4subnet, v6subnet string) *v1.Node {
-	return &v1.Node{
+func nodeFor(name, ipv4, ipv6, v4subnet, v6subnet string) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
@@ -1590,20 +1590,20 @@ func nodeFor(name, ipv4, ipv6, v4subnet, v6subnet string) *v1.Node {
 			},
 			ResourceVersion: "1",
 		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
 				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
 				},
 			},
-			Addresses: []v1.NodeAddress{
+			Addresses: []corev1.NodeAddress{
 				{
-					Type:    v1.NodeInternalIP,
+					Type:    corev1.NodeInternalIP,
 					Address: ipv4,
 				},
 				{
-					Type:    v1.NodeInternalIP,
+					Type:    corev1.NodeInternalIP,
 					Address: ipv6,
 				},
 			},

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,16 +78,16 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 	ginkgo.Context("on startup repair", func() {
 		ginkgo.It("should delete stale mirrored EndpointSlices and create missing ones", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
-				pod := v1.Pod{
+				pod := corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test-pod",
 						Namespace:   namespaceT.Name,
 						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
 					},
-					Status: v1.PodStatus{Phase: v1.PodRunning},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
 				}
 
 				defaultEndpointSlice := discovery.EndpointSlice{
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					Endpoints: []discovery.Endpoint{
 						{
 							Addresses: []string{"10.244.2.3"},
-							TargetRef: &v1.ObjectReference{
+							TargetRef: &corev1.ObjectReference{
 								Kind:      "Pod",
 								Namespace: namespaceT.Name,
 								Name:      pod.Name,
@@ -114,13 +114,13 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				staleEndpointSlice.Annotations[types.SourceEndpointSliceAnnotation] = "non-existing-endpointslice"
 
 				objs := []runtime.Object{
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							pod,
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					if err == nil {
 						return fmt.Errorf("the stale mirrored EndpointSlice should not exist: %v", staleMirror)
 					}
-					if err != nil && !errors.IsNotFound(err) {
+					if err != nil && !apierrors.IsNotFound(err) {
 						return err
 					}
 
@@ -186,16 +186,16 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 	ginkgo.Context("on EndpointSlices changes", func() {
 		ginkgo.It("should not create mirrored EndpointSlices in namespaces that are not using user defined networks as primary", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 
-				pod := v1.Pod{
+				pod := corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test-pod",
 						Namespace:   namespaceT.Name,
 						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"primary"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"secondary}}`},
 					},
-					Status: v1.PodStatus{Phase: v1.PodRunning},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
 				}
 
 				defaultEndpointSlice := discovery.EndpointSlice{
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					Endpoints: []discovery.Endpoint{
 						{
 							Addresses: []string{"10.244.2.3"},
-							TargetRef: &v1.ObjectReference{
+							TargetRef: &corev1.ObjectReference{
 								Kind:      "Pod",
 								Namespace: namespaceT.Name,
 								Name:      pod.Name,
@@ -220,13 +220,13 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				}
 
 				objs := []runtime.Object{
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							pod,
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
@@ -278,17 +278,17 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 		})
 
 		ginkgo.It("should update/delete mirrored EndpointSlices in namespaces that use user defined networks as primary ", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
 
-				pod := v1.Pod{
+				pod := corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test-pod",
 						Namespace:   namespaceT.Name,
 						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
 					},
-					Status: v1.PodStatus{Phase: v1.PodRunning},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
 				}
 
 				defaultEndpointSlice := discovery.EndpointSlice{
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					Endpoints: []discovery.Endpoint{
 						{
 							Addresses: []string{"10.244.2.3"},
-							TargetRef: &v1.ObjectReference{
+							TargetRef: &corev1.ObjectReference{
 								Kind:      "Pod",
 								Namespace: namespaceT.Name,
 								Name:      pod.Name,
@@ -314,13 +314,13 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				}
 				mirroredEndpointSlice := testing.MirrorEndpointSlice(&defaultEndpointSlice, "l3-network", false)
 				objs := []runtime.Object{
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							pod,
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
@@ -372,13 +372,13 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				gomega.Expect(mirroredEndpointSlices[0].Endpoints[0].Addresses).To(gomega.BeEquivalentTo([]string{"10.132.2.4"}))
 
 				ginkgo.By("when the EndpointSlice changes the mirrored one gets updated")
-				newPod := v1.Pod{
+				newPod := corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test-pod-new",
 						Namespace:   namespaceT.Name,
 						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:04","ip_address":"10.244.2.4/24","primary":false},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:05","ip_address":"10.132.2.5/24","primary":true}}`},
 					},
-					Status: v1.PodStatus{Phase: v1.PodRunning},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
 				}
 				_, err = fakeClient.KubeClient.CoreV1().Pods(newPod.Namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -392,7 +392,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 				defaultEndpointSlice.Endpoints = append(defaultEndpointSlice.Endpoints, discovery.Endpoint{
 					Addresses: []string{"10.244.2.4"},
-					TargetRef: &v1.ObjectReference{
+					TargetRef: &corev1.ObjectReference{
 						Kind:      "Pod",
 						Namespace: newPod.Namespace,
 						Name:      newPod.Name,
@@ -447,17 +447,17 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 		})
 
 		ginkgo.It("should create mirrored EndpointSlices for long endpointslice and network names", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
 
-				pod := v1.Pod{
+				pod := corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test-pod",
 						Namespace:   namespaceT.Name,
 						Annotations: map[string]string{util.OvnPodAnnotationName: `{"default":{"mac_address":"0a:58:0a:f4:02:03","ip_address":"10.244.2.3/24","role":"infrastructure-locked"},"testns/l3-network":{"mac_address":"0a:58:0a:84:02:04","ip_address":"10.132.2.4/24","role":"primary"}}`},
 					},
-					Status: v1.PodStatus{Phase: v1.PodRunning},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
 				}
 				longName := strings.Repeat("a", 253)
 
@@ -474,7 +474,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					Endpoints: []discovery.Endpoint{
 						{
 							Addresses: []string{"10.244.2.3"},
-							TargetRef: &v1.ObjectReference{
+							TargetRef: &corev1.ObjectReference{
 								Kind:      "Pod",
 								Namespace: namespaceT.Name,
 								Name:      pod.Name,
@@ -486,13 +486,13 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				longNetName := "network" + longName
 				mirroredEndpointSlice := testing.MirrorEndpointSlice(&defaultEndpointSlice, longNetName, false)
 				objs := []runtime.Object{
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							pod,
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},

--- a/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
+++ b/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
@@ -35,7 +35,7 @@ type FakeClusterManager struct {
 	fakeRecorder *record.FakeRecorder
 }
 
-var isReachable = func(nodeName string, mgmtIPs []net.IP, healthClient healthcheck.EgressIPHealthClient) bool {
+var isReachable = func(string, []net.IP, healthcheck.EgressIPHealthClient) bool {
 	return true
 }
 

--- a/go-controller/pkg/clustermanager/network_cluster_controller_test.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 	ginkgo.Context("Host Subnets", func() {
 		ginkgo.It("removes an unused dual-stack allocation from single-stack cluster", func() {
 			app.Action = func(ctx *cli.Context) error {
-				nodes := []v1.Node{
+				nodes := []corev1.Node{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 						},
 					},
 				}
-				kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
 					Items: nodes,
 				})
 				fakeClient := &util.OVNClusterManagerClientset{
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f, recorder)
-				ncc.Start(ctx.Context)
+				gomega.Expect(ncc.Start(ctx.Context)).To(gomega.Succeed())
 				defer ncc.Stop()
 
 				// Check that the default network controller removes the unused v6 node subnet annotation
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 
 		ginkgo.It("allocates a subnet for a new node", func() {
 			app.Action = func(ctx *cli.Context) error {
-				nodes := []v1.Node{
+				nodes := []corev1.Node{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 						},
 					},
 				}
-				kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
 					Items: nodes,
 				})
 				fakeClient := &util.OVNClusterManagerClientset{
@@ -132,7 +132,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f, recorder)
-				ncc.Start(ctx.Context)
+				gomega.Expect(ncc.Start(ctx.Context)).To(gomega.Succeed())
 				defer ncc.Stop()
 
 				// Check that the default network controller adds a subnet for the new node
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 
 		ginkgo.It("removes an invalid single-stack annotation", func() {
 			app.Action = func(ctx *cli.Context) error {
-				nodes := []v1.Node{
+				nodes := []corev1.Node{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 						},
 					},
 				}
-				kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
 					Items: nodes,
 				})
 				fakeClient := &util.OVNClusterManagerClientset{
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f, recorder)
-				ncc.Start(ctx.Context)
+				gomega.Expect(ncc.Start(ctx.Context)).To(gomega.Succeed())
 				defer ncc.Stop()
 
 				// Check that the default network controller removes the unused v6 node subnet annotation

--- a/go-controller/pkg/clustermanager/node/subnet_allocator_test.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator_test.go
@@ -74,7 +74,7 @@ func allocateNotExpected(sna SubnetAllocator, v4n, v6n int) error {
 	return nil
 }
 
-func expectNumSubnets(t *testing.T, sna SubnetAllocator, v4expected, v6expected uint64) error {
+func expectNumSubnets(sna SubnetAllocator, v4expected, v6expected uint64) error {
 	v4count, v6count := sna.Count()
 	if v4count != v4expected {
 		return fmt.Errorf("expected %d available v4 subnets but got %d", v4expected, v4count)
@@ -91,7 +91,7 @@ func TestAllocateSubnetIPv4(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 256, 0); err != nil {
+	if err := expectNumSubnets(sna, 256, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -111,7 +111,7 @@ func TestAllocateSubnetIPv6(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 0, 65536); err != nil {
+	if err := expectNumSubnets(sna, 0, 65536); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +143,7 @@ func TestAllocateSubnetLargeHostBitsIPv4(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 64, 0); err != nil {
+	if err := expectNumSubnets(sna, 64, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,7 +163,7 @@ func TestAllocateSubnetLargeHostBitsIPv6(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 0, 4096); err != nil {
+	if err := expectNumSubnets(sna, 0, 4096); err != nil {
 		t.Fatal(err)
 	}
 
@@ -182,7 +182,7 @@ func TestAllocateSubnetLargeSubnetBitsIPv4(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 1024, 0); err != nil {
+	if err := expectNumSubnets(sna, 1024, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -219,7 +219,7 @@ func TestAllocateSubnetLargeSubnetBitsIPv6(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 0, 68719476736); err != nil {
+	if err := expectNumSubnets(sna, 0, 68719476736); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,7 +254,7 @@ func TestAllocateSubnetOverlappingIPv4(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
-	if err := expectNumSubnets(t, sna, 256, 0); err != nil {
+	if err := expectNumSubnets(sna, 256, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -45,7 +45,7 @@ type testPod struct {
 }
 
 func (p testPod) getPod(t *testing.T) *corev1.Pod {
-
+	t.Helper()
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "pod",

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -80,40 +80,40 @@ type ipAllocatorStub struct {
 	released bool
 }
 
-func (a *ipAllocatorStub) AddOrUpdateSubnet(name string, subnets []*net.IPNet, excludeSubnets ...*net.IPNet) error {
+func (a *ipAllocatorStub) AddOrUpdateSubnet(string, []*net.IPNet, ...*net.IPNet) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a ipAllocatorStub) DeleteSubnet(name string) {
+func (a ipAllocatorStub) DeleteSubnet(string) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) GetSubnets(name string) ([]*net.IPNet, error) {
+func (a *ipAllocatorStub) GetSubnets(string) ([]*net.IPNet, error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) AllocateUntilFull(name string) error {
+func (a *ipAllocatorStub) AllocateUntilFull(string) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) AllocateIPPerSubnet(name string, ips []*net.IPNet) error {
+func (a *ipAllocatorStub) AllocateIPPerSubnet(string, []*net.IPNet) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) AllocateNextIPs(name string) ([]*net.IPNet, error) {
+func (a *ipAllocatorStub) AllocateNextIPs(string) ([]*net.IPNet, error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) ReleaseIPs(name string, ips []*net.IPNet) error {
+func (a *ipAllocatorStub) ReleaseIPs(string, []*net.IPNet) error {
 	a.released = true
 	return nil
 }
 
-func (a *ipAllocatorStub) ConditionalIPRelease(name string, ips []*net.IPNet, predicate func() (bool, error)) (bool, error) {
+func (a *ipAllocatorStub) ConditionalIPRelease(string, []*net.IPNet, func() (bool, error)) (bool, error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *ipAllocatorStub) ForSubnet(name string) subnet.NamedAllocator {
+func (a *ipAllocatorStub) ForSubnet(string) subnet.NamedAllocator {
 	return &namedAllocatorStub{}
 }
 
@@ -125,19 +125,19 @@ type idAllocatorStub struct {
 	released bool
 }
 
-func (a *idAllocatorStub) AllocateID(name string) (int, error) {
+func (a *idAllocatorStub) AllocateID(string) (int, error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *idAllocatorStub) ReserveID(name string, id int) error {
+func (a *idAllocatorStub) ReserveID(string, int) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *idAllocatorStub) ReleaseID(name string) {
+func (a *idAllocatorStub) ReleaseID(string) {
 	a.released = true
 }
 
-func (a *idAllocatorStub) ForName(name string) id.NamedAllocator {
+func (a *idAllocatorStub) ForName(string) id.NamedAllocator {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -148,7 +148,7 @@ func (a *idAllocatorStub) GetSubnetName([]*net.IPNet) (string, bool) {
 type namedAllocatorStub struct {
 }
 
-func (nas *namedAllocatorStub) AllocateIPs(ips []*net.IPNet) error {
+func (nas *namedAllocatorStub) AllocateIPs([]*net.IPNet) error {
 	return nil
 }
 
@@ -156,7 +156,7 @@ func (nas *namedAllocatorStub) AllocateNextIPs() ([]*net.IPNet, error) {
 	return nil, nil
 }
 
-func (nas *namedAllocatorStub) ReleaseIPs(ips []*net.IPNet) error {
+func (nas *namedAllocatorStub) ReleaseIPs([]*net.IPNet) error {
 	return nil
 }
 
@@ -525,7 +525,7 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 
 			var allocated bool
 			kubeMock.On("UpdatePodStatus", mock.AnythingOfType(fmt.Sprintf("%T", &corev1.Pod{}))).Run(
-				func(args mock.Arguments) {
+				func(mock.Arguments) {
 					allocated = true
 				},
 			).Return(nil)

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -24,7 +24,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
-	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -61,7 +60,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 	ginkgo.Context("Secondary networks", func() {
 		ginkgo.It("Attach secondary layer3 network", func() {
 			app.Action = func(ctx *cli.Context) error {
-				kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{Items: nodes()})
+				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{Items: nodes()})
 				fakeClient := &util.OVNClusterManagerClientset{
 					KubeClient:            kubeFakeClient,
 					IPAMClaimsClient:      fakeipamclaimclient.NewSimpleClientset(),
@@ -116,7 +115,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 			ginkgo.BeforeEach(func() {
 
 				fakeClient = &util.OVNClusterManagerClientset{
-					KubeClient:            fake.NewSimpleClientset(&v1.NodeList{Items: nodes()}),
+					KubeClient:            fake.NewSimpleClientset(&corev1.NodeList{Items: nodes()}),
 					IPAMClaimsClient:      fakeipamclaimclient.NewSimpleClientset(),
 					NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
 				}
@@ -149,7 +148,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 					config.OVNKubernetesFeature.EnableInterconnect = false
 					nc, err := sncm.NewNetworkController(netInfo)
-					gomega.Expect(err).To(gomega.Equal(nad.ErrNetworkControllerTopologyNotManaged))
+					gomega.Expect(err).To(gomega.Equal(networkmanager.ErrNetworkControllerTopologyNotManaged))
 					gomega.Expect(nc).To(gomega.BeNil())
 
 					config.OVNKubernetesFeature.EnableInterconnect = true
@@ -219,7 +218,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 			ginkgo.BeforeEach(func() {
 				fakeClient = &util.OVNClusterManagerClientset{
-					KubeClient:            fake.NewSimpleClientset(&v1.NodeList{Items: nodes()}),
+					KubeClient:            fake.NewSimpleClientset(&corev1.NodeList{Items: nodes()}),
 					NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
 				}
 
@@ -260,7 +259,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					"does not manage localnet topologies on IC deployments for networks without subnets",
 					&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.LocalnetTopology},
 					config.OVNKubernetesFeatureConfig{EnableInterconnect: true, EnableMultiNetwork: true},
-					nad.ErrNetworkControllerTopologyNotManaged,
+					networkmanager.ErrNetworkControllerTopologyNotManaged,
 				),
 				ginkgo.Entry(
 					"manages localnet topologies on IC deployments for networks with subnets",
@@ -276,7 +275,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					"does not manage localnet topologies on non-IC deployments without subnets",
 					&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.LocalnetTopology},
 					config.OVNKubernetesFeatureConfig{EnableMultiNetwork: true},
-					nad.ErrNetworkControllerTopologyNotManaged,
+					networkmanager.ErrNetworkControllerTopologyNotManaged,
 				),
 				ginkgo.Entry(
 					"does not manage localnet topologies on non-IC deployments with subnets",
@@ -286,14 +285,14 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						Subnets:  subnets,
 					},
 					config.OVNKubernetesFeatureConfig{EnableMultiNetwork: true},
-					nad.ErrNetworkControllerTopologyNotManaged,
+					networkmanager.ErrNetworkControllerTopologyNotManaged,
 				),
 			)
 		})
 
 		ginkgo.It("Cleanup", func() {
 			app.Action = func(ctx *cli.Context) error {
-				nodes := []v1.Node{
+				nodes := []corev1.Node{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
@@ -322,7 +321,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						},
 					},
 				}
-				kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
 					Items: nodes,
 				})
 				fakeClient := &util.OVNClusterManagerClientset{
@@ -778,7 +777,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeClient = &util.OVNClusterManagerClientset{
-						KubeClient:            fake.NewSimpleClientset(&v1.NodeList{Items: nodes()}),
+						KubeClient:            fake.NewSimpleClientset(&corev1.NodeList{Items: nodes()}),
 						IPAMClaimsClient:      fakeipamclaimclient.NewSimpleClientset(),
 						NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
 					}
@@ -834,8 +833,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 	})
 })
 
-func nodes() []v1.Node {
-	return []v1.Node{
+func nodes() []corev1.Node {
+	return []corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node1",

--- a/go-controller/pkg/clustermanager/status_manager/zone_tracker/zone_tracker_test.go
+++ b/go-controller/pkg/clustermanager/status_manager/zone_tracker/zone_tracker_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Cluster Manager Zone Tracker", func() {
 		Eventually(func() bool {
 			zoneTracker.zonesLock.RLock()
 			defer zoneTracker.zonesLock.RUnlock()
-			return zoneTracker.zones.Equal(sets.New[string](expectedZones...))
+			return zoneTracker.zones.Equal(sets.New(expectedZones...))
 		}).Should(BeTrue(), fmt.Sprintf("expected zones %v", expectedZones))
 	}
 
@@ -62,7 +62,7 @@ var _ = Describe("Cluster Manager Zone Tracker", func() {
 			for nodeName := range zoneTracker.unknownZoneNodes {
 				nodeNames.Insert(nodeName)
 			}
-			return nodeNames.Equal(sets.New[string](expectedNodes...))
+			return nodeNames.Equal(sets.New(expectedNodes...))
 		}).Should(BeTrue(), fmt.Sprintf("expected unknown nodes %v", expectedNodes))
 	}
 
@@ -88,7 +88,7 @@ var _ = Describe("Cluster Manager Zone Tracker", func() {
 	BeforeEach(func() {
 		fakeClient = util.GetOVNClientset().GetClusterManagerClientset()
 		coreFactory := informerfactory.NewSharedInformerFactory(fakeClient.KubeClient, time.Second)
-		zoneTracker = NewZoneTracker(coreFactory.Core().V1().Nodes(), func(newZones sets.Set[string]) {
+		zoneTracker = NewZoneTracker(coreFactory.Core().V1().Nodes(), func(sets.Set[string]) {
 			subscribeCounter.Add(1)
 		})
 		// reduce timeout for testing

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -12,12 +12,12 @@ import (
 	netv1fakeclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
@@ -114,7 +114,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				}}))
 
 				_, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Get(context.Background(), udn.Name, metav1.GetOptions{})
-				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 
 			It("should NOT fail when required namespace label is missing for secondary network", func() {
@@ -157,14 +157,14 @@ var _ = Describe("User Defined Network Controller", func() {
 				}}))
 
 				_, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Get(context.Background(), udn.Name, metav1.GetOptions{})
-				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 			It("should fail when NAD create fail", func() {
 				udn := testPrimaryUDN()
 				c = newTestController(noopRenderNadStub(), udn, testNamespace("test"))
 
 				expectedError := errors.New("create NAD error")
-				cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("create", "network-attachment-definitions", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+				cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("create", "network-attachment-definitions", func(testing.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, expectedError
 				})
 
@@ -182,7 +182,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				}}))
 
 				_, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Get(context.Background(), udn.Name, metav1.GetOptions{})
-				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 
 			It("should fail when foreign NAD exist", func() {
@@ -346,7 +346,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				c = newTestController(noopRenderNadStub(), udn, testNamespace("test"))
 
 				expectedErr := errors.New("update UDN error")
-				cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("update", "userdefinednetworks", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("update", "userdefinednetworks", func(testing.Action) (bool, runtime.Object, error) {
 					return true, nil, expectedErr
 				})
 
@@ -394,7 +394,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				}).Should(BeEmpty(), "should remove finalizer on UDN following deletion and not being used")
 				_, err = cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nad.Namespace).Get(context.Background(), nad.Name, metav1.GetOptions{})
 				Expect(err).To(HaveOccurred())
-				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 
@@ -831,7 +831,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				for _, nsName := range staleNADsNsNames {
 					_, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nsName).Get(context.Background(), cudn.Name, metav1.GetOptions{})
 					Expect(err).To(HaveOccurred())
-					Expect(kerrors.IsNotFound(err)).To(Equal(true))
+					Expect(apierrors.IsNotFound(err)).To(Equal(true))
 				}
 			})
 		})
@@ -874,7 +874,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			_, err = cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Get(context.Background(), nad.Name, metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
-			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 		It("when UDN is being deleted, and NAD exist, should fail when remove NAD finalizer fails", func() {
 			udn := testsUDNWithDeletionTimestamp(time.Now())
@@ -882,7 +882,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			c := newTestController(noopRenderNadStub(), udn, nad, testNamespace("test"))
 
 			expectedErr := errors.New("update NAD error")
-			cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("update", "network-attachment-definitions", func(action testing.Action) (bool, runtime.Object, error) {
+			cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("update", "network-attachment-definitions", func(testing.Action) (bool, runtime.Object, error) {
 				return true, nil, expectedErr
 			})
 
@@ -915,7 +915,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			c := newTestController(noopRenderNadStub(), udn, nad, testNamespace("test"))
 
 			expectedErr := errors.New("update UDN error")
-			cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("update", "userdefinednetworks", func(action testing.Action) (bool, runtime.Object, error) {
+			cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("update", "userdefinednetworks", func(testing.Action) (bool, runtime.Object, error) {
 				return true, nil, expectedErr
 			})
 
@@ -945,7 +945,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			_, err = cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Get(context.Background(), nad.Name, metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
-			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
 		DescribeTable("when UDN is being deleted, NAD exist, should not remove finalizers when",
@@ -1094,7 +1094,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			c := newTestController(noopRenderNadStub())
 
 			expectedError := errors.New("test err")
-			cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("patch", "userdefinednetworks/status", func(action testing.Action) (bool, runtime.Object, error) {
+			cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("patch", "userdefinednetworks/status", func(testing.Action) (bool, runtime.Object, error) {
 				return true, nil, expectedError
 			})
 
@@ -1195,7 +1195,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			})
 			It("should fail remove NAD finalizer when update NAD fails", func() {
 				expectedErr := errors.New("test err")
-				cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("update", "network-attachment-definitions", func(action testing.Action) (bool, runtime.Object, error) {
+				cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("update", "network-attachment-definitions", func(testing.Action) (bool, runtime.Object, error) {
 					return true, nil, expectedErr
 				})
 
@@ -1204,7 +1204,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			})
 			It("should fail remove NAD finalizer when delete NAD fails", func() {
 				expectedErr := errors.New("test err")
-				cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("delete", "network-attachment-definitions", func(action testing.Action) (bool, runtime.Object, error) {
+				cs.NetworkAttchDefClient.(*netv1fakeclientset.Clientset).PrependReactor("delete", "network-attachment-definitions", func(testing.Action) (bool, runtime.Object, error) {
 					return true, nil, expectedErr
 				})
 
@@ -1224,7 +1224,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			c := newTestController(noopRenderNadStub(), cudn)
 
 			expectedErr := errors.New("test patch error")
-			cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("patch", "clusteruserdefinednetworks", func(action testing.Action) (bool, runtime.Object, error) {
+			cs.UserDefinedNetworkClient.(*udnfakeclient.Clientset).PrependReactor("patch", "clusteruserdefinednetworks", func(testing.Action) (bool, runtime.Object, error) {
 				return true, nil, expectedErr
 			})
 
@@ -1442,8 +1442,8 @@ func testNAD() *netv1.NetworkAttachmentDefinition {
 					Kind:               "UserDefinedNetwork",
 					Name:               "test",
 					UID:                "1",
-					BlockOwnerDeletion: pointer.Bool(true),
-					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: ptr.To(true),
+					Controller:         ptr.To(true),
 				},
 			},
 		},
@@ -1521,8 +1521,8 @@ func testClusterUdnNAD(name, namespace string) *netv1.NetworkAttachmentDefinitio
 					Kind:               "ClusterUserDefinedNetwork",
 					Name:               name,
 					UID:                "1",
-					BlockOwnerDeletion: pointer.Bool(true),
-					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: ptr.To(true),
+					Controller:         ptr.To(true),
 				},
 			},
 		},
@@ -1543,7 +1543,7 @@ func failRenderNadStub(err error) RenderNetAttachDefManifest {
 }
 
 func newRenderNadStub(nad *netv1.NetworkAttachmentDefinition, err error) RenderNetAttachDefManifest {
-	return func(obj client.Object, targetNamespace string) (*netv1.NetworkAttachmentDefinition, error) {
+	return func(client.Object, string) (*netv1.NetworkAttachmentDefinition, error) {
 		return nad, err
 	}
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -720,7 +720,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					for _, nsName := range newNsNames {
 						nads, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nsName).List(context.Background(), metav1.ListOptions{})
 						Expect(err).NotTo(HaveOccurred())
-						Expect(len(nads.Items)).To(Equal(0))
+						Expect(nads.Items).To(BeEmpty())
 					}
 				})
 
@@ -831,7 +831,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				for _, nsName := range staleNADsNsNames {
 					_, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nsName).Get(context.Background(), cudn.Name, metav1.GetOptions{})
 					Expect(err).To(HaveOccurred())
-					Expect(apierrors.IsNotFound(err)).To(Equal(true))
+					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				}
 			})
 		})

--- a/go-controller/pkg/clustermanager/userdefinednetwork/notifier/namespace_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/notifier/namespace_test.go
@@ -115,7 +115,7 @@ var _ = Describe("NamespaceNotifier", func() {
 		ns, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), "test-1", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		ns.Labels["test.io"] = "example"
-		ns, err = kubeClient.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
+		_, err = kubeClient.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]int64 {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
@@ -4,7 +4,7 @@ import (
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -260,8 +260,8 @@ var _ = Describe("NetAttachDefTemplate", func() {
 				Kind:               "UserDefinedNetwork",
 				Name:               "test-net",
 				UID:                "1",
-				BlockOwnerDeletion: pointer.Bool(true),
-				Controller:         pointer.Bool(true),
+				BlockOwnerDeletion: ptr.To(true),
+				Controller:         ptr.To(true),
 			}
 			expectedNAD := &netv1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
@@ -396,8 +396,8 @@ var _ = Describe("NetAttachDefTemplate", func() {
 				Kind:               "ClusterUserDefinedNetwork",
 				Name:               "test-net",
 				UID:                "1",
-				BlockOwnerDeletion: pointer.Bool(true),
-				Controller:         pointer.Bool(true),
+				BlockOwnerDeletion: ptr.To(true),
+				Controller:         ptr.To(true),
 			}
 			expectedNAD := &netv1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{

--- a/go-controller/pkg/cni/bandwidth_test.go
+++ b/go-controller/pkg/cni/bandwidth_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	kexec "k8s.io/utils/exec"
 
@@ -109,9 +110,9 @@ func TestClearPodBandwidth(t *testing.T) {
 			e := clearPodBandwidth("sandboxID")
 
 			if tc.expectedErr {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -236,9 +237,9 @@ func TestSetPodBandwidth(t *testing.T) {
 			e := setPodBandwidth("sandboxID", "ifname", 1, tc.egressBPS)
 
 			if tc.expectedErr {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -367,11 +368,11 @@ func TestGetIngressPodBandwidth(t *testing.T) {
 			bandwidth, e := getOvsPortBandwidth("ifname", Ingress)
 			switch {
 			case tc.expectedErr:
-				assert.Error(t, e)
+				require.Error(t, e)
 			case tc.expectedNotFound:
 				assert.Equal(t, e, BandwidthNotFound)
 			default:
-				assert.Nil(t, e)
+				require.NoError(t, e)
 				assert.Equal(t, bandwidth, tc.bps)
 			}
 			mockCmd.AssertExpectations(t)
@@ -481,11 +482,11 @@ func TestGetEgressPodBandwidth(t *testing.T) {
 			bandwidth, e := getOvsPortBandwidth("ifname", Egress)
 			switch {
 			case tc.expectedErr:
-				assert.Error(t, e)
+				require.Error(t, e)
 			case tc.expectedNotFound:
 				assert.Equal(t, e, BandwidthNotFound)
 			default:
-				assert.Nil(t, e)
+				require.NoError(t, e)
 				assert.Equal(t, bandwidth, tc.bps)
 			}
 			mockCmd.AssertExpectations(t)

--- a/go-controller/pkg/cni/cni_dpu_test.go
+++ b/go-controller/pkg/cni/cni_dpu_test.go
@@ -6,7 +6,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -24,7 +24,7 @@ var _ = Describe("cni_dpu tests", func() {
 	var fakeKubeInterface kubeMocks.Interface
 	var fakeSriovnetOps utilMocks.SriovnetOps
 	var pr PodRequest
-	var pod *v1.Pod
+	var pod *corev1.Pod
 	var podLister v1mocks.PodLister
 	var podNamespaceLister v1mocks.PodNamespaceLister
 
@@ -48,7 +48,7 @@ var _ = Describe("cni_dpu tests", func() {
 			netName:   ovntypes.DefaultNetworkName,
 			nadName:   ovntypes.DefaultNetworkName,
 		}
-		pod = &v1.Pod{
+		pod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pr.PodName,
 				Namespace:   pr.PodNamespace,

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -41,7 +41,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read CNI request response body: %v", err)
 	}
@@ -50,7 +50,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 
 var expectedResult cnitypes.Result
 
-func serverHandleCNI(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth, networkManager networkmanager.Interface) ([]byte, error) {
+func serverHandleCNI(request *PodRequest, _ *ClientSet, _ *KubeAPIAuth, _ networkmanager.Interface) ([]byte, error) {
 	if request.Command == CNIAdd {
 		return json.Marshal(&expectedResult)
 	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck {
@@ -104,7 +104,7 @@ func TestCNIServer(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			Dial: func(proto, addr string) (net.Conn, error) {
+			Dial: func(_, _ string) (net.Conn, error) {
 				return net.Dial("unix", socketPath)
 			},
 		},

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) {
+	t.Helper()
 	data, err := json.Marshal(req)
 	if err != nil {
 		t.Fatalf("failed to marshal CNI request %v: %v", req, err)

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	corev1 "k8s.io/api/core/v1"
@@ -107,9 +108,9 @@ func TestRenameLink(t *testing.T) {
 			err := renameLink(tc.inpCurrName, tc.inpNewName)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 		})
@@ -176,7 +177,7 @@ func TestMoveIfToNetns(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockNetNS.AssertExpectations(t)
@@ -257,7 +258,7 @@ func TestSafeMoveIfToNetns(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockNetNS.AssertExpectations(t)
@@ -444,7 +445,7 @@ func TestSetupNetwork(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -521,11 +522,11 @@ func TestSetupInterface(t *testing.T) {
 			hostIface, contIface, err := setupInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo)
 			t.Log(hostIface, contIface, err)
 			if tc.errExp {
-				assert.NotNil(t, err)
+				require.Error(t, err)
 			} else if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockCNIPlugin.AssertExpectations(t)
@@ -1176,11 +1177,11 @@ func TestSetupSriovInterface(t *testing.T) {
 				err = netNsDoError
 			}
 			if tc.errExp {
-				assert.NotNil(t, err)
+				require.Error(t, err)
 			} else if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockCNIPlugin.AssertExpectations(t)
@@ -1416,9 +1417,9 @@ func TestConfigureOVS(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockSriovnetOps.Mock, tc.sriovnetOpsMockHelper)
 
 			err := util.SetExec(tc.execMock)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			err = SetExec(tc.execMock)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			tc.execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
@@ -1506,7 +1507,7 @@ func TestConfigureOVS(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 
 			mockNetLinkOps.AssertExpectations(t)
@@ -1621,9 +1622,9 @@ func TestConfigureOVS_getPfEncapIpWithError(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockSriovnetOps.Mock, tc.sriovnetOpsMockHelper)
 
 			err := util.SetExec(execMock)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			err = SetExec(execMock)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			execMock.AddFakeCmds(tc.execMockCommands)
 
@@ -1641,7 +1642,7 @@ func TestConfigureOVS_getPfEncapIpWithError(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 
 			mockNetLinkOps.AssertExpectations(t)

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	kexec "k8s.io/utils/exec"
 
@@ -594,11 +594,9 @@ func TestSetupSriovInterface(t *testing.T) {
 				MTU:           1500,
 				NetdevName:    "en01",
 			},
-			inpPCIAddrs:         "0000:03:00.1",
-			errExp:              true,
-			sriovOpsMockHelper:  []ovntest.TestifyMockHelper{},
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}}},
-			onRetArgsCmdList:    []ovntest.TestifyMockHelper{{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("failed to run 'ovs-vsctl")}}},
+			inpPCIAddrs:        "0000:03:00.1",
+			errExp:             true,
+			sriovOpsMockHelper: []ovntest.TestifyMockHelper{},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
@@ -614,11 +612,9 @@ func TestSetupSriovInterface(t *testing.T) {
 				MTU:           1500,
 				NetdevName:    "en01",
 			},
-			inpPCIAddrs:         "0000:03:00.1",
-			errExp:              true,
-			sriovOpsMockHelper:  []ovntest.TestifyMockHelper{},
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}}},
-			onRetArgsCmdList:    []ovntest.TestifyMockHelper{{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}}},
+			inpPCIAddrs:        "0000:03:00.1",
+			errExp:             true,
+			sriovOpsMockHelper: []ovntest.TestifyMockHelper{},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
@@ -641,11 +637,9 @@ func TestSetupSriovInterface(t *testing.T) {
 				MTU:           1500,
 				NetdevName:    "en01",
 			},
-			inpPCIAddrs:         "0000:03:00.1",
-			errExp:              true,
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}}},
-			onRetArgsCmdList:    []ovntest.TestifyMockHelper{{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("failed to run 'ovs-vsctl")}}},
-			runnerInstance:      mockKexecIface,
+			inpPCIAddrs:    "0000:03:00.1",
+			errExp:         true,
+			runnerInstance: mockKexecIface,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf("mock error")}},
 			},
@@ -670,13 +664,9 @@ func TestSetupSriovInterface(t *testing.T) {
 				MTU:           1500,
 				NetdevName:    "en01",
 			},
-			inpPCIAddrs: "0000:03:00.1",
-			errExp:      true,
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("failed to run 'ovs-vsctl")}}},
-			runnerInstance:   mockKexecIface,
+			inpPCIAddrs:    "0000:03:00.1",
+			errExp:         true,
+			runnerInstance: mockKexecIface,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{-1, fmt.Errorf("mock error")}},
@@ -702,13 +692,9 @@ func TestSetupSriovInterface(t *testing.T) {
 				MTU:           1500,
 				NetdevName:    "en01",
 			},
-			inpPCIAddrs: "0000:03:00.1",
-			errExp:      true,
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}}},
-			runnerInstance:   mockKexecIface,
+			inpPCIAddrs:    "0000:03:00.1",
+			errExp:         true,
+			runnerInstance: mockKexecIface,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
@@ -739,10 +725,8 @@ func TestSetupSriovInterface(t *testing.T) {
 			errExp:      true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			},
 			runnerInstance: mockKexecIface,
@@ -779,10 +763,8 @@ func TestSetupSriovInterface(t *testing.T) {
 			errMatch:    fmt.Errorf("failed to set MTU on"),
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			},
 			runnerInstance: mockKexecIface,
@@ -827,13 +809,7 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs:        "0000:03:00.1",
 			errExp:             false,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{},
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-			},
-			runnerInstance: mockKexecIface,
+			runnerInstance:     mockKexecIface,
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
@@ -1193,8 +1169,6 @@ func TestSetupSriovInterface(t *testing.T) {
 
 			runner = tc.runnerInstance
 
-			ovsExec()
-
 			netNsDoError = nil
 			hostIface, contIface, err := setupSriovInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, tc.inpPCIAddrs, false)
 			t.Log(hostIface, contIface, err)
@@ -1519,13 +1493,13 @@ func TestConfigureOVS(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			var pod v1.Pod
+			var pod corev1.Pod
 			pod.UID = "xyz"
 			podNamespaceLister := v1mocks.PodNamespaceLister{}
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(&pod, nil)
 			var podLister v1mocks.PodLister
 			podLister.On("Pods", mock.AnythingOfType("string")).Return(&podNamespaceLister)
-			fakeClient := fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{pod}})
+			fakeClient := fake.NewSimpleClientset(&corev1.PodList{Items: []corev1.Pod{pod}})
 			clientset := NewClientSet(fakeClient, &podLister)
 			err = ConfigureOVS(ctx, tc.podNs, tc.podName, tc.vfRep,
 				tc.ifInfo, sandboxID, vfPciAddress, clientset)
@@ -1656,7 +1630,7 @@ func TestConfigureOVS_getPfEncapIpWithError(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			var pod v1.Pod
+			var pod corev1.Pod
 			podNamespaceLister := v1mocks.PodNamespaceLister{}
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
 

--- a/go-controller/pkg/cni/ovs_test.go
+++ b/go-controller/pkg/cni/ovs_test.go
@@ -29,7 +29,7 @@ d9af11aa-37c3-4ea9-8ba3-a74843cc0f47
 		uuids, err := ovsFind("Interface", "_uuid", "external-ids:iface-id=foobar")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(len(uuids)).To(Equal(3), fmt.Sprintf("got %v", uuids))
+		Expect(uuids).To(HaveLen(3), fmt.Sprintf("got %v", uuids))
 		Expect(uuids[0]).To(Equal("75419b50-ec6e-4989-b769-164488f53375"))
 		Expect(uuids[1]).To(Equal("4609184a-cb69-46ed-880f-807b6a4e99f5"))
 		Expect(uuids[2]).To(Equal("d9af11aa-37c3-4ea9-8ba3-a74843cc0f47"))
@@ -56,7 +56,7 @@ d9af11aa-37c3-4ea9-8ba3-a74843cc0f47
 
 		uuids, err := ovsFind("Interface", "_uuid", "external-ids:iface-id=foobar")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(uuids)).To(Equal(2), fmt.Sprintf("got %v", uuids))
+		Expect(uuids).To(HaveLen(2), fmt.Sprintf("got %v", uuids))
 		Expect(uuids[0]).To(Equal(""))
 		Expect(uuids[1]).To(Equal(""))
 	})
@@ -71,7 +71,7 @@ d9af11aa-37c3-4ea9-8ba3-a74843cc0f47
 
 		uuids, err := ovsFind("Interface", "_uuid", "external-ids:iface-id=foobar")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(uuids)).To(Equal(2), fmt.Sprintf("got %v", uuids))
+		Expect(uuids).To(HaveLen(2), fmt.Sprintf("got %v", uuids))
 		Expect(uuids[0]).To(Equal(`""`))
 		Expect(uuids[1]).To(Equal(`""`))
 	})

--- a/go-controller/pkg/cni/ovs_test.go
+++ b/go-controller/pkg/cni/ovs_test.go
@@ -14,7 +14,7 @@ var _ = Describe("CNI OVS tests", func() {
 
 	BeforeEach(func() {
 		fexec = ovntest.NewFakeExec()
-		SetExec(fexec)
+		Expect(SetExec(fexec)).To(Succeed())
 	})
 
 	It("returns non-empty elements from ovsFind", func() {

--- a/go-controller/pkg/cni/ovs_unit_test.go
+++ b/go-controller/pkg/cni/ovs_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	kexec "k8s.io/utils/exec"
 
@@ -38,7 +39,7 @@ func TestSetExec(t *testing.T) {
 			}
 
 			e := SetExec(mockKexecIface)
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockKexecIface.AssertExpectations(t)
 		})
 	}
@@ -89,9 +90,9 @@ func TestOvsExec(t *testing.T) {
 			_, e := ovsExec()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -129,9 +130,9 @@ func TestOvsCreate(t *testing.T) {
 			_, e := ovsCreate("blah")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -169,9 +170,9 @@ func TestOvsDestroy(t *testing.T) {
 			e := ovsDestroy("table", "record")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -209,9 +210,9 @@ func TestOvsSet(t *testing.T) {
 			e := ovsSet("table", "record")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -263,9 +264,9 @@ func TestOvsFind(t *testing.T) {
 			_, e := ovsFind("table", "record", "condition")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -303,9 +304,9 @@ func TestOvsClear(t *testing.T) {
 			e := ovsClear("table", "record", "columns")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockCmd.AssertExpectations(t)
@@ -358,9 +359,9 @@ func TestOfctlExec(t *testing.T) {
 			_, e := ofctlExec()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 
 			mockKexecIface.AssertExpectations(t)

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -67,13 +67,13 @@ var _ = Describe("CNI Utils tests", func() {
 		It("Returns true if OVN pod network annotation exists", func() {
 			podAnnot := map[string]string{util.OvnPodAnnotationName: defaultPodAnnotation}
 			_, ready := isOvnReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(true))
+			Expect(ready).To(BeTrue())
 		})
 
 		It("Returns false if OVN pod network annotation does not exist", func() {
 			podAnnot := map[string]string{}
 			_, ready := isOvnReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 		})
 	})
 
@@ -83,7 +83,7 @@ var _ = Describe("CNI Utils tests", func() {
 				util.OvnPodAnnotationName:     defaultPodAnnotation,
 				util.DPUConnectionStatusAnnot: `{"Status":"Ready"}`}
 			_, ready := isDPUReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(true))
+			Expect(ready).To(BeTrue())
 		})
 
 		It("Returns false if dpu.connection-status is present and Status is not Ready", func() {
@@ -91,7 +91,7 @@ var _ = Describe("CNI Utils tests", func() {
 				util.OvnPodAnnotationName:     defaultPodAnnotation,
 				util.DPUConnectionStatusAnnot: `{"Status":"NotReady"}`}
 			_, ready := isDPUReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 		})
 
 		It("Returns false if dpu.connection-status Status is not present", func() {
@@ -99,19 +99,19 @@ var _ = Describe("CNI Utils tests", func() {
 				util.OvnPodAnnotationName:     defaultPodAnnotation,
 				util.DPUConnectionStatusAnnot: `{"Foo":"Bar"}`}
 			_, ready := isDPUReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 		})
 
 		It("Returns false if dpu.connection-status is not present", func() {
 			podAnnot := map[string]string{util.OvnPodAnnotationName: defaultPodAnnotation}
 			_, ready := isDPUReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 		})
 
 		It("Returns false if OVN pod-networks is not present", func() {
 			podAnnot := map[string]string{}
 			_, ready := isDPUReady(podAnnot, ovntypes.DefaultNetworkName)
-			Expect(ready).To(Equal(false))
+			Expect(ready).To(BeFalse())
 		})
 	})
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,7 +117,7 @@ var _ = AfterSuite(func() {
 func createTempFile(name string) (string, []byte, error) {
 	fileData := []byte{0x20}
 	fname := filepath.Join(tmpDir, name)
-	if err := ioutil.WriteFile(fname, fileData, 0o644); err != nil {
+	if err := os.WriteFile(fname, fileData, 0o644); err != nil {
 		return "", nil, err
 	}
 	return fname, fileData, nil
@@ -126,7 +125,7 @@ func createTempFile(name string) (string, []byte, error) {
 
 func createTempFileContent(name, value string) (string, error) {
 	fname := filepath.Join(tmpDir, name)
-	if err := ioutil.WriteFile(fname, []byte(value), 0o644); err != nil {
+	if err := os.WriteFile(fname, []byte(value), 0o644); err != nil {
 		return "", err
 	}
 	return fname, nil
@@ -252,7 +251,7 @@ v6-transit-switch-subnet=fd98::/64
 		}
 		newData += line + "\n"
 	}
-	return ioutil.WriteFile(path, []byte(newData), 0o644)
+	return os.WriteFile(path, []byte(newData), 0o644)
 }
 
 var _ = Describe("Config Operations", func() {
@@ -260,7 +259,7 @@ var _ = Describe("Config Operations", func() {
 	var cfgFile *os.File
 
 	var tmpErr error
-	tmpDir, tmpErr = ioutil.TempDir("", "configtest_certdir")
+	tmpDir, tmpErr = os.MkdirTemp("", "configtest_certdir")
 	if tmpErr != nil {
 		GinkgoT().Errorf("failed to create tempdir: %v", tmpErr)
 	}
@@ -275,7 +274,7 @@ var _ = Describe("Config Operations", func() {
 		app.Name = "test"
 		app.Flags = Flags
 
-		cfgFile, err = ioutil.TempFile("", "conftest-")
+		cfgFile, err = os.CreateTemp("", "conftest-")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -888,7 +887,7 @@ var _ = Describe("Config Operations", func() {
 	})
 
 	It("overrides config file and defaults with CLI legacy service-cluster-ip-range option", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
 service-cidrs=172.18.0.0/24
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -911,7 +910,7 @@ service-cidrs=172.18.0.0/24
 	})
 
 	It("accepts legacy service-cidr config file option", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
 service-cidr=172.18.0.0/24
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -947,7 +946,7 @@ service-cidr=172.18.0.0/24
 	})
 
 	It("overrides config file and defaults with CLI legacy cluster-subnet option", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
 cluster-subnets=172.18.0.0/23
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1003,7 +1002,7 @@ cluster-subnets=172.18.0.0/23
 	})
 
 	It("overrides config file and defaults with CLI legacy --init-gateways option", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[gateway]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[gateway]
 mode=local
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1026,7 +1025,7 @@ mode=local
 	})
 
 	It("overrides config file and defaults with CLI legacy --gateway-local option", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[gateway]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[gateway]
 mode=shared
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1050,7 +1049,7 @@ mode=shared
 	})
 
 	It("honors legacy [kubernetes] metrics config file options", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
 metrics-bind-address=1.1.1.1:8080
 ovn-metrics-bind-address=1.1.1.2:8081
 metrics-enable-pprof=true
@@ -1076,7 +1075,7 @@ metrics-enable-pprof=true
 	})
 
 	It("overrides legacy [kubernetes] metrics config file options with [metrics] ones", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
 metrics-bind-address=1.1.1.1:8080
 ovn-metrics-bind-address=1.1.1.2:8081
 metrics-enable-pprof=false
@@ -1559,7 +1558,7 @@ enable-pprof=true
 	})
 
 	It("ignores unknown fields in config file and does not return an error", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
 key=value
 mtu=1234
 
@@ -1589,7 +1588,7 @@ foo=bar
 	})
 
 	It("rejects a config with invalid syntax", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
 mtu=1234
 
 [foobar
@@ -1612,7 +1611,7 @@ foo=bar
 	})
 
 	It("rejects a config with invalid udn allowed services", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
 udn-allowed-default-services=namespace/invalid.name,test
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1632,7 +1631,7 @@ udn-allowed-default-services=namespace/invalid.name,test
 	})
 
 	It("accepts a config with valid udn allowed services", func() {
-		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
 udn-allowed-default-services= ns/svc, ns1/svc1
 `), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -57,7 +57,7 @@ func writeConfigFile(cfgFile *os.File, randomOptData bool, args ...string) error
 
 		if randomOptData {
 			parts := strings.Split(arg, "=")
-			gomega.Expect(len(parts)).To(gomega.Equal(2))
+			gomega.Expect(parts).To(gomega.HaveLen(2))
 			sections[section] = append(sections[section], parts[0]+"=aklsdjfalsdfkjaslfdkjasfdlksa")
 		} else {
 			sections[section] = append(sections[section], arg)
@@ -324,9 +324,9 @@ var _ = Describe("Config Operations", func() {
 				{ovntest.MustParseIPNet("10.128.0.0/14"), 23},
 			}))
 			gomega.Expect(Default.Zone).To(gomega.Equal("global"))
-			gomega.Expect(IPv4Mode).To(gomega.Equal(true))
-			gomega.Expect(IPv6Mode).To(gomega.Equal(false))
-			gomega.Expect(HybridOverlay.Enabled).To(gomega.Equal(false))
+			gomega.Expect(IPv4Mode).To(gomega.BeTrue())
+			gomega.Expect(IPv6Mode).To(gomega.BeFalse())
+			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeFalse())
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeFull))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
 			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal(""))
@@ -647,12 +647,12 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Metrics.BindAddress).To(gomega.Equal("1.1.1.1:8080"))
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("1.1.1.2:8081"))
-			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.Equal(true))
-			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
+			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.BeTrue())
+			gomega.Expect(Metrics.EnablePprof).To(gomega.BeTrue())
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal("/path/to/node-metrics-private.key"))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/path/to/node-metrics.crt"))
-			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.Equal(true))
-			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.Equal(true))
+			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.BeTrue())
+			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.BeTrue())
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/path/to/nb-client-private.key"))
@@ -757,12 +757,12 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Metrics.BindAddress).To(gomega.Equal("2.2.2.2:8080"))
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("2.2.2.3:8081"))
-			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.Equal(true))
-			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
+			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.BeTrue())
+			gomega.Expect(Metrics.EnablePprof).To(gomega.BeTrue())
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal("/tls/nodeprivkey"))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/tls/nodecert"))
-			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.Equal(true))
-			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.Equal(true))
+			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.BeTrue())
+			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.BeTrue())
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/client/privkey"))
@@ -959,8 +959,8 @@ cluster-subnets=172.18.0.0/23
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("172.15.0.0/23"), 24},
 			}))
-			gomega.Expect(IPv4Mode).To(gomega.Equal(true))
-			gomega.Expect(IPv6Mode).To(gomega.Equal(false))
+			gomega.Expect(IPv4Mode).To(gomega.BeTrue())
+			gomega.Expect(IPv6Mode).To(gomega.BeFalse())
 			return nil
 		}
 		cliArgs := []string{
@@ -1063,7 +1063,7 @@ metrics-enable-pprof=true
 			gomega.Expect(cfgPath).To(gomega.Equal(cfgFile.Name()))
 			gomega.Expect(Metrics.BindAddress).To(gomega.Equal("1.1.1.1:8080"))
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("1.1.1.2:8081"))
-			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
+			gomega.Expect(Metrics.EnablePprof).To(gomega.BeTrue())
 			return nil
 		}
 		cliArgs := []string{
@@ -1094,7 +1094,7 @@ enable-pprof=true
 			gomega.Expect(cfgPath).To(gomega.Equal(cfgFile.Name()))
 			gomega.Expect(Metrics.BindAddress).To(gomega.Equal("2.2.2.2:8080"))
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("2.2.2.3:8081"))
-			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
+			gomega.Expect(Metrics.EnablePprof).To(gomega.BeTrue())
 			return nil
 		}
 		cliArgs := []string{
@@ -1418,8 +1418,8 @@ enable-pprof=true
 		app.Action = func(ctx *cli.Context) error {
 			_, err := InitConfig(ctx, kexec.New(), nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(IPv4Mode).To(gomega.Equal(false))
-			gomega.Expect(IPv6Mode).To(gomega.Equal(true))
+			gomega.Expect(IPv4Mode).To(gomega.BeFalse())
+			gomega.Expect(IPv6Mode).To(gomega.BeTrue())
 			return nil
 		}
 		cliArgs := []string{
@@ -1435,8 +1435,8 @@ enable-pprof=true
 		app.Action = func(ctx *cli.Context) error {
 			_, err := InitConfig(ctx, kexec.New(), nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(IPv4Mode).To(gomega.Equal(true))
-			gomega.Expect(IPv6Mode).To(gomega.Equal(true))
+			gomega.Expect(IPv4Mode).To(gomega.BeTrue())
+			gomega.Expect(IPv6Mode).To(gomega.BeTrue())
 			return nil
 		}
 		cliArgs := []string{
@@ -1452,8 +1452,8 @@ enable-pprof=true
 		app.Action = func(ctx *cli.Context) error {
 			_, err := InitConfig(ctx, kexec.New(), nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(IPv4Mode).To(gomega.Equal(true))
-			gomega.Expect(IPv6Mode).To(gomega.Equal(true))
+			gomega.Expect(IPv4Mode).To(gomega.BeTrue())
+			gomega.Expect(IPv6Mode).To(gomega.BeTrue())
 			return nil
 		}
 		cliArgs := []string{

--- a/go-controller/pkg/controller/controller_test.go
+++ b/go-controller/pkg/controller/controller_test.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -30,7 +30,7 @@ func getDefaultConfig[T any](reconcileCounter *atomic.Uint64) *ControllerConfig[
 			}
 			return !reflect.DeepEqual(oldObj, newObj)
 		},
-		Reconcile: func(key string) error {
+		Reconcile: func(string) error {
 			reconcileCounter.Add(1)
 			return nil
 		},
@@ -50,7 +50,7 @@ var _ = Describe("Level-driven controller", func() {
 		namespace1Name = "namespace1"
 	)
 
-	startController := func(config *ControllerConfig[v1.Pod], initialSync func() error, objects ...runtime.Object) {
+	startController := func(config *ControllerConfig[corev1.Pod], initialSync func() error, objects ...runtime.Object) {
 		fakeClient = util.GetOVNClientset(objects...).GetClusterManagerClientset()
 		coreFactory := informerfactory.NewSharedInformerFactory(fakeClient.KubeClient, time.Second)
 
@@ -59,7 +59,7 @@ var _ = Describe("Level-driven controller", func() {
 		if config.RateLimiter == nil {
 			config.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, 5)
 		}
-		controller = NewController[v1.Pod]("controller-name", config)
+		controller = NewController("controller-name", config)
 
 		coreFactory.Start(stopChan)
 
@@ -67,8 +67,8 @@ var _ = Describe("Level-driven controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	getDefaultConfig := func() *ControllerConfig[v1.Pod] {
-		return getDefaultConfig[v1.Pod](&reconcileCounter)
+	getDefaultConfig := func() *ControllerConfig[corev1.Pod] {
+		return getDefaultConfig[corev1.Pod](&reconcileCounter)
 	}
 
 	checkReconcileCounter := func(expected int) {
@@ -98,10 +98,10 @@ var _ = Describe("Level-driven controller", func() {
 	})
 	It("handles initial objects once", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod1 := &v1.Pod{
+		pod1 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
-		pod2 := &v1.Pod{
+		pod2 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod2", namespace.Name),
 		}
 		startController(getDefaultConfig(), nil, namespace, pod1, pod2)
@@ -109,12 +109,12 @@ var _ = Describe("Level-driven controller", func() {
 	})
 	It("retries on failure", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod := &v1.Pod{
+		pod := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
 		config := getDefaultConfig()
 		failureCounter := atomic.Uint64{}
-		config.Reconcile = func(key string) error {
+		config.Reconcile = func(string) error {
 			failureCounter.Add(1)
 			if failureCounter.Load() < 3 {
 				return fmt.Errorf("failure")
@@ -128,12 +128,12 @@ var _ = Describe("Level-driven controller", func() {
 	})
 	It("drops key after maxRetries", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod := &v1.Pod{
+		pod := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
 		config := getDefaultConfig()
 		failureCounter := atomic.Uint64{}
-		config.Reconcile = func(key string) error {
+		config.Reconcile = func(string) error {
 			failureCounter.Add(1)
 			return fmt.Errorf("failure")
 		}
@@ -153,11 +153,11 @@ var _ = Describe("Level-driven controller", func() {
 	})
 	It("ignores events when ObjNeedsUpdate returns false", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod := &v1.Pod{
+		pod := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
 		config := getDefaultConfig()
-		config.ObjNeedsUpdate = func(oldObj, newObj *v1.Pod) bool {
+		config.ObjNeedsUpdate = func(oldObj, _ *corev1.Pod) bool {
 			// only return true on add
 			return oldObj == nil
 		}
@@ -173,7 +173,7 @@ var _ = Describe("Level-driven controller", func() {
 	})
 	It("runs initialSync", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod := &v1.Pod{
+		pod := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
 		config := getDefaultConfig()
@@ -192,10 +192,10 @@ var _ = Describe("Level-driven controller", func() {
 	})
 	It("handles events after InitialSync", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod1 := &v1.Pod{
+		pod1 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
-		pod2 := &v1.Pod{
+		pod2 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod2", namespace.Name),
 		}
 		config := getDefaultConfig()
@@ -219,12 +219,12 @@ var _ = Describe("Level-driven controller", func() {
 		pod2Key, _ := cache.MetaNamespaceKeyFunc(pod2)
 		Eventually(func() sets.Set[string] {
 			keys := sets.New[string]()
-			updatedPods.Range(func(key, value any) bool {
+			updatedPods.Range(func(key, _ any) bool {
 				keys.Insert(key.(string))
 				return true
 			})
 			return keys
-		}).Should(BeEquivalentTo(sets.New[string](pod1Key, pod2Key)))
+		}).Should(BeEquivalentTo(sets.New(pod1Key, pod2Key)))
 	})
 })
 
@@ -243,7 +243,7 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 		namespace1Name = "namespace1"
 	)
 
-	startController := func(podConfig *ControllerConfig[v1.Pod], nsConfig *ControllerConfig[v1.Namespace], initialSync func() error, objects ...runtime.Object) {
+	startController := func(podConfig *ControllerConfig[corev1.Pod], nsConfig *ControllerConfig[corev1.Namespace], initialSync func() error, objects ...runtime.Object) {
 		fakeClient = util.GetOVNClientset(objects...).GetClusterManagerClientset()
 		coreFactory := informerfactory.NewSharedInformerFactory(fakeClient.KubeClient, time.Second)
 
@@ -252,14 +252,14 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 		if podConfig.RateLimiter == nil {
 			podConfig.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, 5)
 		}
-		podController = NewController[v1.Pod]("podController", podConfig)
+		podController = NewController("podController", podConfig)
 
 		nsConfig.Informer = coreFactory.Core().V1().Namespaces().Informer()
 		nsConfig.Lister = coreFactory.Core().V1().Namespaces().Lister().List
 		if nsConfig.RateLimiter == nil {
 			nsConfig.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, 5)
 		}
-		namespaceController = NewController[v1.Namespace]("namespaceController", nsConfig)
+		namespaceController = NewController("namespaceController", nsConfig)
 
 		coreFactory.Start(stopChan)
 
@@ -292,19 +292,19 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 
 	It("handle initial objects once", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod1 := &v1.Pod{
+		pod1 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
-		pod2 := &v1.Pod{
+		pod2 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod2", namespace.Name),
 		}
-		startController(getDefaultConfig[v1.Pod](&reconcilePodCounter), getDefaultConfig[v1.Namespace](&reconcileNsCounter),
+		startController(getDefaultConfig[corev1.Pod](&reconcilePodCounter), getDefaultConfig[corev1.Namespace](&reconcileNsCounter),
 			nil, namespace, pod1, pod2)
 		checkReconcileCountersConsistently(2, 1)
 	})
 	It("run InitialSync", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod := &v1.Pod{
+		pod := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
 		synced := atomic.Bool{}
@@ -315,7 +315,7 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 			synced.Store(true)
 			return nil
 		}
-		startController(getDefaultConfig[v1.Pod](&reconcilePodCounter), getDefaultConfig[v1.Namespace](&reconcileNsCounter),
+		startController(getDefaultConfig[corev1.Pod](&reconcilePodCounter), getDefaultConfig[corev1.Namespace](&reconcileNsCounter),
 			initialSync, namespace, pod)
 		// start only returns after initial sync is finished, we can check synced value immediately
 		Expect(synced.Load()).To(BeEquivalentTo(true))
@@ -323,13 +323,13 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 	})
 	It("handle events after initialSync", func() {
 		namespace := util.NewNamespace(namespace1Name)
-		pod1 := &v1.Pod{
+		pod1 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
 		}
-		pod2 := &v1.Pod{
+		pod2 := &corev1.Pod{
 			ObjectMeta: util.NewObjectMeta("pod2", namespace.Name),
 		}
-		podConfig := getDefaultConfig[v1.Pod](&reconcilePodCounter)
+		podConfig := getDefaultConfig[corev1.Pod](&reconcilePodCounter)
 		updatedObjs := sync.Map{}
 		podConfig.Reconcile = func(key string) error {
 			reconcilePodCounter.Add(1)
@@ -337,7 +337,7 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 			updatedObjs.LoadOrStore(key, true)
 			return nil
 		}
-		nsConfig := getDefaultConfig[v1.Namespace](&reconcileNsCounter)
+		nsConfig := getDefaultConfig[corev1.Namespace](&reconcileNsCounter)
 		nsConfig.Reconcile = func(key string) error {
 			reconcileNsCounter.Add(1)
 			// add keys that were reconciled
@@ -363,12 +363,12 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 		pod2Key, _ := cache.MetaNamespaceKeyFunc(pod2)
 		Eventually(func() sets.Set[string] {
 			keys := sets.New[string]()
-			updatedObjs.Range(func(key, value any) bool {
+			updatedObjs.Range(func(key, _ any) bool {
 				keys.Insert(key.(string))
 				return true
 			})
 			return keys
-		}).Should(BeEquivalentTo(sets.New[string](pod1Key, pod2Key, namespace.Name)))
+		}).Should(BeEquivalentTo(sets.New(pod1Key, pod2Key, namespace.Name)))
 		fmt.Println(reconcilePodCounter.Load())
 		fmt.Println(reconcileNsCounter.Load())
 	})

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -538,7 +538,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				cache.ResourceEventHandlerFuncs{},
 				func(objs []interface{}) error {
 					defer GinkgoRecover()
-					Expect(len(objs)).To(Equal(1))
+					Expect(objs).To(HaveLen(1))
 					return nil
 				}, wf.GetHandlerPriority(objType))
 			Expect(h).NotTo(BeNil())
@@ -562,7 +562,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				cache.ResourceEventHandlerFuncs{},
 				func(objs []interface{}) error {
 					defer GinkgoRecover()
-					Expect(len(objs)).To(Equal(1))
+					Expect(objs).To(HaveLen(1))
 					return nil
 				}, wf.GetHandlerPriority(realObj))
 			Expect(h).NotTo(BeNil())
@@ -1704,7 +1704,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			UpdateFunc: func(_, new interface{}) {
 				newEpSlice := new.(*discovery.EndpointSlice)
 				Expect(reflect.DeepEqual(newEpSlice, added)).To(BeTrue())
-				Expect(len(newEpSlice.Endpoints)).To(Equal(1))
+				Expect(newEpSlice.Endpoints).To(HaveLen(1))
 			},
 			DeleteFunc: func(obj interface{}) {
 				epSlice := obj.(*discovery.EndpointSlice)

--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	kapi "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,10 +26,10 @@ func TestEventHandler(t *testing.T) {
 	RunSpecs(t, "Event Handler Suite")
 }
 
-func newPod(name, namespace string) *kapi.Pod {
-	return &kapi.Pod{
-		Status: kapi.PodStatus{
-			Phase: kapi.PodRunning,
+func newPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -39,8 +39,8 @@ func newPod(name, namespace string) *kapi.Pod {
 				"name": name,
 			},
 		},
-		Spec: kapi.PodSpec{
-			Containers: []kapi.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "containerName",
 					Image: "containerImage",
@@ -75,13 +75,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		deletes := int32(0)
 
 		k := fake.NewSimpleClientset(
-			&kapi.Namespace{
+			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:  types.UID(namespace),
 					Name: namespace,
 				},
-				Spec:   kapi.NamespaceSpec{},
-				Status: kapi.NamespaceStatus{},
+				Spec:   corev1.NamespaceSpec{},
+				Status: corev1.NamespaceStatus{},
 			},
 		)
 
@@ -90,11 +90,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		e, err := NewDefaultEventHandler(
 			"test",
 			f.Core().V1().Pods().Informer(),
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&adds, 1)
 				return nil
 			},
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&deletes, 1)
 				return nil
 			},
@@ -105,8 +105,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		f.Start(stopChan)
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
-			e.Run(1, stopChan)
+			Expect(e.Run(1, stopChan)).To(Succeed())
 		}()
 
 		err = wait.PollUntilContextTimeout(
@@ -141,13 +142,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		deletes := int32(0)
 
 		k := fake.NewSimpleClientset(
-			&kapi.Namespace{
+			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:  types.UID(namespace),
 					Name: namespace,
 				},
-				Spec:   kapi.NamespaceSpec{},
-				Status: kapi.NamespaceStatus{},
+				Spec:   corev1.NamespaceSpec{},
+				Status: corev1.NamespaceStatus{},
 			},
 		)
 
@@ -156,11 +157,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		e, err := NewDefaultEventHandler(
 			"test",
 			f.Core().V1().Pods().Informer(),
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&adds, 1)
 				return nil
 			},
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&deletes, 1)
 				return nil
 			},
@@ -171,8 +172,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		f.Start(stopChan)
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
-			e.Run(1, stopChan)
+			Expect(e.Run(1, stopChan)).To(Succeed())
 		}()
 
 		err = wait.PollUntilContextTimeout(
@@ -212,13 +214,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		pod := newPod("foo", namespace)
 		k := fake.NewSimpleClientset(
 			[]runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						UID:  types.UID(namespace),
 						Name: namespace,
 					},
-					Spec:   kapi.NamespaceSpec{},
-					Status: kapi.NamespaceStatus{},
+					Spec:   corev1.NamespaceSpec{},
+					Status: corev1.NamespaceStatus{},
 				},
 				pod,
 			}...,
@@ -229,11 +231,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		e, err := NewDefaultEventHandler(
 			"test",
 			f.Core().V1().Pods().Informer(),
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&adds, 1)
 				return nil
 			},
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&deletes, 1)
 				return nil
 			},
@@ -244,8 +246,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		f.Start(stopChan)
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
-			e.Run(1, stopChan)
+			Expect(e.Run(1, stopChan)).To(Succeed())
 		}()
 
 		err = wait.PollUntilContextTimeout(
@@ -299,13 +302,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		pod := newPod("foo", namespace)
 		k := fake.NewSimpleClientset(
 			[]runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						UID:  types.UID(namespace),
 						Name: namespace,
 					},
-					Spec:   kapi.NamespaceSpec{},
-					Status: kapi.NamespaceStatus{},
+					Spec:   corev1.NamespaceSpec{},
+					Status: corev1.NamespaceStatus{},
 				},
 				pod,
 			}...,
@@ -316,11 +319,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		e, err := NewDefaultEventHandler(
 			"test",
 			f.Core().V1().Pods().Informer(),
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&adds, 1)
 				return nil
 			},
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&deletes, 1)
 				return nil
 			},
@@ -331,8 +334,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		f.Start(stopChan)
 		wg.Add(1)
 		go func() {
+			GinkgoRecover()
 			defer wg.Done()
-			e.Run(1, stopChan)
+			Expect(e.Run(1, stopChan)).To(Succeed())
 		}()
 
 		err = wait.PollUntilContextTimeout(
@@ -373,13 +377,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 
 		k := fake.NewSimpleClientset(
 			[]runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						UID:  types.UID(namespace),
 						Name: namespace,
 					},
-					Spec:   kapi.NamespaceSpec{},
-					Status: kapi.NamespaceStatus{},
+					Spec:   corev1.NamespaceSpec{},
+					Status: corev1.NamespaceStatus{},
 				},
 				newPod("foo", namespace),
 			}...,
@@ -390,11 +394,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		e, err := NewDefaultEventHandler(
 			"test",
 			f.Core().V1().Pods().Informer(),
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&adds, 1)
 				return nil
 			},
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&deletes, 1)
 				return nil
 			},
@@ -405,8 +409,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		f.Start(stopChan)
 		wg.Add(1)
 		go func() {
+			GinkgoRecover()
 			defer wg.Done()
-			e.Run(1, stopChan)
+			Expect(e.Run(1, stopChan)).To(Succeed())
 		}()
 
 		err = wait.PollUntilContextTimeout(
@@ -447,13 +452,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		pod := newPod("foo", namespace)
 		k := fake.NewSimpleClientset(
 			[]runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						UID:  types.UID(namespace),
 						Name: namespace,
 					},
-					Spec:   kapi.NamespaceSpec{},
-					Status: kapi.NamespaceStatus{},
+					Spec:   corev1.NamespaceSpec{},
+					Status: corev1.NamespaceStatus{},
 				},
 				pod,
 			}...,
@@ -464,11 +469,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		e, err := NewDefaultEventHandler(
 			"test",
 			f.Core().V1().Pods().Informer(),
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&adds, 1)
 				return nil
 			},
-			func(obj interface{}) error {
+			func(interface{}) error {
 				atomic.AddInt32(&deletes, 1)
 				return nil
 			},
@@ -479,8 +484,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		f.Start(stopChan)
 		wg.Add(1)
 		go func() {
+			GinkgoRecover()
 			defer wg.Done()
-			e.Run(1, stopChan)
+			Expect(e.Run(1, stopChan)).To(Succeed())
 		}()
 
 		err = wait.PollUntilContextTimeout(
@@ -524,10 +530,10 @@ var _ = Describe("Event Handler Internals", func() {
 			informer:       factory.Core().V1().Pods().Informer(),
 			deletedIndexer: cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
 			workqueue:      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
-			add: func(obj interface{}) error {
+			add: func(interface{}) error {
 				return nil
 			},
-			delete: func(obj interface{}) error {
+			delete: func(interface{}) error {
 				return nil
 			},
 			updateFilter: ReceiveAllUpdates,
@@ -548,10 +554,10 @@ var _ = Describe("Event Handler Internals", func() {
 			informer:       factory.Core().V1().Pods().Informer(),
 			deletedIndexer: cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
 			workqueue:      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
-			add: func(obj interface{}) error {
+			add: func(interface{}) error {
 				return nil
 			},
-			delete: func(obj interface{}) error {
+			delete: func(interface{}) error {
 				return nil
 			},
 			updateFilter: ReceiveAllUpdates,
@@ -577,10 +583,10 @@ var _ = Describe("Event Handler Internals", func() {
 			informer:       factory.Core().V1().Pods().Informer(),
 			deletedIndexer: cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
 			workqueue:      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
-			add: func(obj interface{}) error {
+			add: func(interface{}) error {
 				return nil
 			},
-			delete: func(obj interface{}) error {
+			delete: func(interface{}) error {
 				return nil
 			},
 			updateFilter: ReceiveAllUpdates,

--- a/go-controller/pkg/kube/annotator_test.go
+++ b/go-controller/pkg/kube/annotator_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -31,7 +31,7 @@ var _ = Describe("Annotator", func() {
 			kube := &Kube{
 				KClient: fakeClient,
 			}
-			newNode := &v1.Node{
+			newNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        nodeName,
 					Annotations: initialAnnotations,

--- a/go-controller/pkg/kube/healthcheck/healthcheck_test.go
+++ b/go-controller/pkg/kube/healthcheck/healthcheck_test.go
@@ -161,7 +161,7 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected port :9376 to be open\n%#v", listener.openPorts)
 	}
 	// test the handler
-	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+	testHandler(t, hcs, nsn, http.StatusServiceUnavailable, 0)
 
 	// sync an endpoint
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 18})
@@ -175,7 +175,7 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 18 endpoints, got %d", hcs.services[nsn].endpoints)
 	}
 	// test the handler
-	testHandler(hcs, nsn, http.StatusOK, 18, t)
+	testHandler(t, hcs, nsn, http.StatusOK, 18)
 
 	// sync zero endpoints
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 0})
@@ -189,7 +189,7 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn].endpoints)
 	}
 	// test the handler
-	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+	testHandler(t, hcs, nsn, http.StatusServiceUnavailable, 0)
 
 	// put the endpoint back
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 11})
@@ -214,7 +214,7 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn].endpoints)
 	}
 	// test the handler
-	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+	testHandler(t, hcs, nsn, http.StatusServiceUnavailable, 0)
 
 	// put the endpoint back
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 18})
@@ -265,9 +265,9 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 3 open ports, got %d\n%#v", len(listener.openPorts), listener.openPorts)
 	}
 	// test the handlers
-	testHandler(hcs, nsn1, http.StatusServiceUnavailable, 0, t)
-	testHandler(hcs, nsn2, http.StatusServiceUnavailable, 0, t)
-	testHandler(hcs, nsn3, http.StatusServiceUnavailable, 0, t)
+	testHandler(t, hcs, nsn1, http.StatusServiceUnavailable, 0)
+	testHandler(t, hcs, nsn2, http.StatusServiceUnavailable, 0)
+	testHandler(t, hcs, nsn3, http.StatusServiceUnavailable, 0)
 
 	// sync endpoints
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{
@@ -291,9 +291,9 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 7 endpoints, got %d", hcs.services[nsn3].endpoints)
 	}
 	// test the handlers
-	testHandler(hcs, nsn1, http.StatusOK, 9, t)
-	testHandler(hcs, nsn2, http.StatusOK, 3, t)
-	testHandler(hcs, nsn3, http.StatusOK, 7, t)
+	testHandler(t, hcs, nsn1, http.StatusOK, 9)
+	testHandler(t, hcs, nsn2, http.StatusOK, 3)
+	testHandler(t, hcs, nsn3, http.StatusOK, 7)
 
 	// sync new services
 	err = hcs.SyncServices(map[types.NamespacedName]uint16{
@@ -318,9 +318,9 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn4].endpoints)
 	}
 	// test the handlers
-	testHandler(hcs, nsn2, http.StatusOK, 3, t)
-	testHandler(hcs, nsn3, http.StatusServiceUnavailable, 0, t)
-	testHandler(hcs, nsn4, http.StatusServiceUnavailable, 0, t)
+	testHandler(t, hcs, nsn2, http.StatusOK, 3)
+	testHandler(t, hcs, nsn3, http.StatusServiceUnavailable, 0)
+	testHandler(t, hcs, nsn4, http.StatusServiceUnavailable, 0)
 
 	// sync endpoints
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{
@@ -345,9 +345,9 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 6 endpoints, got %d", hcs.services[nsn4].endpoints)
 	}
 	// test the handlers
-	testHandler(hcs, nsn2, http.StatusOK, 3, t)
-	testHandler(hcs, nsn3, http.StatusOK, 7, t)
-	testHandler(hcs, nsn4, http.StatusOK, 6, t)
+	testHandler(t, hcs, nsn2, http.StatusOK, 3)
+	testHandler(t, hcs, nsn3, http.StatusOK, 7)
+	testHandler(t, hcs, nsn4, http.StatusOK, 6)
 
 	// sync endpoints, missing nsn2
 	err = hcs.SyncEndpoints(map[types.NamespacedName]int{
@@ -370,12 +370,13 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected 6 endpoints, got %d", hcs.services[nsn4].endpoints)
 	}
 	// test the handlers
-	testHandler(hcs, nsn2, http.StatusServiceUnavailable, 0, t)
-	testHandler(hcs, nsn3, http.StatusOK, 7, t)
-	testHandler(hcs, nsn4, http.StatusOK, 6, t)
+	testHandler(t, hcs, nsn2, http.StatusServiceUnavailable, 0)
+	testHandler(t, hcs, nsn3, http.StatusOK, 7)
+	testHandler(t, hcs, nsn4, http.StatusOK, 6)
 }
 
-func testHandler(hcs *server, nsn types.NamespacedName, status int, endpoints int, t *testing.T) {
+func testHandler(t *testing.T, hcs *server, nsn types.NamespacedName, status int, endpoints int) {
+	t.Helper()
 	handler := hcs.services[nsn].server.(*fakeHTTPServer).handler
 	req, err := http.NewRequest("GET", "/healthz", nil)
 	if err != nil {

--- a/go-controller/pkg/kube/healthcheck/healthcheck_test.go
+++ b/go-controller/pkg/kube/healthcheck/healthcheck_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 type fakeListener struct {
-	openPorts sets.String
+	openPorts sets.Set[string]
 }
 
 func newFakeListener() *fakeListener {
 	return &fakeListener{
-		openPorts: sets.String{},
+		openPorts: sets.New[string](),
 	}
 }
 
@@ -87,7 +87,7 @@ type fakeHTTPServer struct {
 	handler http.Handler
 }
 
-func (fake *fakeHTTPServer) Serve(listener net.Listener) error {
+func (fake *fakeHTTPServer) Serve(net.Listener) error {
 	return nil // Cause the goroutine to return
 }
 
@@ -104,11 +104,6 @@ type hcPayload struct {
 		Name      string
 	}
 	LocalEndpoints int
-}
-
-type healthzPayload struct {
-	LastUpdated string
-	CurrentTime string
 }
 
 func TestServer(t *testing.T) {
@@ -402,24 +397,5 @@ func testHandler(hcs *server, nsn types.NamespacedName, status int, endpoints in
 	}
 	if payload.LocalEndpoints != endpoints {
 		t.Errorf("expected %d endpoints, got %d", endpoints, payload.LocalEndpoints)
-	}
-}
-
-func testHealthzHandler(server HTTPServer, status int, t *testing.T) {
-	handler := server.(*fakeHTTPServer).handler
-	req, err := http.NewRequest("GET", "/healthz", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp := httptest.NewRecorder()
-
-	handler.ServeHTTP(resp, req)
-
-	if resp.Code != status {
-		t.Errorf("expected status code %v, got %v", status, resp.Code)
-	}
-	var payload healthzPayload
-	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
-		t.Fatal(err)
 	}
 }

--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -3,7 +3,7 @@ package kube
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -15,25 +15,25 @@ var _ = Describe("Kube", func() {
 
 	Describe("Taint node operations", func() {
 		var kube Kube
-		var existingNodeTaints []v1.Taint
-		var taint v1.Taint
-		var node *v1.Node
+		var existingNodeTaints []corev1.Taint
+		var taint corev1.Taint
+		var node *corev1.Node
 
 		BeforeEach(func() {
 			fakeClient := fake.NewSimpleClientset()
 			kube = Kube{
 				KClient: fakeClient,
 			}
-			taint = v1.Taint{Key: "my-taint-key", Value: "my-taint-value", Effect: v1.TaintEffectNoSchedule}
+			taint = corev1.Taint{Key: "my-taint-key", Value: "my-taint-value", Effect: corev1.TaintEffectNoSchedule}
 		})
 
 		JustBeforeEach(func() {
 			// create the node with the specified taints just before the tests
-			newNode := &v1.Node{
+			newNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-node",
 				},
-				Spec: v1.NodeSpec{
+				Spec: corev1.NodeSpec{
 					Taints: existingNodeTaints,
 				},
 			}
@@ -47,7 +47,7 @@ var _ = Describe("Kube", func() {
 		Context("with a node not having the taint", func() {
 
 			BeforeEach(func() {
-				existingNodeTaints = make([]v1.Taint, 0)
+				existingNodeTaints = make([]corev1.Taint, 0)
 			})
 
 			Context("SetTaintOnNode", func() {
@@ -76,13 +76,13 @@ var _ = Describe("Kube", func() {
 		Context("with a node having the same taint already", func() {
 
 			BeforeEach(func() {
-				existingNodeTaints = []v1.Taint{taint}
+				existingNodeTaints = []corev1.Taint{taint}
 			})
 
 			Context("SetTaintOnNode", func() {
 				It("should update the taint of the node if effect differs", func() {
 					updatedTaint := taint.DeepCopy()
-					updatedTaint.Effect = v1.TaintEffectPreferNoSchedule
+					updatedTaint.Effect = corev1.TaintEffectPreferNoSchedule
 
 					err := kube.SetTaintOnNode(node.Name, updatedTaint)
 					Expect(err).ToNot(HaveOccurred())
@@ -98,7 +98,7 @@ var _ = Describe("Kube", func() {
 
 					updatedNode, err := kube.GetNode(node.Name)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(updatedNode.Spec.Taints).To(Equal([]v1.Taint{taint}))
+					Expect(updatedNode.Spec.Taints).To(Equal([]corev1.Taint{taint}))
 				})
 			})
 
@@ -141,7 +141,7 @@ var _ = Describe("Kube", func() {
 
 		Context("With a pod having annotations", func() {
 			var (
-				pod                 *v1.Pod
+				pod                 *corev1.Pod
 				existingAnnotations map[string]string
 			)
 
@@ -149,7 +149,7 @@ var _ = Describe("Kube", func() {
 				existingAnnotations = map[string]string{"foo": "foofoo", "bar": "barbar", "baz": "bazbaz"}
 
 				// create the pod
-				newPod := &v1.Pod{
+				newPod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   "default",
 						Name:        "my-pod",

--- a/go-controller/pkg/kubevirt/pod_test.go
+++ b/go-controller/pkg/kubevirt/pod_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Kubevirt Pod", func() {
 		currentPod := params.pods[0]
 		migrationStatus, err := DiscoverLiveMigrationStatus(wf, &currentPod)
 		if params.expectedError == nil {
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		} else {
 			Expect(err).To(MatchError(ContainSubstring(params.expectedError.Error())))
 		}

--- a/go-controller/pkg/libovsdb/ops/model_client_test.go
+++ b/go-controller/pkg/libovsdb/ops/model_client_test.go
@@ -1130,7 +1130,7 @@ func TestLookup(t *testing.T) {
 						Model: &nbdb.AddressSet{
 							Name: adressSetTestName,
 						},
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return false },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return false },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						ErrNotFound:    true,
 					},
@@ -1161,7 +1161,7 @@ func TestLookup(t *testing.T) {
 						Model: &nbdb.AddressSet{
 							UUID: lookupUUID,
 						},
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return false },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return false },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						ErrNotFound:    true,
 					},
@@ -1215,7 +1215,7 @@ func TestLookup(t *testing.T) {
 						Model: &nbdb.AddressSet{
 							Name: adressSetTestName + "-not-found",
 						},
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return false },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return false },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						ErrNotFound:    false,
 					},
@@ -1289,7 +1289,7 @@ func TestLookup(t *testing.T) {
 			generateOp: func() []operationModel {
 				return []operationModel{
 					{
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return false },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return false },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						ErrNotFound:    true,
 					},
@@ -1310,7 +1310,7 @@ func TestLookup(t *testing.T) {
 			generateOp: func() []operationModel {
 				return []operationModel{
 					{
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return false },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return false },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						ErrNotFound:    false,
 					},
@@ -1334,7 +1334,7 @@ func TestLookup(t *testing.T) {
 						Model: &nbdb.AddressSet{
 							Name: adressSetTestName,
 						},
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return false },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return false },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						ErrNotFound:    true,
 						BulkOp:         true,
@@ -1395,7 +1395,7 @@ func TestLookup(t *testing.T) {
 			generateOp: func() []operationModel {
 				return []operationModel{
 					{
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return true },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return true },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						BulkOp:         true,
 					},
@@ -1433,7 +1433,7 @@ func TestLookup(t *testing.T) {
 			generateOp: func() []operationModel {
 				return []operationModel{
 					{
-						ModelPredicate: func(item *nbdb.AddressSet) bool { return true },
+						ModelPredicate: func(*nbdb.AddressSet) bool { return true },
 						ExistingResult: &[]*nbdb.AddressSet{},
 						BulkOp:         false,
 					},

--- a/go-controller/pkg/libovsdb/ops/model_client_test.go
+++ b/go-controller/pkg/libovsdb/ops/model_client_test.go
@@ -44,6 +44,7 @@ type OperationModelTestCase struct {
 }
 
 func runTestCase(t *testing.T, tCase OperationModelTestCase) error {
+	t.Helper()
 	dbSetup := libovsdbtest.TestSetup{
 		NBData: tCase.initialDB,
 	}

--- a/go-controller/pkg/libovsdb/ops/router_test.go
+++ b/go-controller/pkg/libovsdb/ops/router_test.go
@@ -36,14 +36,14 @@ func TestFindNATsUsingPredicate(t *testing.T) {
 	}{
 		{
 			desc: "find no nats",
-			predFunc: func(item *nbdb.NAT) bool {
+			predFunc: func(*nbdb.NAT) bool {
 				return false
 			},
 			expectedRc: []*nbdb.NAT{},
 		},
 		{
 			desc: "find all nats",
-			predFunc: func(item *nbdb.NAT) bool {
+			predFunc: func(*nbdb.NAT) bool {
 				return true
 			},
 			expectedRc: []*nbdb.NAT{fakeNAT1, fakeNAT2},

--- a/go-controller/pkg/libovsdb/ops/switch_test.go
+++ b/go-controller/pkg/libovsdb/ops/switch_test.go
@@ -104,7 +104,7 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 				}
 			}
 
-			p := func(item *nbdb.LogicalSwitch) bool { return true }
+			p := func(*nbdb.LogicalSwitch) bool { return true }
 			err = RemoveACLsFromLogicalSwitchesWithPredicate(nbClient, p, ACLs...)
 			if err != nil && !tt.expectErr {
 				t.Fatal(fmt.Errorf("RemoveACLFromNodeSwitches() error = %v", err))

--- a/go-controller/pkg/libovsdb/util/acl_test.go
+++ b/go-controller/pkg/libovsdb/util/acl_test.go
@@ -38,10 +38,10 @@ func TestConvertK8sProtocolToOVNProtocol(t *testing.T) {
 	for _, tc := range testcases {
 		protocol := ConvertK8sProtocolToOVNProtocol(corev1.Protocol(tc.protocol))
 		if tc.expected == "" {
-			assert.Equal(t, len(protocol), 0)
+			assert.Empty(t, protocol)
 			continue
 		}
-		assert.Equal(t, protocol, tc.expected)
+		assert.Equal(t, tc.expected, protocol)
 	}
 }
 
@@ -162,10 +162,10 @@ func TestGetL4Match(t *testing.T) {
 	for _, tc := range testcases {
 		protocolPortsMap := getProtocolPortsMap(tc.portPolices)
 		if tc.expected == "" {
-			assert.Equal(t, len(protocolPortsMap), 0)
+			assert.Empty(t, protocolPortsMap)
 			continue
 		}
-		assert.Equal(t, len(protocolPortsMap), 1)
+		assert.Len(t, protocolPortsMap, 1)
 		assert.Contains(t, protocolPortsMap, tc.protocol)
 		l4Match := getL4Match(tc.protocol, protocolPortsMap[tc.protocol])
 		assert.Equal(t, tc.expected, l4Match)
@@ -291,7 +291,7 @@ func TestGetL3L4MatchesFromNamedPorts(t *testing.T) {
 		l3l4MatchPerProtocol := GetL3L4MatchesFromNamedPorts(tc.ports)
 		for i, expected := range tc.expected {
 			if expected == "" {
-				assert.Equal(t, len(l3l4MatchPerProtocol), 0)
+				assert.Empty(t, l3l4MatchPerProtocol)
 				continue
 			}
 			assert.Contains(t, l3l4MatchPerProtocol, tc.protocol[i])

--- a/go-controller/pkg/libovsdb/util/acl_test.go
+++ b/go-controller/pkg/libovsdb/util/acl_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestConvertK8sProtocolToOVNProtocol(t *testing.T) {
 	testcases := []struct {
 		desc     string
-		protocol v1.Protocol
+		protocol corev1.Protocol
 		expected string
 	}{
 		{
@@ -36,7 +36,7 @@ func TestConvertK8sProtocolToOVNProtocol(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		protocol := ConvertK8sProtocolToOVNProtocol(v1.Protocol(tc.protocol))
+		protocol := ConvertK8sProtocolToOVNProtocol(corev1.Protocol(tc.protocol))
 		if tc.expected == "" {
 			assert.Equal(t, len(protocol), 0)
 			continue

--- a/go-controller/pkg/libovsdb/util/port_test.go
+++ b/go-controller/pkg/libovsdb/util/port_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
@@ -31,14 +31,14 @@ func TestExtractPortAddresses(t *testing.T) {
 			desc: "test path where lsp.DynamicAddresses is a zero length string and len(addresses)==0",
 			lsp: &nbdb.LogicalSwitchPort{
 				Name:             "test-pod",
-				DynamicAddresses: utilpointer.String(hwAddr + " " + ipAddr),
+				DynamicAddresses: ptr.To(hwAddr + " " + ipAddr),
 			},
 		},
 		{
 			desc: "test path where lsp.DynamicAddresses is non-zero length string and value of first address in addresses list is set to dynamic",
 			lsp: &nbdb.LogicalSwitchPort{
 				Name:             portName,
-				DynamicAddresses: utilpointer.String(hwAddr + " " + ipAddr),
+				DynamicAddresses: ptr.To(hwAddr + " " + ipAddr),
 				Addresses:        []string{"dynamic"},
 			},
 		},
@@ -46,7 +46,7 @@ func TestExtractPortAddresses(t *testing.T) {
 			desc: "test code path where port has MAC but no IPs",
 			lsp: &nbdb.LogicalSwitchPort{
 				Name:             "test-pod",
-				DynamicAddresses: utilpointer.String(hwAddr),
+				DynamicAddresses: ptr.To(hwAddr),
 			},
 			hasNoIP: true,
 		},
@@ -54,7 +54,7 @@ func TestExtractPortAddresses(t *testing.T) {
 			desc: "test the code path where ParseMAC fails",
 			lsp: &nbdb.LogicalSwitchPort{
 				Name:             portName,
-				DynamicAddresses: utilpointer.String(badHWAddr),
+				DynamicAddresses: ptr.To(badHWAddr),
 			},
 			errMatch: fmt.Errorf("failed to parse logical switch port \"%s\" MAC \"%s\": address %s: invalid MAC address", portName, badHWAddr, badHWAddr),
 		},

--- a/go-controller/pkg/libovsdb/util/port_test.go
+++ b/go-controller/pkg/libovsdb/util/port_test.go
@@ -81,17 +81,17 @@ func TestExtractPortAddresses(t *testing.T) {
 			if tc.isNotFound {
 				assert.Nil(t, hardwareAddr)
 				assert.Nil(t, ips)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 
 			} else if tc.hasNoIP {
-				assert.Equal(t, hardwareAddr.String(), hwAddr)
+				assert.Equal(t, hwAddr, hardwareAddr.String())
 				assert.Nil(t, ips)
 			} else if tc.errMatch != nil {
 				assert.Equal(t, err, tc.errMatch)
 			} else {
-				assert.Equal(t, hardwareAddr.String(), hwAddr)
-				assert.Equal(t, len(ips), 1)
-				assert.Equal(t, ips[0].String(), ipAddr)
+				assert.Equal(t, hwAddr, hardwareAddr.String())
+				assert.Len(t, ips, 1)
+				assert.Equal(t, ipAddr, ips[0].String())
 			}
 		})
 	}

--- a/go-controller/pkg/metrics/ovnkube_controller_test.go
+++ b/go-controller/pkg/metrics/ovnkube_controller_test.go
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Config Duration Operations", func() {
 			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
 			ops, txOkCallback, startOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
 			gomega.Expect(ops).Should(gomega.HaveLen(1))
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			txOkCallback()
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("Config Duration Operations", func() {
 			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
 			ops, txOkCallback, startOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
 			gomega.Expect(ops).Should(gomega.HaveLen(1))
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			txOkCallback()
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("Config Duration Operations", func() {
 			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
 			ops, txOkCallback, startOVNTimestamp, err = instance.AddOVN(nbClient, "networkpolicy", testNamespaceB, testPodNameB)
 			gomega.Expect(ops).Should(gomega.HaveLen(1))
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			txOkCallback()
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("Config Duration Operations", func() {
 		ginkgo.It("denies recording when no start called", func() {
 			instance.Run(nbClient, k, 0, time.Millisecond, stop)
 			ops, _, _, _ := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
-			gomega.Expect(ops).Should(gomega.HaveLen(0))
+			gomega.Expect(ops).Should(gomega.BeEmpty())
 		})
 
 		ginkgo.It("allows multiple addOVN records for the same obj", func() {
@@ -202,14 +202,14 @@ var _ = ginkgo.Describe("Config Duration Operations", func() {
 			// first addOVN
 			ops, txOkCallback, firstStartOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
 			gomega.Expect(ops).Should(gomega.HaveLen(1))
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			txOkCallback()
 			// second addOVN
 			ops, txOkCallback, secondStartOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
 			gomega.Expect(ops).Should(gomega.HaveLen(1))
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			txOkCallback()

--- a/go-controller/pkg/metrics/ovs_test.go
+++ b/go-controller/pkg/metrics/ovs_test.go
@@ -29,7 +29,7 @@ func NewFakeOVSClient(data []clientOutput) fakeOVSClient {
 	return fakeOVSClient{data: data}
 }
 
-func (c *fakeOVSClient) FakeCall(args ...string) (string, string, error) {
+func (c *fakeOVSClient) FakeCall(...string) (string, string, error) {
 	output := c.data[c.dataIndex]
 	c.dataIndex++
 	return output.stdout, output.stderr, output.err

--- a/go-controller/pkg/metrics/ovs_test.go
+++ b/go-controller/pkg/metrics/ovs_test.go
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			}
 			ovsOfctl := NewFakeOVSClient(ovsOfctlOutput)
 			err = updateOvsBridgeMetrics(ovsClient, ovsOfctl.FakeCall)
-			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			// There is no easy way (that I can think of besides creating my own interface - none exist upstream) to
 			// mock prometheus.gaugevec.
 			// Validate the number of expected prom time series only.
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			}
 			ovsAppctl := NewFakeOVSClient(ovsAppctlOutput)
 			err = updateOvsBridgeMetrics(ovsClient, ovsAppctl.FakeCall)
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			libovsdbCleanup.Cleanup()
 		})
 
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			}
 			ovsAppctl := NewFakeOVSClient(ovsAppctlOutput)
 			err = updateOvsBridgeMetrics(ovsClient, ovsAppctl.FakeCall)
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			libovsdbCleanup.Cleanup()
 		})
 
@@ -189,7 +189,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			}
 			ovsAppctl := NewFakeOVSClient(ovsAppctlOutput)
 			err = updateOvsBridgeMetrics(ovsClient, ovsAppctl.FakeCall)
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			libovsdbCleanup.Cleanup()
 		})
 	})
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			ovsClient, libovsdbCleanup, err := libovsdbtest.NewOVSTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = updateOvsInterfaceMetrics(ovsClient)
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			gomega.Expect(resetsTotalMock.GetValue()).Should(gomega.BeNumerically("==", 2))
 			gomega.Expect(rxDroppedTotalMock.GetValue()).Should(gomega.BeNumerically("==", 10))
 			gomega.Expect(txDroppedTotalMock.GetValue()).Should(gomega.BeNumerically("==", 100))
@@ -247,7 +247,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			ovsClient, libovsdbCleanup, err := libovsdbtest.NewOVSTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = setOvsHwOffloadMetrics(ovsClient)
-			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			gomega.Expect(hwOffloadMock.GetValue()).Should(gomega.BeNumerically("==", 1))
 			gomega.Expect(tcPolicyMock.GetValue()).Should(gomega.BeNumerically("==", 1))
 			libovsdbCleanup.Cleanup()
@@ -261,7 +261,7 @@ var _ = ginkgo.Describe("OVS metrics", func() {
 			ovsClient, libovsdbCleanup, err := libovsdbtest.NewOVSTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = setOvsHwOffloadMetrics(ovsClient)
-			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err).To(gomega.HaveOccurred())
 			libovsdbCleanup.Cleanup()
 		})
 	})

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 
-	kapiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -111,21 +111,21 @@ func (tcm *testControllerManager) GetDefaultNetworkController() ReconcilableNetw
 	return tcm.defaultNetwork
 }
 
-func (tcm *testControllerManager) Reconcile(name string, old, new util.NetInfo) error {
+func (tcm *testControllerManager) Reconcile(string, util.NetInfo, util.NetInfo) error {
 	return nil
 }
 
 type fakeNamespaceLister struct{}
 
-func (f *fakeNamespaceLister) List(selector labels.Selector) (ret []*kapiv1.Namespace, err error) {
+func (f *fakeNamespaceLister) List(labels.Selector) (ret []*corev1.Namespace, err error) {
 	return nil, nil
 }
 
 // Get retrieves the Namespace from the index for a given name.
 // Objects returned here must be treated as read-only.
-func (f *fakeNamespaceLister) Get(name string) (*kapiv1.Namespace, error) {
-	return &kapiv1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
+func (f *fakeNamespaceLister) Get(name string) (*corev1.Namespace, error) {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: map[string]string{types.RequiredUDNNamespaceLabel: ""},
 		},
@@ -508,8 +508,8 @@ func TestNADController(t *testing.T) {
 					args.network.NADName = args.nad
 					nad, err = buildNAD(name, namespace, args.network)
 					g.Expect(err).ToNot(gomega.HaveOccurred())
-					_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, v1.CreateOptions{})
-					g.Expect(err).To(gomega.Or(gomega.Not(gomega.HaveOccurred()), gomega.MatchError(errors.IsAlreadyExists, "AlreadyExists")))
+					_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, metav1.CreateOptions{})
+					g.Expect(err).To(gomega.Or(gomega.Not(gomega.HaveOccurred()), gomega.MatchError(apierrors.IsAlreadyExists, "AlreadyExists")))
 				}
 
 				err = nadController.syncNAD(args.nad, nad)
@@ -688,12 +688,12 @@ func TestSyncAll(t *testing.T) {
 			expectedPrimaryNetworks := map[string]util.NetInfo{}
 			for _, namespace := range []string{"test", "test2"} {
 				_, err = fakeClient.KubeClient.CoreV1().Namespaces().Create(context.TODO(),
-					&kapiv1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:   namespace,
 							Labels: map[string]string{types.RequiredUDNNamespaceLabel: ""},
 						},
-					}, v1.CreateOptions{},
+					}, metav1.CreateOptions{},
 				)
 			}
 			g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -710,7 +710,7 @@ func TestSyncAll(t *testing.T) {
 				_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(
 					context.Background(),
 					nad,
-					v1.CreateOptions{},
+					metav1.CreateOptions{},
 				)
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 				netInfo := expectedNetworks[testNAD.netconf.Name]
@@ -769,7 +769,7 @@ func buildNAD(name, namespace string, network *ovncnitypes.NetConf) (*nettypes.N
 		return nil, err
 	}
 	nad := &nettypes.NetworkAttachmentDefinition{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},

--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -45,7 +45,7 @@ func TestSetAdvertisements(t *testing.T) {
 	}
 
 	podNetworkRA := ratypes.RouteAdvertisements{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: testRAName,
 		},
 		Spec: ratypes.RouteAdvertisementsSpec{
@@ -55,26 +55,26 @@ func TestSetAdvertisements(t *testing.T) {
 			},
 		},
 		Status: ratypes.RouteAdvertisementsStatus{
-			Conditions: []v1.Condition{
+			Conditions: []metav1.Condition{
 				{
 					Type:   "Accepted",
-					Status: v1.ConditionTrue,
+					Status: metav1.ConditionTrue,
 				},
 			},
 		},
 	}
 	nonPodNetworkRA := ratypes.RouteAdvertisements{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: testRAName,
 		},
 		Spec: ratypes.RouteAdvertisementsSpec{
 			TargetVRF: testVRFName,
 		},
 		Status: ratypes.RouteAdvertisementsStatus{
-			Conditions: []v1.Condition{
+			Conditions: []metav1.Condition{
 				{
 					Type:   "Accepted",
-					Status: v1.ConditionTrue,
+					Status: metav1.ConditionTrue,
 				},
 			},
 		},
@@ -82,17 +82,17 @@ func TestSetAdvertisements(t *testing.T) {
 	podNetworkRANotAccepted := podNetworkRA
 	podNetworkRANotAccepted.Status = ratypes.RouteAdvertisementsStatus{}
 	podNetworkRARejected := *podNetworkRA.DeepCopy()
-	podNetworkRARejected.Status.Conditions[0].Status = v1.ConditionFalse
+	podNetworkRARejected.Status.Conditions[0].Status = metav1.ConditionFalse
 	podNetworkRAOutdated := podNetworkRA
 	podNetworkRAOutdated.Generation = 1
 
 	testNode := corev1.Node{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: testNodeName,
 		},
 	}
 	testNodeOnZone := corev1.Node{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: testNodeOnZoneName,
 			Annotations: map[string]string{
 				util.OvnNodeZoneName: testZoneName,
@@ -100,7 +100,7 @@ func TestSetAdvertisements(t *testing.T) {
 		},
 	}
 	otherNode := corev1.Node{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "otherNode",
 		},
 	}
@@ -190,11 +190,11 @@ func TestSetAdvertisements(t *testing.T) {
 			nad, err := buildNADWithAnnotations(name, namespace, tt.network, nadAnnotations)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			_, err = fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), &tt.node, v1.CreateOptions{})
+			_, err = fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), &tt.node, metav1.CreateOptions{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), tt.ra, v1.CreateOptions{})
+			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), tt.ra, metav1.CreateOptions{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, v1.CreateOptions{})
+			_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, metav1.CreateOptions{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
 			err = wf.Start()

--- a/go-controller/pkg/node/base_node_network_controller_dpu_test.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -78,8 +78,8 @@ func checkOVSPortPodInfo(execMock *ovntest.FakeExec, vfRep string, exists bool, 
 	})
 }
 
-func newFakeKubeClientWithPod(pod *v1.Pod) *fake.Clientset {
-	return fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*pod}})
+func newFakeKubeClientWithPod(pod *corev1.Pod) *fake.Clientset {
+	return fake.NewSimpleClientset(&corev1.PodList{Items: []corev1.Pod{*pod}})
 }
 
 var _ = Describe("Node DPU tests", func() {
@@ -88,7 +88,7 @@ var _ = Describe("Node DPU tests", func() {
 	var execMock *ovntest.FakeExec
 	var kubeMock kubemocks.Interface
 	var factoryMock factorymocks.NodeWatchFactory
-	var pod v1.Pod
+	var pod corev1.Pod
 	var dnnc *DefaultNodeNetworkController
 	var podInformer coreinformermocks.PodInformer
 	var podLister v1mocks.PodLister
@@ -100,7 +100,7 @@ var _ = Describe("Node DPU tests", func() {
 	origNetlinkOps := util.GetNetLinkOps()
 
 	BeforeEach(func() {
-		config.PrepareTestConfig()
+		Expect(config.PrepareTestConfig()).To(Succeed())
 		sriovnetOpsMock = utilMocks.SriovnetOps{}
 		netlinkOpsMock = utilMocks.NetLinkOps{}
 		execMock = ovntest.NewFakeExec()
@@ -125,7 +125,7 @@ var _ = Describe("Node DPU tests", func() {
 		podLister = v1mocks.PodLister{}
 		podLister.On("Pods", mock.AnythingOfType("string")).Return(&podNamespaceLister)
 
-		pod = v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		pod = corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name:        "a-pod",
 			Namespace:   "foo-ns",
 			UID:         "a-pod",

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/pkg/util/iptables"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	kexec "k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
@@ -98,7 +97,6 @@ const (
 	egressIP3IPCIDR                 = egressIP3IP + "/32"
 	egressIPv4Mask                  = "32"
 	egressIPv6Mask                  = "128"
-	oneSec                          = time.Second
 	dummyLink1Name                  = "dummy1"
 	dummyLink2Name                  = "dummy2"
 	dummyLink3Name                  = "dummy3"
@@ -157,7 +155,7 @@ func setupFakeNode(nodeInitialConfig nodeConfig) (ns.NetNS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new network namespace: %v", err)
 	}
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err = testNS.Do(func(ns.NetNS) error {
 		// adding links
 		for _, link := range nodeInitialConfig.linkConfigs {
 			if err = addLinkAndAddresses(link.linkName, link.address); err != nil {
@@ -171,9 +169,9 @@ func setupFakeNode(nodeInitialConfig nodeConfig) (ns.NetNS, error) {
 			}
 		}
 		// adding IPTable rules
-		ipTableV4Client := iptables.New(kexec.New(), iptables.ProtocolIPv4)
-		ipTableV6Client := iptables.New(kexec.New(), iptables.ProtocolIPv6)
-		var ipTableClient iptables.Interface
+		ipTableV4Client := utiliptables.New(kexec.New(), utiliptables.ProtocolIPv4)
+		ipTableV6Client := utiliptables.New(kexec.New(), utiliptables.ProtocolIPv6)
+		var ipTableClient utiliptables.Interface
 		for _, iptableRule := range nodeInitialConfig.iptableRules {
 			if len(iptableRule.Args) != 0 {
 				if isIPTableRuleArgIPV6(iptableRule.Args) {
@@ -200,12 +198,12 @@ func setupFakeNode(nodeInitialConfig nodeConfig) (ns.NetNS, error) {
 	return testNS, nil
 }
 
-func ensureIPTableChainAndRule(ipt iptables.Interface, ruleArgs []string) error {
-	_, err := ipt.EnsureChain(iptables.TableNAT, iptChainName)
+func ensureIPTableChainAndRule(ipt utiliptables.Interface, ruleArgs []string) error {
+	_, err := ipt.EnsureChain(utiliptables.TableNAT, iptChainName)
 	if err != nil {
 		return fmt.Errorf("failed to create chain %s in NAT table: %v", iptChainName, err)
 	}
-	_, err = ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptChainName, ruleArgs...)
+	_, err = ipt.EnsureRule(utiliptables.Prepend, utiliptables.TableNAT, iptChainName, ruleArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to ensure IPTables rule (%v): %v", ruleArgs, err)
 	}
@@ -234,7 +232,7 @@ func createVRFAndEnslaveLink(testNS ns.NetNS, linkName, vrfName string, vrfTable
 		LinkAttrs: netlink.LinkAttrs{Name: vrfName},
 		Table:     vrfTable,
 	}
-	return testNS.Do(func(netNS ns.NetNS) error {
+	return testNS.Do(func(ns.NetNS) error {
 		if err := netlink.LinkAdd(vrfLink); err != nil {
 			return fmt.Errorf("failed to create VRF link %s and table ID %d: %v", vrfName, vrfTable, err)
 		}
@@ -271,7 +269,7 @@ func initController(namespaces []corev1.Namespace, pods []corev1.Pod, egressIPs 
 	}
 	linkManager := linkmanager.NewController(node1Name, v4, v6, nil)
 	// only CDN network is supported
-	getActiveNetForNsFn := func(namespace string) (util.NetInfo, error) {
+	getActiveNetForNsFn := func(string) (util.NetInfo, error) {
 		return &util.DefaultNetInfo{}, nil
 	}
 	c, err := NewController(&ovnkube.Kube{KClient: kubeClient}, watchFactory.EgressIPInformer(), watchFactory.NodeInformer(), watchFactory.NamespaceInformer(),
@@ -310,6 +308,7 @@ func initController(namespaces []corev1.Namespace, pods []corev1.Pod, egressIPs 
 }
 
 func runController(testNS ns.NetNS, c *Controller) (cleanupFn, error) {
+	ginkgo.GinkgoHelper()
 	stopCh := make(chan struct{})
 	for _, se := range []struct {
 		resourceName string
@@ -329,7 +328,7 @@ func runController(testNS ns.NetNS, c *Controller) (cleanupFn, error) {
 	wg := &sync.WaitGroup{}
 	runSubControllers(testNS, c, wg, stopCh)
 
-	err := testNS.Do(func(netNS ns.NetNS) error {
+	err := testNS.Do(func(ns.NetNS) error {
 		return c.ruleManager.OwnPriority(rulePriority)
 	})
 	if err != nil {
@@ -344,18 +343,20 @@ func runController(testNS ns.NetNS, c *Controller) (cleanupFn, error) {
 		} {
 			wg.Add(1)
 			go func(fn func(*sync.WaitGroup)) {
+				defer ginkgo.GinkgoRecover()
 				defer wg.Done()
-				_ = testNS.Do(func(netNS ns.NetNS) error {
+				err := testNS.Do(func(ns.NetNS) error {
 					wait.Until(func() {
 						fn(wg)
 					}, 10*time.Millisecond, stopCh)
 					return nil
 				})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			}(workerFn)
 		}
 	}
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err = testNS.Do(func(ns.NetNS) error {
 		if err = c.ruleManager.OwnPriority(rulePriority); err != nil {
 			return err
 		}
@@ -393,28 +394,41 @@ func runController(testNS ns.NetNS, c *Controller) (cleanupFn, error) {
 }
 
 func runSubControllers(testNS ns.NetNS, c *Controller, wg *sync.WaitGroup, stopCh chan struct{}) {
+	ginkgo.GinkgoHelper()
 	// we do not call start for our controller because the newly created goroutines will not be set to the correct network namespace,
 	// so we invoke them manually here and call reconcile manually
 	// normally executed during Run but we call it manually here because run spawns a go routine that we cannot control its netns during test
 	c.linkManager.Run(stopCh, wg)
 	wg.Add(1)
-	go testNS.Do(func(netNS ns.NetNS) error {
-		c.iptablesManager.Run(stopCh, 10*time.Millisecond)
-		wg.Done()
-		return nil
-	})
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		defer wg.Done()
+		err := testNS.Do(func(ns.NetNS) error {
+			c.iptablesManager.Run(stopCh, 10*time.Millisecond)
+			return nil
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}()
 	wg.Add(1)
-	go testNS.Do(func(netNS ns.NetNS) error {
-		c.routeManager.Run(stopCh, 10*time.Millisecond)
-		wg.Done()
-		return nil
-	})
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		defer wg.Done()
+		err := testNS.Do(func(ns.NetNS) error {
+			c.routeManager.Run(stopCh, 10*time.Millisecond)
+			return nil
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}()
 	wg.Add(1)
-	go testNS.Do(func(netNS ns.NetNS) error {
-		c.ruleManager.Run(stopCh, 10*time.Millisecond)
-		wg.Done()
-		return nil
-	})
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		defer wg.Done()
+		err := testNS.Do(func(ns.NetNS) error {
+			c.ruleManager.Run(stopCh, 10*time.Millisecond)
+			return nil
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}()
 }
 
 // FIXME(mk) - Within GH VM, if I need to create a new NetNs. I see the following error:
@@ -481,11 +495,11 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 			}
 			return nil
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify expected IP routes match what was found")
 		// Ensure only the routes we expect are present in a specific route table
 		gomega.Eventually(func() error {
-			return testNS.Do(func(netNS ns.NetNS) error {
+			return testNS.Do(func(ns.NetNS) error {
 				// loop over egress IPs
 				for _, expectedEIPConfig := range expectedEIPConfigs {
 					if len(expectedEIPConfig.podConfigs) == 0 {
@@ -521,7 +535,7 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 				return nil
 			})
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify expected IP rules match what was found")
 		// verify the correct rules are present and also no rule entries we do not expect
 		expectedIPRules := make(map[string][]netlink.Rule, 0)
@@ -548,7 +562,7 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 		}
 		// verify expected IP rules versus what was found
 		gomega.Eventually(func() error {
-			return testNS.Do(func(netNS ns.NetNS) error {
+			return testNS.Do(func(ns.NetNS) error {
 				for _, expectedEIPConfig := range expectedEIPConfigs {
 					if len(expectedEIPConfig.podConfigs) == 0 {
 						// no pod configs expected therefore no IP routes
@@ -589,13 +603,13 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 				return nil
 			})
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify expected egress IPs are assigned to interface")
 		gomega.Eventually(func() error {
-			return testNS.Do(func(netNS ns.NetNS) error {
+			return testNS.Do(func(ns.NetNS) error {
 				for _, expectedEIPConfig := range expectedEIPConfigs {
 					if expectedEIPConfig.addr == nil {
-						return nil
+						continue
 					}
 					link, err := netlink.LinkByName(expectedEIPConfig.inf)
 					if err != nil {
@@ -614,10 +628,10 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 				return nil
 			})
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		// save annotations before removing EIP in-order to validate the addresses aren't assigned to a link anymore
 		var annotationEIPs sets.Set[string]
-		err = testNS.Do(func(netNS ns.NetNS) error {
+		err = testNS.Do(func(ns.NetNS) error {
 			annotationEIPs, err = c.getAnnotation()
 			return err
 		})
@@ -636,10 +650,10 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				return fmt.Errorf("expected zero IPTable rules but found %d", len(foundIPTRules))
 			}
 			return nil
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify IP routes are removed")
 		gomega.Eventually(func() error {
-			return testNS.Do(func(netNS ns.NetNS) error {
+			return testNS.Do(func(ns.NetNS) error {
 				// loop over all interfaces and ensure no EIP configured routes associated with links
 				for _, linkConfig := range nodeConfig.linkConfigs {
 					link, err := netlink.LinkByName(linkConfig.linkName)
@@ -657,10 +671,10 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 				return nil
 			})
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify IP rules are removed")
 		gomega.Eventually(func() error {
-			return testNS.Do(func(netNS ns.NetNS) error {
+			return testNS.Do(func(ns.NetNS) error {
 				filter, mask := filterRuleByPriority(rulePriority)
 				foundRules, err := netlink.RuleListFiltered(netlink.FAMILY_ALL, filter, mask)
 				if err != nil {
@@ -671,7 +685,7 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 				return nil
 			})
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify assigned IP addresses are removed from annotation")
 		gomega.Eventually(func() error {
 			eipIPs, err := c.getAnnotation()
@@ -682,10 +696,10 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				return fmt.Errorf("expected 0 EIPs in annotation but found %d", eipIPs.Len())
 			}
 			return nil
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("ensure no Egress IP is still assigned to a link")
 		gomega.Eventually(func() error {
-			return testNS.Do(func(netNS ns.NetNS) error {
+			return testNS.Do(func(ns.NetNS) error {
 				for _, linkConfig := range nodeConfig.linkConfigs {
 					link, err := netlink.LinkByName(linkConfig.linkName)
 					if err != nil {
@@ -704,7 +718,7 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 				}
 				return nil
 			})
-		}).WithTimeout(oneSec).Should(gomega.Succeed())
+		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		gomega.Expect(cleanupControllerFn()).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(cleanupNodeFn()).ShouldNot(gomega.HaveOccurred())
 	},
@@ -1079,7 +1093,7 @@ var _ = ginkgo.Describe("label to annotations migration", func() {
 	})
 
 	ginkgo.It("creates annotation", func() {
-		gomega.Expect(testNS.Do(func(netNS ns.NetNS) error {
+		gomega.Expect(testNS.Do(func(ns.NetNS) error {
 			return c.migrateFromAddrLabelToAnnotation()
 		})).Should(gomega.Succeed())
 		gomega.Eventually(func() bool {
@@ -1120,7 +1134,7 @@ var _ = ginkgo.Describe("VRF", func() {
 		gomega.Expect(createVRFAndEnslaveLink(testNS, dummyLink1Name, vrfName, vrfTable)).Should(gomega.Succeed())
 		ginkgo.By("add route to routing table associated with VRF")
 		vrfRoute := getDstRouteForTable(getLinkIndex(dummyLink1Name), int(vrfTable), dummy3IPv4CIDR)
-		gomega.Expect(testNS.Do(func(netNS ns.NetNS) error {
+		gomega.Expect(testNS.Do(func(ns.NetNS) error {
 			return netlink.RouteAdd(&vrfRoute)
 		})).Should(gomega.Succeed())
 		egressIPList := []egressipv1.EgressIP{*newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel)}
@@ -1181,10 +1195,10 @@ var _ = ginkgo.DescribeTable("repair node", func(expectedStateFollowingClean []e
 	c, _, err := initController(namespaces, pods, egressIPList, nodeConfigsBeforeRepair, v4, v6, true)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	wg := &sync.WaitGroup{}
-	stopCh := make(chan struct{}, 0)
+	stopCh := make(chan struct{})
 	runSubControllers(testNS, c, wg, stopCh)
 	// for now, we expect it to always succeed
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err = testNS.Do(func(ns.NetNS) error {
 		return c.repairNode()
 	})
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -1438,7 +1452,7 @@ func getNodeObj(testNode nodeConfig, createEIPAnnot bool) corev1.Node {
 func getLinkAddresses(testNS ns.NetNS, infs ...string) (map[string][]netlink.Addr, error) {
 	var err error
 	linkAddresses := make(map[string][]netlink.Addr)
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err = testNS.Do(func(ns.NetNS) error {
 		links, err := netlink.LinkList()
 		if err != nil {
 			return err
@@ -1464,8 +1478,7 @@ func getLinkAddresses(testNS ns.NetNS, infs ...string) (map[string][]netlink.Add
 
 func getIPTableRules(testNS ns.NetNS, iptablesManager *ovniptables.Controller, v4, v6 bool) ([]ovniptables.RuleArg, error) {
 	var foundIPTRules []ovniptables.RuleArg
-	var err error
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err := testNS.Do(func(ns.NetNS) error {
 		if v4 {
 			foundIPTRulesV4, err := iptablesManager.GetIPv4ChainRuleArgs(utiliptables.TableNAT, iptChainName)
 			if err != nil {
@@ -1488,7 +1501,7 @@ func getIPTableRules(testNS ns.NetNS, iptablesManager *ovniptables.Controller, v
 func getRoutesForLinkFromTable(testNS ns.NetNS, linkName string) ([]netlink.Route, error) {
 	var err error
 	var routes []netlink.Route
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err = testNS.Do(func(ns.NetNS) error {
 		link, err := netlink.LinkByName(linkName)
 		if err != nil {
 			return err
@@ -1506,7 +1519,7 @@ func getRoutesForLinkFromTable(testNS ns.NetNS, linkName string) ([]netlink.Rout
 func getRoutesFromTable(testNS ns.NetNS, table, family int) ([]netlink.Route, error) {
 	var err error
 	var routes []netlink.Route
-	err = testNS.Do(func(netNS ns.NetNS) error {
+	err = testNS.Do(func(ns.NetNS) error {
 		filterRoute, filterMask := filterRouteByTable(table)
 		routes, err = netlink.RouteListFiltered(family, filterRoute, filterMask)
 		if err != nil {
@@ -1548,8 +1561,8 @@ func newEgressIP(name, ip, node string, namespaceLabels, podLabels map[string]st
 		},
 		Status: egressipv1.EgressIPStatus{
 			Items: []egressipv1.EgressIPStatusItem{{
-				node,
-				ip,
+				Node:     node,
+				EgressIP: ip,
 			}},
 		},
 	}
@@ -1652,18 +1665,6 @@ func getDstRouteForTable(linkIndex, table int, dst string) netlink.Route {
 	return netlink.Route{LinkIndex: linkIndex, Dst: dstIPNet, Table: table}
 }
 
-func getDstWithSrcRoute(linkIndex int, dst, src string) netlink.Route {
-	_, dstIPNet, err := net.ParseCIDR(dst)
-	if err != nil {
-		panic(err.Error())
-	}
-	ip := net.ParseIP(src)
-	if len(ip) == 0 {
-		panic("invalid src IP")
-	}
-	return netlink.Route{LinkIndex: linkIndex, Dst: dstIPNet, Src: ip, Table: util.CalculateRouteTableID(linkIndex)}
-}
-
 func getLinkLocalRoute(linkIndex int) netlink.Route {
 	return netlink.Route{LinkIndex: linkIndex, Dst: linkLocalCIDR, Table: util.CalculateRouteTableID(linkIndex)}
 }
@@ -1674,42 +1675,6 @@ func getNetlinkAddr(ip, netmask string) *netlink.Addr {
 		panic(fmt.Sprintf("failed to parse %q: %v", ip, err))
 	}
 	return addr
-}
-
-// areRoutesEqual turns true if routes are partially equal. A limited set of fields within a route are checked to ensure
-// they are equal. The reason a limit set is checked is that a user may define a limited subset of fields but when we retrieve
-// this route from the system, other fields are populated by default.
-// Duplicate routes aren't tolerated.
-func areRoutesEqual(routes1 []netlink.Route, routes2 []netlink.Route) bool {
-	if len(routes1) != len(routes2) {
-		return false
-	}
-	var found bool
-	for _, route1 := range routes1 {
-		found = false
-		for _, route2 := range routes2 {
-			if routemanager.RoutePartiallyEqual(route1, route2) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	for _, route2 := range routes2 {
-		found = false
-		for _, route1 := range routes1 {
-			if routemanager.RoutePartiallyEqual(route2, route1) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
 }
 
 // containsRoutes returns true if routes in routes1 are presents in routes routes2
@@ -1778,7 +1743,7 @@ func isStrInArray(elements []string, candidate string) bool {
 }
 
 func setDepreciatedManagedAddressLabel(testNS ns.NetNS, cidrs ...string) error {
-	return testNS.Do(func(netNS ns.NetNS) error {
+	return testNS.Do(func(ns.NetNS) error {
 		links, err := netlink.LinkList()
 		if err != nil {
 			return nil

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
 
-	kapi "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -256,14 +256,14 @@ var _ = Describe("Node", func() {
 					interval int    = 100000
 					ofintval int    = 180
 				)
-				node := kapi.Node{
+				node := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: nodeName,
 					},
-					Status: kapi.NodeStatus{
-						Addresses: []kapi.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
-								Type:    kapi.NodeExternalIP,
+								Type:    corev1.NodeExternalIP,
 								Address: nodeIP,
 							},
 						},
@@ -362,14 +362,14 @@ var _ = Describe("Node", func() {
 					interval int    = 100000
 					ofintval int    = 180
 				)
-				node := kapi.Node{
+				node := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: nodeName,
 					},
-					Status: kapi.NodeStatus{
-						Addresses: []kapi.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
-								Type:    kapi.NodeExternalIP,
+								Type:    corev1.NodeExternalIP,
 								Address: nodeIP,
 							},
 						},
@@ -432,14 +432,14 @@ var _ = Describe("Node", func() {
 				)
 				ipfixIP := net.IP{1, 2, 3, 4}
 
-				node := kapi.Node{
+				node := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: nodeName,
 					},
-					Status: kapi.NodeStatus{
-						Addresses: []kapi.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
-								Type:    kapi.NodeExternalIP,
+								Type:    corev1.NodeExternalIP,
 								Address: nodeIP,
 							},
 						},
@@ -507,14 +507,14 @@ var _ = Describe("Node", func() {
 				)
 				ipfixIP := net.IP{1, 2, 3, 4}
 
-				node := kapi.Node{
+				node := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: nodeName,
 					},
-					Status: kapi.NodeStatus{
-						Addresses: []kapi.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
-								Type:    kapi.NodeExternalIP,
+								Type:    corev1.NodeExternalIP,
 								Address: nodeIP,
 							},
 						},
@@ -582,14 +582,14 @@ var _ = Describe("Node", func() {
 					interval int    = 100000
 					ofintval int    = 180
 				)
-				node := kapi.Node{
+				node := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: nodeName,
 					},
-					Status: kapi.NodeStatus{
-						Addresses: []kapi.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
-								Type:    kapi.NodeExternalIP,
+								Type:    corev1.NodeExternalIP,
 								Address: nodeIP,
 							},
 						},

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -36,7 +38,6 @@ add rule inet ovn-kubernetes egress-services snat to ip saddr map @egress-servic
 var _ = Describe("Egress Service Operations", func() {
 	var (
 		app         *cli.App
-		fakeOvnNode *FakeOVNNode
 		fExec       *ovntest.FakeExec
 		nft         *knftables.Fake
 		netlinkMock *mocks.NetLinkOps
@@ -54,10 +55,8 @@ var _ = Describe("Egress Service Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 		fExec = ovntest.NewLooseCompareFakeExec()
-		fakeOvnNode = NewFakeOVNNode(fExec)
-		fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd: "ovs-vsctl --timeout=15 --no-heading --data=bare --format=csv --columns name list interface",
-		})
+		err := util.SetExec(fExec)
+		Expect(err).NotTo(HaveOccurred())
 
 		config.OVNKubernetesFeature.EnableEgressService = true
 		_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
@@ -67,15 +66,14 @@ var _ = Describe("Egress Service Operations", func() {
 	})
 
 	AfterEach(func() {
-		fakeOvnNode.shutdown()
 		util.SetNetLinkOpMockInst(origNetlinkInst)
 		config.OVNKubernetesFeature.EnableEgressService = false
 	})
 
 	Context("on egress service resource changes", func() {
 		It("repairs nftables and ip rules when stale entries are present", func() {
-			app.Action = func(ctx *cli.Context) error {
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+			app.Action = func(*cli.Context) error {
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 --json rule show",
 					Output: "[{\"priority\":5000,\"src\":\"10.128.0.3\",\"table\":\"wrongTable\"},{\"priority\":5000,\"src\":\"goneEp\",\"table\":\"mynetwork\"}," +
 						"{\"priority\":5000,\"src\":\"10.128.0.3\",\"table\":\"mynetwork\"},{\"priority\":5000,\"src\":\"10.129.0.2\",\"table\":\"mynetwork\"}," +
@@ -85,15 +83,15 @@ var _ = Describe("Egress Service Operations", func() {
 						fmt.Sprintf("{\"priority\":5000,\"src\":\"%s\",\"sport\":30300,\"table\":\"mynetwork2\"}]", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table wrongTable",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from goneEp table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 31111 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
@@ -151,18 +149,18 @@ var _ = Describe("Egress Service Operations", func() {
 					},
 				}
 				service := *newService("service1", "namespace1", "10.129.0.2",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(31111),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.5",
 							}},
 						},
@@ -204,18 +202,18 @@ var _ = Describe("Egress Service Operations", func() {
 					},
 				}
 				service2 := *newService("service2", "namespace1", "10.129.0.3",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(30300),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.6",
 							}},
 						},
@@ -246,18 +244,18 @@ var _ = Describe("Egress Service Operations", func() {
 					},
 				}
 				service3 := *newService("service3", "namespace1", "10.129.0.4",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(32222),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "6.6.6.6",
 							}},
 						},
@@ -272,37 +270,42 @@ var _ = Describe("Egress Service Operations", func() {
 					"service3",
 					"namespace1",
 					[]discovery.Endpoint{ep3_1},
-					[]discovery.EndpointPort{epPort})
-
-				fakeOvnNode.start(ctx,
-					&v1.ServiceList{
-						Items: []v1.Service{
-							service,
-							service2,
-							service3,
-						},
-					},
-					&discovery.EndpointSliceList{
-						Items: []discovery.EndpointSlice{
-							endpointSlice,
-							endpointSlice2,
-							endpointSlice3,
-						},
-					},
-					&egressserviceapi.EgressServiceList{
-						Items: []egressserviceapi.EgressService{
-							egressService,
-							egressService2,
-							egressService3,
-						},
-					},
+					[]discovery.EndpointPort{epPort},
 				)
 
-				wf := fakeOvnNode.watcher.(*factory.WatchFactory)
-				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
-					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
+				objects := []runtime.Object{
+					&service,
+					&service2,
+					&service3,
+					&endpointSlice,
+					&endpointSlice2,
+					&endpointSlice3,
+					&egressService,
+					&egressService2,
+					&egressService3,
+				}
+				stopChan := make(chan struct{})
+				wg := &sync.WaitGroup{}
+				fakeClient := util.GetOVNClientset(objects...).GetNodeClientset()
+				wf, err := factory.NewNodeWatchFactory(fakeClient, "node")
 				Expect(err).ToNot(HaveOccurred())
-				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(wf.Start()).To(Succeed())
+				defer func() {
+					close(stopChan)
+					wg.Wait()
+					wf.Shutdown()
+				}()
+
+				c, err := egressservice.NewController(
+					stopChan,
+					ovnKubeNodeSNATMark,
+					"node",
+					wf.EgressServiceInformer(),
+					wf.ServiceInformer(),
+					wf.EndpointSliceInformer(),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				err = c.Run(wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT := nftablesRulesEgressServicesBase + `
@@ -313,7 +316,7 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.4 comment "nam
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				return nil
 			}
@@ -321,8 +324,8 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.4 comment "nam
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("manages iptables rules for LoadBalancer egress service backed by cluster networked pods", func() {
-			app.Action = func(ctx *cli.Context) error {
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+			app.Action = func(*cli.Context) error {
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip -4 --json rule show",
 					Output: "[]",
 					Err:    nil,
@@ -341,18 +344,18 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.4 comment "nam
 					},
 				}
 				service := *newService("service1", "namespace1", "10.129.0.2",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(31111),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.5",
 							}},
 						},
@@ -379,31 +382,36 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.4 comment "nam
 					"service1",
 					"namespace1",
 					[]discovery.Endpoint{ep1, ep2},
-					[]discovery.EndpointPort{epPort})
-
-				fakeOvnNode.start(ctx,
-					&v1.ServiceList{
-						Items: []v1.Service{
-							service,
-						},
-					},
-					&discovery.EndpointSliceList{
-						Items: []discovery.EndpointSlice{
-							endpointSlice,
-						},
-					},
-					&egressserviceapi.EgressServiceList{
-						Items: []egressserviceapi.EgressService{
-							egressService,
-						},
-					},
+					[]discovery.EndpointPort{epPort},
 				)
 
-				wf := fakeOvnNode.watcher.(*factory.WatchFactory)
-				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
-					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
+				objects := []runtime.Object{
+					&service,
+					&endpointSlice,
+					&egressService,
+				}
+				stopChan := make(chan struct{})
+				wg := &sync.WaitGroup{}
+				fakeClient := util.GetOVNClientset(objects...).GetNodeClientset()
+				wf, err := factory.NewNodeWatchFactory(fakeClient, "node")
 				Expect(err).ToNot(HaveOccurred())
-				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(wf.Start()).To(Succeed())
+				defer func() {
+					close(stopChan)
+					wg.Wait()
+					wf.Shutdown()
+				}()
+
+				c, err := egressservice.NewController(
+					stopChan,
+					ovnKubeNodeSNATMark,
+					"node",
+					wf.EgressServiceInformer(),
+					wf.ServiceInformer(),
+					wf.EndpointSliceInformer(),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				err = c.Run(wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT := nftablesRulesEgressServicesBase + `
@@ -413,7 +421,7 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "nam
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				err = fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT = nftablesRulesEgressServicesBase
@@ -421,7 +429,7 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "nam
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				return nil
 			}
@@ -430,49 +438,49 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "nam
 		})
 
 		It("manages iptables/ip rules for LoadBalancer egress service backed by ovn-k pods with Network", func() {
-			app.Action = func(ctx *cli.Context) error {
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+			app.Action = func(*cli.Context) error {
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip -4 --json rule show",
 					Output: "[]",
 					Err:    nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.129.0.10 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.128.0.11 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule add prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.10 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.11 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
@@ -493,18 +501,18 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "nam
 				}
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(31111),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.5",
 							}},
 						},
@@ -547,18 +555,18 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "nam
 				}
 
 				service2 := *newService("service2", "namespace1", "10.129.0.10",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(30300),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.6",
 							}},
 						},
@@ -576,34 +584,39 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.3 comment "nam
 					"service2",
 					"namespace1",
 					[]discovery.Endpoint{ep3},
-					[]discovery.EndpointPort{epPort})
-
-				fakeOvnNode.start(ctx,
-					&v1.ServiceList{
-						Items: []v1.Service{
-							service,
-							service2,
-						},
-					},
-					&discovery.EndpointSliceList{
-						Items: []discovery.EndpointSlice{
-							endpointSlice,
-							endpointSlice2,
-						},
-					},
-					&egressserviceapi.EgressServiceList{
-						Items: []egressserviceapi.EgressService{
-							egressService,
-							egressService2,
-						},
-					},
+					[]discovery.EndpointPort{epPort},
 				)
 
-				wf := fakeOvnNode.watcher.(*factory.WatchFactory)
-				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
-					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
+				objects := []runtime.Object{
+					&service,
+					&service2,
+					&endpointSlice,
+					&endpointSlice2,
+					&egressService,
+					&egressService2,
+				}
+				stopChan := make(chan struct{})
+				wg := &sync.WaitGroup{}
+				fakeClient := util.GetOVNClientset(objects...).GetNodeClientset()
+				wf, err := factory.NewNodeWatchFactory(fakeClient, "node")
 				Expect(err).ToNot(HaveOccurred())
-				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(wf.Start()).To(Succeed())
+				defer func() {
+					close(stopChan)
+					wg.Wait()
+					wf.Shutdown()
+				}()
+
+				c, err := egressservice.NewController(
+					stopChan,
+					ovnKubeNodeSNATMark,
+					"node",
+					wf.EgressServiceInformer(),
+					wf.ServiceInformer(),
+					wf.EndpointSliceInformer(),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				err = c.Run(wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT := nftablesRulesEgressServicesBase + `
@@ -614,10 +627,10 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				err = fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
+				err = fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT = nftablesRulesEgressServicesBase
@@ -625,7 +638,7 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 					return nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				}).ShouldNot(HaveOccurred())
 
-				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fakeOvnNode.fakeExec.ErrorDesc)
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -633,29 +646,29 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 		})
 
 		It("manages ip rules for LoadBalancer egress service backed by ovn-k pods with Network and Host=ALL", func() {
-			app.Action = func(ctx *cli.Context) error {
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+			app.Action = func(*cli.Context) error {
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip -4 --json rule show",
 					Output: "[]",
 					Err:    nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.129.0.10 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.128.0.11 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule add prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
@@ -676,18 +689,18 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(31111),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.5",
 							}},
 						},
@@ -738,18 +751,18 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}
 
 				service2 := *newService("service2", "namespace1", "10.129.0.10",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(30300),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.6",
 							}},
 						},
@@ -766,34 +779,39 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 					"service2",
 					"namespace1",
 					[]discovery.Endpoint{ep4},
-					[]discovery.EndpointPort{epPort})
-
-				fakeOvnNode.start(ctx,
-					&v1.ServiceList{
-						Items: []v1.Service{
-							service,
-							service2,
-						},
-					},
-					&discovery.EndpointSliceList{
-						Items: []discovery.EndpointSlice{
-							endpointSlice,
-							endpointSlice2,
-						},
-					},
-					&egressserviceapi.EgressServiceList{
-						Items: []egressserviceapi.EgressService{
-							egressService,
-							egressService2,
-						},
-					},
+					[]discovery.EndpointPort{epPort},
 				)
 
-				wf := fakeOvnNode.watcher.(*factory.WatchFactory)
-				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
-					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
+				objects := []runtime.Object{
+					&service,
+					&service2,
+					&endpointSlice,
+					&endpointSlice2,
+					&egressService,
+					&egressService2,
+				}
+				stopChan := make(chan struct{})
+				wg := &sync.WaitGroup{}
+				fakeClient := util.GetOVNClientset(objects...).GetNodeClientset()
+				wf, err := factory.NewNodeWatchFactory(fakeClient, "node")
 				Expect(err).ToNot(HaveOccurred())
-				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(wf.Start()).To(Succeed())
+				defer func() {
+					close(stopChan)
+					wg.Wait()
+					wf.Shutdown()
+				}()
+
+				c, err := egressservice.NewController(
+					stopChan,
+					ovnKubeNodeSNATMark,
+					"node",
+					wf.EgressServiceInformer(),
+					wf.ServiceInformer(),
+					wf.EndpointSliceInformer(),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				err = c.Run(wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT := nftablesRulesEgressServicesBase
@@ -802,34 +820,34 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
-					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+					return fExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.10 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.11 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				err = fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
+				err = fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service2", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT = nftablesRulesEgressServicesBase
@@ -838,7 +856,7 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
-					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+					return fExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 				return nil
 			}
@@ -847,17 +865,17 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 		})
 
 		It("updates network ip rules for LoadBalancer egress service when ETP changes", func() {
-			app.Action = func(ctx *cli.Context) error {
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+			app.Action = func(*cli.Context) error {
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip -4 --json rule show",
 					Output: "[]",
 					Err:    nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
@@ -878,18 +896,18 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
-					[]v1.ServicePort{
+					[]corev1.ServicePort{
 						{
 							NodePort: int32(30300),
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							Port:     int32(8080),
 						},
 					},
-					v1.ServiceTypeLoadBalancer,
+					corev1.ServiceTypeLoadBalancer,
 					[]string{},
-					v1.ServiceStatus{
-						LoadBalancer: v1.LoadBalancerStatus{
-							Ingress: []v1.LoadBalancerIngress{{
+					corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
 								IP: "5.5.5.5",
 							}},
 						},
@@ -926,29 +944,33 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 					[]discovery.Endpoint{ep1, ep2, ep3},
 					[]discovery.EndpointPort{epPort})
 
-				fakeOvnNode.start(ctx,
-					&v1.ServiceList{
-						Items: []v1.Service{
-							service,
-						},
-					},
-					&discovery.EndpointSliceList{
-						Items: []discovery.EndpointSlice{
-							endpointSlice,
-						},
-					},
-					&egressserviceapi.EgressServiceList{
-						Items: []egressserviceapi.EgressService{
-							egressService,
-						},
-					},
-				)
-
-				wf := fakeOvnNode.watcher.(*factory.WatchFactory)
-				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
-					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
+				objects := []runtime.Object{
+					&service,
+					&endpointSlice,
+					&egressService,
+				}
+				stopChan := make(chan struct{})
+				wg := &sync.WaitGroup{}
+				fakeClient := util.GetOVNClientset(objects...).GetNodeClientset()
+				wf, err := factory.NewNodeWatchFactory(fakeClient, "node")
 				Expect(err).ToNot(HaveOccurred())
-				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(wf.Start()).To(Succeed())
+				defer func() {
+					close(stopChan)
+					wg.Wait()
+					wf.Shutdown()
+				}()
+
+				c, err := egressservice.NewController(
+					stopChan,
+					ovnKubeNodeSNATMark,
+					"node",
+					wf.EgressServiceInformer(),
+					wf.ServiceInformer(),
+					wf.EndpointSliceInformer(),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				err = c.Run(wg, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT := nftablesRulesEgressServicesBase
@@ -957,17 +979,17 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
-					return fakeOvnNode.fakeExec.CalledMatchesExpected()
-				}).Should(BeTrue())
+					return fExec.CalledMatchesExpected()
+				}).Should(BeTrue(), fExec.ErrorDesc)
 
 				By("switching to ETP=Local an ip rule should be created for the masquerade IP")
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule add prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
-				service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+				service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
 				service.ResourceVersion = "100"
-				_, err = fakeOvnNode.fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
+				_, err = fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT = nftablesRulesEgressServicesBase
@@ -976,17 +998,17 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
-					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+					return fExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 
 				By("switching back to ETP=Cluster the masquerade ip rule should be deleted")
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: fmt.Sprintf("ip -4 rule del prio 5000 from %s sport 30300 table mynetwork", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP),
 					Err: nil,
 				})
-				service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyCluster
+				service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
 				service.ResourceVersion = "110"
-				_, err = fakeOvnNode.fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
+				_, err = fakeClient.KubeClient.CoreV1().Services("namespace1").Update(context.TODO(), &service, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT = nftablesRulesEgressServicesBase
@@ -995,20 +1017,20 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
-					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+					return fExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 
 				By("deleting the egress service the ip rules should be deleted")
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				err = fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedNFT = nftablesRulesEgressServicesBase
@@ -1017,7 +1039,7 @@ add element inet ovn-kubernetes egress-service-snat-v4 { 10.128.0.11 comment "na
 				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
-					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+					return fExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 				return nil
 			}

--- a/go-controller/pkg/node/gateway_egressip_test.go
+++ b/go-controller/pkg/node/gateway_egressip_test.go
@@ -310,7 +310,7 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process valid EgressIPs")
 			node, err := addrMgr.kube.GetNode(nodeName)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(len(parseEIPsFromAnnotation(node))).Should(gomega.BeZero())
+			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.BeEmpty())
 		})
 	})
 })

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -2065,7 +2065,7 @@ var _ = Describe("Gateway unit tests", func() {
 				gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 				Expect(errors.As(err, new(*GatewayInterfaceMismatchError))).To(BeTrue())
 				Expect(gatewayIntf).To(Equal(""))
-				Expect(len(gatewayNextHops)).To(Equal(0))
+				Expect(gatewayNextHops).To(BeEmpty())
 			})
 		})
 	})

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -218,7 +218,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		_, err = config.InitConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		existingNode := v1.Node{
+		existingNode := corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
@@ -230,8 +230,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		if setNodeIP {
 			expectedAddr, err := netlink.ParseAddr(eth0CIDR)
 			Expect(err).NotTo(HaveOccurred())
-			nodeAddr := v1.NodeAddress{Type: v1.NodeInternalIP, Address: expectedAddr.IP.String()}
-			existingNode.Status = v1.NodeStatus{Addresses: []v1.NodeAddress{nodeAddr}}
+			nodeAddr := corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: expectedAddr.IP.String()}
+			existingNode.Status = corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}}
 		}
 
 		_, nodeNet, err := net.ParseCIDR(nodeSubnet)
@@ -257,8 +257,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		err = setupManagementPortNFTables(&fakeMgmtPortConfig)
 		Expect(err).NotTo(HaveOccurred())
 
-		kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-			Items: []v1.Node{existingNode},
+		kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+			Items: []corev1.Node{existingNode},
 		})
 		fakeClient := &util.OVNNodeClientset{
 			KubeClient:            kubeFakeClient,
@@ -287,12 +287,15 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		Expect(err).NotTo(HaveOccurred())
 		rm := routemanager.NewController()
 		wg.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
+		go func() {
 			defer GinkgoRecover()
-			rm.Run(stop, 10*time.Second)
-			wg.Done()
-			return nil
-		})
+			defer wg.Done()
+			err := testNS.Do(func(ns.NetNS) error {
+				rm.Run(stop, 10*time.Second)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
@@ -659,15 +662,15 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		_, err = config.InitConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		nodeAddr := v1.NodeAddress{Type: v1.NodeInternalIP, Address: dpuIP}
-		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
+		nodeAddr := corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: dpuIP}
+		existingNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 		},
-			Status: v1.NodeStatus{Addresses: []v1.NodeAddress{nodeAddr}},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}},
 		}
 
-		kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-			Items: []v1.Node{existingNode},
+		kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+			Items: []corev1.Node{existingNode},
 		})
 		fakeClient := &util.OVNNodeClientset{
 			KubeClient:            kubeFakeClient,
@@ -722,12 +725,15 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		defer runtime.UnlockOSThread()
 		rm := routemanager.NewController()
 		wg.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
+		go func() {
 			defer GinkgoRecover()
-			rm.Run(stop, 10*time.Second)
-			wg.Done()
-			return nil
-		})
+			defer wg.Done()
+			err := testNS.Do(func(ns.NetNS) error {
+				rm.Run(stop, 10*time.Second)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		// FIXME(mk): starting the gateway causing go routines to be spawned within sub functions and therefore they escape the
 		// netns we wanted to set it to originally here. Refactor test cases to not spawn a go routine or just fake out everything
 		// and remove need to create netns
@@ -827,15 +833,15 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 		_, err = config.InitConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		nodeAddr := v1.NodeAddress{Type: v1.NodeInternalIP, Address: hostIP}
-		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
+		nodeAddr := corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: hostIP}
+		existingNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 		},
-			Status: v1.NodeStatus{Addresses: []v1.NodeAddress{nodeAddr}},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}},
 		}
 
-		kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-			Items: []v1.Node{existingNode},
+		kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+			Items: []corev1.Node{existingNode},
 		})
 		fakeClient := &util.OVNNodeClientset{
 			KubeClient:             kubeFakeClient,
@@ -862,12 +868,15 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 		nc := newDefaultNodeNetworkController(cnnci, stop, wg, routeManager)
 		// must run route manager manually which is usually started with nc.Start()
 		wg.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
+		go func() {
 			defer GinkgoRecover()
-			nc.routeManager.Run(stop, 10*time.Second)
-			wg.Done()
-			return nil
-		})
+			defer wg.Done()
+			err := testNS.Do(func(ns.NetNS) error {
+				nc.routeManager.Run(stop, 10*time.Second)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
@@ -1107,24 +1116,24 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 
 		expectedAddr, err := netlink.ParseAddr(eth0CIDR)
 		Expect(err).NotTo(HaveOccurred())
-		nodeAddr := v1.NodeAddress{Type: v1.NodeInternalIP, Address: expectedAddr.IP.String()}
-		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
+		nodeAddr := corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: expectedAddr.IP.String()}
+		existingNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 		},
-			Status: v1.NodeStatus{Addresses: []v1.NodeAddress{nodeAddr}},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{nodeAddr}},
 		}
 		externalIP := "1.1.1.1"
 		externalIPPort := int32(8032)
 		service := *newService("service1", "namespace1", "10.129.0.2",
-			[]v1.ServicePort{
+			[]corev1.ServicePort{
 				{
 					Port:     externalIPPort,
-					Protocol: v1.ProtocolTCP,
+					Protocol: corev1.ProtocolTCP,
 				},
 			},
-			v1.ServiceTypeClusterIP,
+			corev1.ServiceTypeClusterIP,
 			[]string{externalIP},
-			v1.ServiceStatus{},
+			corev1.ServiceStatus{},
 			false, false,
 		)
 		endpointSlice := *newEndpointSlice("service1", "namespace1", []discovery.Endpoint{}, []discovery.EndpointPort{})
@@ -1155,8 +1164,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		}
 
 		kubeFakeClient := fake.NewSimpleClientset(
-			&v1.NodeList{
-				Items: []v1.Node{existingNode},
+			&corev1.NodeList{
+				Items: []corev1.Node{existingNode},
 			},
 			&service,
 			&endpointSlice,
@@ -1191,11 +1200,14 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		ip, ipNet, _ := net.ParseCIDR(eth0CIDR)
 		ipNet.IP = ip
 		rm := routemanager.NewController()
-		go testNS.Do(func(netNS ns.NetNS) error {
+		go func() {
 			defer GinkgoRecover()
-			rm.Run(stop, 10*time.Second)
-			return nil
-		})
+			err := testNS.Do(func(ns.NetNS) error {
+				rm.Run(stop, 10*time.Second)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -2000,7 +2000,7 @@ var _ = Describe("Node Operations", func() {
 					f4 := iptV4.(*util.FakeIPTables)
 					err = f4.MatchState(expectedTables, nil)
 					g.Expect(err).NotTo(HaveOccurred())
-				})
+				}).Should(Succeed())
 
 				// TODO Make delete operation fail, check retry entry, run a successful delete
 				return nil

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -668,7 +668,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			localGw.openflowManager.syncFlows()
 			flowMap := udnGateway.gateway.openflowManager.flowCache
 
-			Expect(len(flowMap["DEFAULT"])).To(Equal(46))
+			Expect(flowMap["DEFAULT"]).To(HaveLen(46))
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
 			for _, flows := range flowMap {
@@ -681,12 +681,12 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				}
 			}
 			Expect(udnFlows).To(Equal(0))
-			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(1)) // only default network
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(1)) // only default network
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(64))                                // 18 UDN Flows are added by default
-			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(2)) // default network + UDN network
+			Expect(flowMap["DEFAULT"]).To(HaveLen(64))                                // 18 UDN Flows are added by default
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["default"]
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["bluenet"]
 			bridgeMAC := udnGateway.openflowManager.defaultBridge.macAddress.String()
@@ -721,8 +721,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(46))                                // only default network flows are present
-			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(1)) // default network only
+			Expect(flowMap["DEFAULT"]).To(HaveLen(46))                                // only default network flows are present
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
 				for _, flow := range flows {
@@ -892,7 +892,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			localGw.openflowManager.syncFlows()
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(46))
+			Expect(flowMap["DEFAULT"]).To(HaveLen(46))
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
 			for _, flows := range flowMap {
@@ -905,12 +905,12 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				}
 			}
 			Expect(udnFlows).To(Equal(0))
-			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(1)) // only default network
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(1)) // only default network
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(64))                                // 18 UDN Flows are added by default
-			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(2)) // default network + UDN network
+			Expect(flowMap["DEFAULT"]).To(HaveLen(64))                                // 18 UDN Flows are added by default
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["default"]
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["bluenet"]
 			bridgeMAC := udnGateway.openflowManager.defaultBridge.macAddress.String()
@@ -945,8 +945,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(46))                                // only default network flows are present
-			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(1)) // default network only
+			Expect(flowMap["DEFAULT"]).To(HaveLen(46))                                // only default network flows are present
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
 				for _, flow := range flows {
@@ -999,7 +999,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			routes, err := udnGateway.computeRoutesForUDN(vrfTableId, mplink)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(routes)).To(Equal(7))
+			Expect(routes).To(HaveLen(7))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*routes[0].Dst).To(Equal(*ovntest.MustParseIPNet("172.16.1.0/24"))) // default service subnet
 			Expect(routes[0].LinkIndex).To(Equal(bridgelink.Attrs().Index))
@@ -1068,7 +1068,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			routes, err := udnGateway.computeRoutesForUDN(vrfTableId, mplink)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(routes)).To(Equal(8))
+			Expect(routes).To(HaveLen(8))
 			Expect(err).NotTo(HaveOccurred())
 			// 1st and 2nd routes are the service routes from user-provided config value
 			Expect(*routes[0].Dst).To(Equal(*config.Kubernetes.ServiceCIDRs[0]))
@@ -1274,7 +1274,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, 3, node, nil, nil, nil, nil, &gateway{})
 			g.Expect(err).NotTo(HaveOccurred())
 			rules, delRules, err := udnGateway.constructUDNVRFIPRules(test.vrftableID)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))
@@ -1438,12 +1438,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 			nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 				types.Layer3Topology, cidr, types.NetworkRolePrimary)
 			netInfo, err := util.ParseNADInfo(nad)
+			g.Expect(err).ToNot(HaveOccurred())
 			mutableNetInfo := util.NewMutableNetInfo(netInfo)
 			mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{node.Name: {"bluenet"}})
 			udnGateway, err := NewUserDefinedNetworkGateway(mutableNetInfo, 3, node, nil, nil, nil, nil, &gateway{})
 			g.Expect(err).NotTo(HaveOccurred())
 			rules, delRules, err := udnGateway.constructUDNVRFIPRules(test.vrftableID)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))

--- a/go-controller/pkg/node/healthcheck_node_test.go
+++ b/go-controller/pkg/node/healthcheck_node_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,16 +27,16 @@ const healthzAddress string = "127.0.0.1:10256"
 var ovnkNodePodName string = "ovnkube-node-test"
 var nodeName string = "test-node"
 
-func newFakeOvnkNodePod(deletionTimestamp *metav1.Time) *v1.Pod {
-	return &v1.Pod{
+func newFakeOvnkNodePod(deletionTimestamp *metav1.Time) *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              ovnkNodePodName,
 			UID:               types.UID(ovnkNodePodName),
 			Namespace:         config.Kubernetes.OVNConfigNamespace,
 			DeletionTimestamp: deletionTimestamp,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "ovnkube-node",
 					Image: "ovnkube-image",
@@ -48,17 +48,14 @@ func newFakeOvnkNodePod(deletionTimestamp *metav1.Time) *v1.Pod {
 }
 
 func initWatchFactoryWithObjects(objects ...runtime.Object) *factory.WatchFactory {
-	v1Objects := []runtime.Object{}
-	for _, object := range objects {
-		v1Objects = append(v1Objects, object)
-	}
+	v1Objects := append([]runtime.Object{}, objects...)
 	fakeClient := &util.OVNNodeClientset{
 		KubeClient: fake.NewSimpleClientset(v1Objects...),
 	}
 
 	watcher, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
 	Expect(err).NotTo(HaveOccurred())
-	watcher.Start()
+	Expect(watcher.Start()).To(Succeed())
 	return watcher
 }
 
@@ -86,7 +83,7 @@ var _ = Describe("Node healthcheck tests", func() {
 	)
 
 	BeforeEach(func() {
-		config.PrepareTestConfig()
+		Expect(config.PrepareTestConfig()).To(Succeed())
 		stopCh = make(chan struct{})
 		wg = &sync.WaitGroup{}
 		os.Setenv("POD_NAME", ovnkNodePodName)
@@ -103,8 +100,8 @@ var _ = Describe("Node healthcheck tests", func() {
 			recorder := record.NewFakeRecorder(10)
 
 			watchFactory = initWatchFactoryWithObjects(
-				&v1.PodList{
-					Items: []v1.Pod{
+				&corev1.PodList{
+					Items: []corev1.Pod{
 						*newFakeOvnkNodePod(nil),
 					},
 				})
@@ -122,8 +119,8 @@ var _ = Describe("Node healthcheck tests", func() {
 			recorder := record.NewFakeRecorder(10)
 			now := metav1.Now()
 			watchFactory = initWatchFactoryWithObjects(
-				&v1.PodList{
-					Items: []v1.Pod{
+				&corev1.PodList{
+					Items: []corev1.Pod{
 						*newFakeOvnkNodePod(&now),
 					},
 				})

--- a/go-controller/pkg/node/helper_linux_test.go
+++ b/go-controller/pkg/node/helper_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -282,9 +282,9 @@ func TestGetDefaultGatewayInterfaceByFamily(t *testing.T) {
 
 			t.Log(err)
 			if tc.expErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -437,9 +437,9 @@ func TestGetDefaultGatewayInterfaceDetails(t *testing.T) {
 
 			t.Log(err)
 			if tc.expErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
@@ -16,8 +16,6 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 )
 
-const oneSec = 1 * time.Second
-
 // FIXME(mk) - Within GH VM, if I need to create a new NetNs. I see the following error:
 // "failed to create new network namespace: mount --make-rshared /run/user/1001/netns failed: "operation not permitted""
 var _ = ginkgo.XDescribe("IP Rule Manager", func() {
@@ -50,11 +48,15 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		stopCh = make(chan struct{})
 		wg.Add(1)
 		c = NewController(true, true)
-		go testNS.Do(func(netNS ns.NetNS) error {
-			c.Run(stopCh, time.Millisecond*50)
-			wg.Done()
-			return nil
-		})
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer wg.Done()
+			err := testNS.Do(func(ns.NetNS) error {
+				c.Run(stopCh, time.Millisecond*50)
+				return nil
+			})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		}()
 	})
 
 	ginkgo.AfterEach(func() {
@@ -68,13 +70,13 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 	ginkgo.Context("Add rule", func() {
 		ginkgo.It("ensure rule exist", func() {
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return c.Add(*ruleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -84,18 +86,18 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("ensure rule is restored if it is removed", func() {
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return c.Add(*ruleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -105,15 +107,15 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return netlink.RuleDel(ruleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 			// check that rule is restored
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -123,23 +125,23 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("ensure multiple rules are restored if they're removed", func() {
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return c.Add(*ruleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return c.Add(*ruleWithSrc)
 				})
 			}()).Should(gomega.Succeed())
 
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -152,15 +154,15 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return netlink.RuleDel(ruleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -170,15 +172,15 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return netlink.RuleDel(ruleWithSrc)
 				})
 			}()).Should(gomega.Succeed())
 
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -188,14 +190,14 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 		})
 	})
 
 	ginkgo.Context("Del rule", func() {
 		ginkgo.It("doesn't fail when no rule to delete", func() {
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return c.Delete(*ruleWithDst)
 				})
 			}()).Should(gomega.Succeed())
@@ -203,7 +205,7 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 
 		ginkgo.It("deletes a rule", func() {
 			gomega.Expect(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					if err := c.Add(*ruleWithDst); err != nil {
 						return err
 					}
@@ -215,7 +217,7 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 			}()).Should(gomega.Succeed())
 
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 					if err != nil {
 						return err
@@ -225,7 +227,7 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					}
 					return nil
 				})
-			}).WithTimeout(oneSec).Should(gomega.Succeed())
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
 		})
 	})
 })

--- a/go-controller/pkg/node/iptables/iptables_manager_test.go
+++ b/go-controller/pkg/node/iptables/iptables_manager_test.go
@@ -69,29 +69,29 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 				return c.OwnChain(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4)
 			})).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				_, err := c.iptV4.ChainExists(utiliptables.TableNAT, testChainName)
 				return err
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("ensure chain recovers following manual removal", func() {
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				if err := c.OwnChain(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4); err != nil {
 					return err
 				}
 				_, err := c.iptV4.ChainExists(utiliptables.TableNAT, testChainName)
 				return err
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			gomega.Expect(testNS.Do(func(ns.NetNS) error {
 				return c.iptV4.DeleteChain(utiliptables.TableNAT, testChainName)
 			})).Should(gomega.Succeed())
 
 			time.Sleep(100 * time.Millisecond)
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				_, err := c.iptV4.ChainExists(utiliptables.TableNAT, testChainName)
 				return err
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 		})
 		ginkgo.It("owning a chain create a chain", func() {
 			gomega.Expect(testNS.Do(func(ns.NetNS) error {
@@ -141,15 +141,15 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 				}
 				return nil
 			})).Should(gomega.Succeed())
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				return c.iptV4.DeleteRule(utiliptables.TableNAT, testChainName, testRuleArgs[0].Args...)
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return containsRuleArgs(testNS, c.iptV4, utiliptables.TableNAT, testChainName, testRuleArgs)
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
 		})
 		ginkgo.It("doesn't remove unknown rules in un-owned chain", func() {
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				if _, err := c.iptV4.EnsureChain(utiliptables.TableNAT, testChainName); err != nil {
 					return err
 				}
@@ -157,14 +157,14 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 					return err
 				}
 				return nil
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			time.Sleep(100 * time.Millisecond)
 			gomega.Eventually(func() bool {
 				return containsRuleArg(testNS, c.iptV4, utiliptables.TableNAT, testChainName, differentRuleArg)
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
 		})
 		ginkgo.It("does remove unknown rules in owned chain", func() {
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				if err := c.OwnChain(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4); err != nil {
 					return err
 				}
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 					return err
 				}
 				return nil
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return containsRuleArg(testNS, c.iptV4, utiliptables.TableNAT, testChainName, differentRuleArg)
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeFalse())
@@ -219,15 +219,15 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 				}
 				return nil
 			})).Should(gomega.Succeed())
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				return c.iptV6.DeleteRule(utiliptables.TableNAT, testChainName, testRuleArgs[0].Args...)
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return containsRuleArgs(testNS, c.iptV6, utiliptables.TableNAT, testChainName, testRuleArgs)
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
 		})
 		ginkgo.It("doesn't remove unknown rules in un-owned chain", func() {
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				if _, err := c.iptV6.EnsureChain(utiliptables.TableNAT, testChainName); err != nil {
 					return err
 				}
@@ -235,14 +235,14 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 					return err
 				}
 				return nil
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			time.Sleep(100 * time.Millisecond)
 			gomega.Eventually(func() bool {
 				return containsRuleArg(testNS, c.iptV6, utiliptables.TableNAT, testChainName, differentRuleArg)
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
 		})
 		ginkgo.It("removes unknown rules in owned chain", func() {
-			gomega.Eventually(testNS.Do(func(ns.NetNS) error {
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
 				if err := c.OwnChain(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv6); err != nil {
 					return err
 				}
@@ -253,7 +253,7 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 					return err
 				}
 				return nil
-			})).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return containsRuleArg(testNS, c.iptV6, utiliptables.TableNAT, testChainName, differentRuleArg)
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeFalse())

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -133,7 +133,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expectedMgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipnet).IP)
 			config.Default.MTU = 1400
-			node := &v1.Node{
+			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "k8s-worker0",
 					Annotations: map[string]string{
@@ -166,8 +166,8 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{*node},
+			fakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{*node},
 			})
 			fakeNodeClient := &util.OVNNodeClientset{
 				KubeClient: fakeClient,
@@ -188,7 +188,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expectedMgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipnet).IP)
 			config.Default.MTU = 1400
-			node := &v1.Node{
+			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "k8s-worker0",
 					Annotations: map[string]string{
@@ -215,8 +215,8 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{*node},
+			fakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{*node},
 			})
 			fakeNodeClient := &util.OVNNodeClientset{
 				KubeClient: fakeClient,

--- a/go-controller/pkg/node/management-port_test.go
+++ b/go-controller/pkg/node/management-port_test.go
@@ -18,14 +18,14 @@ var _ = Describe("Mananagement port tests", func() {
 	Context("NewManagementPort Creates Management port object according to config.OvnKubeNode.Mode", func() {
 		It("Creates managementPort by default", func() {
 			mgmtPorts := NewManagementPorts("worker-node", nil, "", "")
-			Expect(len(mgmtPorts)).To(Equal(1))
+			Expect(mgmtPorts).To(HaveLen(1))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPort{}).String()))
 		})
 		It("Creates managementPortRepresentor for Ovnkube Node mode dpu", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPU
 			netdevName, rep := "", "ens1f0v0"
 			mgmtPorts := NewManagementPorts("worker-node", nil, netdevName, rep)
-			Expect(len(mgmtPorts)).To(Equal(1))
+			Expect(mgmtPorts).To(HaveLen(1))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPortRepresentor{}).String()))
 			port, _ := mgmtPorts[0].(*managementPortRepresentor)
 			Expect(port.repName).To(Equal(rep))
@@ -33,13 +33,13 @@ var _ = Describe("Mananagement port tests", func() {
 		It("Creates managementPortNetdev for Ovnkube Node mode dpu-host", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
 			mgmtPorts := NewManagementPorts("worker-node", nil, "", "")
-			Expect(len(mgmtPorts)).To(Equal(1))
+			Expect(mgmtPorts).To(HaveLen(1))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPortNetdev{}).String()))
 		})
 		It("Creates managementPortNetdev and managementPortRepresentor for Ovnkube Node mode full", func() {
 			config.OvnKubeNode.MgmtPortNetdev = "ens1f0v0"
 			mgmtPorts := NewManagementPorts("worker-node", nil, "", "")
-			Expect(len(mgmtPorts)).To(Equal(2))
+			Expect(mgmtPorts).To(HaveLen(2))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPortNetdev{}).String()))
 			Expect(reflect.TypeOf(mgmtPorts[1]).String()).To(Equal(reflect.TypeOf(&managementPortRepresentor{}).String()))
 		})
@@ -47,7 +47,7 @@ var _ = Describe("Mananagement port tests", func() {
 			netdevName, rep := "ens1f0v0", "ens1f0_0"
 			config.OvnKubeNode.MgmtPortNetdev = netdevName
 			mgmtPorts := NewManagementPorts("worker-node", nil, netdevName, rep)
-			Expect(len(mgmtPorts)).To(Equal(2))
+			Expect(mgmtPorts).To(HaveLen(2))
 			Expect(reflect.TypeOf(mgmtPorts[1]).String()).To(Equal(reflect.TypeOf(&managementPortRepresentor{}).String()))
 			port, _ := mgmtPorts[1].(*managementPortRepresentor)
 			Expect(port.repName).To(Equal("ens1f0_0"))

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -352,7 +352,7 @@ func configureKubeOVNContextWithNs(nodeName string) *testCtx {
 	}
 	Expect(testNs.Do(func(ns.NetNS) error {
 		return setupPrimaryInfFn()
-	}))
+	})).To(Succeed())
 	useNetlink := true
 	var tc *testCtx
 	err = testNs.Do(func(ns.NetNS) error {

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
 	"k8s.io/klog/v2"
@@ -45,7 +46,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 
 	var initialCPUset unix.CPUSet
 	err := unix.SchedGetaffinity(os.Getpid(), &initialCPUset)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer func() {
 		// Restore any previous CPU affinity value it was in place before the test
@@ -59,7 +60,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 		var tmpCPUset unix.CPUSet
 		tmpCPUset.Set(i)
 		err = unix.SchedSetaffinity(os.Getpid(), &tmpCPUset)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		klog.Infof("Test CPU Affinity %x", tmpCPUset)
 
@@ -69,19 +70,19 @@ func TestAlignCPUAffinity(t *testing.T) {
 
 	// Disable the feature by making the enabler file empty
 	err = os.WriteFile(featureEnablerFile, []byte(""), 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var tmpCPUset unix.CPUSet
 	tmpCPUset.Set(0)
 	err = unix.SchedSetaffinity(os.Getpid(), &tmpCPUset)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertNeverPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
 	assertNeverPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
 
 	// Enable the feature back by putting contents in the enabler file
 	err = os.WriteFile(featureEnablerFile, []byte("1"), 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
 	assertPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
@@ -89,11 +90,11 @@ func TestAlignCPUAffinity(t *testing.T) {
 	// Disable the feature by deleting the enabler file
 	klog.Infof("Remove the enabler file to disable the feature")
 	err = os.Remove(featureEnablerFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpCPUset.Set(1)
 	err = unix.SchedSetaffinity(os.Getpid(), &tmpCPUset)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertNeverPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
 	assertNeverPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
@@ -101,7 +102,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 	// Re-enable the feature back by recreating the enabler file
 	klog.Infof("Re-enable the feature")
 	err = os.WriteFile(featureEnablerFile, []byte("1"), 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
 	assertPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
@@ -111,18 +112,18 @@ func TestIsFileNotEmpty(t *testing.T) {
 	defer mockFeatureEnableFile(t, "")()
 
 	result, err := isFileNotEmpty(featureEnablerFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, result)
 
 	err = os.WriteFile(featureEnablerFile, []byte("1"), 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	result, err = isFileNotEmpty(featureEnablerFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, result)
 
 	os.Remove(featureEnablerFile)
 	result, err = isFileNotEmpty(featureEnablerFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, result)
 }
 
@@ -183,7 +184,7 @@ func mockOvsVSwitchdProcess(t *testing.T) (int, func()) {
 
 	cmd := exec.CommandContext(ctx, "go", "run", "testdata/fake_thread_process.go")
 	err := cmd.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	previousGetter := getOvsVSwitchdPIDFn
 	getOvsVSwitchdPIDFn = func() (string, error) {
@@ -215,7 +216,7 @@ func setTickDuration(d time.Duration) func() {
 func mockFeatureEnableFile(t *testing.T, data string) func() {
 
 	f, err := os.CreateTemp("", "enable_dynamic_cpu_affinity")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	previousValue := featureEnablerFile
 	featureEnablerFile = f.Name()
@@ -239,11 +240,11 @@ func assertPIDHasSchedAffinity(t *testing.T, pid int, expectedCPUSet unix.CPUSet
 	}, time.Second, 10*time.Millisecond, "pid[%d] Expected CPUSet %0x != Actual CPUSet %0x", pid, expectedCPUSet, actual)
 
 	tasks, err := getThreadsOfProcess(pid)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, task := range tasks {
 		err := unix.SchedGetaffinity(task, &actual)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedCPUSet, actual,
 			"task[%d] of process[%d] Expected CPUSet %0x != Actual CPUSet %0x", task, pid, expectedCPUSet, actual)
 	}

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -114,7 +114,8 @@ func TestIsFileNotEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	os.WriteFile(featureEnablerFile, []byte("1"), 0)
+	err = os.WriteFile(featureEnablerFile, []byte("1"), 0)
+	assert.NoError(t, err)
 	result, err = isFileNotEmpty(featureEnablerFile)
 	assert.NoError(t, err)
 	assert.True(t, result)
@@ -219,7 +220,7 @@ func mockFeatureEnableFile(t *testing.T, data string) func() {
 	previousValue := featureEnablerFile
 	featureEnablerFile = f.Name()
 
-	os.WriteFile(featureEnablerFile, []byte(data), 0)
+	err = os.WriteFile(featureEnablerFile, []byte(data), 0)
 	assert.NoError(t, err)
 
 	return func() {

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -161,6 +161,7 @@ func TestPrintCPUSetRanges(t *testing.T) {
 }
 
 func mockOvsdbProcess(t *testing.T) (int, func()) {
+	t.Helper()
 	ctx, stopCmd := context.WithCancel(context.Background())
 
 	cmd := exec.CommandContext(ctx, "sleep", "10")
@@ -180,6 +181,7 @@ func mockOvsdbProcess(t *testing.T) (int, func()) {
 }
 
 func mockOvsVSwitchdProcess(t *testing.T) (int, func()) {
+	t.Helper()
 	ctx, stopCmd := context.WithCancel(context.Background())
 
 	cmd := exec.CommandContext(ctx, "go", "run", "testdata/fake_thread_process.go")
@@ -214,7 +216,7 @@ func setTickDuration(d time.Duration) func() {
 }
 
 func mockFeatureEnableFile(t *testing.T, data string) func() {
-
+	t.Helper()
 	f, err := os.CreateTemp("", "enable_dynamic_cpu_affinity")
 	require.NoError(t, err)
 
@@ -231,6 +233,7 @@ func mockFeatureEnableFile(t *testing.T, data string) func() {
 }
 
 func assertPIDHasSchedAffinity(t *testing.T, pid int, expectedCPUSet unix.CPUSet) {
+	t.Helper()
 	var actual unix.CPUSet
 	assert.Eventually(t, func() bool {
 		err := unix.SchedGetaffinity(pid, &actual)
@@ -251,6 +254,7 @@ func assertPIDHasSchedAffinity(t *testing.T, pid int, expectedCPUSet unix.CPUSet
 }
 
 func assertNeverPIDHasSchedAffinity(t *testing.T, pid int, targetCPUSet unix.CPUSet) {
+	t.Helper()
 	var actual unix.CPUSet
 	assert.Never(t, func() bool {
 		err := unix.SchedGetaffinity(pid, &actual)

--- a/go-controller/pkg/node/port_claim_test.go
+++ b/go-controller/pkg/node/port_claim_test.go
@@ -64,7 +64,7 @@ func (p *fakePortManager) close(desc string, ip string, port int32, protocol cor
 		return portError
 	}
 	_, exists := p.tPortsMap[*localPort]
-	Expect(exists).To(Equal(true))
+	Expect(exists).To(BeTrue())
 	delete(p.tPortsMap, *localPort)
 	// check that we set the values for assertion
 	if len(p.tPortClose) > 0 {
@@ -630,8 +630,8 @@ var _ = Describe("Node Operations", func() {
 				)
 
 				errors := handleService(service, lpm.open)
-				Expect(len(errors)).To(Equal(0))
-				Expect(len(lpm.portsMap)).To(Equal(4))
+				Expect(errors).To(BeEmpty())
+				Expect(lpm.portsMap).To(HaveLen(4))
 				lps := make([]*utilnet.LocalPort, 0)
 				lp, err := utilnet.NewLocalPort(getDescription("", service, true), "", "", 32221, utilnet.TCP)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -648,11 +648,11 @@ var _ = Describe("Node Operations", func() {
 
 				for _, lp = range lps {
 					_, exists := lpm.portsMap[*lp]
-					Expect(exists).To(Equal(true))
+					Expect(exists).To(BeTrue())
 				}
 				errors = handleService(service, lpm.close)
-				Expect(len(errors)).To(Equal(0))
-				Expect(len(lpm.portsMap)).To(Equal(0))
+				Expect(errors).To(BeEmpty())
+				Expect(lpm.portsMap).To(BeEmpty())
 
 				return nil
 			}

--- a/go-controller/pkg/node/routemanager/route_manager_test.go
+++ b/go-controller/pkg/node/routemanager/route_manager_test.go
@@ -278,7 +278,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 			// clear routes and wait for sync to reapply
 			routeList, err := getRouteList(testNS, loLink, netlink.FAMILY_ALL)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(len(routeList)).Should(gomega.BeNumerically(">", 0))
+			gomega.Expect(routeList).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(deleteRoutes(testNS, routeList...)).ShouldNot(gomega.HaveOccurred())
 			// wait for sync to activate since managed routes have been deleted
 			gomega.Eventually(func() bool {
@@ -295,7 +295,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 			// clear routes and wait for sync to reapply
 			routeList, err := getRouteList(testNS, loLink, netlink.FAMILY_ALL)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(len(routeList)).Should(gomega.BeNumerically(">", 0))
+			gomega.Expect(routeList).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(deleteRoutes(testNS, routeList...)).ShouldNot(gomega.HaveOccurred())
 			// wait for sync to activate since managed routes have been deleted
 			gomega.Eventually(func() bool {

--- a/go-controller/pkg/node/routemanager/route_manager_test.go
+++ b/go-controller/pkg/node/routemanager/route_manager_test.go
@@ -55,8 +55,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		stopCh = make(chan struct{})
 		syncPeriod := 300 * time.Millisecond
 		rm = NewController()
-		err = testNS.Do(func(netNS ns.NetNS) error {
-			defer ginkgo.GinkgoRecover()
+		err = testNS.Do(func(ns.NetNS) error {
 			loLink, err = netlink.LinkByName(loLinkName)
 			if err != nil {
 				return err
@@ -73,13 +72,17 @@ var _ = ginkgo.Describe("Route Manager", func() {
 			}
 			return nil
 		})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		wg.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
-			defer wg.Done()
+		go func() {
 			defer ginkgo.GinkgoRecover()
-			rm.Run(stopCh, syncPeriod)
-			return nil
-		})
+			defer wg.Done()
+			err := testNS.Do(func(ns.NetNS) error {
+				rm.Run(stopCh, syncPeriod)
+				return nil
+			})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		}()
 	})
 
 	ginkgo.AfterEach(func() {
@@ -162,23 +165,23 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		ginkgo.It("two equal routes, different tables", func() {
 			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: 5}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
-			validateRoute := func(testNS ns.NetNS, link netlink.Link, r netlink.Route, family, tableID int) func() bool {
+			validateRoute := func(testNS ns.NetNS, r netlink.Route, tableID int) func() bool {
 				return func() bool {
 					return isRouteInTable(testNS, r, loLink.Attrs().Index, tableID)
 				}
 			}
-			gomega.Eventually(validateRoute(testNS, loLink, r, netlink.FAMILY_V4, 5)).WithTimeout(time.Second).Should(gomega.BeTrue())
+			gomega.Eventually(validateRoute(testNS, r, 5)).WithTimeout(time.Second).Should(gomega.BeTrue())
 			r.Table = 6
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
-			gomega.Eventually(validateRoute(testNS, loLink, r, netlink.FAMILY_V4, 6)).WithTimeout(time.Second).Should(gomega.BeTrue())
+			gomega.Eventually(validateRoute(testNS, r, 6)).WithTimeout(time.Second).Should(gomega.BeTrue())
 			// delete route in table 6
 			gomega.Eventually(func() error {
-				return testNS.Do(func(netNS ns.NetNS) error {
+				return testNS.Do(func(ns.NetNS) error {
 					return netlink.RouteDel(&r)
 				})
 			}).WithTimeout(time.Second).Should(gomega.Succeed())
 			// validate it is restored in table 6
-			gomega.Eventually(validateRoute(testNS, loLink, r, netlink.FAMILY_V4, 6), time.Second).Should(gomega.BeTrue())
+			gomega.Eventually(validateRoute(testNS, r, 6), time.Second).Should(gomega.BeTrue())
 		})
 	})
 
@@ -326,7 +329,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 				Name:         "dummy",
 				HardwareAddr: mac,
 			}}
-			gomega.Expect(testNS.Do(func(netNS ns.NetNS) error {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
 				if err := netlink.LinkAdd(dummy); err != nil {
 					return err
 				}
@@ -348,14 +351,14 @@ var _ = ginkgo.Describe("Route Manager", func() {
 })
 
 func addRouteViaManager(rm *Controller, targetNS ns.NetNS, r netlink.Route) error {
-	return targetNS.Do(func(netNS ns.NetNS) error { return rm.Add(r) })
+	return targetNS.Do(func(ns.NetNS) error { return rm.Add(r) })
 }
 func delRouteViaManager(rm *Controller, targetNS ns.NetNS, r netlink.Route) error {
-	return targetNS.Do(func(netNS ns.NetNS) error { return rm.Del(r) })
+	return targetNS.Do(func(ns.NetNS) error { return rm.Del(r) })
 }
 
 func addRoute(targetNS ns.NetNS, r netlink.Route) error {
-	return targetNS.Do(func(netNS ns.NetNS) error {
+	return targetNS.Do(func(ns.NetNS) error {
 		return netlink.RouteAdd(&r)
 	})
 }
@@ -372,7 +375,7 @@ func isRoutesInTable(targetNs ns.NetNS, expectedRoutes []netlink.Route, linkInde
 	}
 	existingRoutes := make([]netlink.Route, 0)
 	var err error
-	err = targetNs.Do(func(netNS ns.NetNS) error {
+	err = targetNs.Do(func(ns.NetNS) error {
 		filter, mask := filterRouteByTable(linkIndex, table)
 		existingRoutes, err = netlink.RouteListFiltered(getIPFamily(expectedRoutes[0].Dst.IP), filter, mask)
 		return err
@@ -402,7 +405,7 @@ func isRoutesInTable(targetNs ns.NetNS, expectedRoutes []netlink.Route, linkInde
 func getRouteList(targetNs ns.NetNS, link netlink.Link, ipFamily int) ([]netlink.Route, error) {
 	routesFound := make([]netlink.Route, 0)
 	var err error
-	err = targetNs.Do(func(netNS ns.NetNS) error {
+	err = targetNs.Do(func(ns.NetNS) error {
 		routesFound, err = netlink.RouteList(link, ipFamily)
 		if err != nil {
 			return err
@@ -414,7 +417,7 @@ func getRouteList(targetNs ns.NetNS, link netlink.Link, ipFamily int) ([]netlink
 
 func deleteRoutes(targetNs ns.NetNS, routes ...netlink.Route) error {
 	var err error
-	err = targetNs.Do(func(netNS ns.NetNS) error {
+	err = targetNs.Do(func(ns.NetNS) error {
 		for _, route := range routes {
 			if err = netlink.RouteDel(&route); err != nil {
 				return err
@@ -433,7 +436,7 @@ func setLinkDown(targetNS ns.NetNS, link netlink.Link) error {
 	return setLink(targetNS, link, netlink.LinkSetDown)
 }
 func setLink(targetNS ns.NetNS, link netlink.Link, nlFunc func(link2 netlink.Link) error) error {
-	err := targetNS.Do(func(netNS ns.NetNS) error {
+	err := targetNS.Do(func(ns.NetNS) error {
 		if err := nlFunc(link); err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -352,7 +352,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vrfLink.Type()).To(Equal("vrf"))
 			vrfDev, ok := vrfLink.(*netlink.Vrf)
-			Expect(ok).To(Equal(true))
+			Expect(ok).To(BeTrue())
 			mplink, err := util.GetNetLinkOps().LinkByName(mgtPort)
 			Expect(err).NotTo(HaveOccurred())
 			vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
@@ -364,7 +364,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			Eventually(func() error {
 				_, err := util.GetNetLinkOps().LinkByName(vrfDeviceName)
 				return err
-			}).WithTimeout(120 * time.Second).Should(BeNil())
+			}).WithTimeout(120 * time.Second).Should(Succeed())
 
 			By("check iprules are created for the network")
 			rulesFound, err := netlink.RuleList(netlink.FAMILY_ALL)
@@ -385,7 +385,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			Eventually(func() error {
 				_, err := util.GetNetLinkOps().LinkByName(vrfDeviceName)
 				return err
-			}).WithTimeout(120 * time.Second).ShouldNot(BeNil())
+			}).WithTimeout(120 * time.Second).ShouldNot(Succeed())
 
 			By("check masquerade iprules are deleted for the network")
 			rulesFound, err = netlink.RuleList(netlink.FAMILY_ALL)
@@ -396,7 +396,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 					udnRules = append(udnRules, rule)
 				}
 			}
-			Expect(udnRules).To(HaveLen(0))
+			Expect(udnRules).To(BeEmpty())
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/udn_isolation_test.go
+++ b/go-controller/pkg/node/udn_isolation_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -296,7 +296,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 	}
 
 	BeforeEach(func() {
-		config.PrepareTestConfig()
+		Expect(config.PrepareTestConfig()).To(Succeed())
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.IPv4Mode = true
@@ -316,7 +316,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 	})
 
 	It("correctly handles host-network and not ready pods on initial sync", func() {
-		hostNetPod := &v1.Pod{
+		hostNetPod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostnet",
 				UID:       ktypes.UID("hostnet"),
@@ -324,7 +324,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 			},
 		}
 		hostNetPod.Spec.HostNetwork = true
-		notReadyPod := &v1.Pod{
+		notReadyPod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "notready",
 				UID:       ktypes.UID("notready"),
@@ -351,7 +351,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 	})
 
 	It("correctly handles not ready pods", func() {
-		notReadyPod := &v1.Pod{
+		notReadyPod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "notready",
 				UID:       ktypes.UID("notready"),
@@ -534,7 +534,7 @@ func getOpenPortAnnotation(openPorts []util.OpenPort) map[string]string {
 }
 
 // newPodWithIPs creates a new pod with the given IPs, only filled for default network.
-func newPodWithIPs(namespace, name string, primaryUDN bool, ips []string, openPorts ...util.OpenPort) *v1.Pod {
+func newPodWithIPs(namespace, name string, primaryUDN bool, ips []string, openPorts ...util.OpenPort) *corev1.Pod {
 	annoPodIPs := make([]string, len(ips))
 	for i, ip := range ips {
 		if net.ParseIP(ip).To4() != nil {
@@ -551,7 +551,7 @@ func newPodWithIPs(namespace, name string, primaryUDN bool, ips []string, openPo
 	annotations[util.OvnPodAnnotationName] = fmt.Sprintf(`{"default": {"role": "%s", "ip_addresses":[%s], "mac_address":"0a:58:0a:f4:02:03"}}`,
 		role, strings.Join(annoPodIPs, ","))
 
-	return &v1.Pod{
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			UID:         ktypes.UID(name),

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -325,6 +325,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			asFactory = NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
 
 			as, err := asFactory.NewAddressSet(addrsetDbIDs, []string{ipAddress1, ipAddress2})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = as.Destroy()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -571,6 +572,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = asFactory.NewAddressSet(addrsetDbIDs, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				expectedDatabaseState := []libovsdbtest.TestData{
 					getDbAddrSets(addrsetDbIDs, ipv4InternalID, nil),
 					getDbAddrSets(addrsetDbIDs, ipv6InternalID, nil),

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -290,7 +290,7 @@ func (f *FakeAddressSetFactory) EventuallyExpectNoAddressSet(dbIDsOrNsName any) 
 
 // ExpectNumberOfAddressSets ensures the number of created address sets equals given number
 func (f *FakeAddressSetFactory) ExpectNumberOfAddressSets(n int) {
-	gomega.Expect(len(f.sets)).To(gomega.Equal(n))
+	gomega.Expect(f.sets).To(gomega.HaveLen(n))
 }
 
 type removeFunc func(string)

--- a/go-controller/pkg/ovn/admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/admin_network_policy_test.go
@@ -1990,9 +1990,9 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(dupANP.Status.Conditions[0].Message).To(gomega.Equal("Setting up OVN DB plumbing was successful"))
 				gomega.Expect(dupANP.Status.Conditions[0].Reason).To(gomega.Equal("SetupSucceeded"))
 				gomega.Expect(dupANP.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(1))
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.HaveLen(1))
 				recordedEvent := <-fakeOVN.fakeRecorder.Events // FIFO dequeued
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(0))
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.BeEmpty())
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring(anpovn.ANPWithDuplicatePriorityEvent))
 				return nil
 			}
@@ -2020,7 +2020,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(dupANP.Status.Conditions[0].Message).To(gomega.Equal("Setting up OVN DB plumbing was successful"))
 				gomega.Expect(dupANP.Status.Conditions[0].Reason).To(gomega.Equal("SetupSucceeded"))
 				gomega.Expect(dupANP.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(0))
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.BeEmpty())
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2043,7 +2043,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(dupANP.Status.Conditions[0].Message).To(gomega.Equal("Setting up OVN DB plumbing was successful"))
 				gomega.Expect(dupANP.Status.Conditions[0].Reason).To(gomega.Equal("SetupSucceeded"))
 				gomega.Expect(dupANP.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(0)) // no new event
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.BeEmpty()) // no new event
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2065,7 +2065,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				gomega.Expect(dupANP.Status.Conditions[0].Message).To(gomega.Equal("Setting up OVN DB plumbing was successful"))
 				gomega.Expect(dupANP.Status.Conditions[0].Reason).To(gomega.Equal("SetupSucceeded"))
 				gomega.Expect(dupANP.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(0)) // no new event
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.BeEmpty()) // no new event
 
 				// now update the priority of harry-potter to 6 and ensure event is generated
 				ginkgo.By("3. update existing harry-potter ANP's priority to 6")
@@ -2088,7 +2088,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				}, "2s").Should(gomega.Equal(1))
 				recordedEvent := <-fakeOVN.fakeRecorder.Events // FIFO dequeued
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring(anpovn.ANPWithDuplicatePriorityEvent))
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(0))
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.BeEmpty())
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2165,7 +2165,7 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 				}, "2s").Should(gomega.Equal(1))
 				recordedEvent := <-fakeOVN.fakeRecorder.Events // FIFO dequeued
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring(anpovn.ANPWithUnsupportedPriorityEvent))
-				gomega.Expect(len(fakeOVN.fakeRecorder.Events)).To(gomega.Equal(0))
+				gomega.Expect(fakeOVN.fakeRecorder.Events).To(gomega.BeEmpty())
 				return nil
 			}
 			err := app.Run([]string{app.Name})

--- a/go-controller/pkg/ovn/base_network_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace_test.go
@@ -5,6 +5,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -71,7 +72,7 @@ func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 			config.OVNKubernetesFeature.EnableNetworkSegmentation = tt.enableNetSeg
 			config.OVNKubernetesFeature.EnableMultiNetworkPolicy = tt.enableMultiNetPolicies
 			netInfo, err := util.NewNetInfo(tt.netCfg)
-			assert.Nil(t, err, "failed to create network info")
+			require.NoError(t, err, "failed to create network info")
 			bnc := &BaseNetworkController{
 				ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo),
 			}

--- a/go-controller/pkg/ovn/base_network_controller_secondary_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary_test.go
@@ -69,7 +69,6 @@ var _ = Describe("BaseSecondaryNetworkController", func() {
 		vmName                string
 		ips                   []string
 		dns                   []string
-		gateways              []string
 		expectedDHCPv4Options *nbdb.DHCPOptions
 		expectedDHCPv6Options *nbdb.DHCPOptions
 	}

--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	anpapi "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 	anpfake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
@@ -119,7 +118,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		config.OVNKubernetesFeature.EnableAdminNetworkPolicy = true
 
 		app = cli.NewApp()
@@ -135,7 +134,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 
 	ginkgo.Context("on baseline admin network policy changes", func() {
 		ginkgo.It("should create/update/delete address-sets, acls, port-groups correctly", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				banpNamespaceSubject := *newNamespaceWithLabels(banpSubjectNamespaceName, anpLabel)
 				banpNamespacePeer := *newNamespaceWithLabels(banpPeerNamespaceName, peerDenyLabel)
 				config.IPv4Mode = true
@@ -158,14 +157,14 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					},
 				}
 				fakeOVN.startWithDBSetup(dbSetup,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							banpNamespaceSubject,
 							banpNamespacePeer,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
@@ -339,19 +338,19 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 						Ports: &[]anpapi.AdminNetworkPolicyPort{ // test different ports combination
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolTCP,
+									Protocol: corev1.ProtocolTCP,
 									Port:     int32(12345),
 								},
 							},
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolUDP,
+									Protocol: corev1.ProtocolUDP,
 									Port:     int32(12345),
 								},
 							},
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolSCTP,
+									Protocol: corev1.ProtocolSCTP,
 									Port:     int32(12345),
 								},
 							},
@@ -432,19 +431,19 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 						Ports: &[]anpapi.AdminNetworkPolicyPort{ // test different ports combination
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolTCP,
+									Protocol: corev1.ProtocolTCP,
 									Port:     int32(12345),
 								},
 							},
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolUDP,
+									Protocol: corev1.ProtocolUDP,
 									Port:     int32(12345),
 								},
 							},
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolSCTP,
+									Protocol: corev1.ProtocolSCTP,
 									Port:     int32(12345),
 								},
 							},
@@ -624,7 +623,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 
 				ginkgo.By("15. update the subject pod to go into completed state; check if port group is updated")
 				banpSubjectPod.ResourceVersion = "3"
-				banpSubjectPod.Status.Phase = v1.PodSucceeded
+				banpSubjectPod.Status.Phase = corev1.PodSucceeded
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(banpSubjectPod.Namespace).Update(context.TODO(), &banpSubjectPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg = getDefaultPGForANPSubject(banp.Name, nil, newACLs, true) // no ports in PG
@@ -756,7 +755,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 		ginkgo.It("ACL Logging for BANP", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = true
 				config.IPv6Mode = true
 				fakeOVN.start()
@@ -824,9 +823,9 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					// update ACL logging information
 					acl.Log = true
 					if acl.Action == nbdb.ACLActionDrop {
-						acl.Severity = utilpointer.String(nbdb.ACLSeverityAlert)
+						acl.Severity = ptr.To(nbdb.ACLSeverityAlert)
 					} else if acl.Action == nbdb.ACLActionAllowRelated {
-						acl.Severity = utilpointer.String(nbdb.ACLSeverityInfo)
+						acl.Severity = ptr.To(nbdb.ACLSeverityInfo)
 					}
 					expectedDatabaseState = append(expectedDatabaseState, acl)
 				}
@@ -850,9 +849,9 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					// update ACL logging information
 					acl.Log = true
 					if acl.Action == nbdb.ACLActionDrop {
-						acl.Severity = utilpointer.String(nbdb.ACLSeverityWarning)
+						acl.Severity = ptr.To(nbdb.ACLSeverityWarning)
 					} else if acl.Action == nbdb.ACLActionAllowRelated {
-						acl.Severity = utilpointer.String(nbdb.ACLSeverityDebug)
+						acl.Severity = ptr.To(nbdb.ACLSeverityDebug)
 					}
 				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
@@ -875,7 +874,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 		ginkgo.It("egress node+network peers: should create/update/delete address-sets, acls, port-groups correctly", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				banpNamespaceSubject := *newNamespaceWithLabels(banpSubjectNamespaceName, anpLabel)
 				banpNamespacePeer := *newNamespaceWithLabels(banpPeerNamespaceName, peerDenyLabel)
 				config.IPv4Mode = true
@@ -923,19 +922,19 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					},
 				}
 				fakeOVN.startWithDBSetup(dbSetup,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							banpNamespaceSubject,
 							banpNamespacePeer,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							anpSubjectPod, // subject pod ("house": "gryffindor")
 							anpPeerPod,    // peer pod ("house": "slytherin")
 						},
@@ -1028,20 +1027,20 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 						Ports: &[]anpapi.AdminNetworkPolicyPort{ // test different ports combination
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolTCP,
+									Protocol: corev1.ProtocolTCP,
 									Port:     int32(12345),
 								},
 							},
 							{
 								PortRange: &anpapi.PortRange{
-									Protocol: v1.ProtocolUDP,
+									Protocol: corev1.ProtocolUDP,
 									Start:    int32(12345),
 									End:      int32(65000),
 								},
 							},
 							{
 								PortNumber: &anpapi.Port{
-									Protocol: v1.ProtocolSCTP,
+									Protocol: corev1.ProtocolSCTP,
 									Port:     int32(12345),
 								},
 							},
@@ -1171,7 +1170,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 		ginkgo.It("NamedPort matching pods Rules for BANP", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = true
 				config.IPv6Mode = true
 				banpSubjectNamespace := *newNamespaceWithLabels(banpSubjectNamespaceName, anpLabel)
@@ -1199,19 +1198,19 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					`"mac_address":"0a:58:0a:80:01:04","gateway_ips":["10.128.1.1","fe00:10:128:1::1"],"routes":[{"dest":"10.128.1.0/24","nextHop":"10.128.1.1"}],` +
 					`"ip_address":"10.128.1.4/24","gateway_ip":"10.128.1.1"}}`
 				banpPeerPod.Spec.Containers = append(banpPeerPod.Spec.Containers,
-					v1.Container{
+					corev1.Container{
 						Name:  "containerName",
 						Image: "containerImage",
-						Ports: []v1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "web",
 								ContainerPort: 3535,
-								Protocol:      v1.ProtocolTCP,
+								Protocol:      corev1.ProtocolTCP,
 							},
 							{
 								Name:          "web123",
 								ContainerPort: 35356,
-								Protocol:      v1.ProtocolSCTP,
+								Protocol:      corev1.ProtocolSCTP,
 							},
 						},
 					},
@@ -1232,11 +1231,11 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banpSubjectPod.Annotations["k8s.ovn.org/pod-networks"] = `{"default":{"ip_addresses":["10.128.1.3/24","fe00:10:128:1::3/64"],` +
 					`"mac_address":"0a:58:0a:80:01:03","gateway_ips":["10.128.1.1","fe00:10:128:1::1"],"routes":[{"dest":"10.128.1.0/24","nextHop":"10.128.1.1"}],` +
 					`"ip_address":"10.128.1.3/24","gateway_ip":"10.128.1.1"}}`
-				banpSubjectPod.Spec.Containers[0].Ports = []v1.ContainerPort{
+				banpSubjectPod.Spec.Containers[0].Ports = []corev1.ContainerPort{
 					{
 						Name:          "dns",
 						ContainerPort: 5353,
-						Protocol:      v1.ProtocolUDP,
+						Protocol:      corev1.ProtocolUDP,
 					},
 				}
 				dbSetup := libovsdbtest.TestSetup{
@@ -1245,20 +1244,20 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					},
 				}
 				fakeOVN.startWithDBSetup(dbSetup,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							banpSubjectNamespace,
 							banpNamespacePeer,
 							banpNamespacePeer2,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node1,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							banpPeerPod, // peer pod ("house": "slytherin")
 						},
 					},
@@ -1305,7 +1304,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					{
 						PortNumber: &anpapi.Port{
 							Port:     36363,
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 						},
 					},
 					{
@@ -1315,7 +1314,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 						PortRange: &anpapi.PortRange{
 							Start:    36330,
 							End:      36550,
-							Protocol: v1.ProtocolSCTP,
+							Protocol: corev1.ProtocolSCTP,
 						},
 					},
 					{
@@ -1325,7 +1324,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 						PortRange: &anpapi.PortRange{
 							Start:    36330,
 							End:      36550,
-							Protocol: v1.ProtocolUDP,
+							Protocol: corev1.ProtocolUDP,
 						},
 					},
 					{

--- a/go-controller/pkg/ovn/controller/admin_network_policy/repair_test.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/repair_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
 
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
@@ -373,7 +373,7 @@ func accessControlList(name string, gressPrefix libovsdbutil.ACLDirection, prior
 		ExternalIDs: objIDs.GetExternalIDs(),
 		Log:         true,
 		Match:       "match",
-		Name:        utilpointer.String(name),
+		Name:        ptr.To(name),
 		Options:     map[string]string{"key": "value"},
 		Priority:    int(priority),
 		Tier:        1,

--- a/go-controller/pkg/ovn/controller/admin_network_policy/status_test.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/status_test.go
@@ -41,8 +41,8 @@ func createTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
 	return nil
 }
 
-func deleteTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
-	p := func(nbGlobal *nbdb.NBGlobal) bool {
+func deleteTestNBGlobal(nbClient libovsdbclient.Client, _ string) error {
+	p := func(*nbdb.NBGlobal) bool {
 		return true
 	}
 
@@ -88,7 +88,7 @@ func newANPController(initANPs anpapi.AdminNetworkPolicyList, initBANPs anpapi.B
 
 func newANPControllerWithDBSetup(dbSetup libovsdbtest.TestSetup, initANPs anpapi.AdminNetworkPolicyList, initBANPs anpapi.BaselineAdminNetworkPolicyList) (*Controller, error) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	config.PrepareTestConfig()
+	gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 	config.OVNKubernetesFeature.EnableAdminNetworkPolicy = true
 	nbClient, _, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
 	if err != nil {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -8,7 +8,7 @@ import (
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -33,9 +33,9 @@ const (
 	network_status         = `[{"name":"foo","interface":"net1","ips":["%s"],"mac":"01:23:45:67:89:10"}]`
 )
 
-func newPolicy(policyName string, fromNSSelector *v1.LabelSelector, staticHopsGWIPs sets.Set[string], dynamicHopsNSSelector *v1.LabelSelector, dynamicHopsPodSelector *v1.LabelSelector, bfdEnabled bool) *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute {
+func newPolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHopsGWIPs sets.Set[string], dynamicHopsNSSelector *metav1.LabelSelector, dynamicHopsPodSelector *metav1.LabelSelector, bfdEnabled bool) *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute {
 	p := adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{
-		ObjectMeta: v1.ObjectMeta{Name: policyName},
+		ObjectMeta: metav1.ObjectMeta{Name: policyName},
 		Spec: adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteSpec{
 			From: adminpolicybasedrouteapi.ExternalNetworkSource{
 				NamespaceSelector: *fromNSSelector,
@@ -62,31 +62,31 @@ func newPolicy(policyName string, fromNSSelector *v1.LabelSelector, staticHopsGW
 }
 
 func deletePolicy(policyName string, fakeRouteClient *adminpolicybasedrouteclient.Clientset) {
-	err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Delete(context.TODO(), policyName, v1.DeleteOptions{})
+	err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Delete(context.TODO(), policyName, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
 func deleteNamespace(namespaceName string, fakeClient *fake.Clientset) {
-	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), namespaceName, v1.GetOptions{})
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	ns.ObjectMeta.DeletionTimestamp = &v1.Time{Time: time.Now()}
-	_, err = fakeClient.CoreV1().Namespaces().Update(context.Background(), ns, v1.UpdateOptions{})
+	ns.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	_, err = fakeClient.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	err = fakeClient.CoreV1().Namespaces().Delete(context.Background(), namespaceName, v1.DeleteOptions{})
+	err = fakeClient.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
 func createNamespace(namespace *corev1.Namespace) {
-	_, err := fakeClient.CoreV1().Namespaces().Create(context.Background(), namespace, v1.CreateOptions{})
+	_, err := fakeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
 func updateNamespaceLabel(namespaceName string, labels map[string]string, fakeClient *fake.Clientset) {
-	ns, err := fakeClient.CoreV1().Namespaces().Get(context.TODO(), namespaceName, v1.GetOptions{})
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.TODO(), namespaceName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	incrementResourceVersion(ns)
 	ns.Labels = labels
-	_, err = fakeClient.CoreV1().Namespaces().Update(context.Background(), ns, v1.UpdateOptions{})
+	_, err = fakeClient.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -160,17 +160,17 @@ var _ = Describe("OVN External Gateway namespace", func() {
 		targetNamespace2Match = map[string]string{"name": targetNamespaceName2}
 
 		namespaceGW = &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{Name: gatewayNamespaceName,
+			ObjectMeta: metav1.ObjectMeta{Name: gatewayNamespaceName,
 				Labels: gatewayNamespaceMatch}}
 		namespaceTarget = &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{Name: targetNamespaceName,
+			ObjectMeta: metav1.ObjectMeta{Name: targetNamespaceName,
 				Labels: map[string]string{"name": targetNamespaceName, "match": targetNamespaceLabel}},
 		}
 		targetPod1 = newPod("pod_target1", namespaceTarget.Name, "192.169.10.1",
 			map[string]string{"key": "pod", "name": "pod_target1"})
 
 		namespaceTarget2 = &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{Name: targetNamespaceName2,
+			ObjectMeta: metav1.ObjectMeta{Name: targetNamespaceName2,
 				Labels: map[string]string{"name": targetNamespaceName2, "match": targetNamespaceLabel}},
 		}
 		targetPod2 = newPod("pod_target2", namespaceTarget2.Name, "192.169.10.2",
@@ -178,16 +178,16 @@ var _ = Describe("OVN External Gateway namespace", func() {
 
 		dynamicPolicy = newPolicy(
 			"dynamic",
-			&v1.LabelSelector{MatchLabels: targetNamespace2Match},
+			&metav1.LabelSelector{MatchLabels: targetNamespace2Match},
 			nil,
-			&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-			&v1.LabelSelector{MatchLabels: map[string]string{"name": "pod"}},
+			&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+			&metav1.LabelSelector{MatchLabels: map[string]string{"name": "pod"}},
 			false,
 		)
 
 		staticPolicy = newPolicy(
 			"static",
-			&v1.LabelSelector{MatchLabels: targetNamespace1Match},
+			&metav1.LabelSelector{MatchLabels: targetNamespace1Match},
 			sets.New(staticHopGWIP),
 			nil,
 			nil,
@@ -195,7 +195,7 @@ var _ = Describe("OVN External Gateway namespace", func() {
 		)
 
 		annotatedPodGW = &corev1.Pod{
-			ObjectMeta: v1.ObjectMeta{Name: "annotatedPod", Namespace: namespaceGW.Name,
+			ObjectMeta: metav1.ObjectMeta{Name: "annotatedPod", Namespace: namespaceGW.Name,
 				Labels: map[string]string{"name": "annotatedPod"},
 				Annotations: map[string]string{"k8s.ovn.org/routing-namespaces": "test",
 					"k8s.ovn.org/routing-network": "",
@@ -205,7 +205,7 @@ var _ = Describe("OVN External Gateway namespace", func() {
 		}
 
 		podGW = &corev1.Pod{
-			ObjectMeta: v1.ObjectMeta{Name: "pod", Namespace: namespaceGW.Name,
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: namespaceGW.Name,
 				Labels:      map[string]string{"name": "pod"},
 				Annotations: map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, dynamicHopHostNetPodIP)}},
 			Status: corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: dynamicHopHostNetPodIP}}, Phase: corev1.PodRunning},
@@ -284,10 +284,10 @@ var _ = Describe("OVN External Gateway namespace", func() {
 			It("registers a new namespace with one policy with dynamic GWs and the IP of an annotated pod", func() {
 				dynamicPolicy = newPolicy(
 					"dynamic",
-					&v1.LabelSelector{MatchLabels: targetNamespace2Match},
+					&metav1.LabelSelector{MatchLabels: targetNamespace2Match},
 					nil,
-					&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-					&v1.LabelSelector{},
+					&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+					&metav1.LabelSelector{},
 					false,
 				)
 				initController([]runtime.Object{namespaceTarget2, targetPod2, namespaceGW, podGW, annotatedPodGW}, []runtime.Object{dynamicPolicy})
@@ -410,7 +410,7 @@ var _ = Describe("OVN External Gateway namespace", func() {
 		It("validates that a namespace is targeted by an existing policy after its labels are updated to match "+
 			"the policy's label selector", func() {
 			namespaceTarget := &corev1.Namespace{
-				ObjectMeta: v1.ObjectMeta{Name: "test",
+				ObjectMeta: metav1.ObjectMeta{Name: "test",
 					Labels: map[string]string{"name": "test"}},
 			}
 			targetPod := newPod("pod_target1", namespaceTarget.Name, "192.169.10.1",
@@ -490,10 +490,10 @@ var _ = Describe("OVN External Gateway namespace", func() {
 		It("validates that a namespace can't be targeted by 2 policies", func() {
 			dynamicPolicy = newPolicy(
 				"dynamic",
-				&v1.LabelSelector{MatchLabels: map[string]string{"extra": "label"}},
+				&metav1.LabelSelector{MatchLabels: map[string]string{"extra": "label"}},
 				nil,
-				&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-				&v1.LabelSelector{MatchLabels: map[string]string{"name": "pod"}},
+				&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+				&metav1.LabelSelector{MatchLabels: map[string]string{"name": "pod"}},
 				false,
 			)
 			initController([]runtime.Object{namespaceTarget, namespaceGW, targetPod1, podGW}, []runtime.Object{staticPolicy, dynamicPolicy})

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -31,17 +31,17 @@ var _ = Describe("OVN External Gateway pod", func() {
 		targetNamespace2Match = map[string]string{"name": targetNamespaceName2}
 
 		namespaceGW = &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{Name: gatewayNamespaceName,
+			ObjectMeta: metav1.ObjectMeta{Name: gatewayNamespaceName,
 				Labels: gatewayNamespaceMatch}}
 		namespaceTarget = &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{Name: targetNamespaceName,
+			ObjectMeta: metav1.ObjectMeta{Name: targetNamespaceName,
 				Labels: map[string]string{"name": targetNamespaceName, "match": targetNamespaceLabel}},
 		}
 		targetPod1 = newPod("pod_target1", namespaceTarget.Name, "192.169.10.1",
 			map[string]string{"key": "pod", "name": "pod_target1"})
 
 		namespaceTarget2 = &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{Name: targetNamespaceName2,
+			ObjectMeta: metav1.ObjectMeta{Name: targetNamespaceName2,
 				Labels: map[string]string{"name": targetNamespaceName2, "match": targetNamespaceLabel}},
 		}
 		targetPod2 = newPod("pod_target2", namespaceTarget2.Name, "192.169.10.2",
@@ -49,28 +49,28 @@ var _ = Describe("OVN External Gateway pod", func() {
 
 		dynamicPolicy = newPolicy(
 			"dynamic",
-			&v1.LabelSelector{MatchLabels: targetNamespace2Match},
+			&metav1.LabelSelector{MatchLabels: targetNamespace2Match},
 			nil,
-			&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-			&v1.LabelSelector{MatchLabels: map[string]string{"key": "pod"}},
+			&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+			&metav1.LabelSelector{MatchLabels: map[string]string{"key": "pod"}},
 			false,
 		)
 
 		dynamicPolicyDiffTargetNS = newPolicy(
 			"dynamic2",
-			&v1.LabelSelector{MatchLabels: targetNamespace1Match},
+			&metav1.LabelSelector{MatchLabels: targetNamespace1Match},
 			nil,
-			&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-			&v1.LabelSelector{MatchLabels: map[string]string{"key": "pod"}},
+			&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+			&metav1.LabelSelector{MatchLabels: map[string]string{"key": "pod"}},
 			false,
 		)
 
 		dynamicPolicyDiffTargetNSAndPodSel = newPolicy(
 			"dynamic2",
-			&v1.LabelSelector{MatchLabels: targetNamespace1Match},
+			&metav1.LabelSelector{MatchLabels: targetNamespace1Match},
 			nil,
-			&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-			&v1.LabelSelector{MatchLabels: map[string]string{"duplicated": "true"}},
+			&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+			&metav1.LabelSelector{MatchLabels: map[string]string{"duplicated": "true"}},
 			false,
 		)
 
@@ -133,7 +133,7 @@ var _ = Describe("OVN External Gateway pod", func() {
 			eventuallyExpectConfig(dynamicPolicy.Name, expectedPolicy1, expectedRefs1)
 			eventuallyExpectConfig(dynamicPolicyDiffTargetNS.Name, expectedPolicy2, expectedRefs2)
 
-			_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.Background(), pod1, v1.CreateOptions{})
+			_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.Background(), pod1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedPolicy1, expectedRefs1 = expectedPolicyStateAndRefs(
@@ -155,10 +155,10 @@ var _ = Describe("OVN External Gateway pod", func() {
 		It("processes the pod that has no policy match", func() {
 			noMatchPolicy := newPolicy(
 				"noMatchPolicy",
-				&v1.LabelSelector{MatchLabels: targetNamespace1Match},
+				&metav1.LabelSelector{MatchLabels: targetNamespace1Match},
 				nil,
-				&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-				&v1.LabelSelector{MatchLabels: map[string]string{"key": "nomatch"}},
+				&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+				&metav1.LabelSelector{MatchLabels: map[string]string{"key": "nomatch"}},
 				false,
 			)
 			initController([]runtime.Object{namespaceGW, namespaceTarget}, []runtime.Object{noMatchPolicy})
@@ -246,10 +246,10 @@ var _ = Describe("OVN External Gateway pod", func() {
 		It("deletes a gateway pod that does not match any policy", func() {
 			noMatchPolicy := newPolicy(
 				"noMatchPolicy",
-				&v1.LabelSelector{MatchLabels: targetNamespace1Match},
+				&metav1.LabelSelector{MatchLabels: targetNamespace1Match},
 				nil,
-				&v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
-				&v1.LabelSelector{MatchLabels: map[string]string{"key": "nomatch"}},
+				&metav1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+				&metav1.LabelSelector{MatchLabels: map[string]string{"key": "nomatch"}},
 				false,
 			)
 			initController([]runtime.Object{namespaceGW, namespaceTarget, pod1}, []runtime.Object{noMatchPolicy})
@@ -451,34 +451,34 @@ var _ = Describe("OVN External Gateway pod", func() {
 })
 
 func deletePod(pod *corev1.Pod, fakeClient *fake.Clientset) {
-	err = fakeClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, v1.DeleteOptions{})
+	err = fakeClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
 func createPod(pod *corev1.Pod, fakeClient *fake.Clientset) {
-	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, v1.CreateOptions{})
+	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
 func updatePodLabels(pod *corev1.Pod, newLabels map[string]string, fakeClient *fake.Clientset) {
-	p, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, v1.GetOptions{})
+	p, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	incrementResourceVersion(p)
 	p.Labels = newLabels
-	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, v1.UpdateOptions{})
+	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
 func updatePodStatus(pod *corev1.Pod, podStatus corev1.PodStatus) {
-	p, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, v1.GetOptions{})
+	p, err := fakeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	incrementResourceVersion(p)
 	p.Status = podStatus
-	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, v1.UpdateOptions{})
+	_, err = fakeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), p, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func incrementResourceVersion(obj v1.Object) {
+func incrementResourceVersion(obj metav1.Object) {
 	var rs int64
 	if obj.GetResourceVersion() != "" {
 		rs, err = strconv.ParseInt(obj.GetResourceVersion(), 10, 64)

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -1218,9 +1219,9 @@ func Test_buildClusterLBs(t *testing.T) {
 
 	globalconfig.IPv4Mode = true
 	l3UDN, err := getSampleUDNNetInfo(namespace, "layer3")
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	l2UDN, err := getSampleUDNNetInfo(namespace, "layer2")
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	udnNets := []util.NetInfo{l3UDN, l2UDN}
 
 	tc := []struct {
@@ -1483,9 +1484,9 @@ func Test_buildPerNodeLBs(t *testing.T) {
 	namespace := "testns"
 
 	l3UDN, err := getSampleUDNNetInfo(namespace, "layer3")
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	l2UDN, err := getSampleUDNNetInfo(namespace, "layer2")
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	udnNetworks := []util.NetInfo{l3UDN, l2UDN}
 
 	defaultService := &corev1.Service{

--- a/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -25,10 +25,10 @@ func TestEnsureStaleLBs(t *testing.T) {
 	}
 	t.Cleanup(cleanup.Cleanup)
 
-	defaultService := &v1.Service{
+	defaultService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
 		},
 	}
 
@@ -94,20 +94,20 @@ func TestEnsureStaleLBs(t *testing.T) {
 func TestEnsureLBs(t *testing.T) {
 	tests := []struct {
 		desc    string
-		service *v1.Service
+		service *corev1.Service
 		LBs     []LB
 		finalLB *nbdb.LoadBalancer
 	}{
 		{
 			desc: "create service with permanent session affinity",
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-				Spec: v1.ServiceSpec{
-					Type:            v1.ServiceTypeClusterIP,
-					SessionAffinity: v1.ServiceAffinityClientIP,
-					SessionAffinityConfig: &v1.SessionAffinityConfig{
-						ClientIP: &v1.ClientIPConfig{
-							TimeoutSeconds: utilpointer.Int32(86400),
+				Spec: corev1.ServiceSpec{
+					Type:            corev1.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityClientIP,
+					SessionAffinityConfig: &corev1.SessionAffinityConfig{
+						ClientIP: &corev1.ClientIPConfig{
+							TimeoutSeconds: ptr.To(int32(86400)),
 						},
 					},
 				},
@@ -145,14 +145,14 @@ func TestEnsureLBs(t *testing.T) {
 		},
 		{
 			desc: "create service with default session affinity timeout",
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-				Spec: v1.ServiceSpec{
-					Type:            v1.ServiceTypeClusterIP,
-					SessionAffinity: v1.ServiceAffinityClientIP,
-					SessionAffinityConfig: &v1.SessionAffinityConfig{
-						ClientIP: &v1.ClientIPConfig{
-							TimeoutSeconds: utilpointer.Int32(10800),
+				Spec: corev1.ServiceSpec{
+					Type:            corev1.ServiceTypeClusterIP,
+					SessionAffinity: corev1.ServiceAffinityClientIP,
+					SessionAffinityConfig: &corev1.SessionAffinityConfig{
+						ClientIP: &corev1.ClientIPConfig{
+							TimeoutSeconds: ptr.To(int32(10800)),
 						},
 					},
 				},

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/onsi/gomega/format"
 	"golang.org/x/exp/maps"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	utilnet "k8s.io/utils/net"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 
@@ -39,8 +39,8 @@ var (
 	nodeA = "node-a"
 	nodeB = "node-b"
 
-	tcp = v1.ProtocolTCP
-	udp = v1.ProtocolUDP
+	tcp = corev1.ProtocolTCP
+	udp = corev1.ProtocolUDP
 )
 
 type serviceController struct {
@@ -244,7 +244,7 @@ func TestSyncServices(t *testing.T) {
 		nodeBInfo    *nodeInfo
 		enableIPv6   bool
 		slices       []discovery.EndpointSlice
-		service      *v1.Service
+		service      *corev1.Service
 		networks     []networkData
 		gatewayMode  string
 		nodeToDelete string
@@ -266,16 +266,16 @@ func TestSyncServices(t *testing.T) {
 					Endpoints:   []discovery.Endpoint{},
 				},
 			},
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
-				Spec: v1.ServiceSpec{
-					Type:       v1.ServiceTypeClusterIP,
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeClusterIP,
 					ClusterIP:  serviceClusterIP,
 					ClusterIPs: []string{serviceClusterIP},
 					Selector:   map[string]string{"foo": "bar"},
-					Ports: []v1.ServicePort{{
+					Ports: []corev1.ServicePort{{
 						Port:       servicePort,
-						Protocol:   v1.ProtocolTCP,
+						Protocol:   corev1.ProtocolTCP,
 						TargetPort: intstr.FromInt32(outPort),
 					}},
 				},
@@ -434,16 +434,16 @@ func TestSyncServices(t *testing.T) {
 					Endpoints:   []discovery.Endpoint{},
 				},
 			},
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
-				Spec: v1.ServiceSpec{
-					Type:       v1.ServiceTypeClusterIP,
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeClusterIP,
 					ClusterIP:  serviceClusterIP,
 					ClusterIPs: []string{serviceClusterIP},
 					Selector:   map[string]string{"foo": "bar"},
-					Ports: []v1.ServicePort{{
+					Ports: []corev1.ServicePort{{
 						Port:       servicePort,
-						Protocol:   v1.ProtocolTCP,
+						Protocol:   corev1.ProtocolTCP,
 						TargetPort: intstr.FromInt32(outPort),
 					}},
 				},
@@ -647,14 +647,14 @@ func TestSyncServices(t *testing.T) {
 					Endpoints: []discovery.Endpoint{
 						{
 							Conditions: discovery.EndpointConditions{
-								Ready: utilpointer.Bool(true),
+								Ready: ptr.To(true),
 							},
 							Addresses: []string{nodeAEndpoint},
 							NodeName:  &nodeA,
 						},
 						{
 							Conditions: discovery.EndpointConditions{
-								Ready: utilpointer.Bool(true),
+								Ready: ptr.To(true),
 							},
 							Addresses: []string{nodeBEndpointIP},
 							NodeName:  &nodeB,
@@ -662,16 +662,16 @@ func TestSyncServices(t *testing.T) {
 					},
 				},
 			},
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
-				Spec: v1.ServiceSpec{
-					Type:       v1.ServiceTypeClusterIP,
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeClusterIP,
 					ClusterIP:  serviceClusterIP,
 					ClusterIPs: []string{serviceClusterIP},
 					Selector:   map[string]string{"foo": "bar"},
-					Ports: []v1.ServicePort{{
+					Ports: []corev1.ServicePort{{
 						Port:       servicePort,
-						Protocol:   v1.ProtocolTCP,
+						Protocol:   corev1.ProtocolTCP,
 						TargetPort: intstr.FromInt32(outPort),
 						NodePort:   nodePort,
 					}},
@@ -716,8 +716,8 @@ func TestSyncServices(t *testing.T) {
 						nodeLogicalRouter(nodeA, initialLrGroups),
 						nodeLogicalRouter(nodeB, initialLrGroups),
 						lbGroup(types.ClusterLBGroupName, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
-						lbGroup(types.ClusterSwitchLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol)),
-						lbGroup(types.ClusterRouterLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol)),
+						lbGroup(types.ClusterSwitchLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol)),
+						lbGroup(types.ClusterRouterLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol)),
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
 					},
@@ -779,8 +779,8 @@ func TestSyncServices(t *testing.T) {
 						lbGroup(types.ClusterSwitchLBGroupName),
 						lbGroup(types.ClusterRouterLBGroupName),
 						lbGroupForNetwork(types.ClusterLBGroupName, l3UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l3UDN)),
-						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN)),
-						lbGroupForNetwork(types.ClusterRouterLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN)),
+						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN)),
+						lbGroupForNetwork(types.ClusterRouterLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN)),
 
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
@@ -841,8 +841,8 @@ func TestSyncServices(t *testing.T) {
 						lbGroup(types.ClusterSwitchLBGroupName),
 						lbGroup(types.ClusterRouterLBGroupName),
 						lbGroupForNetwork(types.ClusterLBGroupName, l2UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l2UDN)),
-						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN)),
-						lbGroupForNetwork(types.ClusterRouterLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN)),
+						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN)),
+						lbGroupForNetwork(types.ClusterRouterLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN)),
 
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
@@ -871,14 +871,14 @@ func TestSyncServices(t *testing.T) {
 					Endpoints: []discovery.Endpoint{
 						{
 							Conditions: discovery.EndpointConditions{
-								Ready: utilpointer.Bool(true),
+								Ready: ptr.To(true),
 							},
 							Addresses: []string{nodeAEndpoint},
 							NodeName:  &nodeA,
 						},
 						{
 							Conditions: discovery.EndpointConditions{
-								Ready: utilpointer.Bool(true),
+								Ready: ptr.To(true),
 							},
 							Addresses: []string{nodeBEndpointIP},
 							NodeName:  &nodeB,
@@ -886,16 +886,16 @@ func TestSyncServices(t *testing.T) {
 					},
 				},
 			},
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
-				Spec: v1.ServiceSpec{
-					Type:       v1.ServiceTypeClusterIP,
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeClusterIP,
 					ClusterIP:  serviceClusterIP,
 					ClusterIPs: []string{serviceClusterIP},
 					Selector:   map[string]string{"foo": "bar"},
-					Ports: []v1.ServicePort{{
+					Ports: []corev1.ServicePort{{
 						Port:       servicePort,
-						Protocol:   v1.ProtocolTCP,
+						Protocol:   corev1.ProtocolTCP,
 						TargetPort: intstr.FromInt32(outPort),
 						NodePort:   nodePort,
 					}},
@@ -940,8 +940,8 @@ func TestSyncServices(t *testing.T) {
 						nodeLogicalRouter(nodeA, initialLrGroups),
 						nodeLogicalRouter(nodeB, initialLrGroups),
 						lbGroup(types.ClusterLBGroupName, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
-						lbGroup(types.ClusterSwitchLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol)),
-						lbGroup(types.ClusterRouterLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol)),
+						lbGroup(types.ClusterSwitchLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol)),
+						lbGroup(types.ClusterRouterLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol)),
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
 					},
@@ -962,8 +962,8 @@ func TestSyncServices(t *testing.T) {
 						nodeLogicalRouter(nodeA, initialLrGroups),
 						nodeLogicalRouter(nodeB, initialLrGroups),
 						lbGroup(types.ClusterLBGroupName, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
-						lbGroup(types.ClusterSwitchLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol)),
-						lbGroup(types.ClusterRouterLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol)),
+						lbGroup(types.ClusterSwitchLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol)),
+						lbGroup(types.ClusterRouterLBGroupName, nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol)),
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
 					},
@@ -1024,8 +1024,8 @@ func TestSyncServices(t *testing.T) {
 						lbGroup(types.ClusterSwitchLBGroupName),
 						lbGroup(types.ClusterRouterLBGroupName),
 						lbGroupForNetwork(types.ClusterLBGroupName, l3UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l3UDN)),
-						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN)),
-						lbGroupForNetwork(types.ClusterRouterLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN)),
+						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN)),
+						lbGroupForNetwork(types.ClusterRouterLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN)),
 
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
@@ -1056,8 +1056,8 @@ func TestSyncServices(t *testing.T) {
 						lbGroup(types.ClusterSwitchLBGroupName),
 						lbGroup(types.ClusterRouterLBGroupName),
 						lbGroupForNetwork(types.ClusterLBGroupName, l3UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l3UDN)),
-						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN)),
-						lbGroupForNetwork(types.ClusterRouterLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN)),
+						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN)),
+						lbGroupForNetwork(types.ClusterRouterLBGroupName, l3UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN)),
 
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
@@ -1117,8 +1117,8 @@ func TestSyncServices(t *testing.T) {
 						lbGroup(types.ClusterSwitchLBGroupName),
 						lbGroup(types.ClusterRouterLBGroupName),
 						lbGroupForNetwork(types.ClusterLBGroupName, l2UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l2UDN)),
-						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN)),
-						lbGroupForNetwork(types.ClusterRouterLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN)),
+						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN)),
+						lbGroupForNetwork(types.ClusterRouterLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN)),
 
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
@@ -1148,8 +1148,8 @@ func TestSyncServices(t *testing.T) {
 						lbGroup(types.ClusterSwitchLBGroupName),
 						lbGroup(types.ClusterRouterLBGroupName),
 						lbGroupForNetwork(types.ClusterLBGroupName, l2UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l2UDN)),
-						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN)),
-						lbGroupForNetwork(types.ClusterRouterLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN)),
+						lbGroupForNetwork(types.ClusterSwitchLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN)),
+						lbGroupForNetwork(types.ClusterRouterLBGroupName, l2UDN, nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN)),
 
 						nodeIPTemplate(nodeAInfo),
 						nodeIPTemplate(nodeBInfo),
@@ -1187,18 +1187,18 @@ func TestSyncServices(t *testing.T) {
 					Endpoints:   kubetest.MakeReadyEndpointList(nodeA, nodeAEndpointV6, nodeAEndpoint2V6),
 				},
 			},
-			service: &v1.Service{
+			service: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
-				Spec: v1.ServiceSpec{
-					Type:                  v1.ServiceTypeNodePort,
+				Spec: corev1.ServiceSpec{
+					Type:                  corev1.ServiceTypeNodePort,
 					ClusterIP:             serviceClusterIP,
 					ClusterIPs:            []string{serviceClusterIP, serviceClusterIPv6},
-					IPFamilies:            []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+					IPFamilies:            []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
 					Selector:              map[string]string{"foo": "bar"},
-					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-					Ports: []v1.ServicePort{{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+					Ports: []corev1.ServicePort{{
 						Port:       servicePort,
-						Protocol:   v1.ProtocolTCP,
+						Protocol:   corev1.ProtocolTCP,
 						TargetPort: intstr.FromInt32(outPort),
 						NodePort:   30123,
 					}},
@@ -1228,8 +1228,8 @@ func TestSyncServices(t *testing.T) {
 							ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(ns, serviceName)),
 						},
 						&nbdb.LoadBalancer{
-							UUID:     nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol),
-							Name:     nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol),
+							UUID:     nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol),
+							Name:     nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol),
 							Options:  templateServicesOptions(),
 							Protocol: &nbdb.LoadBalancerProtocolTCP,
 							Vips: map[string]string{
@@ -1240,8 +1240,8 @@ func TestSyncServices(t *testing.T) {
 							ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(ns, serviceName)),
 						},
 						&nbdb.LoadBalancer{
-							UUID:     nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv6Protocol),
-							Name:     nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv6Protocol),
+							UUID:     nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv6Protocol),
+							Name:     nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv6Protocol),
 							Options:  templateServicesOptionsV6(),
 							Protocol: &nbdb.LoadBalancerProtocolTCP,
 							Vips: map[string]string{
@@ -1254,21 +1254,21 @@ func TestSyncServices(t *testing.T) {
 						nodeLogicalRouter(nodeA, initialLrGroups),
 						lbGroup(types.ClusterLBGroupName, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
 						lbGroup(types.ClusterSwitchLBGroupName,
-							nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol),
-							nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv6Protocol)),
+							nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol),
+							nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv6Protocol)),
 						lbGroup(types.ClusterRouterLBGroupName,
-							nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv4Protocol),
-							nodeMergedTemplateLoadBalancerName(ns, serviceName, v1.IPv6Protocol)),
+							nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv4Protocol),
+							nodeMergedTemplateLoadBalancerName(ns, serviceName, corev1.IPv6Protocol)),
 
 						&nbdb.ChassisTemplateVar{
 							UUID: nodeA, Chassis: nodeA,
 							Variables: map[string]string{
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "0": nodeAMultiAddressesV4[0],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "1": nodeAMultiAddressesV4[1],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "2": nodeAMultiAddressesV4[2],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "0": nodeAMultiAddressesV4[0],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "1": nodeAMultiAddressesV4[1],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "2": nodeAMultiAddressesV4[2],
 
-								makeLBNodeIPTemplateNamePrefix(v1.IPv6Protocol) + "0": nodeAMultiAddressesV6[0],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv6Protocol) + "1": nodeAMultiAddressesV6[1],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv6Protocol) + "0": nodeAMultiAddressesV6[0],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv6Protocol) + "1": nodeAMultiAddressesV6[1],
 							},
 						},
 					},
@@ -1302,8 +1302,8 @@ func TestSyncServices(t *testing.T) {
 							ExternalIDs: loadBalancerExternalIDsForNetwork(namespacedServiceName(ns, serviceName), l3UDN.GetNetworkName()),
 						},
 						&nbdb.LoadBalancer{
-							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN),
-							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN),
+							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN),
+							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN),
 							Options:  templateServicesOptions(),
 							Protocol: &nbdb.LoadBalancerProtocolTCP,
 							Vips: map[string]string{
@@ -1314,8 +1314,8 @@ func TestSyncServices(t *testing.T) {
 							ExternalIDs: loadBalancerExternalIDsForNetwork(namespacedServiceName(ns, serviceName), l3UDN.GetNetworkName()),
 						},
 						&nbdb.LoadBalancer{
-							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l3UDN),
-							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l3UDN),
+							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l3UDN),
+							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l3UDN),
 							Options:  templateServicesOptionsV6(),
 							Protocol: &nbdb.LoadBalancerProtocolTCP,
 							Vips: map[string]string{
@@ -1338,22 +1338,22 @@ func TestSyncServices(t *testing.T) {
 						lbGroupForNetwork(types.ClusterLBGroupName, l3UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l3UDN)),
 						lbGroupForNetwork(types.ClusterSwitchLBGroupName,
 							l3UDN,
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN),
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l3UDN)),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l3UDN)),
 						lbGroupForNetwork(types.ClusterRouterLBGroupName,
 							l3UDN,
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l3UDN),
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l3UDN)),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l3UDN),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l3UDN)),
 
 						&nbdb.ChassisTemplateVar{
 							UUID: nodeAInfo.chassisID, Chassis: nodeAInfo.chassisID,
 							Variables: map[string]string{
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "0": nodeAMultiAddressesV4[0],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "1": nodeAMultiAddressesV4[1],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "2": nodeAMultiAddressesV4[2],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "0": nodeAMultiAddressesV4[0],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "1": nodeAMultiAddressesV4[1],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "2": nodeAMultiAddressesV4[2],
 
-								makeLBNodeIPTemplateNamePrefix(v1.IPv6Protocol) + "0": nodeAMultiAddressesV6[0],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv6Protocol) + "1": nodeAMultiAddressesV6[1],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv6Protocol) + "0": nodeAMultiAddressesV6[0],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv6Protocol) + "1": nodeAMultiAddressesV6[1],
 							},
 						},
 					},
@@ -1387,8 +1387,8 @@ func TestSyncServices(t *testing.T) {
 							ExternalIDs: loadBalancerExternalIDsForNetwork(namespacedServiceName(ns, serviceName), l2UDN.GetNetworkName()),
 						},
 						&nbdb.LoadBalancer{
-							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN),
-							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN),
+							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN),
+							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN),
 							Options:  templateServicesOptions(),
 							Protocol: &nbdb.LoadBalancerProtocolTCP,
 							Vips: map[string]string{
@@ -1399,8 +1399,8 @@ func TestSyncServices(t *testing.T) {
 							ExternalIDs: loadBalancerExternalIDsForNetwork(namespacedServiceName(ns, serviceName), l2UDN.GetNetworkName()),
 						},
 						&nbdb.LoadBalancer{
-							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l2UDN),
-							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l2UDN),
+							UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l2UDN),
+							Name:     nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l2UDN),
 							Options:  templateServicesOptionsV6(),
 							Protocol: &nbdb.LoadBalancerProtocolTCP,
 							Vips: map[string]string{
@@ -1423,22 +1423,22 @@ func TestSyncServices(t *testing.T) {
 						lbGroupForNetwork(types.ClusterLBGroupName, l2UDN, clusterWideTCPServiceLoadBalancerNameForNetwork(ns, serviceName, l2UDN)),
 						lbGroupForNetwork(types.ClusterSwitchLBGroupName,
 							l2UDN,
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN),
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l2UDN)),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l2UDN)),
 						lbGroupForNetwork(types.ClusterRouterLBGroupName,
 							l2UDN,
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv4Protocol, l2UDN),
-							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, v1.IPv6Protocol, l2UDN)),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv4Protocol, l2UDN),
+							nodeMergedTemplateLoadBalancerNameForNetwork(ns, serviceName, corev1.IPv6Protocol, l2UDN)),
 
 						&nbdb.ChassisTemplateVar{
 							UUID: nodeAInfo.chassisID, Chassis: nodeAInfo.chassisID,
 							Variables: map[string]string{
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "0": nodeAMultiAddressesV4[0],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "1": nodeAMultiAddressesV4[1],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "2": nodeAMultiAddressesV4[2],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "0": nodeAMultiAddressesV4[0],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "1": nodeAMultiAddressesV4[1],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "2": nodeAMultiAddressesV4[2],
 
-								makeLBNodeIPTemplateNamePrefix(v1.IPv6Protocol) + "0": nodeAMultiAddressesV6[0],
-								makeLBNodeIPTemplateNamePrefix(v1.IPv6Protocol) + "1": nodeAMultiAddressesV6[1],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv6Protocol) + "0": nodeAMultiAddressesV6[0],
+								makeLBNodeIPTemplateNamePrefix(corev1.IPv6Protocol) + "1": nodeAMultiAddressesV6[1],
 							},
 						},
 					},
@@ -1489,9 +1489,11 @@ func TestSyncServices(t *testing.T) {
 
 				// Add k8s objects
 				for _, slice := range tt.slices {
-					controller.endpointSliceStore.Add(&slice)
+					err = controller.endpointSliceStore.Add(&slice)
+					g.Expect(err).NotTo(gomega.HaveOccurred())
 				}
-				controller.serviceStore.Add(tt.service)
+				err = controller.serviceStore.Add(tt.service)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Setup node tracker
 				controller.nodeTracker.nodes = map[string]nodeInfo{}
@@ -1505,7 +1507,8 @@ func TestSyncServices(t *testing.T) {
 				// Add mirrored endpoint slices when the controller runs on a UDN
 				if !netInfo.IsDefault() {
 					for _, slice := range tt.slices {
-						controller.endpointSliceStore.Add(kubetest.MirrorEndpointSlice(&slice, netInfo.GetNetworkName(), true))
+						err = controller.endpointSliceStore.Add(kubetest.MirrorEndpointSlice(&slice, netInfo.GetNetworkName(), true))
+						g.Expect(err).NotTo(gomega.HaveOccurred())
 					}
 				}
 
@@ -1644,11 +1647,11 @@ func clusterWideTCPServiceLoadBalancerNameForNetwork(ns string, serviceName stri
 	return netInfo.GetNetworkScopedLoadBalancerName(baseName)
 }
 
-func nodeMergedTemplateLoadBalancerName(serviceNamespace string, serviceName string, addressFamily v1.IPFamily) string {
+func nodeMergedTemplateLoadBalancerName(serviceNamespace string, serviceName string, addressFamily corev1.IPFamily) string {
 	return nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace, serviceName, addressFamily, &util.DefaultNetInfo{})
 }
 
-func nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace string, serviceName string, addressFamily v1.IPFamily, netInfo util.NetInfo) string {
+func nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace string, serviceName string, addressFamily corev1.IPFamily, netInfo util.NetInfo) string {
 	baseName := fmt.Sprintf(
 		"Service_%s/%s_TCP_node_switch_template_%s_merged",
 		serviceNamespace,
@@ -1719,7 +1722,7 @@ func nodeIPTemplate(node *nodeInfo) *nbdb.ChassisTemplateVar {
 		UUID:    node.chassisID,
 		Chassis: node.chassisID,
 		Variables: map[string]string{
-			makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "0": node.hostAddresses[0].String(),
+			makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "0": node.hostAddresses[0].String(),
 		},
 	}
 }
@@ -1729,10 +1732,10 @@ func nodeMergedTemplateLoadBalancer(nodePort int32, serviceName string, serviceN
 }
 
 func nodeMergedTemplateLoadBalancerForNetwork(nodePort int32, serviceName string, serviceNamespace string, outputPort int32, netInfo util.NetInfo, endpointIPs ...string) *nbdb.LoadBalancer {
-	nodeTemplateIP := makeTemplate(makeLBNodeIPTemplateNamePrefix(v1.IPv4Protocol) + "0")
+	nodeTemplateIP := makeTemplate(makeLBNodeIPTemplateNamePrefix(corev1.IPv4Protocol) + "0")
 	return &nbdb.LoadBalancer{
-		UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace, serviceName, v1.IPv4Protocol, netInfo),
-		Name:     nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace, serviceName, v1.IPv4Protocol, netInfo),
+		UUID:     nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace, serviceName, corev1.IPv4Protocol, netInfo),
+		Name:     nodeMergedTemplateLoadBalancerNameForNetwork(serviceNamespace, serviceName, corev1.IPv4Protocol, netInfo),
 		Options:  templateServicesOptions(),
 		Protocol: &nbdb.LoadBalancerProtocolTCP,
 		Vips: map[string]string{
@@ -1815,7 +1818,7 @@ func createTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
 }
 
 func deleteTestNBGlobal(nbClient libovsdbclient.Client) error {
-	p := func(nbGlobal *nbdb.NBGlobal) bool {
+	p := func(*nbdb.NBGlobal) bool {
 		return true
 	}
 

--- a/go-controller/pkg/ovn/controller/services/svc_template_var_test.go
+++ b/go-controller/pkg/ovn/controller/services/svc_template_var_test.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_NodeIPTemplates_SingleIP(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	// System Under Test
-	sut := NewNodeIPsTemplates(v1.IPv4Protocol)
+	sut := NewNodeIPsTemplates(corev1.IPv4Protocol)
 
 	sut.AddIP("ch1", net.ParseIP("11.11.0.1"))
 	sut.AddIP("ch2", net.ParseIP("11.11.0.2"))
@@ -36,7 +36,7 @@ func Test_NodeIPTemplates_DifferentIPCount(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	// System Under Test
-	sut := NewNodeIPsTemplates(v1.IPv4Protocol)
+	sut := NewNodeIPsTemplates(corev1.IPv4Protocol)
 
 	sut.AddIP("ch1", net.ParseIP("11.11.0.1"))
 	sut.AddIP("ch2", net.ParseIP("11.11.0.2"))

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -20,7 +21,7 @@ func TestExternalIDsForLoadBalancer(t *testing.T) {
 	defaultNetInfo := util.DefaultNetInfo{}
 	config.IPv4Mode = true
 	UDNNetInfo, err := getSampleUDNNetInfo(namespace, "layer3")
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	assert.Equal(t,
 		map[string]string{
 			types.LoadBalancerKindExternalID:  "Service",

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -26,7 +26,7 @@ func TestExternalIDsForLoadBalancer(t *testing.T) {
 			types.LoadBalancerKindExternalID:  "Service",
 			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
 		},
-		getExternalIDsForLoadBalancer(&v1.Service{
+		getExternalIDsForLoadBalancer(&corev1.Service{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Service",
 				APIVersion: "v1",
@@ -44,7 +44,7 @@ func TestExternalIDsForLoadBalancer(t *testing.T) {
 			types.LoadBalancerKindExternalID:  "Service",
 			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
 		},
-		getExternalIDsForLoadBalancer(&v1.Service{
+		getExternalIDsForLoadBalancer(&corev1.Service{
 			// also handle no TypeMeta, which can happen.
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -61,7 +61,7 @@ func TestExternalIDsForLoadBalancer(t *testing.T) {
 			types.NetworkExternalID:           UDNNetInfo.GetNetworkName(),
 			types.NetworkRoleExternalID:       types.NetworkRolePrimary,
 		},
-		getExternalIDsForLoadBalancer(&v1.Service{
+		getExternalIDsForLoadBalancer(&corev1.Service{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Service",
 				APIVersion: "v1",

--- a/go-controller/pkg/ovn/controller/udnenabledsvc/udn_enabled_svc_test.go
+++ b/go-controller/pkg/ovn/controller/udnenabledsvc/udn_enabled_svc_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -168,7 +168,7 @@ func TestUDNEnabledServices(t *testing.T) {
 			t.Logf("delete all services and ensure address map is empty")
 			for ns, name := range map[string]string{service1Namespace: service1Name, service2Namespace: service2Name} {
 				err = ovnClient.KubeClient.CoreV1().Services(ns).Delete(context.Background(), name, metav1.DeleteOptions{})
-				if err != nil && !errors.IsNotFound(err) {
+				if err != nil && !apierrors.IsNotFound(err) {
 					t.Fatalf("failed to ensure service %s/%s is deleted: %v", ns, name, err)
 				}
 			}
@@ -209,7 +209,7 @@ func createOrUpdateServices(client *util.OVNKubeControllerClientset, services []
 	for _, service := range services {
 		_, err := client.KubeClient.CoreV1().Services(service.Namespace).Get(context.Background(), service.Name, metav1.GetOptions{})
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				_, err = client.KubeClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 				if err != nil {
 					return fmt.Errorf("failed to create service %s/%s: %v", service.Namespace, service.Name, err)

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -162,6 +162,6 @@ var _ = Describe("Unidling Controller", func() {
 			unidledAt := alteredSvc.Annotations["k8s.ovn.org/unidled-at"]
 			g.Expect(unidledAt).ToNot(BeNil())
 			g.Expect(unidledAt >= testStartTime).To(BeTrue(), "expected %s >= %s", unidledAt, testStartTime)
-		})
+		}).Should(Succeed())
 	})
 })

--- a/go-controller/pkg/ovn/dns_name_resolver/dns_test.go
+++ b/go-controller/pkg/ovn/dns_name_resolver/dns_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	utilnet "k8s.io/utils/net"
 
@@ -28,7 +29,7 @@ func TestNewEgressDNS(t *testing.T) {
 	dbSetup := libovsdbtest.TestSetup{}
 
 	libovsdbOvnNBClient, _, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	t.Cleanup(libovsdbCleanup.Cleanup)
 
 	testOvnAddFtry := addressset.NewOvnAddressSetFactory(libovsdbOvnNBClient, config.IPv4Mode, config.IPv6Mode)
@@ -68,9 +69,9 @@ func TestNewEgressDNS(t *testing.T) {
 			_, err := NewEgressDNS(testOvnAddFtry, DefaultNetworkControllerName, testCh, 0)
 			//t.Log(res, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockDnsOps.AssertExpectations(t)
 		})
@@ -369,16 +370,16 @@ func TestAdd(t *testing.T) {
 				call.Once()
 			}
 			res, err := NewEgressDNS(mockAddressSetFactoryOps, DefaultNetworkControllerName, testCh, tc.syncTime)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = res.Run()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = res.Add("addNamespace", test1DNSName)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				for stay, timeout := true, time.After(10*time.Second); stay; {
 					_, dnsResolves, _ := res.getDNSEntry(tc.dnsName)
 					if dnsResolves != nil {
@@ -524,17 +525,16 @@ func TestDelete(t *testing.T) {
 				call.Once()
 			}
 			res, err := NewEgressDNS(mockAddressSetFactoryOps, DefaultNetworkControllerName, testCh, tc.syncTime)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = res.Run()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = res.Add("addNamespace", test1DNSName)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				for stay, timeout := true, time.After(10*time.Second); stay; {
 					_, dnsResolves, _ := res.getDNSEntry(tc.dnsName)
 					if dnsResolves != nil {
@@ -551,7 +551,7 @@ func TestDelete(t *testing.T) {
 			}
 			_, dnsResolves, _ := res.getDNSEntry(tc.dnsName)
 			err = res.Delete("addNamespace")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			for stay, timeout := true, time.After(10*time.Second); stay; {
 				_, dnsResolves, _ = res.getDNSEntry(tc.dnsName)
 				if dnsResolves == nil {

--- a/go-controller/pkg/ovn/dns_name_resolver/dns_test.go
+++ b/go-controller/pkg/ovn/dns_name_resolver/dns_test.go
@@ -43,13 +43,13 @@ func TestNewEgressDNS(t *testing.T) {
 			desc:   "fails to read the /etc/resolv.conf file",
 			errExp: true,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
+				{OnCallMethodName: "ClientConfigFromFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}, CallTimes: 1},
 			},
 		},
 		{
 			desc: "positive tests case",
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{}, nil}, 0, 1},
+				{OnCallMethodName: "ClientConfigFromFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&dns.ClientConfig{}, nil}, CallTimes: 1},
 			},
 		},
 	}
@@ -117,12 +117,20 @@ func TestAdd(t *testing.T) {
 			errExp:   true,
 			syncTime: 5 * time.Minute,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
+				{
+					OnCallMethodName:    "ClientConfigFromFile",
+					OnCallMethodArgType: []string{"string"},
+					RetArgList:          []interface{}{&dns.ClientConfig{Servers: []string{"1.1.1.1"}, Port: "1234"}, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
+				{
+					OnCallMethodName:    "NewAddressSet",
+					OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"},
+					RetArgList:          []interface{}{nil, fmt.Errorf("mock error")},
+					CallTimes:           1,
+				},
 			},
 		},
 		{
@@ -134,16 +142,22 @@ func TestAdd(t *testing.T) {
 			configIPv6: false,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{
+					OnCallMethodName: "ClientConfigFromFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&dns.ClientConfig{
+						Servers: []string{"1.1.1.1"},
+						Port:    "1234"}, nil}, CallTimes: 1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{OnCallMethodName: "NewAddressSet", OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{mockAddressSetOps, nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
 				{
@@ -162,17 +176,23 @@ func TestAdd(t *testing.T) {
 			configIPv6: false,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{},
-					[]interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, clusterSubnetIP, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{
+					OnCallMethodName:    "ClientConfigFromFile",
+					OnCallMethodArgType: []string{"string"},
+					RetArgList:          []interface{}{&dns.ClientConfig{Servers: []string{"1.1.1.1"}, Port: "1234"}, nil},
+					CallTimes:           1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, clusterSubnetIP, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{OnCallMethodName: "NewAddressSet", OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{mockAddressSetOps, nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
 				{
@@ -191,17 +211,22 @@ func TestAdd(t *testing.T) {
 			configIPv6: false,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{},
-					[]interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300"), generateRR(test1DNSName, clusterSubnetIP, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{
+					OnCallMethodName:    "ClientConfigFromFile",
+					OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&dns.ClientConfig{Servers: []string{"1.1.1.1"}, Port: "1234"}, nil},
+					CallTimes: 1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300"), generateRR(test1DNSName, clusterSubnetIP, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{OnCallMethodName: "NewAddressSet", OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"}, RetArgList: []interface{}{mockAddressSetOps, nil}, CallTimes: 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
 				{
@@ -221,18 +246,31 @@ func TestAdd(t *testing.T) {
 			configIPv6:               true,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{
+					OnCallMethodName:    "ClientConfigFromFile",
+					OnCallMethodArgType: []string{"string"},
+					RetArgList:          []interface{}{&dns.ClientConfig{Servers: []string{"1.1.1.1"}, Port: "1234"}, nil},
+					CallTimes:           1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{OnCallMethodName: "NewAddressSet", OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{mockAddressSetOps, nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
 				{
@@ -252,21 +290,33 @@ func TestAdd(t *testing.T) {
 			configIPv6:               false,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
 
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{OnCallMethodName: "ClientConfigFromFile",
+					OnCallMethodArgType: []string{"string"},
+					RetArgList:          []interface{}{&dns.ClientConfig{Servers: []string{"1.1.1.1"}, Port: "1234"}, nil},
+					CallTimes:           1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
 				// return a very low ttl so that the update based on ttl timeout occurs
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "4")}}, 1 * time.Second, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4Update, "300")}}, 1 * time.Second, nil}, 0, 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "4")}}, 1 * time.Second, nil},
+					CallTimes:           1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4Update, "300")}}, 1 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{OnCallMethodName: "NewAddressSet", OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{mockAddressSetOps, nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
 				{
@@ -321,7 +371,8 @@ func TestAdd(t *testing.T) {
 			res, err := NewEgressDNS(mockAddressSetFactoryOps, DefaultNetworkControllerName, testCh, tc.syncTime)
 			assert.NoError(t, err)
 
-			res.Run()
+			err = res.Run()
+			assert.NoError(t, err)
 
 			_, err = res.Add("addNamespace", test1DNSName)
 			if tc.errExp {
@@ -404,22 +455,35 @@ func TestDelete(t *testing.T) {
 			configIPv6:               true,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
-					Servers: []string{"1.1.1.1"},
-					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{
+					OnCallMethodName:    "ClientConfigFromFile",
+					OnCallMethodArgType: []string{"string"},
+					RetArgList:          []interface{}{&dns.ClientConfig{Servers: []string{"1.1.1.1"}, Port: "1234"}, nil},
+					CallTimes:           1,
+				},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{test1DNSName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"*ops.DbObjectIDs", "[]string"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{OnCallMethodName: "NewAddressSet", OnCallMethodArgType: []string{"*ops.DbObjectIDs", "[]string"}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{mockAddressSetOps, nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
-				{"SetAddresses", []string{"[]string"}, []interface{}{}, []interface{}{nil}, 0, 1},
-				{"Destroy", []string{}, []interface{}{}, []interface{}{nil}, 0, 1},
+				{OnCallMethodName: "SetAddresses", OnCallMethodArgType: []string{"[]string"}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
+				{OnCallMethodName: "Destroy", OnCallMethodArgType: []string{}, OnCallMethodArgs: []interface{}{}, RetArgList: []interface{}{nil}, OnCallMethodsArgsStrTypeAppendCount: 0, CallTimes: 1},
 			},
 		},
 	}
@@ -462,7 +526,8 @@ func TestDelete(t *testing.T) {
 			res, err := NewEgressDNS(mockAddressSetFactoryOps, DefaultNetworkControllerName, testCh, tc.syncTime)
 			assert.NoError(t, err)
 
-			res.Run()
+			err = res.Run()
+			assert.NoError(t, err)
 
 			_, err = res.Add("addNamespace", test1DNSName)
 			if tc.errExp {
@@ -485,7 +550,8 @@ func TestDelete(t *testing.T) {
 				}
 			}
 			_, dnsResolves, _ := res.getDNSEntry(tc.dnsName)
-			res.Delete("addNamespace")
+			err = res.Delete("addNamespace")
+			assert.NoError(t, err)
 			for stay, timeout := true, time.After(10*time.Second); stay; {
 				_, dnsResolves, _ = res.getDNSEntry(tc.dnsName)
 				if dnsResolves == nil {

--- a/go-controller/pkg/ovn/dns_name_resolver/external_dns_test.go
+++ b/go-controller/pkg/ovn/dns_name_resolver/external_dns_test.go
@@ -53,7 +53,7 @@ func newDNSNameResolverObject(name, namespace, dnsName string, addresses []strin
 
 func expectDNSNameWithAddresses(extEgDNS *ExternalEgressDNS, dnsName string, expectedAddresses []string) {
 	var resolvedName *dnsResolvedName
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, true, func(context.Context) (done bool, err error) {
 		var exists bool
 		resolvedName, exists = extEgDNS.getResolvedName(dnsName)
 		if !exists {
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("Egress Firewall External DNS Operations", func() {
 				Delete(context.TODO(), dnsNameResolver.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, true, func(context.Context) (done bool, err error) {
 				_, exists := extEgDNS.getResolvedName(dnsName)
 				if exists {
 					return false, nil
@@ -280,7 +280,7 @@ var _ = ginkgo.Describe("Egress Firewall External DNS Operations", func() {
 		err = extEgDNS.Delete(namespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, true, func(context.Context) (done bool, err error) {
 			_, exists := extEgDNS.getResolvedName(dnsName)
 			if exists {
 				return false, nil

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/utils/net"
@@ -31,7 +31,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
-	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	t "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	util_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
@@ -78,8 +77,8 @@ func newDNSNameResolverObject(name, namespace, dnsName string, ip string) *ocpne
 	}
 }
 
-func getEFExpectedDb(initialData []libovsdbtest.TestData, fakeOVN *FakeOVN, nsName string, dstMatch, portMatch string,
-	action nbdb.ACLAction) []libovsdbtest.TestData {
+func getEFExpectedDb(initialData []libovsdb.TestData, fakeOVN *FakeOVN, nsName string, dstMatch, portMatch string,
+	action nbdb.ACLAction) []libovsdb.TestData {
 	pgName := fakeOVN.controller.getNamespacePortGroupName(nsName)
 	dbIDs := fakeOVN.controller.getEgressFirewallACLDbIDs(nsName, 0)
 	match := dstMatch + " && inport == @" + pgName
@@ -108,7 +107,7 @@ func getEFExpectedDb(initialData []libovsdbtest.TestData, fakeOVN *FakeOVN, nsNa
 	return append(initialData, acl, namespacePortGroup)
 }
 
-func getEFExpectedDbAfterDelete(prevExpectedData []libovsdbtest.TestData) []libovsdbtest.TestData {
+func getEFExpectedDbAfterDelete(prevExpectedData []libovsdb.TestData) []libovsdb.TestData {
 	pg := prevExpectedData[len(prevExpectedData)-1].(*nbdb.PortGroup)
 	pg.ACLs = nil
 	return append(prevExpectedData[:len(prevExpectedData)-2], pg)
@@ -120,8 +119,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		fakeOVN                *FakeOVN
 		clusterPortGroup       *nbdb.PortGroup
 		nodeSwitch, joinSwitch *nbdb.LogicalSwitch
-		initialData            []libovsdbtest.TestData
-		dbSetup                libovsdbtest.TestSetup
+		initialData            []libovsdb.TestData
+		dbSetup                libovsdb.TestSetup
 		mockDnsOps             *util_mocks.DNSOps
 	)
 	const (
@@ -172,9 +171,14 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 	setDNSOpsMock := func(dnsName, retIP string) {
 		methods := []ovntest.TestifyMockHelper{
-			{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
-			{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-			{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(dnsName, retIP, "300")}}, 500 * time.Second, nil}, 0, 1},
+			{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1},
+			{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+			{
+				OnCallMethodName:    "Exchange",
+				OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+				RetArgList:          []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(dnsName, retIP, "300")}}, 500 * time.Second, nil},
+				CallTimes:           1,
+			},
 		}
 		for _, item := range methods {
 			call := mockDnsOps.On(item.OnCallMethodName)
@@ -207,16 +211,16 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		}
 	}
 
-	startOvnWithNodes := func(dbSetup libovsdb.TestSetup, namespaces []v1.Namespace, egressFirewalls []egressfirewallapi.EgressFirewall,
-		nodes []v1.Node, oldDNS bool) {
+	startOvnWithNodes := func(dbSetup libovsdb.TestSetup, namespaces []corev1.Namespace, egressFirewalls []egressfirewallapi.EgressFirewall,
+		nodes []corev1.Node, oldDNS bool) {
 		fakeOVN.startWithDBSetup(dbSetup,
 			&egressfirewallapi.EgressFirewallList{
 				Items: egressFirewalls,
 			},
-			&v1.NamespaceList{
+			&corev1.NamespaceList{
 				Items: namespaces,
 			},
-			&v1.NodeList{
+			&corev1.NodeList{
 				Items: nodes,
 			},
 		)
@@ -243,13 +247,13 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		}
 	}
 
-	startOvn := func(dbSetup libovsdb.TestSetup, namespaces []v1.Namespace, egressFirewalls []egressfirewallapi.EgressFirewall, oldDNS bool) {
+	startOvn := func(dbSetup libovsdb.TestSetup, namespaces []corev1.Namespace, egressFirewalls []egressfirewallapi.EgressFirewall, oldDNS bool) {
 		startOvnWithNodes(dbSetup, namespaces, egressFirewalls, nil, oldDNS)
 	}
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		config.OVNKubernetesFeature.EnableEgressFirewall = true
 
 		app = cli.NewApp()
@@ -266,13 +270,13 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			UUID: "join-UUID",
 			Name: "join",
 		}
-		initialData = []libovsdbtest.TestData{
+		initialData = []libovsdb.TestData{
 			nodeSwitch,
 			joinSwitch,
 			clusterPortGroup,
 			clusterRouter,
 		}
-		dbSetup = libovsdbtest.TestSetup{
+		dbSetup = libovsdb.TestSetup{
 			NBData: initialData,
 		}
 	})
@@ -289,7 +293,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		ginkgo.Context("on startup", func() {
 			ginkgo.It(fmt.Sprintf("reconciles stale ACLs, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					// owned by non-existing namespace
 					fakeController := getFakeController(DefaultNetworkControllerName)
 					purgeIDs := fakeController.getEgressFirewallACLDbIDs("none", 0)
@@ -374,8 +378,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					joinSwitch.ACLs = []string{purgeACL.UUID, purgeACL2.UUID, updateACL.UUID, ignoreACL.UUID}
 					clusterPortGroup.ACLs = []string{purgeACL.UUID, purgeACL2.UUID, updateACL.UUID, ignoreACL.UUID}
 
-					dbSetup := libovsdbtest.TestSetup{
-						NBData: []libovsdbtest.TestData{
+					dbSetup := libovsdb.TestSetup{
+						NBData: []libovsdb.TestData{
 							purgeACL,
 							purgeACL2,
 							ignoreACL,
@@ -388,7 +392,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					}
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					// All ACLs in the egress firewall priority range will be removed from the switches
 					joinSwitch.ACLs = []string{ignoreACL.UUID}
@@ -422,7 +426,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						namespacePG,
 					}
 
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
 
@@ -432,7 +436,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("reconciles an existing egressFirewall with IPv4 CIDR, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -443,7 +447,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
@@ -451,7 +455,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -462,7 +466,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("reconciles an existing egressFirewall with IPv6 CIDR, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -474,11 +478,11 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					})
 
 					config.IPv6Mode = true
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64)", "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -489,7 +493,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("removes stale acl for delete egress firewall, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					fakeController := getFakeController(DefaultNetworkControllerName)
 					fakeOVN.controller = fakeController
@@ -498,13 +502,13 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					// no egress firewalls exist
 					dbSetup := getEFExpectedDb(initialData, fakeOVN, "namespace1", "(ip4.dst == 1.2.3.4/23)",
 						"", nbdb.ACLActionAllow)
-					startOvn(libovsdbtest.TestSetup{NBData: dbSetup}, []v1.Namespace{namespace1}, nil, true)
+					startOvn(libovsdb.TestSetup{NBData: dbSetup}, []corev1.Namespace{namespace1}, nil, true)
 
 					// re-create initial db, since startOvn may add more objects to initialData
 					initialDatabaseState := getEFExpectedDb(initialData, fakeOVN, "namespace1", "(ip4.dst == 1.2.3.4/23)",
 						"", nbdb.ACLActionAllow)
 					expectedDatabaseState := getEFExpectedDbAfterDelete(initialDatabaseState)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
 
@@ -519,7 +523,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				}
 				config.Gateway.Mode = gwMode
 
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					resolvedIP := "1.1.1.1"
 					namespace1 := *newNamespace("namespace1")
 					dnsName := util.LowerCaseFQDN("www.example.com")
@@ -536,7 +540,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						"(ip4.dst == $"+addrSetUUID+")", "", nbdb.ACLActionAllow)
 					addrSetDbState := append(dbWithACLAndPG, addrSet)
 
-					startOvn(libovsdbtest.TestSetup{NBData: addrSetDbState}, []v1.Namespace{namespace1}, nil, oldDNS)
+					startOvn(libovsdb.TestSetup{NBData: addrSetDbState}, []corev1.Namespace{namespace1}, nil, oldDNS)
 
 					// re-create initial db, since startOvn may add more objects to initialData.
 					dbWithACLAndPG = getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
@@ -544,7 +548,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					expectedDatabaseState := getEFExpectedDbAfterDelete(dbWithACLAndPG)
 
 					// check dns address set is cleaned up on initial sync.
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -558,7 +562,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		ginkgo.Context("during execution", func() {
 			ginkgo.It(fmt.Sprintf("correctly creates an egressfirewall denying traffic udp traffic on port 100, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -574,14 +578,14 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "((udp && ( udp.dst == 100 )))", nbdb.ACLActionDrop)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -589,7 +593,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("correctly deletes an egressfirewall, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -606,17 +610,17 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.5/23)", "((tcp && ( tcp.dst == 100 )))", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState = getEFExpectedDbAfterDelete(expectedDatabaseState)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -626,7 +630,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("correctly updates an egressfirewall, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -645,11 +649,11 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -658,7 +662,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					expectedDatabaseState = getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionDrop)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -677,7 +681,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.IPv4Mode = true
 				config.IPv6Mode = true
 
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					labelKey := "name"
 					labelValue := "test"
@@ -691,8 +695,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvnWithNodes(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
-						[]v1.Node{
+					startOvnWithNodes(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
+						[]corev1.Node{
 							{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: nodeName,
@@ -722,7 +726,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					expectedDatabaseState := getEFExpectedDb(initialData,
 						fakeOVN, namespace1.Name,
 						fmt.Sprintf("(ip4.dst == %s || ip4.dst == %s || ip6.dst == %s)", nodeIP2, nodeIP, nodeIP3), "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					ginkgo.By("Updating a node to not match nodeSelector on Egress Firewall")
 					patch.Metadata = map[string]interface{}{"labels": map[string]string{labelKey: libovsdbutil.UnspecifiedL4Match}}
@@ -734,7 +738,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState = getEFExpectedDbAfterDelete(expectedDatabaseState)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -752,7 +756,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.IPv4Mode = true
 				config.IPv6Mode = true
 
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					labelKey := "name"
 					labelValue := "test"
@@ -766,8 +770,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvnWithNodes(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
-						[]v1.Node{
+					startOvnWithNodes(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
+						[]corev1.Node{
 							{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: nodeName,
@@ -782,7 +786,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					expectedDatabaseState := getEFExpectedDb(initialData,
 						fakeOVN, namespace1.Name,
 						fmt.Sprintf("(ip4.dst == %s || ip4.dst == %s || ip6.dst == %s)", nodeIP2, nodeIP, nodeIP3), "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					ginkgo.By("Deleting a node")
 					// trigger delete event
@@ -791,7 +795,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState = getEFExpectedDbAfterDelete(expectedDatabaseState)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -808,7 +812,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				v4NodeSubnet := "10.128.0.0/16"
 
 				config.IPv4Mode = true
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespace1 := *newNamespace("namespace1")
 					labelKey := "name"
@@ -823,7 +827,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewallObj}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewallObj}, true)
 					err = fakeOVN.controller.WatchNodes()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -837,7 +841,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// now add node, then update node, check that both events are handled immediately
 					// check that egressfirewall node event is only handled after lock release
-					node := &v1.Node{
+					node := &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: nodeName,
 							Annotations: map[string]string{
@@ -903,7 +907,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 			ginkgo.It(fmt.Sprintf("correctly retries deleting an egressfirewall, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
@@ -921,17 +925,17 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvnWithNodes(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
-						[]v1.Node{
+					startOvnWithNodes(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
+						[]corev1.Node{
 							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
+								Status: corev1.NodeStatus{
+									Phase: corev1.NodeRunning,
 								},
 								ObjectMeta: newObjectMeta(node1Name, ""),
 							},
 							{
-								Status: v1.NodeStatus{
-									Phase: v1.NodeRunning,
+								Status: corev1.NodeStatus{
+									Phase: corev1.NodeRunning,
 								},
 								ObjectMeta: newObjectMeta(node2Name, ""),
 							},
@@ -939,7 +943,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.5/23)", "((tcp && ( tcp.dst == 100 )))", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					ginkgo.By("Bringing down NBDB")
 					// inject transient problem, nbdb is down
@@ -969,7 +973,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					fakeOVN.controller.retryEgressFirewalls.RequestRetryObjs()
 
 					expectedDatabaseState = getEFExpectedDbAfterDelete(expectedDatabaseState)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					// check the cache no longer has the entry
 					retry.CheckRetryObjectEventually(key, false, fakeOVN.controller.retryEgressFirewalls)
 					return nil
@@ -980,7 +984,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("correctly retries adding and updating an egressfirewall, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -999,11 +1003,11 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					ginkgo.By("Bringing down NBDB")
 					// inject transient problem, nbdb is down
@@ -1043,7 +1047,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					expectedDatabaseState = getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionDrop)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
 
@@ -1053,7 +1057,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("correctly updates an egressfirewall's ACL logging, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -1064,11 +1068,11 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.4/23)", "", nbdb.ACLActionAllow)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					// get the current namespace
 					namespace, err := fakeOVN.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
@@ -1085,7 +1089,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					acl := expectedDatabaseState[len(expectedDatabaseState)-2].(*nbdb.ACL)
 					acl.Log = true
 					acl.Severity = &logSeverity
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -1111,7 +1115,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						config.IPv6Mode = true
 						nodeCIDR = nodeIP6CIDR
 					}
-					app.Action = func(ctx *cli.Context) error {
+					app.Action = func(*cli.Context) error {
 						labelKey := "name"
 						labelValue := "test"
 						selector := metav1.LabelSelector{MatchLabels: map[string]string{labelKey: labelValue}}
@@ -1128,8 +1132,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						mdata.Labels = map[string]string{labelKey: labelValue}
 						mdata.Annotations = map[string]string{util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", nodeCIDR)}
 
-						startOvnWithNodes(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
-							[]v1.Node{
+						startOvnWithNodes(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall},
+							[]corev1.Node{
 								{
 									ObjectMeta: mdata,
 								},
@@ -1142,7 +1146,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						}
 						expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 							match, "", nbdb.ACLActionAllow)
-						gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+						gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 						return nil
 					}
@@ -1153,7 +1157,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			}
 			ginkgo.It(fmt.Sprintf("correctly creates an egressfirewall with subnet exclusion, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					clusterSubnetStr := "10.128.0.0/14"
 					_, clusterSubnet, _ := net.ParseCIDR(clusterSubnetStr)
 					config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: clusterSubnet}}
@@ -1167,14 +1171,14 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 0.0.0.0/0 && ip4.dst != "+clusterSubnetStr+")", "", nbdb.ACLActionDrop)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -1182,7 +1186,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
 			ginkgo.It(fmt.Sprintf("correctly creates an egressfirewall for namespace name > 43 symbols, gateway mode %s", gwMode), func() {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					// 52 characters namespace
 					namespace1 := *newNamespace("abcdefghigklmnopqrstuvwxyzabcdefghigklmnopqrstuvwxyz")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
@@ -1200,7 +1204,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						},
 					})
 
-					startOvn(dbSetup, []v1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
 
 					dbWith1ACL := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == 1.2.3.5/23)", "", nbdb.ACLActionAllow)
@@ -1224,18 +1228,18 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					pg.ACLs = append(pg.ACLs, ipv4ACL2.UUID)
 
 					expectedDatabaseState := append(dbWith1ACL, ipv4ACL2)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					err := fakeOVN.controller.syncEgressFirewall([]interface{}{egressFirewall})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					// ACL should be removed from the port group egfw is deleted
 					expectedDatabaseState = getEFExpectedDbAfterDelete(dbWith1ACL)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					return nil
 				}
@@ -1245,7 +1249,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 			})
 			ginkgo.It(fmt.Sprintf("correctly deletes object that failed to be created, gateway mode %s", gwMode), func() {
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
@@ -1256,7 +1260,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, nil, true)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, nil, true)
 
 					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Create(context.TODO(), egressFirewall, metav1.CreateOptions{})
@@ -1287,7 +1291,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					// enable the dns name resolver flag.
 					config.OVNKubernetesFeature.EnableDNSNameResolver = true
 				}
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					dnsName := "a.b.c"
 					dnsNameLowerCaseFQDN := util.LowerCaseFQDN(dnsName)
@@ -1331,7 +1335,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						dnsnameresolver.GetEgressFirewallDNSAddrSetDbIDs(dnsNameForAddrSet, fakeOVN.controller.controllerName),
 						[]string{resolvedIP})
 					expectedDatabaseState := append(initialData, addrSet)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 
 					// delete failed object
 					err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
@@ -1350,7 +1354,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					}
 
 					// check dns address set is cleaned up on delete
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(initialData))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(initialData))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -1365,7 +1369,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					config.OVNKubernetesFeature.EnableDNSNameResolver = true
 				}
 				config.Gateway.Mode = gwMode
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
 					dnsNameLowerCaseFQDN := util.LowerCaseFQDN(dnsName)
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
@@ -1376,7 +1380,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, nil, oldDNS)
+					startOvn(dbSetup, []corev1.Namespace{namespace1}, nil, oldDNS)
 
 					if oldDNS {
 						setDNSOpsMock(dnsName, resolvedIP)
@@ -1405,7 +1409,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					dbWithACLAndPG := getEFExpectedDb(initialData, fakeOVN, namespace1.Name,
 						"(ip4.dst == $"+addrSetUUID+")", "", nbdb.ACLActionAllow)
 					addrSetDbState := append(dbWithACLAndPG, addrSet)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(addrSetDbState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(addrSetDbState))
 
 					// delete the egress firewall object.
 					err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
@@ -1421,7 +1425,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// check dns address set is cleaned up on delete.
 					expectedDatabaseState := getEFExpectedDbAfterDelete(dbWithACLAndPG)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -1454,7 +1458,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each test
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		config.Gateway.Mode = config.GatewayModeShared
 		config.OVNKubernetesFeature.EnableEgressFirewall = true
 
@@ -1462,22 +1466,22 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		dbSetup := libovsdbtest.TestSetup{}
+		dbSetup := libovsdb.TestSetup{}
 		fakeOVN = NewFakeOVN(false)
 		a := newObjectMeta(node1Name, "")
 		a.Labels = nodeLabel
 		a.Annotations = map[string]string{
 			util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s/24\"]", node1Addr),
 		}
-		node1 := v1.Node{ObjectMeta: a}
+		node1 := corev1.Node{ObjectMeta: a}
 		b := newObjectMeta(node2Name, "")
 		b.Annotations = map[string]string{
 			util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s/24\"]", node2Addr),
 		}
-		node2 := v1.Node{
+		node2 := corev1.Node{
 			ObjectMeta: b,
 		}
-		fakeOVN.startWithDBSetup(dbSetup, &v1.NodeList{Items: []v1.Node{node1, node2}})
+		fakeOVN.startWithDBSetup(dbSetup, &corev1.NodeList{Items: []corev1.Node{node1, node2}})
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -24,7 +24,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -61,7 +60,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 	ginkgo.Context("on setting namespace gateway annotations", func() {
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace single exgw annotation already set", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1"}
@@ -92,18 +91,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -204,7 +203,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace single exgw annotation already set with pod event first", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1"}
@@ -235,13 +234,13 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -345,7 +344,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace double exgw annotation already set", func(bfd bool, finalNB []libovsdbtest.TestData) {
 
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2"}
@@ -376,18 +375,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -519,7 +518,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				initNB []libovsdbtest.TestData,
 				finalNB []libovsdbtest.TestData,
 			) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespaceT := *newNamespace(namespaceName)
 					namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2"}
@@ -541,18 +540,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT,
 							},
 						},
-						&v1.NodeList{
-							Items: []v1.Node{
+						&corev1.NodeList{
+							Items: []corev1.Node{
 								*newNode("node1", "192.168.126.202/24"),
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -681,7 +680,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			func(bfd bool,
 				initNB []libovsdbtest.TestData,
 				finalNB []libovsdbtest.TestData) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespaceT := *newNamespace(namespaceName)
 					namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "fd2e:6f44:5dd8::89,fd2e:6f44:5dd8::76"}
 					if bfd {
@@ -702,18 +701,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT,
 							},
 						},
-						&v1.NodeList{
-							Items: []v1.Node{
+						&corev1.NodeList{
+							Items: []corev1.Node{
 								*newNode("node1", "192.168.126.202/24"),
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -797,7 +796,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				initNB []libovsdbtest.TestData,
 				finalNB []libovsdbtest.TestData,
 			) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespaceT := *newNamespace(namespaceName)
 					namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2"}
@@ -819,18 +818,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT,
 							},
 						},
-						&v1.NodeList{
-							Items: []v1.Node{
+						&corev1.NodeList{
+							Items: []corev1.Node{
 								*newNode("node1", "192.168.126.202/24"),
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -992,7 +991,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gwPodName      = "gwPod"
 		)
 		ginkgo.DescribeTable("reconciles a host networked pod acting as a exgw for another namespace for new pod", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceX := *newNamespace(namespace2Name)
@@ -1029,26 +1028,27 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node2", "192.168.126.51/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							gwPod,
 						},
 					},
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				injectNode(fakeOvn)
-				err := fakeOvn.controller.WatchNamespaces()
+				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1154,7 +1154,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles a host networked pod acting as a exgw for another namespace for existing pod", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceX := *newNamespace(namespace2Name)
@@ -1191,26 +1191,27 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node2", "192.168.126.51/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				injectNode(fakeOvn)
-				err := fakeOvn.controller.WatchNamespaces()
+				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1314,7 +1315,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles a multus networked pod acting as a exgw for another namespace for new pod", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				ns := nettypes.NetworkStatus{Name: "dummy", IPs: []string{"11.0.0.1"}}
 				networkStatuses := []nettypes.NetworkStatus{ns}
 				nsEncoded, err := json.Marshal(networkStatuses)
@@ -1359,24 +1360,25 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node2", "192.168.126.51/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							gwPod,
 						},
 					},
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				err = fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				injectNode(fakeOvn)
 				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1489,7 +1491,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				afterDeleteNB []libovsdbtest.TestData,
 				expectedNamespaceAnnotation string,
 				apbExternalRouteCRList *adminpolicybasedrouteapi.AdminPolicyBasedExternalRouteList) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespaceT := *newNamespace(namespaceName)
 					namespaceX := *newNamespace(namespace2Name)
@@ -1526,28 +1528,29 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 								},
 							},
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT, namespaceX,
 							},
 						},
-						&v1.NodeList{
-							Items: []v1.Node{
+						&corev1.NodeList{
+							Items: []corev1.Node{
 								*newNode("node1", "192.168.126.202/24"),
 								*newNode("node2", "192.168.126.50/24"),
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
 						apbExternalRouteCRList,
 					)
 					t.populateLogicalSwitchCache(fakeOvn)
-					fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+					err := fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					injectNode(fakeOvn)
-					err := fakeOvn.controller.WatchNamespaces()
+					err = fakeOvn.controller.WatchNamespaces()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					err = fakeOvn.controller.WatchPods()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1817,7 +1820,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 	})
 	ginkgo.Context("on using bfd", func() {
 		ginkgo.It("should enable bfd only on the namespace gw when set", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1"}
@@ -1854,27 +1857,28 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 							*newNode("node2", "192.168.126.50/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				injectNode(fakeOvn)
-				err := fakeOvn.controller.WatchNamespaces()
+				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1949,7 +1953,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should enable bfd only on the gw pod when set", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1"}
@@ -1987,27 +1991,28 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 							*newNode("node2", "192.168.126.50/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch("node2", []*net.IPNet{ovntest.MustParseIPNet("10.128.2.0/24")})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				injectNode(fakeOvn)
-				err := fakeOvn.controller.WatchNamespaces()
+				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2082,7 +2087,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should disable bfd when removing the annotation from the namespace", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace(namespaceName)
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1"}
 				namespaceT.Annotations["k8s.ovn.org/bfd-enabled"] = ""
@@ -2128,18 +2133,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -2202,7 +2207,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 	})
 	ginkgo.Context("hybrid route policy operations in lgw mode", func() {
 		ginkgo.It("add hybrid route policy for pods", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				fakeOvn.startWithDBSetup(
@@ -2226,7 +2231,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				finalNB := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						UUID:     "2a7a61cb-fb13-4266-a3f0-9ac5c4471123 [u2596996164]",
-						Priority: types.HybridOverlayReroutePriority,
+						Priority: ovntypes.HybridOverlayReroutePriority,
 						Action:   nbdb.LogicalRouterPolicyActionReroute,
 						Nexthops: []string{"100.64.0.4"},
 						Match:    "inport == \"rtos-node1\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
@@ -2257,7 +2262,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should reconcile a pod and create/delete the hybridRoutePolicy accordingly", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				namespaceT := *newNamespace("namespace1")
@@ -2296,18 +2301,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -2328,7 +2333,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Action:   "reroute",
 						Match:    "inport == \"rtos-node1\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
 						Nexthops: []string{"100.64.0.4"},
-						Priority: types.HybridOverlayReroutePriority,
+						Priority: ovntypes.HybridOverlayReroutePriority,
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + "node1" + "-UUID",
@@ -2413,7 +2418,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 		})
 		ginkgo.DescribeTable("should keep the hybrid route policy after deleting the namespace gateway annotation when there is an APB External Route CR overlapping the same external gateway IP", func(legacyFirst bool) {
 
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				namespaceT := *newNamespace("namespace1")
@@ -2452,18 +2457,18 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -2475,7 +2480,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				apbRoute := newPolicy("policy",
 					&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespaceT.Name}},
-					sets.NewString("9.0.0.1"),
+					sets.New("9.0.0.1"),
 					false,
 					nil,
 					nil,
@@ -2510,7 +2515,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Action:   "reroute",
 						Match:    "inport == \"rtos-node1\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
 						Nexthops: []string{"100.64.0.4"},
-						Priority: types.HybridOverlayReroutePriority,
+						Priority: ovntypes.HybridOverlayReroutePriority,
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + "node1" + "-UUID",
@@ -2581,7 +2586,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			ginkgo.Entry("when external_gw handles first", true))
 
 		ginkgo.It("should create a single policy for concurrent addHybridRoutePolicy for the same node", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				fakeOvn.startWithDBSetup(
@@ -2605,7 +2610,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				finalNB := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						UUID:     "lrp1",
-						Priority: types.HybridOverlayReroutePriority,
+						Priority: ovntypes.HybridOverlayReroutePriority,
 						Action:   nbdb.LogicalRouterPolicyActionReroute,
 						Nexthops: []string{"100.64.0.4"},
 						Match:    "inport == \"rtos-node1\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
@@ -2629,9 +2634,11 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					podIndex := i
 					wg.Add(1)
 					go func() {
+						defer ginkgo.GinkgoRecover()
 						defer wg.Done()
 						<-c
-						fakeOvn.controller.addHybridRoutePolicyForPod(net.ParseIP(fmt.Sprintf("10.128.1.%d", podIndex)), "node1")
+						// errors can happen due to server side concurrency check
+						_ = fakeOvn.controller.addHybridRoutePolicyForPod(net.ParseIP(fmt.Sprintf("10.128.1.%d", podIndex)), "node1")
 					}()
 				}
 				close(c)
@@ -2650,7 +2657,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete hybrid route policy for pods", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				asIndex := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				asv4, _ := addressset.GetHashNamesForAS(asIndex)
@@ -2659,7 +2666,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPolicy{
 								UUID:     "2a7a61cb-fb13-4266-a3f0-9ac5c4471123 [u2596996164]",
-								Priority: types.HybridOverlayReroutePriority,
+								Priority: ovntypes.HybridOverlayReroutePriority,
 								Action:   nbdb.LogicalRouterPolicyActionReroute,
 								Nexthops: []string{"100.64.0.4"},
 								Match:    "inport == \"rtos-node1\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
@@ -2713,7 +2720,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete hybrid route policy for pods with force", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				asIndex1 := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				as1v4, _ := addressset.GetHashNamesForAS(asIndex1)
@@ -2724,14 +2731,14 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPolicy{
 								UUID:     "501-1st-UUID",
-								Priority: types.HybridOverlayReroutePriority,
+								Priority: ovntypes.HybridOverlayReroutePriority,
 								Action:   nbdb.LogicalRouterPolicyActionReroute,
 								Nexthops: []string{"100.64.0.4"},
 								Match:    "inport == \"rtos-node1\" && ip4.src == $" + as1v4 + " && ip4.dst != 10.128.0.0/14",
 							},
 							&nbdb.LogicalRouterPolicy{
 								UUID:     "501-2nd-UUID",
-								Priority: types.HybridOverlayReroutePriority,
+								Priority: ovntypes.HybridOverlayReroutePriority,
 								Action:   nbdb.LogicalRouterPolicyActionReroute,
 								Nexthops: []string{"100.64.1.4"},
 								Match:    "inport == \"rtos-node2\" && ip4.src == $" + as2v4 + " && ip4.dst != 10.128.0.0/14",
@@ -2784,7 +2791,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete legacy hybrid route policies", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				asIndex := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				asv4, _ := addressset.GetHashNamesForAS(asIndex)
@@ -2793,21 +2800,21 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPolicy{
 								UUID:     "501-1st-UUID",
-								Priority: types.HybridOverlayReroutePriority,
+								Priority: ovntypes.HybridOverlayReroutePriority,
 								Action:   nbdb.LogicalRouterPolicyActionReroute,
 								Nexthops: []string{"100.64.0.4"},
 								Match:    "inport == \"rtos-node1\" && ip4.src == 1.3.3.7 && ip4.dst != 10.128.0.0/14",
 							},
 							&nbdb.LogicalRouterPolicy{
 								UUID:     "501-2nd-UUID",
-								Priority: types.HybridOverlayReroutePriority,
+								Priority: ovntypes.HybridOverlayReroutePriority,
 								Action:   nbdb.LogicalRouterPolicyActionReroute,
 								Nexthops: []string{"100.64.1.4"},
 								Match:    "inport == \"rtos-node2\" && ip4.src == 1.3.3.8 && ip4.dst != 10.128.0.0/14",
 							},
 							&nbdb.LogicalRouterPolicy{
 								UUID:     "501-new-UUID",
-								Priority: types.HybridOverlayReroutePriority,
+								Priority: ovntypes.HybridOverlayReroutePriority,
 								Action:   nbdb.LogicalRouterPolicyActionReroute,
 								Nexthops: []string{"100.64.1.4"},
 								Match:    "inport == \"rtos-node2\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
@@ -2833,7 +2840,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				finalNB := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						UUID:     "501-new-UUID",
-						Priority: types.HybridOverlayReroutePriority,
+						Priority: ovntypes.HybridOverlayReroutePriority,
 						Action:   nbdb.LogicalRouterPolicyActionReroute,
 						Nexthops: []string{"100.64.1.4"},
 						Match:    "inport == \"rtos-node2\" && ip4.src == $" + asv4 + " && ip4.dst != 10.128.0.0/14",
@@ -2865,7 +2872,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete stale addresses from legacy hybrid route policies on startup", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				asIndex := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				asv4, _ := addressset.GetHashNamesForAS(asIndex)
@@ -2931,8 +2938,8 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							testNode,
 						},
 					},
@@ -2982,7 +2989,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 	})
 	ginkgo.Context("SNAT on gateway router operations", func() {
 		ginkgo.It("add/delete SNAT per pod on gateway router", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				config.Gateway.DisableSNATMultipleGWs = true
 
@@ -2999,7 +3006,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					namespaceT.Name,
 				)
 
-				pod := []v1.Pod{
+				pod := []corev1.Pod{
 					*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 				}
 
@@ -3012,8 +3019,8 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 								Networks: []string{"100.64.0.4/32"},
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + nodeName,
-								UUID:  types.GWRouterPrefix + nodeName + "-UUID",
+								Name:  ovntypes.GWRouterPrefix + nodeName,
+								UUID:  ovntypes.GWRouterPrefix + nodeName + "-UUID",
 								Ports: []string{ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID"},
 							},
 							&nbdb.LogicalSwitch{
@@ -3022,17 +3029,17 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
+					&corev1.PodList{
 						Items: pod,
 					},
 				)
@@ -3045,8 +3052,8 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Type:       nbdb.NATTypeSNAT,
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + nodeName,
-						UUID:  types.GWRouterPrefix + nodeName + "-UUID",
+						Name:  ovntypes.GWRouterPrefix + nodeName,
+						UUID:  ovntypes.GWRouterPrefix + nodeName + "-UUID",
 						Ports: []string{ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID"},
 						Nat:   []string{"nat-UUID"},
 					},
@@ -3076,8 +3083,8 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + nodeName,
-						UUID:  types.GWRouterPrefix + nodeName + "-UUID",
+						Name:  ovntypes.GWRouterPrefix + nodeName,
+						UUID:  ovntypes.GWRouterPrefix + nodeName + "-UUID",
 						Ports: []string{ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID"},
 						Nat:   []string{},
 					},
@@ -3106,7 +3113,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 // injectNode adds a valid node to the nodeinformer so the get
 // to understand if there are two bridged won't fail
 func injectNode(fakeOvn *FakeOVN) {
-	node := &v1.Node{
+	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Annotations: map[string]string{"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.2/24", "next-hop":"169.254.33.1"}}`,

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -8154,7 +8154,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-				gomega.Eventually(eIP.Status.Items).Should(gomega.HaveLen(0))
+				gomega.Eventually(eIP.Status.Items).Should(gomega.BeEmpty())
 
 				node.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
@@ -9594,7 +9594,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					egressNodeIPsASv4,
 				}
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-				gomega.Eventually(eIP.Status.Items).Should(gomega.HaveLen(0))
+				gomega.Eventually(eIP.Status.Items).Should(gomega.BeEmpty())
 
 				node1.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -2604,12 +2604,6 @@ func buildEgressIPServedPodsAddressSetsForController(ips []string, network, cont
 
 }
 
-// returns the address set with externalID "k8s.ovn.org/name": "node-ips"
-func buildEgressIPNodeAddressSetsForController(ips []string) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, DefaultNetworkControllerName)
-	return addressset.GetTestDbAddrSets(dbIDs, ips)
-}
-
 // returns the LRP for marking reply traffic and not routing
 func getNoReRouteReplyTrafficPolicyForController(network, controller string) *nbdb.LogicalRouterPolicy {
 	return &nbdb.LogicalRouterPolicy{

--- a/go-controller/pkg/ovn/egressqos_test.go
+++ b/go-controller/pkg/ovn/egressqos_test.go
@@ -225,7 +225,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					_, err := fakeOVN.fakeClient.EgressQoSClient.K8sV1().EgressQoSes(namespaceT.Name).Get(context.TODO(),
 						"default", metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
-				}, time.Second).Should(gomega.Equal(true))
+				}, time.Second).Should(gomega.BeTrue())
 
 				return nil
 			}
@@ -424,7 +424,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					_, err := fakeOVN.fakeClient.EgressQoSClient.K8sV1().EgressQoSes(namespaceT.Name).Get(context.TODO(),
 						"default", metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
-				}, time.Second).Should(gomega.Equal(true))
+				}, time.Second).Should(gomega.BeTrue())
 
 				return nil
 			}
@@ -629,7 +629,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				_, err := fakeOVN.fakeClient.EgressQoSClient.K8sV1().EgressQoSes(namespaceT.Name).Get(context.TODO(),
 					"default", metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
-			}, time.Second).Should(gomega.Equal(true))
+			}, time.Second).Should(gomega.BeTrue())
 
 			return nil
 		}
@@ -762,7 +762,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				_, err := fakeOVN.fakeClient.EgressQoSClient.K8sV1().EgressQoSes(namespaceT.Name).Get(context.TODO(),
 					"default", metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
-			}, time.Second).Should(gomega.Equal(true))
+			}, time.Second).Should(gomega.BeTrue())
 
 			return nil
 		}
@@ -1108,5 +1108,5 @@ func expectEgressQoSStatusMessageEventually(fakeOVN *FakeOVN, namespace string, 
 			return len(defaultEq.Status.Conditions) > 0 &&
 				strings.Contains(defaultEq.Status.Conditions[0].Message, egressQoSAppliedCorrectly)
 		}
-	}).Should(gomega.Equal(true), fmt.Sprintf("expected EgressQoS status message with expectFailure=%v", expectFailure))
+	}).Should(gomega.BeTrue(), fmt.Sprintf("expected EgressQoS status message with expectFailure=%v", expectFailure))
 }

--- a/go-controller/pkg/ovn/external_gateway_apb_test.go
+++ b/go-controller/pkg/ovn/external_gateway_apb_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
@@ -26,7 +26,6 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -49,14 +48,14 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 		return newPolicy(
 			policyName,
 			&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespaceName}},
-			sets.NewString("9.0.0.1"),
+			sets.New("9.0.0.1"),
 			bfd, nil, nil, false, "")
 	}
 
 	getStaticPolicy2IPs := func(bfd bool, ipv6 bool) adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute {
-		ips := sets.NewString("9.0.0.1", "9.0.0.2")
+		ips := sets.New("9.0.0.1", "9.0.0.2")
 		if ipv6 {
-			ips = sets.NewString("fd2e:6f44:5dd8::89", "fd2e:6f44:5dd8::76")
+			ips = sets.New("fd2e:6f44:5dd8::89", "fd2e:6f44:5dd8::76")
 		}
 		return newPolicy(
 			policyName,
@@ -79,7 +78,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 	getStaticDynamicPolicy := func(bfdStatic, bfdDynamic bool, targetNamespace, targetPod string) adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute {
 		return newPolicy(policyName,
 			&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespaceName}},
-			sets.NewString("9.0.0.1"),
+			sets.New("9.0.0.1"),
 			bfdStatic,
 			&metav1.LabelSelector{MatchLabels: map[string]string{"name": targetNamespace}},
 			&metav1.LabelSelector{MatchLabels: map[string]string{"name": targetPod}},
@@ -105,7 +104,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 	ginkgo.Context("on setting namespace gateway static hop", func() {
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace single exgw static GW already set", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 
@@ -133,13 +132,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -247,7 +246,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace single exgw static GW after policy is created", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 
@@ -275,8 +274,8 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
@@ -393,7 +392,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace single exgw static gateway already set with pod event first", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 
@@ -421,8 +420,8 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -533,7 +532,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 
 		ginkgo.DescribeTable("reconciles an new pod with namespace double exgw static gateways already set", func(bfd bool, finalNB []libovsdbtest.TestData) {
 
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 
@@ -561,13 +560,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -707,7 +706,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 				syncNB []libovsdbtest.TestData,
 				finalNB []libovsdbtest.TestData,
 			) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespaceT := *newNamespace(namespaceName)
 
@@ -726,13 +725,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT,
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -923,7 +922,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 		ginkgo.DescribeTable("reconciles deleting a pod with namespace double exgw static gateway already set IPV6",
 			func(bfd bool,
 				initNB, syncNB, finalNB []libovsdbtest.TestData) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 					namespaceT := *newNamespace(namespaceName)
 
 					t := newTPod(
@@ -941,13 +940,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT,
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -1067,7 +1066,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 				initNB []libovsdbtest.TestData,
 				finalNB []libovsdbtest.TestData,
 			) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespaceT := *newNamespace(namespaceName)
 
@@ -1086,13 +1085,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT,
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -1258,7 +1257,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 
 	ginkgo.Context("on setting pod dynamic gateways", func() {
 		ginkgo.DescribeTable("reconciles a host networked pod acting as a exgw for another namespace for new pod", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceX := *newNamespace("namespace2")
@@ -1288,13 +1287,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							gwPod,
 						},
 					},
@@ -1408,7 +1407,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles a host networked pod acting as a exgw for another namespace for existing pod", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceX := *newNamespace("namespace2")
@@ -1437,13 +1436,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -1550,7 +1549,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			}))
 
 		ginkgo.DescribeTable("reconciles a multus networked pod acting as a exgw for another namespace for new pod", func(bfd bool, finalNB []libovsdbtest.TestData) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				ns := nettypes.NetworkStatus{Name: "dummy", IPs: []string{"11.0.0.1"}}
 				networkStatuses := []nettypes.NetworkStatus{ns}
 				nsEncoded, err := json.Marshal(networkStatuses)
@@ -1586,13 +1585,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							gwPod,
 						},
 					},
@@ -1715,7 +1714,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			func(bfd bool,
 				beforeDeleteNB []libovsdbtest.TestData,
 				afterDeleteNB []libovsdbtest.TestData) {
-				app.Action = func(ctx *cli.Context) error {
+				app.Action = func(*cli.Context) error {
 
 					namespaceT := *newNamespace(namespaceName)
 					namespaceX := *newNamespace("namespace2")
@@ -1744,13 +1743,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 								},
 							},
 						},
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
+						&corev1.NamespaceList{
+							Items: []corev1.Namespace{
 								namespaceT, namespaceX,
 							},
 						},
-						&v1.PodList{
-							Items: []v1.Pod{
+						&corev1.PodList{
+							Items: []corev1.Pod{
 								*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 							},
 						},
@@ -1922,7 +1921,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 	})
 	ginkgo.Context("on using bfd", func() {
 		ginkgo.It("should enable bfd only on the namespace gw when set", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceX := *newNamespace("namespace2")
@@ -1953,13 +1952,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -2042,7 +2041,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should enable bfd only on the gw pod when set", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace(namespaceName)
 				namespaceX := *newNamespace("namespace2")
@@ -2073,13 +2072,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT, namespaceX,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -2163,7 +2162,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should disable bfd when removing the static hop from the namespace", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace(namespaceName)
 
 				t := newTPod(
@@ -2207,13 +2206,13 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 				}
 				fakeOvn.startWithDBSetup(
 					initNB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -2311,7 +2310,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 
 				updatePolicy(policyName,
 					&metav1.LabelSelector{MatchLabels: map[string]string{"name": namespaceT.Name}},
-					sets.NewString("9.0.0.1"),
+					sets.New[string]("9.0.0.1"),
 					false,
 					nil,
 					nil,
@@ -2368,7 +2367,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 	})
 	ginkgo.Context("hybrid route policy operations in lgw mode", func() {
 		ginkgo.It("add hybrid route policy for pods", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				fakeOvn.startWithDBSetup(
@@ -2433,7 +2432,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should reconcile a pod and create/delete the hybridRoutePolicy accordingly", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				namespaceT := *newNamespace("namespace1")
@@ -2471,18 +2470,18 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
@@ -2593,7 +2592,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should create a single policy for concurrent addHybridRoutePolicy for the same node", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
 				fakeOvn.startWithDBSetup(
@@ -2651,9 +2650,11 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 					podIndex := i
 					wg.Add(1)
 					go func() {
+						defer ginkgo.GinkgoRecover()
 						defer wg.Done()
 						<-c
-						fakeOvn.controller.apbExternalRouteController.AddHybridRoutePolicyForPod(net.ParseIP(fmt.Sprintf("10.128.1.%d", podIndex)), "node1")
+						// errors can happen due to server side concurrency check
+						_ = fakeOvn.controller.apbExternalRouteController.AddHybridRoutePolicyForPod(net.ParseIP(fmt.Sprintf("10.128.1.%d", podIndex)), "node1")
 					}()
 				}
 				close(c)
@@ -2672,7 +2673,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete hybrid route policy for pods", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				asIndex := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				asv4, _ := addressset.GetHashNamesForAS(asIndex)
@@ -2737,7 +2738,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete hybrid route policy for pods with force", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				asIndex1 := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				as1v4, _ := addressset.GetHashNamesForAS(asIndex1)
@@ -2811,7 +2812,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete legacy hybrid route policies", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				asIndex := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				asv4, _ := addressset.GetHashNamesForAS(asIndex)
@@ -2893,7 +2894,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("delete stale addresses from apb hybrid route policies on startup", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				asIndex := apbroute.GetHybridRouteAddrSetDbIDs("node1", DefaultNetworkControllerName)
 				asv4, _ := addressset.GetHashNamesForAS(asIndex)
@@ -2959,8 +2960,8 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							testNode,
 						},
 					},
@@ -3010,7 +3011,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 	})
 	ginkgo.Context("SNAT on gateway router operations", func() {
 		ginkgo.It("add/delete SNAT per pod on gateway router", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				config.Gateway.DisableSNATMultipleGWs = true
 
@@ -3027,7 +3028,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 					namespaceT.Name,
 				)
 
-				pod := []v1.Pod{
+				pod := []corev1.Pod{
 					*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 				}
 
@@ -3040,8 +3041,8 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 								Networks: []string{"100.64.0.4/32"},
 							},
 							&nbdb.LogicalRouter{
-								Name:  types.GWRouterPrefix + nodeName,
-								UUID:  types.GWRouterPrefix + nodeName + "-UUID",
+								Name:  ovntypes.GWRouterPrefix + nodeName,
+								UUID:  ovntypes.GWRouterPrefix + nodeName + "-UUID",
 								Ports: []string{ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID"},
 							},
 							&nbdb.LogicalSwitch{
@@ -3050,12 +3051,12 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 							},
 						},
 					},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.PodList{
+					&corev1.PodList{
 						Items: pod,
 					},
 				)
@@ -3069,8 +3070,8 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 						Type:       nbdb.NATTypeSNAT,
 					},
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + nodeName,
-						UUID:  types.GWRouterPrefix + nodeName + "-UUID",
+						Name:  ovntypes.GWRouterPrefix + nodeName,
+						UUID:  ovntypes.GWRouterPrefix + nodeName + "-UUID",
 						Ports: []string{ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID"},
 						Nat:   []string{"nat-UUID"},
 					},
@@ -3102,8 +3103,8 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{
 					&nbdb.LogicalRouter{
-						Name:  types.GWRouterPrefix + nodeName,
-						UUID:  types.GWRouterPrefix + nodeName + "-UUID",
+						Name:  ovntypes.GWRouterPrefix + nodeName,
+						UUID:  ovntypes.GWRouterPrefix + nodeName + "-UUID",
 						Ports: []string{ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID"},
 						Nat:   []string{},
 					},
@@ -3129,7 +3130,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 	})
 })
 
-func newPolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHopsGWIPs sets.String, bfdStatic bool,
+func newPolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHopsGWIPs sets.Set[string], bfdStatic bool,
 	dynamicHopsNSSelector *metav1.LabelSelector, dynamicHopsPodSelector *metav1.LabelSelector, bfdDynamic bool, networkAttachementName string) adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute {
 	p := adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: policyName},
@@ -3158,7 +3159,7 @@ func newPolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHo
 	return p
 }
 
-func updatePolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHopsGWIPs sets.String, bfdStatic bool, dynamicHopsNSSelector *metav1.LabelSelector, dynamicHopsPodSelector *metav1.LabelSelector, bfdDynamic bool, networkAttachementName string, fakeRouteClient adminpolicybasedrouteclientset.Interface) {
+func updatePolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHopsGWIPs sets.Set[string], bfdStatic bool, dynamicHopsNSSelector *metav1.LabelSelector, dynamicHopsPodSelector *metav1.LabelSelector, bfdDynamic bool, networkAttachementName string, fakeRouteClient adminpolicybasedrouteclientset.Interface) {
 
 	p, err := fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), policyName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3230,8 +3231,8 @@ func checkAPBRouteStatus(fakeOVN *FakeOVN, policyName string, expectFailure bool
 
 	// as soon as status is set, it should match expected status, without extra retries
 	if expectFailure {
-		gomega.Expect(status.Messages[0]).To(gomega.ContainSubstring(types.APBRouteErrorMsg))
+		gomega.Expect(status.Messages[0]).To(gomega.ContainSubstring(ovntypes.APBRouteErrorMsg))
 	} else {
-		gomega.Expect(status.Messages[0]).ToNot(gomega.ContainSubstring(types.APBRouteErrorMsg))
+		gomega.Expect(status.Messages[0]).ToNot(gomega.ContainSubstring(ovntypes.APBRouteErrorMsg))
 	}
 }

--- a/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -33,7 +33,7 @@ type aclSync struct {
 }
 
 func testSyncerWithData(data []aclSync, controllerName string, initialDbState, finalDbState []libovsdbtest.TestData,
-	existingNodes []*v1.Node) {
+	existingNodes []*corev1.Node) {
 	// create initial db setup
 	pgBefore := &nbdb.PortGroup{
 		UUID: types.ClusterPortGroupNameBase,
@@ -322,7 +322,7 @@ var _ = ginkgo.Describe("OVN ACL Syncer", func() {
 		hostSubnets := map[string][]string{types.DefaultNetworkName: {"10.244.0.0/24", "fd02:0:0:2::2895/64"}}
 		bytes, err := json.Marshal(hostSubnets)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		existingNodes := []*v1.Node{
+		existingNodes := []*corev1.Node{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        nodeName,

--- a/go-controller/pkg/ovn/external_ids_syncer/port_group/port_group_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/port_group/port_group_sync_test.go
@@ -32,7 +32,7 @@ func testSyncerWithData(data []pgSync, initialDbState, finalDbState []libovsdbte
 	var fakePortUUID string
 	var dbPortAndSwitch []libovsdbtest.TestData
 
-	dbSetup := libovsdbtest.TestSetup{NBData: append(initialDbState)}
+	dbSetup := libovsdbtest.TestSetup{NBData: initialDbState}
 	for _, pgSync := range data {
 		dbSetup.NBData = append(dbSetup.NBData, pgSync.before)
 		if len(pgSync.before.Ports) > 0 {
@@ -91,7 +91,7 @@ func testSyncerWithData(data []pgSync, initialDbState, finalDbState []libovsdbte
 	// run sync
 	syncer := NewPortGroupSyncer(libovsdbOvnNBClient)
 	// to make sure batching works, set it to 0.5 to cover number of batches = 0,1,>1
-	syncer.getPGWeight = func(acls, ports int) float64 {
+	syncer.getPGWeight = func(_, _ int) float64 {
 		return 0.5
 	}
 	err = syncer.SyncPortGroups()

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -70,6 +70,9 @@ func TestGetOvnGateways(t *testing.T) {
 			t.Cleanup(cleanup.Cleanup)
 
 			got, err := GetOvnGateways(libovsdbOvnNBClient)
+			if err != nil {
+				t.Errorf("failed to GetOvnGateways: %v", err)
+			}
 			if !sets.NewString(got...).HasAll(tt.want...) {
 				t.Errorf("GetOvnGateways() got = %v, want %v", got, tt.want)
 			}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -353,7 +353,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		fakeOvn = NewFakeOVN(true)
 	})
@@ -623,7 +623,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			a.Annotations = map[string]string{
 				util.OvnNodeMasqCIDR: "{\"ipv4\":\"170.254.169.0/16\",\"ipv6\":\"fd69::/112\"}",
 			}
-			node1 := v1.Node{ObjectMeta: a}
+			node1 := corev1.Node{ObjectMeta: a}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					// tests migration from local to shared
@@ -641,7 +641,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedRouterLBGroup,
 				},
 			},
-				&v1.NodeList{Items: []v1.Node{node1}},
+				&corev1.NodeList{Items: []corev1.Node{node1}},
 			)
 
 			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -8,7 +8,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/utils/net"
 
@@ -42,7 +42,7 @@ func (n network) copyNetworkAndSetLRPs(lrps ...*nbdb.LogicalRouterPolicy) networ
 }
 
 func (n network) generateTestData(nodeName string) []libovsdbtest.TestData {
-	data := make([]libovsdbtest.TestData, 0, 0)
+	var data []libovsdbtest.TestData
 	lrpUUIDs := make([]string, 0, len(n.initialLRPs))
 	for _, lrp := range n.initialLRPs {
 		lrpUUIDs = append(lrpUUIDs, lrp.UUID)
@@ -547,7 +547,7 @@ func TestAddHostCIDRPolicy(t *testing.T) {
 			mgntIPv4:    node1UDNMgntIPv4Str,
 			mgntIPv6:    node1UDNMgntIPv6Str,
 		}
-		node = &v1.Node{
+		node = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: node1Name,
 				Annotations: map[string]string{

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -40,7 +40,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Node {
+func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) corev1.Node {
 	var err error
 	annotations := make(map[string]string)
 	if ovnHostSubnet != "" {
@@ -53,16 +53,16 @@ func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Nod
 	if drMAC != "" {
 		annotations[hotypes.HybridOverlayDRMAC] = drMAC
 	}
-	return v1.Node{
+	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Labels:      map[string]string{v1.LabelOSStable: os},
+			Labels:      map[string]string{corev1.LabelOSStable: os},
 			Annotations: annotations,
 		},
 	}
 }
 
-func newTestHONode(name, hybridHostSubnet, drMAC string) v1.Node {
+func newTestHONode(name, hybridHostSubnet, drMAC string) corev1.Node {
 	annotations := make(map[string]string)
 	if hybridHostSubnet != "" {
 		annotations[hotypes.HybridOverlayNodeSubnet] = hybridHostSubnet
@@ -71,10 +71,10 @@ func newTestHONode(name, hybridHostSubnet, drMAC string) v1.Node {
 		annotations[hotypes.HybridOverlayDRMAC] = drMAC
 	}
 	annotations[util.OvnNodeChassisID] = "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec"
-	return v1.Node{
+	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Labels:      map[string]string{v1.LabelOSStable: "windows"},
+			Labels:      map[string]string{corev1.LabelOSStable: "windows"},
 			Annotations: annotations,
 		},
 	}
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -186,8 +186,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			dbSetup := libovsdbtest.TestSetup{}
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{
 					newTestNode(nodeName, "windows", "", "", ""),
 				},
 			})
@@ -263,7 +263,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 		err := app.Run([]string{
 			app.Name,
 			"-loglevel=5",
-			"-no-hostsubnet-nodes=" + v1.LabelOSStable + "=windows",
+			"-no-hostsubnet-nodes=" + corev1.LabelOSStable + "=windows",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
 			"-init-gateways",
@@ -300,8 +300,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 			testNode := node1.k8sNode("2")
 
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{testNode},
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{testNode},
 			})
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
 			egressIPFakeClient := &egressipfake.Clientset{}
@@ -581,8 +581,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 
 			testNode := node1.k8sNode("2")
 
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{testNode},
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{testNode},
 			})
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
 			egressIPFakeClient := &egressipfake.Clientset{}
@@ -779,13 +779,13 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 			testNode := node1.k8sNode("2")
 
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{
 
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   winNodeName,
-							Labels: map[string]string{v1.LabelOSStable: "windows"},
+							Labels: map[string]string{corev1.LabelOSStable: "windows"},
 							Annotations: map[string]string{
 								hotypes.HybridOverlayNodeSubnet: winNodeSubnet,
 							},
@@ -1086,8 +1086,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			testNode2 := node2.k8sNode("3")
 			testNode2.Annotations["k8s.ovn.org/node-subnets"] = "{\"default\":[\"10.1.3.0/24\"]}"
 
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{
 					testNode1,
 					testNode2,
 				},
@@ -1199,7 +1199,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
 
 			// switch the node to a HO node
-			testNode2.Labels = map[string]string{v1.LabelOSStable: "windows"}
+			testNode2.Labels = map[string]string{corev1.LabelOSStable: "windows"}
 			testNode2.Annotations[hotypes.HybridOverlayNodeSubnet] = hoNodeSubnet
 			testNode2.Annotations[hotypes.HybridOverlayDRMAC] = hoNodeDRMAC
 			_, err = fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode2, metav1.UpdateOptions{})
@@ -1299,8 +1299,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				DnatSnatIP:           "169.254.0.1",
 			}
 			testNode := node1.k8sNode("2")
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{
 					newTestHONode(hoNodeName, hoNodeSubnet, hoNodeDRMAC),
 					testNode,
 				},
@@ -1504,8 +1504,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 			testNode := node1.k8sNode("2")
 
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{testNode},
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{testNode},
 			})
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
 			egressIPFakeClient := &egressipfake.Clientset{}
@@ -1732,8 +1732,8 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				"k8s.ovn.org/ovn-node-id":  "2",
 				util.OVNNodeGRLRPAddrs:     "{\"default\":{\"ipv4\":\"100.64.0.2/16\"}}"}
 
-			kubeFakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{testNode},
+			kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+				Items: []corev1.Node{testNode},
 			})
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
 			egressIPFakeClient := &egressipfake.Clientset{}

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -478,7 +478,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 					return nil, err
 				}
 				return clusterRouter.Policies, nil
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() error {
 				_, err := libovsdbops.GetLogicalSwitchPort(clusterController.nbClient, &nbdb.LogicalSwitchPort{Name: "jtor-GR_node1"})
@@ -496,7 +496,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				}
 				return ovnJoinSwitch.Ports, err
 
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			//check if the hybrid overlay elements have been cleaned up
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterStaticRoute, error) {
@@ -512,7 +512,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 					return nil, err
 				}
 				return logicalRouterStaticRoutes, nil
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterPolicy, error) {
 				p := func(item *nbdb.LogicalRouterPolicy) bool {
@@ -528,7 +528,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				}
 				return logicalRouterPolicies, nil
 
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() error {
 				_, err := libovsdbops.GetLogicalSwitchPort(clusterController.nbClient, &nbdb.LogicalSwitchPort{Name: "int-node1"})
@@ -538,7 +538,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				return nil
 			}, 2).Should(gomega.Equal(libovsdbclient.ErrNotFound))
 
-			gomega.Eventually(clusterController.nbClient.Get(context.Background(), expectedStaticMACBinding), 2).Should(gomega.Equal(libovsdbclient.ErrNotFound))
+			gomega.Eventually(clusterController.nbClient.Get, 2).WithArguments(context.Background(), expectedStaticMACBinding).Should(gomega.Equal(libovsdbclient.ErrNotFound))
 
 			return nil
 		}
@@ -961,7 +961,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 					return nil, err
 				}
 				return clusterRouter.Policies, nil
-			}, 20).Should(gomega.HaveLen(0))
+			}, 20).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() error {
 				_, err := libovsdbops.GetLogicalSwitchPort(clusterController.nbClient, &nbdb.LogicalSwitchPort{Name: "jtor-GR_node1"})
@@ -979,7 +979,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				}
 				return ovnJoinSwitch.Ports, err
 
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			//check if the hybrid overlay elements have been cleaned up
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterStaticRoute, error) {
@@ -995,7 +995,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 					return nil, err
 				}
 				return logicalRouterStaticRoutes, nil
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterPolicy, error) {
 				p := func(item *nbdb.LogicalRouterPolicy) bool {
@@ -1011,7 +1011,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				}
 				return logicalRouterPolicies, nil
 
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() error {
 				_, err := libovsdbops.GetLogicalSwitchPort(clusterController.nbClient, &nbdb.LogicalSwitchPort{Name: "int-node1"})
@@ -1449,7 +1449,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 					return nil, err
 				}
 				return logicalRouterStaticRoutes, nil
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterPolicy, error) {
 				p := func(item *nbdb.LogicalRouterPolicy) bool {
@@ -1461,7 +1461,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				}
 				return logicalRouterPolicies, nil
 
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			return nil
 		}
@@ -1884,7 +1884,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 					return nil, err
 				}
 				return logicalRouterStaticRoutes, nil
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterPolicy, error) {
 				p := func(item *nbdb.LogicalRouterPolicy) bool {
@@ -1900,7 +1900,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				}
 				return logicalRouterPolicies, nil
 
-			}, 2).Should(gomega.HaveLen(0))
+			}, 2).Should(gomega.BeEmpty())
 
 			gomega.Eventually(func() error {
 				_, err := libovsdbops.GetLogicalSwitchPort(clusterController.nbClient, &nbdb.LogicalSwitchPort{Name: "int-node1"})
@@ -1910,7 +1910,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				return nil
 			}, 2).Should(gomega.Equal(libovsdbclient.ErrNotFound))
 
-			gomega.Eventually(clusterController.nbClient.Get(context.Background(), expectedStaticMACBinding), 2).Should(gomega.Equal(libovsdbclient.ErrNotFound))
+			gomega.Eventually(clusterController.nbClient.Get, 2).WithArguments(context.Background(), expectedStaticMACBinding).Should(gomega.Equal(libovsdbclient.ErrNotFound))
 
 			return nil
 		}

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -81,8 +81,8 @@ const (
 	ovnNodeSubnets       = "k8s.ovn.org/node-subnets"
 )
 
-func (n tNode) k8sNode(nodeID string) v1.Node {
-	node := v1.Node{
+func (n tNode) k8sNode(nodeID string) corev1.Node {
+	node := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: n.Name,
 			Annotations: map[string]string{
@@ -92,8 +92,8 @@ func (n tNode) k8sNode(nodeID string) v1.Node {
 				ovnNodePrimaryIfAddr:   fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", fmt.Sprintf("%s/24", n.NodeIP), ""),
 			},
 		},
-		Status: v1.NodeStatus{
-			Addresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: n.NodeIP}},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: n.NodeIP}},
 		},
 	}
 
@@ -921,7 +921,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 
 		dbSetup        libovsdbtest.TestSetup
 		node1          tNode
-		testNode       v1.Node
+		testNode       corev1.Node
 		fakeClient     *util.OVNMasterClientset
 		kubeFakeClient *fake.Clientset
 		oc             *DefaultNetworkController
@@ -1015,8 +1015,8 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		}
 		testNode = node1.k8sNode("2")
 
-		kubeFakeClient = fake.NewSimpleClientset(&v1.NodeList{
-			Items: []v1.Node{testNode},
+		kubeFakeClient = fake.NewSimpleClientset(&corev1.NodeList{
+			Items: []corev1.Node{testNode},
 		})
 		egressFirewallFakeClient := &egressfirewallfake.Clientset{}
 		egressIPFakeClient := &egressipfake.Clientset{}
@@ -1159,7 +1159,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				Nexthop:  "10.244.0.6",
 			}
 			ginkgo.By("Creating stale route")
-			p := func(item *nbdb.LogicalRouterStaticRoute) bool { return false }
+			p := func(*nbdb.LogicalRouterStaticRoute) bool { return false }
 			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient,
 				types.OVNClusterRouter, badRoute, p)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1229,7 +1229,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 	}
 	ginkgo.DescribeTable(
 		"reconciles pod network SNATs from syncGateway",
-		func(condition func(*DefaultNetworkController), expectedExtraNATs ...*nbdb.NAT) {
+		func(condition func(*DefaultNetworkController) error, expectedExtraNATs ...*nbdb.NAT) {
 			app.Action = func(ctx *cli.Context) error {
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1251,7 +1251,8 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// generate specific test conditions
-				condition(oc)
+				err = condition(oc)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// ensure the stale SNAT's are cleaned up
 				gomega.Expect(oc.StartServiceController(wg, false)).To(gomega.Succeed())
@@ -1295,36 +1296,38 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		},
 		ginkgo.Entry(
 			"When DisableSNATMultipleGWs is true",
-			func(*DefaultNetworkController) {
+			func(*DefaultNetworkController) error {
 				config.Gateway.DisableSNATMultipleGWs = true
+				return nil
 			},
 			newNodeSNAT("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP), // won't be deleted since pod exists on this node
 			newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"),        // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
 		),
 		ginkgo.Entry(
 			"When DisableSNATMultipleGWs is false",
-			func(*DefaultNetworkController) {
+			func(*DefaultNetworkController) error {
 				config.Gateway.DisableSNATMultipleGWs = false
+				return nil
 			},
 			newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
 		),
 		ginkgo.Entry(
 			"When pod network is advertised and DisableSNATMultipleGWs is true",
-			func(oc *DefaultNetworkController) {
+			func(oc *DefaultNetworkController) error {
 				config.Gateway.DisableSNATMultipleGWs = true
 				mutableNetInfo := util.NewMutableNetInfo(oc.GetNetInfo())
 				mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{"node1": {"vrf"}})
-				oc.Reconcile(mutableNetInfo)
+				return oc.Reconcile(mutableNetInfo)
 			},
 			newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
 		),
 		ginkgo.Entry(
 			"When pod network is advertised and DisableSNATMultipleGWs is false",
-			func(oc *DefaultNetworkController) {
+			func(oc *DefaultNetworkController) error {
 				config.Gateway.DisableSNATMultipleGWs = false
 				mutableNetInfo := util.NewMutableNetInfo(oc.GetNetInfo())
 				mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{"node1": {"vrf"}})
-				oc.Reconcile(mutableNetInfo)
+				return oc.Reconcile(mutableNetInfo)
 			},
 			newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
 		),
@@ -1347,9 +1350,9 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			ginkgo.By("modifying the node and triggering an update")
 
 			var podsWereListed uint32
-			kubeFakeClient.PrependReactor("list", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+			kubeFakeClient.PrependReactor("list", "pods", func(clienttesting.Action) (bool, runtime.Object, error) {
 				atomic.StoreUint32(&podsWereListed, 1)
-				podList := &v1.PodList{}
+				podList := &corev1.PodList{}
 				return true, podList, nil
 			})
 
@@ -1506,7 +1509,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			startFakeController(oc, wg)
-			newNode := &v1.Node{
+			newNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "newNode",
 					Annotations: map[string]string{},
@@ -1648,7 +1651,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			newNodeSubnet := "10.1.1.0/24"
-			newNode := &v1.Node{
+			newNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newNode",
 					Annotations: map[string]string{
@@ -1710,7 +1713,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			gomega.Expect(config.IPv6Mode).To(gomega.BeTrue())
 
 			newNodeIpv4Subnet := "10.1.1.0/24"
-			newNode := &v1.Node{
+			newNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newNode",
 					Annotations: map[string]string{
@@ -1806,11 +1809,11 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			// the namespace gets created. Hence starting OVN with an empty NodeList and adding the node
 			// after the namespace is created successfully
 			fakeOvn.startWithDBSetup(dbSetup,
-				&v1.NamespaceList{
-					Items: []v1.Namespace{*newNamespace(config.Kubernetes.HostNetworkNamespace)},
+				&corev1.NamespaceList{
+					Items: []corev1.Namespace{*newNamespace(config.Kubernetes.HostNetworkNamespace)},
 				},
-				&v1.NodeList{
-					Items: []v1.Node{},
+				&corev1.NodeList{
+					Items: []corev1.Node{},
 				},
 			)
 
@@ -2072,7 +2075,7 @@ func TestController_syncNodes(t *testing.T) {
 				wg.Wait()
 			}()
 
-			testNode := v1.Node{
+			testNode := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 				},
@@ -2150,12 +2153,12 @@ func TestController_deleteStaleNodeChassis(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	tests := []struct {
 		name         string
-		node         v1.Node
+		node         corev1.Node
 		initialSBDB  []libovsdbtest.TestData
 		expectedSBDB []libovsdbtest.TestData
 	}{
 		{
-			node: v1.Node{
+			node: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -258,7 +258,7 @@ func getNodeData(netInfo util.NetInfo, nodeName string) []libovsdb.TestData {
 	}
 }
 
-func newNodeWithNad(nad *nadapi.NetworkAttachmentDefinition, networkName, networkID string) *v1.Node {
+func newNodeWithNad(nad *nadapi.NetworkAttachmentDefinition, networkName, networkID string) *corev1.Node {
 	n := newNode(nodeName, "192.168.126.202/24")
 	if nad != nil {
 		n.Annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf("{\"default\":\"192.168.126.202/24\", \"%s\":\"192.168.127.202/24\"}", networkName)
@@ -271,7 +271,7 @@ func newNodeWithNad(nad *nadapi.NetworkAttachmentDefinition, networkName, networ
 	return n
 }
 
-func createTestPods(nodeName, namespace string, useIPv4, useIPv6 bool) (pods []v1.Pod, tPods []testPod, tPodIPs []string) {
+func createTestPods(nodeName, namespace string, useIPv4, useIPv6 bool) (pods []corev1.Pod, tPods []testPod, tPodIPs []string) {
 	nPodTestV4 := newTPod(
 		nodeName,
 		"10.128.1.0/24",
@@ -306,7 +306,7 @@ func createTestPods(nodeName, namespace string, useIPv4, useIPv6 bool) (pods []v
 	return
 }
 
-func updateMulticast(fakeOvn *FakeOVN, ns *v1.Namespace, enable bool) {
+func updateMulticast(fakeOvn *FakeOVN, ns *corev1.Namespace, enable bool) {
 	if enable {
 		ns.Annotations[util.NsMulticastAnnotation] = "true"
 	} else {
@@ -363,7 +363,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		Expect(config.PrepareTestConfig()).To(Succeed())
 		config.EnableMulticast = true
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
@@ -390,7 +390,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 
 	Context("on startup", func() {
 		DescribeTable("creates default Multicast ACLs", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -423,7 +423,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("updates stale default Multicast ACLs", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -455,7 +455,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("cleans up Multicast resources when multicast is disabled", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -469,8 +469,8 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				// namespace is still present, but multicast support is disabled
 				namespace1 := *newNamespace(namespaceName1)
 				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: initialData},
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
@@ -502,7 +502,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("creates namespace Multicast ACLs", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -514,8 +514,8 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace1.Annotations[util.NsMulticastAnnotation] = "true"
 
-				objs := []runtime.Object{&v1.NamespaceList{
-					Items: []v1.Namespace{
+				objs := []runtime.Object{&corev1.NamespaceList{
+					Items: []corev1.Namespace{
 						namespace1,
 					},
 				}}
@@ -547,7 +547,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("updates stale namespace Multicast ACLs", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -560,8 +560,8 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace1.Annotations[util.NsMulticastAnnotation] = "true"
 
-				objs := []runtime.Object{&v1.NamespaceList{
-					Items: []v1.Namespace{
+				objs := []runtime.Object{&corev1.NamespaceList{
+					Items: []corev1.Namespace{
 						namespace1,
 					},
 				}}
@@ -594,7 +594,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("cleans up namespace Multicast ACLs when multicast is disabled for namespace", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -606,8 +606,8 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				namespaceMulticastData := getMulticastPolicyExpectedData(netInfo, namespaceName1, nil)
 				namespace1 := *newNamespace(namespaceName1)
 
-				objs := []runtime.Object{&v1.NamespaceList{
-					Items: []v1.Namespace{
+				objs := []runtime.Object{&corev1.NamespaceList{
+					Items: []corev1.Namespace{
 						namespace1,
 					},
 				}}
@@ -643,15 +643,15 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 
 	Context("during execution", func() {
 		DescribeTable("tests enabling/disabling multicast in a namespace", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
 				netInfo := getNetInfoFromNAD(nad)
 				namespace1 := *newNamespace(namespaceName1)
 
-				objs := []runtime.Object{&v1.NamespaceList{
-					Items: []v1.Namespace{
+				objs := []runtime.Object{&corev1.NamespaceList{
+					Items: []corev1.Namespace{
 						namespace1,
 					},
 				}}
@@ -703,7 +703,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("tests enabling multicast in a namespace with a pod", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -716,17 +716,17 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				pods, tPods, tPodIPs := createTestPods(nodeName, namespaceName1, useIPv4, useIPv6)
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node,
 						},
 					},
-					&v1.PodList{
+					&corev1.PodList{
 						Items: pods,
 					},
 				}
@@ -777,7 +777,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("tests enabling multicast in multiple namespaces with a long name > 42 characters", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -788,14 +788,14 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				node := newNodeWithNad(nad, networkName, networkID)
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 							namespace2,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node,
 						},
 					},
@@ -859,7 +859,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 		)
 
 		DescribeTable("tests adding a pod to a multicast enabled namespace", func(useIPv4, useIPv6 bool, nad *nadapi.NetworkAttachmentDefinition) {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.IPv4Mode = useIPv4
 				config.IPv6Mode = useIPv6
 
@@ -877,13 +877,13 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 				}
 
 				objs := []runtime.Object{
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*node,
 						},
 					},

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -9,7 +9,7 @@ import (
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 
@@ -18,7 +18,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -141,7 +140,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 				hasSubnets bool
 			)
 			if len(subnets) > 0 {
-				subnet = ovntest.MustParseIPNet(subnets)
+				subnet = testing.MustParseIPNet(subnets)
 				hasSubnets = true
 			}
 
@@ -274,7 +273,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 			if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
 				em.gatewayConfig != nil {
 				if ocInfo.bnc.TopologyType() == ovntypes.Layer3Topology {
-					data = append(data, expectedGWEntities(pod.nodeName, subnets, ocInfo.bnc, *em.gatewayConfig)...)
+					data = append(data, expectedGWEntities(pod.nodeName, ocInfo.bnc, *em.gatewayConfig)...)
 					data = append(data, expectedLayer3EgressEntities(ocInfo.bnc, *em.gatewayConfig, subnet)...)
 				} else {
 					data = append(data, expectedLayer2EgressEntities(ocInfo.bnc, *em.gatewayConfig, pod.nodeName)...)
@@ -349,14 +348,6 @@ func newExpectedSwitchToRouterPort(lspUUID string, portName string, pod testPod,
 	lrp.PortSecurity = nil
 	lrp.Type = "router"
 	return lrp
-}
-
-func subnetsAsString(subnetInfo []config.CIDRNetworkEntry) []string {
-	var subnets []string
-	for _, cidr := range subnetInfo {
-		subnets = append(subnets, cidr.String())
-	}
-	return subnets
 }
 
 func managementPortName(switchName string) string {
@@ -461,7 +452,7 @@ func nonICClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
 	return config
 }
 
-func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
+func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...secondaryNetInfo) *corev1.Pod {
 	pod := newMultiHomedPod(testPod, multiHomingConfigs...)
 	pod.Labels[kubevirtv1.VirtualMachineNameLabel] = vmName
 	pod.Status.Phase = liveMigrationInfo.podPhase
@@ -472,7 +463,7 @@ func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodI
 	return pod
 }
 
-func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
+func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *corev1.Pod {
 	pod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 	var secondaryNetworks []nadapi.NetworkSelectionElement
 	if len(pod.Annotations) == 0 {

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -359,7 +359,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 		ocInfo, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
 		gomega.Expect(ok).To(gomega.BeTrue())
 		asf := ocInfo.asf
-		gomega.Expect(asf).NotTo(gomega.Equal(nil))
+		gomega.Expect(asf).NotTo(gomega.BeNil())
 		gomega.Expect(asf.ControllerName).To(gomega.Equal(getNetworkControllerName(secondaryNetworkName)))
 
 		for _, ocInfo := range fakeOvn.secondaryControllers {
@@ -505,7 +505,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 
 				ocInfo := fakeOvn.secondaryControllers[secondaryNetworkName]
 				portInfo := nPodTest.getNetworkPortInfo(secondaryNetworkName, nadNamespacedName)
-				gomega.Expect(portInfo).NotTo(gomega.Equal(nil))
+				gomega.Expect(portInfo).NotTo(gomega.BeNil())
 				ocInfo.asf.ExpectAddressSetWithAddresses(namespaceName1, []string{portInfo.podIP})
 
 				dataParams2 := newNetpolDataParams(networkPolicy).

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			gwLRPIPs, err := util.ParseNodeGatewayRouterJoinAddrs(&testNode, ovntypes.DefaultNetworkName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(len(gwLRPIPs) != 0).To(gomega.BeTrue())
+			gomega.Expect(gwLRPIPs).ToNot(gomega.BeEmpty())
 
 			err = fakeOvn.controller.WatchNamespaces()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/network_segmentation_test.go
+++ b/go-controller/pkg/ovn/network_segmentation_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe("OVN Pod Operations with network segmentation", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("OVN Pod Operations with network segmentation", func() {
 
 	ginkgo.Context("on startup", func() {
 		ginkgo.It("reconciles an existing pod with missing 'role=primary' ovn annotation field", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				// use 2 pods for different test options
 				t1 := newTPod(
@@ -100,18 +100,18 @@ var _ = ginkgo.Describe("OVN Pod Operations with network segmentation", func() {
 				pod1 := newPod(t1.namespace, t1.podName, t1.nodeName, t1.podIP)
 				setPodAnnotations(pod1, t1)
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*pod1,
 						},
 					},

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -291,7 +291,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 }
 
 // creates the global entities that should remain after a UDN created and removed
-func generateUDNPostInitDB(testData []libovsdbtest.TestData, netName string) []libovsdbtest.TestData {
+func generateUDNPostInitDB(testData []libovsdbtest.TestData) []libovsdbtest.TestData {
 	testData = append(testData, &nbdb.MeterBand{
 		UUID:   "25-pktps-rate-limiter-UUID",
 		Action: types.MeterAction,
@@ -467,7 +467,7 @@ func createTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
 }
 
 func deleteTestNBGlobal(nbClient libovsdbclient.Client) error {
-	p := func(nbGlobal *nbdb.NBGlobal) bool {
+	p := func(*nbdb.NBGlobal) bool {
 		return true
 	}
 
@@ -591,7 +591,7 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 	return nil
 }
 
-func (o *FakeOVN) patchEgressIPObj(nodeName, egressIPName, egressIP, network string) {
+func (o *FakeOVN) patchEgressIPObj(nodeName, egressIPName, egressIP string) {
 	// NOTE: Cluster manager is the one who patches the egressIP object.
 	// For the sake of unit testing egressip zone controller we need to patch egressIP object manually
 	// There are tests in cluster-manager package covering the patch logic.

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -593,7 +593,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					}).List(ctext, &lsl)
 
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(len(lsl)).To(gomega.Equal(1))
+				gomega.Expect(lsl).To(gomega.HaveLen(1))
 
 				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -756,7 +756,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
-				}, 2).Should(gomega.HaveLen(0))
+				}, 2).Should(gomega.BeEmpty())
 				myPod2Key, err := retry.GetResourceKey(myPod2)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				retry.CheckRetryObjectEventually(myPod2Key, true, fakeOvn.controller.retryPods)
@@ -869,7 +869,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t2.namespace, t2.podName)
-				}, 2).Should(gomega.HaveLen(0))
+				}, 2).Should(gomega.BeEmpty())
 
 				myPod2Key, err := retry.GetResourceKey(myPod2)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -955,7 +955,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t3.namespace, t3.podName)
-				}, 2).Should(gomega.HaveLen(0))
+				}, 2).Should(gomega.BeEmpty())
 
 				// should be in retry because there are no more IPs left
 				myPod3Key, err := retry.GetResourceKey(myPod3)
@@ -2323,7 +2323,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// port should not be in cache, because it should never have been added
 				_, err = fakeOvn.controller.logicalPortCache.get(pod, ovntypes.DefaultNetworkName)
-				gomega.Expect(err).NotTo(gomega.BeNil())
+				gomega.Expect(err).To(gomega.HaveOccurred())
 				myPod1Key, err := retry.GetResourceKey(pod)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				retry.CheckRetryObjectEventually(myPod1Key, true, fakeOvn.controller.retryPods)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
-	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -53,15 +53,15 @@ func newPodMeta(namespace, name string, additionalLabels map[string]string) meta
 	}
 }
 
-func newPodWithLabelsAllIPFamilies(namespace, name, node string, podIPs []string, additionalLabels map[string]string) *v1.Pod {
-	podIPList := []v1.PodIP{}
+func newPodWithLabelsAllIPFamilies(namespace, name, node string, podIPs []string, additionalLabels map[string]string) *corev1.Pod {
+	podIPList := []corev1.PodIP{}
 	for _, podIP := range podIPs {
-		podIPList = append(podIPList, v1.PodIP{IP: podIP})
+		podIPList = append(podIPList, corev1.PodIP{IP: podIP})
 	}
-	return &v1.Pod{
+	return &corev1.Pod{
 		ObjectMeta: newPodMeta(namespace, name, additionalLabels),
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "containerName",
 					Image: "containerImage",
@@ -69,22 +69,22 @@ func newPodWithLabelsAllIPFamilies(namespace, name, node string, podIPs []string
 			},
 			NodeName: node,
 		},
-		Status: v1.PodStatus{
-			Phase:  v1.PodRunning,
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
 			PodIP:  podIPList[0].IP,
 			PodIPs: podIPList,
 		},
 	}
 }
-func newPodWithLabels(namespace, name, node, podIP string, additionalLabels map[string]string) *v1.Pod {
-	podIPs := []v1.PodIP{}
+func newPodWithLabels(namespace, name, node, podIP string, additionalLabels map[string]string) *corev1.Pod {
+	podIPs := []corev1.PodIP{}
 	if podIP != "" {
-		podIPs = append(podIPs, v1.PodIP{IP: podIP})
+		podIPs = append(podIPs, corev1.PodIP{IP: podIP})
 	}
-	return &v1.Pod{
+	return &corev1.Pod{
 		ObjectMeta: newPodMeta(namespace, name, additionalLabels),
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "containerName",
 					Image: "containerImage",
@@ -92,27 +92,27 @@ func newPodWithLabels(namespace, name, node, podIP string, additionalLabels map[
 			},
 			NodeName: node,
 		},
-		Status: v1.PodStatus{
-			Phase:  v1.PodRunning,
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
 			PodIP:  podIP,
 			PodIPs: podIPs,
 		},
 	}
 }
 
-func newPod(namespace, name, node, podIP string) *v1.Pod {
-	podIPs := []v1.PodIP{}
+func newPod(namespace, name, node, podIP string) *corev1.Pod {
+	podIPs := []corev1.PodIP{}
 	ips := strings.Split(podIP, " ")
 	if len(ips) > 0 {
 		podIP = ips[0]
 		for _, ip := range ips {
-			podIPs = append(podIPs, v1.PodIP{IP: ip})
+			podIPs = append(podIPs, corev1.PodIP{IP: ip})
 		}
 	}
-	return &v1.Pod{
+	return &corev1.Pod{
 		ObjectMeta: newPodMeta(namespace, name, nil),
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  "containerName",
 					Image: "containerImage",
@@ -120,16 +120,16 @@ func newPod(namespace, name, node, podIP string) *v1.Pod {
 			},
 			NodeName: node,
 		},
-		Status: v1.PodStatus{
-			Phase:  v1.PodRunning,
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
 			PodIP:  podIP,
 			PodIPs: podIPs,
 		},
 	}
 }
 
-func newNode(nodeName, nodeIPv4CIDR string) *v1.Node {
-	return &v1.Node{
+func newNode(nodeName, nodeIPv4CIDR string) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
@@ -142,19 +142,19 @@ func newNode(nodeName, nodeIPv4CIDR string) *v1.Node {
 				"k8s.ovn.org/egress-assignable": "",
 			},
 		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
 				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
 				},
 			},
 		},
 	}
 }
 
-func newNodeGlobalZoneNotEgressableV4Only(nodeName, nodeIPv4 string) *v1.Node {
-	return &v1.Node{
+func newNodeGlobalZoneNotEgressableV4Only(nodeName, nodeIPv4 string) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
@@ -164,19 +164,19 @@ func newNodeGlobalZoneNotEgressableV4Only(nodeName, nodeIPv4 string) *v1.Node {
 				"k8s.ovn.org/zone-name":           "global",
 			},
 		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
 				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
 				},
 			},
 		},
 	}
 }
 
-func newNodeGlobalZoneNotEgressableV6Only(nodeName, nodeIPv6 string) *v1.Node {
-	return &v1.Node{
+func newNodeGlobalZoneNotEgressableV6Only(nodeName, nodeIPv6 string) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
@@ -186,16 +186,16 @@ func newNodeGlobalZoneNotEgressableV6Only(nodeName, nodeIPv6 string) *v1.Node {
 				"k8s.ovn.org/zone-name":           "global",
 			},
 		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
 				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
 				},
 			},
-			Addresses: []v1.NodeAddress{
+			Addresses: []corev1.NodeAddress{
 				{
-					Type:    v1.NodeInternalIP,
+					Type:    corev1.NodeInternalIP,
 					Address: nodeIPv6,
 				},
 			},
@@ -311,7 +311,7 @@ func newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC,
 		if gwIP == nil {
 			continue
 		}
-		to.routes = append(to.routes, util.PodRoute{rs, *gwIP})
+		to.routes = append(to.routes, util.PodRoute{Dest: rs, NextHop: *gwIP})
 	}
 
 	return to
@@ -425,7 +425,7 @@ func (p testPod) getAnnotationsJson() string {
 	return string(bytes)
 }
 
-func setPodAnnotations(podObj *v1.Pod, testPod testPod) {
+func setPodAnnotations(podObj *corev1.Pod, testPod testPod) {
 	if podObj.Annotations == nil {
 		podObj.Annotations = map[string]string{}
 	}
@@ -526,7 +526,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -550,7 +550,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 	ginkgo.Context("during execution", func() {
 
 		ginkgo.It("reconciles an existing pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				// this flag will create namespaced port group
 				config.OVNKubernetesFeature.EnableEgressFirewall = true
 				namespaceT := *newNamespace("namespace1")
@@ -567,18 +567,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -630,7 +630,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("reconciles a new pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -644,18 +644,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{},
+					&corev1.PodList{
+						Items: []corev1.Pod{},
 					},
 				)
 
@@ -666,7 +666,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.MatchError(kapierrors.IsNotFound, "IsNotFound"))
+				gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"))
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
 					newPod(t.namespace, t.podName, t.nodeName, t.podIP), metav1.CreateOptions{})
@@ -685,7 +685,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("allows allocation after pods are completed", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -699,18 +699,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{},
+					&corev1.PodList{
+						Items: []corev1.Pod{},
 					},
 				)
 
@@ -721,7 +721,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.MatchError(kapierrors.IsNotFound, "IsNotFound"))
+				gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"))
 
 				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
@@ -736,7 +736,8 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				ginkgo.By("Allocating all of the rest of the node subnet")
 				// allocate all the rest of the IPs in the subnet
-				fakeOvn.controller.lsManager.AllocateUntilFull("node1")
+				err = fakeOvn.controller.lsManager.AllocateUntilFull("node1")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("Creating another pod which will fail due to allocation full")
 				t2 := newTPod(
@@ -762,7 +763,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				ginkgo.By("Marking myPod as completed should free IP")
-				myPod.Status.Phase = v1.PodSucceeded
+				myPod.Status.Phase = corev1.PodSucceeded
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(),
 					myPod, metav1.UpdateOptions{})
@@ -797,7 +798,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("should not deallocate in-use and previously freed completed pods IP", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -811,18 +812,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode("node1", "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{},
+					&corev1.PodList{
+						Items: []corev1.Pod{},
 					},
 				)
 
@@ -833,7 +834,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.MatchError(kapierrors.IsNotFound, "IsNotFound"))
+				gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"))
 
 				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
@@ -848,7 +849,8 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				ginkgo.By("Allocating all of the rest of the node subnet")
 				// allocate all the rest of the IPs in the subnet
-				fakeOvn.controller.lsManager.AllocateUntilFull("node1")
+				err = fakeOvn.controller.lsManager.AllocateUntilFull("node1")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("Creating another pod which will fail due to allocation full")
 				t2 := newTPod(
@@ -874,7 +876,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				retry.CheckRetryObjectEventually(myPod2Key, true, fakeOvn.controller.retryPods)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				ginkgo.By("Marking myPod as completed should free IP")
-				myPod.Status.Phase = v1.PodSucceeded
+				myPod.Status.Phase = corev1.PodSucceeded
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(),
 					myPod, metav1.UpdateOptions{})
@@ -969,7 +971,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("should not allocate a completed pod on start up", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -982,21 +984,21 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
-				myPod.Status.Phase = v1.PodSucceeded
+				myPod.Status.Phase = corev1.PodSucceeded
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*myPod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*myPod},
 					},
 				)
 
@@ -1018,7 +1020,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("retryPod cache operations while adding a new pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				config.Gateway.DisableSNATMultipleGWs = true
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
@@ -1033,18 +1035,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{},
+					&corev1.PodList{
+						Items: []corev1.Pod{},
 					},
 				)
 
@@ -1055,10 +1057,10 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.MatchError(kapierrors.IsNotFound, "IsNotFound"))
+				gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"))
 
-				podObj := &v1.Pod{
-					Spec: v1.PodSpec{NodeName: "node1"},
+				podObj := &corev1.Pod{
+					Spec: corev1.PodSpec{NodeName: "node1"},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      t.podName,
 						Namespace: namespaceT.Name,
@@ -1075,7 +1077,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(retry.RetryObjsLen(fakeOvn.controller.retryPods)).To(gomega.Equal(1))
 				gomega.Expect(retry.CheckRetryObj(key, fakeOvn.controller.retryPods)).To(gomega.BeTrue())
 				newObj := retry.GetNewObjFieldFromRetryObj(key, fakeOvn.controller.retryPods)
-				storedPod, ok := newObj.(*v1.Pod)
+				storedPod, ok := newObj.(*corev1.Pod)
 				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(storedPod.UID).To(gomega.Equal(podObj.UID))
 
@@ -1090,7 +1092,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("correctly retries a failure while adding a pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace("namespace1")
 				podTest := newTPod(
 					"node1",
@@ -1108,18 +1110,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*pod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*pod},
 					},
 				)
 
@@ -1167,7 +1169,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("correctly retries a failure while deleting a pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace("namespace1")
 				podTest := newTPod(
 					"node1",
@@ -1184,18 +1186,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				key, err := retry.GetResourceKey(pod)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*pod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*pod},
 					},
 				)
 
@@ -1244,7 +1246,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("correctly stops retrying adding a pod after failing n times", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace("namespace1")
 				podTest := newTPod(
 					"node1",
@@ -1263,18 +1265,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*pod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*pod},
 					},
 				)
 
@@ -1356,7 +1358,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("correctly stops retrying deleting a pod after failing n times", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace("namespace1")
 				podTest := newTPod(
 					"node1",
@@ -1375,18 +1377,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				key, err := retry.GetResourceKey(pod)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*pod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*pod},
 					},
 				)
 
@@ -1452,7 +1454,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				// check that the pod is not in API server
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(
 					context.TODO(), podTest.podName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.MatchError(kapierrors.IsNotFound, "IsNotFound"))
+				gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"))
 
 				// check that the retry cache no longer has the entry
 				retry.CheckRetryObjectEventually(key, false, fakeOvn.controller.retryPods)
@@ -1468,7 +1470,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("correctly remove a LSP from a pod that has stale nodeName annotation", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace("namespace1")
 				podTest := newTPod(
 					"node1",
@@ -1485,18 +1487,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				key, err := retry.GetResourceKey(pod)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespace1,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*pod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*pod},
 					},
 				)
 
@@ -1554,7 +1556,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("remove a LSP from a pod that has no OVN annotations", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -1568,18 +1570,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 				pod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*pod,
 						},
 					},
@@ -1599,7 +1601,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("reconciles a deleted pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace("namespace1")
 				// Setup an assigned pod
@@ -1615,18 +1617,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -1648,7 +1650,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.MatchError(kapierrors.IsNotFound, "IsNotFound"))
+				gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"))
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getDefaultNetExpectedPodsAndSwitches([]testPod{}, []string{"node1"})))
 				return nil
@@ -1659,7 +1661,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("retries a failed pod Add on Update", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace("namespace1")
 				// Setup an unassigned pod, perform an update later on which assigns it.
@@ -1675,18 +1677,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -1725,7 +1727,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("pod Add should succeed even when namespace doesn't yet exist", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := newNamespace("namespace1")
 				t := newTPod(
@@ -1741,8 +1743,8 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				podJSON := t.getAnnotationsJson()
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
@@ -1775,7 +1777,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 	ginkgo.Context("on startup", func() {
 
 		ginkgo.It("reconciles a new pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
@@ -1790,18 +1792,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 						},
 					},
@@ -1834,7 +1836,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing pod without an existing logical switch port", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
@@ -1850,18 +1852,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
 				setPodAnnotations(pod, t)
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*pod,
 						},
 					},
@@ -1892,7 +1894,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing logical switch port without an existing pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				// create ovsdb with no pod
 				initialDB = libovsdbtest.TestSetup{
@@ -1913,31 +1915,32 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					},
 				}
 
-				testNode := v1.Node{
+				testNode := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node1",
 					},
 				}
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							testNode,
 						},
 					},
 					// no pods
-					&v1.PodList{
-						Items: []v1.Pod{},
+					&corev1.PodList{
+						Items: []corev1.Pod{},
 					},
 				)
 
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch(testNode.Name, []*net.IPNet{ovntest.MustParseIPNet(v4Node1Subnet)})
-				err := fakeOvn.controller.WatchNamespaces()
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch(testNode.Name, []*net.IPNet{ovntest.MustParseIPNet(v4Node1Subnet)})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1963,7 +1966,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing pod with an existing logical switch port", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				// use 3 pods for different test options
 				t1 := newTPod(
@@ -2071,19 +2074,19 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod3 := newPod(t3.namespace, t3.podName, t3.nodeName, t3.podIP)
 				setPodAnnotations(pod3, t3)
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 							*newNode(node2Name, "192.168.126.51/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*pod1,
 							*pod2,
 							*pod3,
@@ -2126,7 +2129,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			// expect reconciliation not to fail and to continue reconciliation for existing pods.
 			// this test proves reconciliation continues for existing pods by checking a pod that doesn't exist in kapi
 			// is cleaned up in OVN.
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				initialDB := libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
 						&nbdb.LogicalSwitchPort{
@@ -2144,31 +2147,32 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 						},
 					},
 				}
-				testNodeWithLS := v1.Node{
+				testNodeWithLS := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node1",
 					},
 				}
-				testNodeWithoutLS := v1.Node{
+				testNodeWithoutLS := corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 					},
 				}
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							testNodeWithLS,
 							testNodeWithoutLS,
 						},
 					},
 					// no pods - we want to test that cleanup of pod LSP is successful within OVN DB despite one node having
 					// no logical switch
-					&v1.PodList{
-						Items: []v1.Pod{},
+					&corev1.PodList{
+						Items: []corev1.Pod{},
 					},
 				)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch(testNodeWithLS.Name, []*net.IPNet{ovntest.MustParseIPNet(v4Node1Subnet)})
-				err := fakeOvn.controller.WatchPods()
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch(testNodeWithLS.Name, []*net.IPNet{ovntest.MustParseIPNet(v4Node1Subnet)})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// expect stale logical switch port removed if reconciliation is successful
 				expectData := []libovsdbtest.TestData{
@@ -2188,7 +2192,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("Negative test: fails to add existing pod with an existing logical switch port on wrong node", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				// use 2 pods for different test options
 				t1 := newTPod(
@@ -2234,18 +2238,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod1 := newPod(t1.namespace, t1.podName, t1.nodeName, t1.podIP)
 				setPodAnnotations(pod1, t1)
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*pod1,
 						},
 					},
@@ -2271,7 +2275,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("reconciles a terminating pod with no node", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
@@ -2290,18 +2294,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				p.SetDeletionTimestamp(&now)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*p,
 						},
 					},
@@ -2321,6 +2325,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				_, err = fakeOvn.controller.logicalPortCache.get(pod, ovntypes.DefaultNetworkName)
 				gomega.Expect(err).NotTo(gomega.BeNil())
 				myPod1Key, err := retry.GetResourceKey(pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				retry.CheckRetryObjectEventually(myPod1Key, true, fakeOvn.controller.retryPods)
 				return nil
 			}
@@ -2330,7 +2335,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("deletes an outdated hybrid overlay subnet route in dual stack configuration", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
@@ -2361,18 +2366,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				setPodAnnotations(pod, t)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*pod,
 						},
 					},
@@ -2404,7 +2409,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("won't release a completed pod IP if a running pod has the same IP", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 
 				completedTPod := newTPod(
@@ -2420,7 +2425,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				completedPod := newPod(completedTPod.namespace, completedTPod.podName, completedTPod.nodeName, completedTPod.podIP)
 				setPodAnnotations(completedPod, completedTPod)
 				completedPod.UID = types.UID(completedPod.ObjectMeta.Name)
-				completedPod.Status.Phase = v1.PodSucceeded
+				completedPod.Status.Phase = corev1.PodSucceeded
 
 				runningTPod := newTPod(
 					"node1",
@@ -2437,18 +2442,18 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				runningPod.UID = types.UID(runningPod.ObjectMeta.Name)
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{
+					&corev1.PodList{
+						Items: []corev1.Pod{
 							*runningPod,
 							*completedPod,
 						},
@@ -2473,7 +2478,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("should handle a scheduled or failed remote pod with no IPs annotated", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -2490,21 +2495,21 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				// testing how a scheduled non-annotated pod is handled is
 				// tricky, let's settle with a failed pod which should be
 				// handled in a similar way
-				myPod.Status.Phase = v1.PodFailed
+				myPod.Status.Phase = corev1.PodFailed
 
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							*newNode(node1Name, "192.168.126.202/24"),
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*myPod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*myPod},
 					},
 				)
 
@@ -2533,7 +2538,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should correctly handle a pod running on no node", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespaceT := *newNamespace("namespace1")
 				t := newTPod(
 					"node1",
@@ -2546,22 +2551,22 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
-				myPod.Status.Phase = v1.PodRunning
+				myPod.Status.Phase = corev1.PodRunning
 				setPodAnnotations(myPod, t)
 				initialDB = libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{},
 				}
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{},
+					&corev1.NodeList{
+						Items: []corev1.Node{},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*myPod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*myPod},
 					},
 				)
 
@@ -2575,45 +2580,46 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		})
 
 		ginkgo.It("should correctly handle a pod running on a no host subnet node", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				testNs := "namespace1"
 				testPodIP := "10.128.1.3"
 				namespaceT := *newNamespace(testNs)
 				myPod := newPod(testNs, "myPod", node2Name, testPodIP)
-				myPod.Status.Phase = v1.PodRunning
+				myPod.Status.Phase = corev1.PodRunning
 				initialDB = libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{},
 				}
 				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{
 							namespaceT,
 						},
 					},
-					&v1.NodeList{
-						Items: []v1.Node{
+					&corev1.NodeList{
+						Items: []corev1.Node{
 							// Add a hybrid overlay node
 							{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: nodeName,
 								},
-								Status: v1.NodeStatus{
-									Conditions: []v1.NodeCondition{
+								Status: corev1.NodeStatus{
+									Conditions: []corev1.NodeCondition{
 										{
-											Type:   v1.NodeReady,
-											Status: v1.ConditionTrue,
+											Type:   corev1.NodeReady,
+											Status: corev1.ConditionTrue,
 										},
 									},
 								},
 							},
 						},
 					},
-					&v1.PodList{
-						Items: []v1.Pod{*myPod},
+					&corev1.PodList{
+						Items: []corev1.Pod{*myPod},
 					},
 				)
-				fakeOvn.controller.lsManager.AddOrUpdateSwitch(myPod.Spec.NodeName, nil)
-				err := fakeOvn.controller.WatchPods()
+				err := fakeOvn.controller.lsManager.AddOrUpdateSwitch(myPod.Spec.NodeName, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// check that the pod IP is added to the namespace AS

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -217,7 +217,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		fakeOvn = NewFakeOVN(true)
 
 		initialData := getHairpinningACLsV4AndPortGroup()
@@ -230,9 +230,9 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 		fakeOvn.shutdown()
 	})
 
-	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy) {
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, networkPolicies []knet.NetworkPolicy) {
 		fakeOvn.startWithDBSetup(dbSetup,
-			&v1.NamespaceList{
+			&corev1.NamespaceList{
 				Items: namespaces,
 			},
 			&knet.NetworkPolicyList{
@@ -261,7 +261,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			initialData := initialDB.NBData
 			initialData = append(initialData, gressPolicyInitialData...)
 			initialData = append(initialData, defaultDenyInitialData...)
-			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 				[]knet.NetworkPolicy{*networkPolicy})
 
 			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
@@ -289,7 +289,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			initialData := initialDB.NBData
 			initialData = append(initialData, gressPolicyInitialData...)
 			initialData = append(initialData, defaultDenyInitialData...)
-			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 				[]knet.NetworkPolicy{*networkPolicy})
 
 			fakeOvn.asf.ExpectEmptyAddressSet(longNamespaceName63)
@@ -327,7 +327,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			_, err := fakeOvn.asf.NewAddressSet(staleAddrSetIDs, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 				[]knet.NetworkPolicy{*networkPolicy})
 
 			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/urfave/cli/v2"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
@@ -29,7 +29,6 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -531,7 +530,7 @@ func getMatchLabelsNetworkPolicy(policyName, netpolNamespace, peerNamespace, pee
 }
 
 func getPortNetworkPolicy(policyName, namespace, labelName, labelVal string, tcpPort int32) *knet.NetworkPolicy {
-	tcpProtocol := v1.ProtocolTCP
+	tcpProtocol := corev1.ProtocolTCP
 	return newNetworkPolicy(policyName, namespace,
 		metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -561,8 +560,8 @@ func buildNetworkPolicyPeerAddressSets(namespaceName string, peer knet.NetworkPo
 
 // buildNetworkPolicyAddressSets builds all the addresssets for all the network policy peers of a network policy
 // the limitation is that all the addressSets must be empty
-func buildNetworkPolicyAddressSets(networkPolicy *knet.NetworkPolicy) []libovsdb.TestData {
-	addressSets := []libovsdb.TestData{}
+func buildNetworkPolicyAddressSets(networkPolicy *knet.NetworkPolicy) []libovsdbtest.TestData {
+	addressSets := []libovsdbtest.TestData{}
 	for _, egress := range networkPolicy.Spec.Egress {
 		for _, peer := range egress.To {
 			if peer.PodSelector != nil {
@@ -628,7 +627,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -655,9 +654,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		format.MaxLength = gomegaFormatMaxLength
 	})
 
-	startOvnWithHostNetPods := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+	startOvnWithHostNetPods := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, networkPolicies []knet.NetworkPolicy,
 		pods []testPod, podLabels map[string]string, hostNetPods bool) {
-		var podsList []v1.Pod
+		var podsList []corev1.Pod
 		for _, testPod := range pods {
 			knetPod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 			if len(podLabels) > 0 {
@@ -669,15 +668,15 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			podsList = append(podsList, *knetPod)
 		}
 		fakeOvn.startWithDBSetup(dbSetup,
-			&v1.NamespaceList{
+			&corev1.NamespaceList{
 				Items: namespaces,
 			},
-			&v1.NodeList{
-				Items: []v1.Node{
+			&corev1.NodeList{
+				Items: []corev1.Node{
 					*newNode(nodeName, "192.168.126.202/24"),
 				},
 			},
-			&v1.PodList{
+			&corev1.PodList{
 				Items: podsList,
 			},
 			&knet.NetworkPolicyList{
@@ -700,7 +699,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
-	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, networkPolicies []knet.NetworkPolicy,
 		pods []testPod, podLabels map[string]string) {
 		startOvnWithHostNetPods(dbSetup, namespaces, networkPolicies, pods, podLabels, false)
 	}
@@ -712,7 +711,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 	ginkgo.Context("on startup", func() {
 		ginkgo.It("creates default hairpinning ACLs", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				clusterPortGroup = newClusterPortGroup()
 				initialDB = libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
@@ -734,7 +733,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("deletes stale port groups", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				// network policy with peer selector
 				networkPolicy1 := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
@@ -772,7 +771,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing networkPolicy with empty db", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
@@ -782,7 +781,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					namespace2.Name, "", true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					nil, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -800,7 +799,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles an ingress networkPolicy updating an existing ACL", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
@@ -817,7 +816,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
 
-				startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+				startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 					[]knet.NetworkPolicy{*networkPolicy}, nil, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -835,13 +834,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing networkPolicy with a pod selector in its own namespace from empty db", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				// network policy with peer pod selector
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					"", nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
@@ -863,7 +862,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles an existing networkPolicy with a pod and namespace selector in another namespace from empty db", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
@@ -872,7 +871,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// network policy with peer pod and namespace selector
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					namespace2.Name, nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
@@ -896,7 +895,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles existing networkPolicies with equivalent rules", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				peer := knet.NetworkPolicyPeer{
@@ -934,7 +933,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						From: []knet.NetworkPolicyPeer{peer},
 					}}, nil)
 
-				startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1},
+				startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1},
 					[]knet.NetworkPolicy{*networkPolicy1Updated, *networkPolicy2},
 					nil, nil)
 
@@ -967,7 +966,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					},
 				}, nil)
 				initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4, namespace2AddressSetv4)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*netpol}, nil, nil)
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*netpol}, nil, nil)
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(netpol).withPeerNamespaces(peerNamespaces...),
@@ -1029,13 +1028,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		)
 
 		ginkgo.It("correctly creates and deletes a networkpolicy allowing a port to a local pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
 				initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
 
 				ginkgo.By("Check networkPolicy applied to a pod data")
@@ -1090,11 +1089,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("correctly retries creating a network policy allowing a port to a local pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
 
 				ginkgo.By("Check networkPolicy applied to a pod data")
@@ -1151,11 +1150,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("correctly retries recreating a network policy with the same name", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
 
 				ginkgo.By("Check networkPolicy applied to a pod data")
@@ -1225,13 +1224,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles a deleted namespace referenced by a networkpolicy with a local running pod", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					namespace2.Name, "", true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 				// create networkPolicy, check db
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -1270,12 +1269,12 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles a deleted namespace referenced by a networkpolicy", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					namespace2.Name, "", true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					nil, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -1314,12 +1313,12 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles a deleted pod referenced by a networkpolicy in its own namespace", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					"", nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -1356,14 +1355,14 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles a deleted pod referenced by a networkpolicy in another namespace", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := getTestPod(namespace2.Name, nodeName)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					nPodTest.namespace, nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -1399,13 +1398,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles an updated namespace label", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
 				nPodTest := getTestPod(namespace2.Name, nodeName)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					nPodTest.namespace, nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
@@ -1440,12 +1439,12 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("reconciles a deleted networkpolicy", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					"", nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -1481,12 +1480,12 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("retries a deleted network policy", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					"", nPodTest.podName, true, true)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				gomega.Eventually(func() bool {
@@ -1548,10 +1547,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			// Even though a policy might isolate for ingress only, we need to
 			// process the egress rules in case an additional policy isolating
 			// for egress is added in the future.
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
-				tcpProtocol := v1.Protocol(v1.ProtocolTCP)
+				tcpProtocol := corev1.Protocol(corev1.ProtocolTCP)
 				networkPolicy := newNetworkPolicy(netPolicyName1, namespace1.Name,
 					metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1567,7 +1566,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					}},
 					knet.PolicyTypeIngress,
 				)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
 
 				ginkgo.By("Creating a network policy that isolates a pod for ingress with egress rules")
@@ -1606,10 +1605,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			// Even though a policy might isolate for egress only, we need to
 			// process the ingress rules in case an additional policy isolating
 			// for ingress is added in the future.
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
-				tcpProtocol := v1.Protocol(v1.ProtocolTCP)
+				tcpProtocol := corev1.Protocol(corev1.ProtocolTCP)
 				networkPolicy := newNetworkPolicy(netPolicyName1, namespace1.Name,
 					metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1625,7 +1624,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					nil,
 					knet.PolicyTypeEgress,
 				)
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
 
 				ginkgo.By("Creating a network policy that isolates a pod for egress with ingress rules")
@@ -1662,7 +1661,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("can reconcile network policy with long name", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				// this problem can be reproduced by starting ovn with existing db rows for network policy
 				// from namespace with long name, but WatchNetworkPolicy doesn't return error on initial netpol add,
 				// it just puts network policy to retry loop.
@@ -1677,7 +1676,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				longNamespace := *newNamespace(longNameSpaceName)
 				networkPolicy1 := getPortNetworkPolicy(netPolicyName1, longNamespace.Name, labelName, labelVal, portNum)
 
-				startOvn(initialDB, []v1.Namespace{longNamespace}, []knet.NetworkPolicy{*networkPolicy1},
+				startOvn(initialDB, []corev1.Namespace{longNamespace}, []knet.NetworkPolicy{*networkPolicy1},
 					nil, map[string]string{labelName: labelVal})
 
 				ginkgo.By("Simulate the initial re-add of all network policies during upgrade and ensure we are stable")
@@ -1693,9 +1692,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("can handle network policies with equivalent rules", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
-				startOvn(initialDB, []v1.Namespace{namespace1}, nil, nil, nil)
+				startOvn(initialDB, []corev1.Namespace{namespace1}, nil, nil, nil)
 
 				peer := knet.NetworkPolicyPeer{
 					IPBlock: &knet.IPBlock{
@@ -1744,7 +1743,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("references all namespace address sets for empty namespace selector, even if they don't have pods (HostNetworkNamespace)", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				hostNamespaceName := "host-network"
 				hostNamespace := *newNamespace(hostNamespaceName)
 
@@ -1757,7 +1756,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						}},
 					},
 				}, nil)
-				startOvn(initialDB, []v1.Namespace{namespace1, hostNamespace}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1, hostNamespace}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
 				// emulate namespace handler adding management IPs for this address set
@@ -1770,7 +1769,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// emulate management IP being added to the hostNetwork address set, but no pods in that namespace
-				as.AddAddresses([]string{"10.244.0.2"})
+				err = as.AddAddresses([]string{"10.244.0.2"})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// create networkPolicy, check db
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -1793,7 +1793,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("cleans up retryFramework resources", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace1.Labels = map[string]string{"name": "label1"}
 				networkPolicy := newNetworkPolicy(netPolicyName2, namespace1.Name, metav1.LabelSelector{},
@@ -1804,7 +1804,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 							}},
 						}},
 					}, nil)
-				startOvn(initialDB, []v1.Namespace{namespace1}, nil, nil, nil)
+				startOvn(initialDB, []corev1.Namespace{namespace1}, nil, nil, nil)
 
 				// let the system settle down before counting goroutines
 				time.Sleep(100 * time.Millisecond)
@@ -1836,7 +1836,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 		ginkgo.It("correctly creates networkpolicy targeting hostNetwork pods with non-nil podSelector", func() {
 			// check useNamespaceAddrSet function comments to explain this behaviour
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace1.Labels = map[string]string{labelName: labelVal}
 				nPodTest := getTestPod(namespace1.Name, nodeName)
@@ -1855,7 +1855,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					knet.PolicyTypeEgress,
 				)
 
-				startOvnWithHostNetPods(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvnWithHostNetPods(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil, true)
 
 				ginkgo.By("Check networkPolicy includes hostNetwork")
@@ -1881,7 +1881,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 		ginkgo.It("correctly creates networkpolicy ignoring hostNetwork pods with nil podSelector", func() {
 			// check useNamespaceAddrSet function comments to explain this behaviour
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				namespace1.Labels = map[string]string{labelName: labelVal}
 				nPodTest := getTestPod(namespace1.Name, nodeName)
@@ -1899,7 +1899,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					knet.PolicyTypeEgress,
 				)
 
-				startOvnWithHostNetPods(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvnWithHostNetPods(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil, true)
 
 				ginkgo.By("Check networkPolicy doesn't select hostNetwork pods")
@@ -1924,9 +1924,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 	ginkgo.Context("ACL logging for network policies", func() {
 
-		var originalNamespace v1.Namespace
+		var originalNamespace corev1.Namespace
 
-		updateNamespaceACLLogSeverity := func(namespaceToUpdate *v1.Namespace, desiredDenyLogLevel string, desiredAllowLogLevel string) error {
+		updateNamespaceACLLogSeverity := func(namespaceToUpdate *corev1.Namespace, desiredDenyLogLevel string, desiredAllowLogLevel string) error {
 			ginkgo.By("updating the namespace's ACL logging severity")
 			updatedLogSeverity := fmt.Sprintf(`{ "deny": "%s", "allow": "%s" }`, desiredDenyLogLevel, desiredAllowLogLevel)
 			namespaceToUpdate.Annotations[util.AclLoggingAnnotation] = updatedLogSeverity
@@ -1953,8 +1953,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					withAllowLogSeverity(nbdb.ACLSeverityNotice))...)
 			initialExpectedData = append(initialExpectedData, initialDB.NBData...)
 
-			app.Action = func(ctx *cli.Context) error {
-				startOvn(initialDB, []v1.Namespace{originalNamespace}, []knet.NetworkPolicy{*initialDenyAllPolicy},
+			app.Action = func(*cli.Context) error {
+				startOvn(initialDB, []corev1.Namespace{originalNamespace}, []knet.NetworkPolicy{*initialDenyAllPolicy},
 					nil, nil)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(originalNamespace.Name, nil)
 				initialExpectedData = append(initialExpectedData, namespace1AddressSetv4)
@@ -2014,8 +2014,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				getMatchLabelsNetworkPolicy(netPolicyName1, namespaceName1, namespaceName2, "tiny-winy-pod", true, false)))
 
 		ginkgo.It("policies created after namespace logging level updates inherit updated logging level", func() {
-			app.Action = func(ctx *cli.Context) error {
-				startOvn(initialDB, []v1.Namespace{originalNamespace}, nil, nil, nil)
+			app.Action = func(*cli.Context) error {
+				startOvn(initialDB, []corev1.Namespace{originalNamespace}, nil, nil, nil)
 				desiredLogSeverity := nbdb.ACLSeverityDebug
 				// update namespace log severity
 				gomega.Expect(
@@ -2043,14 +2043,14 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		})
 
 		ginkgo.It("creates stateless OVN ACLs based off of the annotation", func() {
-			app.Action = func(ctx *cli.Context) error {
+			app.Action = func(*cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
 				networkPolicy.Annotations = map[string]string{
 					ovnStatelessNetPolAnnotationName: "true",
 				}
-				startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, map[string]string{labelName: labelVal})
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -2274,7 +2274,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 			controllerName        = DefaultNetworkControllerName
 		)
 		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		asFactory = addressset.NewFakeAddressSetFactory(controllerName)
 		config.IPv4Mode = true
 		config.IPv6Mode = false

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -70,7 +70,7 @@ func createTransitSwitchPortBindings(sbClient libovsdbclient.Client, netName str
 
 func getNetworkScopedName(netName, name string) string {
 	if netName == types.DefaultNetworkName {
-		return fmt.Sprintf("%s", name)
+		return name
 	}
 	return fmt.Sprintf("%s%s", util.GetSecondaryNetworkPrefix(netName), name)
 }

--- a/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
@@ -89,7 +89,7 @@ var (
 func TestEnsureLocalRaftServerID(t *testing.T) {
 	var mockCalls map[string]*mockRes
 	unexpectedKeys := make([]string, 0)
-	mock := func(timeout int, args ...string) (string, string, error) {
+	mock := func(_ int, args ...string) (string, string, error) {
 		key := keyForArgs(args...)
 		res, ok := mockCalls[key]
 		if !ok {
@@ -253,7 +253,7 @@ func TestEnsureClusterRaftMembership(t *testing.T) {
 	var mockCalls map[string]*mockRes
 	unexpectedKeys := make([]string, 0)
 
-	mock := func(timeout int, args ...string) (string, string, error) {
+	mock := func(_ int, args ...string) (string, string, error) {
 		key := keyForArgs(args...)
 		res, ok := mockCalls[key]
 		if !ok {
@@ -385,7 +385,7 @@ func TestEnsureClusterDNSRaftMembership(t *testing.T) {
 	var mockCalls map[string]*mockRes
 	unexpectedKeys := make([]string, 0)
 
-	mock := func(timeout int, args ...string) (string, string, error) {
+	mock := func(_ int, args ...string) (string, string, error) {
 		key := keyForArgs(args...)
 		res, ok := mockCalls[key]
 		if !ok {
@@ -516,7 +516,7 @@ func TestEnsureClusterDNSRaftMembership(t *testing.T) {
 func TestEnsureElectionTimeout(t *testing.T) {
 	var mockCalls map[string]*mockRes
 	unexpectedKeys := make([]string, 0)
-	mock := func(timeout int, args ...string) (string, string, error) {
+	mock := func(_ int, args ...string) (string, string, error) {
 		key := keyForArgs(args...)
 		res, ok := mockCalls[key]
 		if !ok {
@@ -673,7 +673,7 @@ func TestResetRaftDB(t *testing.T) {
 
 	var mockCalls map[string]*mockRes
 	unexpectedKeys := make([]string, 0)
-	mock := func(timeout int, args ...string) (string, string, error) {
+	mock := func(_ int, args ...string) (string, string, error) {
 		key := keyForArgs(args...)
 		res, ok := mockCalls[key]
 		if !ok {

--- a/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
@@ -773,6 +773,7 @@ func keyForArgs(args ...string) string {
 
 // create file with name, fail on error or if the file already exists
 func createDbFile(t *testing.T, name string) {
+	t.Helper()
 	_, err := os.Stat(name)
 	if os.IsNotExist(err) {
 		f, err := os.OpenFile(name, os.O_RDONLY|os.O_CREATE, 0o644)
@@ -788,6 +789,7 @@ func createDbFile(t *testing.T, name string) {
 // failOnErrorMismatch fails either if an error is seen but not expected
 // or if an error is expected but when the substring does not match the error
 func failOnErrorMismatch(t *testing.T, receivedErr error, expectedErrorString string) {
+	t.Helper()
 	if receivedErr != nil {
 		if expectedErrorString == "" {
 			t.Errorf("No error expected. However, received '%v' from method under test.", receivedErr)

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"golang.org/x/exp/maps"
@@ -397,7 +396,7 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
-			if !reflect.DeepEqual(err, tt.expectedErr) {
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
 			}
@@ -437,7 +436,7 @@ func TestNodeAdmission_ValidateUpdateIC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
-			if !reflect.DeepEqual(err, tt.expectedErr) {
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("ValidateUpdateIC() error = %v, wantErr %v", err, tt.expectedErr)
 				return
 			}
@@ -496,7 +495,7 @@ func TestNodeAdmission_ValidateUpdateHybridOverlay(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
-			if !reflect.DeepEqual(err, tt.expectedErr) {
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("ValidateUpdateIC() error = %v, wantErr %v", err, tt.expectedErr)
 				return
 			}
@@ -557,7 +556,7 @@ func TestNodeAdmission_ValidateUpdateExtraUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
-			if !reflect.DeepEqual(err, tt.expectedErr) {
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("ValidateUpdateIC() error = %v, wantErr %v", err, tt.expectedErr)
 				return
 			}

--- a/go-controller/pkg/ovnwebhook/podadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/podadmission_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -26,7 +25,7 @@ type fakeNodeLister struct {
 	nodes map[string]*corev1.Node
 }
 
-func (f *fakeNodeLister) List(selector labels.Selector) (ret []*corev1.Node, err error) {
+func (f *fakeNodeLister) List(labels.Selector) (ret []*corev1.Node, err error) {
 	panic("implement me")
 }
 
@@ -426,7 +425,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 	additionalPodAdmissions := PodAdmissionConditionOption{
 		CommonNamePrefix:         additionalNamePrefix,
 		AllowedPodAnnotations:    allowedPodAnnotations,
-		AllowedPodAnnotationKeys: sets.New[string](allowedPodAnnotations...),
+		AllowedPodAnnotationKeys: sets.New(allowedPodAnnotations...),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -436,7 +435,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 				additionalPodAdmissions,
 			})
 			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
-			if !reflect.DeepEqual(err, tt.expectedErr) {
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
 			}
@@ -516,7 +515,7 @@ func TestPodAdmission_ValidateUpdateExtraUsers(t *testing.T) {
 	additionalPodAdmissions := PodAdmissionConditionOption{
 		CommonNamePrefix:         additionalNamePrefix,
 		AllowedPodAnnotations:    allowedPodAnnotations,
-		AllowedPodAnnotationKeys: sets.New[string](allowedPodAnnotations...),
+		AllowedPodAnnotationKeys: sets.New(allowedPodAnnotations...),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -526,7 +525,7 @@ func TestPodAdmission_ValidateUpdateExtraUsers(t *testing.T) {
 				additionalPodAdmissions,
 			}, extraUser)
 			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
-			if !reflect.DeepEqual(err, tt.expectedErr) {
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
 			}

--- a/go-controller/pkg/util/batching/batch_test.go
+++ b/go-controller/pkg/util/batching/batch_test.go
@@ -1,7 +1,6 @@
 package batching
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -68,7 +67,7 @@ func TestBatch(t *testing.T) {
 			if tCase.expectErr != "" && strings.Contains(err.Error(), tCase.expectErr) {
 				continue
 			}
-			t.Fatal(fmt.Sprintf("test %s failed: %v", tCase.name, err))
+			t.Fatalf("test %s failed: %v", tCase.name, err)
 		}
 		// tCase.data/tCase.batchSize round up
 		expectedBatchNum := (len(tCase.data) + tCase.batchSize - 1) / tCase.batchSize
@@ -215,7 +214,7 @@ func TestBatchMap(t *testing.T) {
 			if tCase.expectErr != "" && strings.Contains(err.Error(), tCase.expectErr) {
 				continue
 			}
-			t.Fatal(fmt.Sprintf("test %s failed: %v", tCase.name, err))
+			t.Fatalf("test %s failed: %v", tCase.name, err)
 		}
 		g.Expect(batchNum).To(gomega.Equal(tCase.expectedBatchesNum))
 		g.Expect(result).To(gomega.Equal(tCase.data))

--- a/go-controller/pkg/util/dns_test.go
+++ b/go-controller/pkg/util/dns_test.go
@@ -27,14 +27,14 @@ func TestNewDNS(t *testing.T) {
 			desc:   "fails to read config file ",
 			errExp: true,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
+				{OnCallMethodName: "ClientConfigFromFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}, CallTimes: 1},
 			},
 		},
 		{
 			desc:   "positive test case",
 			errExp: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{}, nil}, 0, 1},
+				{OnCallMethodName: "ClientConfigFromFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&dns.ClientConfig{}, nil}, CallTimes: 1},
 			},
 		},
 	}
@@ -79,9 +79,14 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 			ipv4Mode: true,
 			ipv6Mode: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{"www.test.com"}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")}, 0, 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"www.test.com"}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")},
+					CallTimes:           1,
+				},
 			},
 		},
 		{
@@ -90,9 +95,14 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 			ipv4Mode: true,
 			ipv6Mode: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{"www.test.com"}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: 2}}, 0 * time.Second, nil}, 0, 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"www.test.com"}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: 2}}, 0 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 		},
 	}
@@ -155,9 +165,14 @@ func TestUpdate(t *testing.T) {
 			},
 			},
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")}, 0, 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")},
+					CallTimes:           1,
+				},
 			},
 			errExp: true,
 		},
@@ -168,9 +183,14 @@ func TestUpdate(t *testing.T) {
 			},
 			},
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, 0, 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			errExp:    false,
 			changeExp: false,
@@ -182,9 +202,14 @@ func TestUpdate(t *testing.T) {
 			},
 			},
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, 0, 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 			errExp:    false,
 			changeExp: true,
@@ -240,18 +265,28 @@ func TestAdd(t *testing.T) {
 			desc:   "Add fails",
 			errExp: true,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{}}, 0 * time.Second, nil}, 0, 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{}}, 0 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 		},
 		{
 			desc:   "Add succeeds ",
 			errExp: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: addedIP}}}, 0 * time.Second, nil}, 0, 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1},
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{
+					OnCallMethodName:    "Exchange",
+					OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"},
+					RetArgList:          []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: addedIP}}}, 0 * time.Second, nil},
+					CallTimes:           1,
+				},
 			},
 		},
 	}

--- a/go-controller/pkg/util/dns_test.go
+++ b/go-controller/pkg/util/dns_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -53,9 +54,9 @@ func TestNewDNS(t *testing.T) {
 			res, err := NewDNS("DNS temp Name")
 			t.Log(res, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockDNSOps.AssertExpectations(t)
 
@@ -130,9 +131,9 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 			res, _, err := testDNS.getIPsAndMinTTL("www.test.com")
 			t.Log(res, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockDNSOps.AssertExpectations(t)
 		})
@@ -235,12 +236,12 @@ func TestUpdate(t *testing.T) {
 			}
 			returned, err := dns.Update(dnsName)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.changeExp, returned, "the change expected varaible should match the return from dns.Update()")
 
-				assert.Equal(t, len(dns.dnsMap[dnsName].ips), 1)
+				assert.Len(t, dns.dnsMap[dnsName].ips, 1)
 				assert.Equal(t, dns.dnsMap[dnsName].ips[0], newIP)
 
 			}
@@ -308,10 +309,10 @@ func TestAdd(t *testing.T) {
 			}
 			err := dns.Add(dnsName)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, len(dns.dnsMap[dnsName].ips), 1)
+				require.NoError(t, err)
+				assert.Len(t, dns.dnsMap[dnsName].ips, 1)
 				assert.Equal(t, dns.dnsMap[dnsName].ips[0], addedIP)
 			}
 		})

--- a/go-controller/pkg/util/egressfirewall_test.go
+++ b/go-controller/pkg/util/egressfirewall_test.go
@@ -166,7 +166,10 @@ func TestValidateAndGetEgressFirewallDestination(t *testing.T) {
 		},
 	}
 
-	config.PrepareTestConfig()
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to PrepareTestConfig: %v", err)
+	}
+
 	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: clusterSubnet}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go-controller/pkg/util/egressfirewall_test.go
+++ b/go-controller/pkg/util/egressfirewall_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -181,9 +182,9 @@ func TestValidateAndGetEgressFirewallDestination(t *testing.T) {
 			cidrSelector, dnsName, clusterSubnetIntersection, nodeSelector, err :=
 				ValidateAndGetEgressFirewallDestination(tc.egressFirewallDestination)
 			if tc.expectedErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.expectedOutput.dnsName, dnsName)
 				assert.Equal(t, tc.expectedOutput.cidrSelector, cidrSelector)
 				assert.Equal(t, tc.expectedOutput.clusterSubnetIntersection, clusterSubnetIntersection)

--- a/go-controller/pkg/util/errors/join_test.go
+++ b/go-controller/pkg/util/errors/join_test.go
@@ -41,7 +41,7 @@ func TestJoin(t *testing.T) {
 		want: []error{err1, err2},
 	}} {
 		got := Join(test.errs...).(interface{ Unwrap() []error }).Unwrap()
-		if !reflect.DeepEqual(got, test.want) {
+		if !reflect.DeepEqual(got, test.want) { //nolint:govet
 			t.Errorf("Join(%v) = %v; want %v", test.errs, got, test.want)
 		}
 		if len(got) != cap(got) {

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	kapi "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -20,11 +19,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	kubetest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-)
-
-var (
-	nodeA = "node-a"
-	nodeB = "node-b"
 )
 
 // Go Daddy Class 2 CA
@@ -119,22 +113,22 @@ func TestNewClientset(t *testing.T) {
 func TestIsClusterIPSet(t *testing.T) {
 	tests := []struct {
 		desc   string
-		inp    v1.Service
+		inp    corev1.Service
 		expOut bool
 	}{
 		{
 			desc: "false: test when ClusterIP set to ClusterIPNone",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
-					ClusterIP: v1.ClusterIPNone,
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ClusterIP: corev1.ClusterIPNone,
 				},
 			},
 			expOut: false,
 		},
 		{
 			desc: "false: test when ClusterIP set to empty string",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					ClusterIP: "",
 				},
 			},
@@ -142,8 +136,8 @@ func TestIsClusterIPSet(t *testing.T) {
 		},
 		{
 			desc: "true: test when ClusterIP set to NON-empty string",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					ClusterIP: "blah",
 				},
 			},
@@ -162,13 +156,13 @@ func TestIsClusterIPSet(t *testing.T) {
 func TestValidateProtocol(t *testing.T) {
 	tests := []struct {
 		desc   string
-		inp    v1.Protocol
-		expOut v1.Protocol
+		inp    corev1.Protocol
+		expOut corev1.Protocol
 		expErr bool
 	}{
 		{
 			desc: "valid protocol SCTP",
-			inp:  v1.ProtocolSCTP,
+			inp:  corev1.ProtocolSCTP,
 		},
 		{
 			desc:   "invalid protocol -> blah",
@@ -191,13 +185,13 @@ func TestValidateProtocol(t *testing.T) {
 func TestServiceTypeHasClusterIP(t *testing.T) {
 	tests := []struct {
 		desc   string
-		inp    v1.Service
+		inp    corev1.Service
 		expOut bool
 	}{
 		{
 			desc: "true: test when Type set to `ClusterIP`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "ClusterIP",
 				},
 			},
@@ -205,8 +199,8 @@ func TestServiceTypeHasClusterIP(t *testing.T) {
 		},
 		{
 			desc: "true: test when Type set to `NodePort`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "NodePort",
 				},
 			},
@@ -214,8 +208,8 @@ func TestServiceTypeHasClusterIP(t *testing.T) {
 		},
 		{
 			desc: "true: test when Type set to `LoadBalancer`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "LoadBalancer",
 				},
 			},
@@ -223,8 +217,8 @@ func TestServiceTypeHasClusterIP(t *testing.T) {
 		},
 		{
 			desc: "false: test when Type set to `loadbalancer`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "loadbalancer",
 				},
 			},
@@ -243,13 +237,13 @@ func TestServiceTypeHasClusterIP(t *testing.T) {
 func TestServiceTypeHasNodePort(t *testing.T) {
 	tests := []struct {
 		desc   string
-		inp    v1.Service
+		inp    corev1.Service
 		expOut bool
 	}{
 		{
 			desc: "true: test when Type set to `ClusterIP`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "ClusterIP",
 				},
 			},
@@ -257,8 +251,8 @@ func TestServiceTypeHasNodePort(t *testing.T) {
 		},
 		{
 			desc: "true: test when Type set to `NodePort`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "NodePort",
 				},
 			},
@@ -266,8 +260,8 @@ func TestServiceTypeHasNodePort(t *testing.T) {
 		},
 		{
 			desc: "true: test when Type set to `LoadBalancer`",
-			inp: v1.Service{
-				Spec: v1.ServiceSpec{
+			inp: corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Type: "LoadBalancer",
 				},
 			},
@@ -286,16 +280,16 @@ func TestServiceTypeHasNodePort(t *testing.T) {
 func TestGetNodePrimaryIP(t *testing.T) {
 	tests := []struct {
 		desc   string
-		inp    v1.Node
+		inp    corev1.Node
 		expErr bool
 		expOut string
 	}{
 		{
 			desc: "error: node has neither external nor internal IP",
-			inp: v1.Node{
-				Status: v1.NodeStatus{
-					Addresses: []v1.NodeAddress{
-						{Type: v1.NodeHostName, Address: "HN"},
+			inp: corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeHostName, Address: "HN"},
 					},
 				},
 			},
@@ -304,12 +298,12 @@ func TestGetNodePrimaryIP(t *testing.T) {
 		},
 		{
 			desc: "success: node's internal IP returned",
-			inp: v1.Node{
-				Status: v1.NodeStatus{
-					Addresses: []v1.NodeAddress{
-						{Type: v1.NodeHostName, Address: "HN"},
-						{Type: v1.NodeInternalIP, Address: "192.168.1.1"},
-						{Type: v1.NodeExternalIP, Address: "90.90.90.90"},
+			inp: corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeHostName, Address: "HN"},
+						{Type: corev1.NodeInternalIP, Address: "192.168.1.1"},
+						{Type: corev1.NodeExternalIP, Address: "90.90.90.90"},
 					},
 				},
 			},
@@ -317,11 +311,11 @@ func TestGetNodePrimaryIP(t *testing.T) {
 		},
 		{
 			desc: "success: node's external IP returned",
-			inp: v1.Node{
-				Status: v1.NodeStatus{
-					Addresses: []v1.NodeAddress{
-						{Type: v1.NodeHostName, Address: "HN"},
-						{Type: v1.NodeExternalIP, Address: "90.90.90.90"},
+			inp: corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeHostName, Address: "HN"},
+						{Type: corev1.NodeExternalIP, Address: "90.90.90.90"},
 					},
 				},
 			},
@@ -344,7 +338,7 @@ func TestGetNodePrimaryIP(t *testing.T) {
 func Test_GetNodePrimaryIP(t *testing.T) {
 	cases := []struct {
 		name     string
-		nodeInfo *v1.Node
+		nodeInfo *corev1.Node
 		hostname string
 		address  string
 		wantErr  bool
@@ -397,54 +391,49 @@ func Test_GetNodePrimaryIP(t *testing.T) {
 }
 
 // makeNodeWithAddresses return a node object with the specified parameters
-func makeNodeWithAddresses(name, internal, external string) *v1.Node {
+func makeNodeWithAddresses(name, internal, external string) *corev1.Node {
 	if name == "" {
-		return &v1.Node{}
+		return &corev1.Node{}
 	}
 
-	node := &v1.Node{
+	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Status: v1.NodeStatus{
-			Addresses: []v1.NodeAddress{},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{},
 		},
 	}
 
 	if internal != "" {
 		node.Status.Addresses = append(node.Status.Addresses,
-			v1.NodeAddress{Type: v1.NodeInternalIP, Address: internal},
+			corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: internal},
 		)
 	}
 
 	if external != "" {
 		node.Status.Addresses = append(node.Status.Addresses,
-			v1.NodeAddress{Type: v1.NodeExternalIP, Address: external},
+			corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: external},
 		)
 	}
 
 	return node
 }
 
-// protoPtr takes a Protocol and returns a pointer to it.
-func protoPtr(proto v1.Protocol) *v1.Protocol {
-	return &proto
-}
-
 func TestPodScheduled(t *testing.T) {
 	tests := []struct {
 		desc      string
-		inpPod    v1.Pod
+		inpPod    corev1.Pod
 		expResult bool
 	}{
 		{
 			desc:      "Pod is scheduled to a node",
-			inpPod:    v1.Pod{Spec: v1.PodSpec{NodeName: "node-1"}},
+			inpPod:    corev1.Pod{Spec: corev1.PodSpec{NodeName: "node-1"}},
 			expResult: true,
 		},
 		{
 			desc:      "Pod is not scheduled to a node",
-			inpPod:    v1.Pod{},
+			inpPod:    corev1.Pod{},
 			expResult: false,
 		},
 	}
@@ -458,32 +447,30 @@ func TestPodScheduled(t *testing.T) {
 }
 
 var (
-	testNode   string      = "testNode"
-	otherNode              = "otherNode"
-	ep1Address string      = "10.244.0.3"
-	ep2Address string      = "10.244.0.4"
-	ep3Address string      = "10.244.1.3"
-	tcpv1      v1.Protocol = v1.ProtocolTCP
-	udpv1      v1.Protocol = v1.ProtocolUDP
+	testNode   string          = "testNode"
+	otherNode                  = "otherNode"
+	ep1Address string          = "10.244.0.3"
+	ep2Address string          = "10.244.0.4"
+	ep3Address string          = "10.244.1.3"
+	tcpv1      corev1.Protocol = corev1.ProtocolTCP
+	udpv1      corev1.Protocol = corev1.ProtocolUDP
 
-	httpPortName    string = "http"
-	httpPortValue   int32  = int32(80)
 	httpsPortName   string = "https"
 	httpsPortValue  int32  = int32(443)
 	customPortName  string = "customApp"
 	customPortValue int32  = int32(10600)
 )
 
-func getSampleService(publishNotReadyAddresses bool) *v1.Service {
+func getSampleService(publishNotReadyAddresses bool) *corev1.Service {
 	name := "service-test"
 	namespace := "test"
-	return &v1.Service{
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       k8stypes.UID(namespace),
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			PublishNotReadyAddresses: publishNotReadyAddresses,
 		},
 	}
@@ -491,7 +478,7 @@ func getSampleService(publishNotReadyAddresses bool) *v1.Service {
 
 // returns an endpoint slice with three endpoints, two of which belong to the expected local node
 // and one belongs to "otherNode"
-func getSampleEndpointSlice(service *kapi.Service) *discovery.EndpointSlice {
+func getSampleEndpointSlice(service *corev1.Service) *discovery.EndpointSlice {
 
 	epPortHttps := discovery.EndpointPort{
 		Name:     &httpsPortName,
@@ -820,7 +807,7 @@ func TestDoesEndpointSliceContainEligibleEndpoint(t *testing.T) {
 		endpointSlice *discovery.EndpointSlice
 		epIP          string
 		epPort        int32
-		protocol      v1.Protocol
+		protocol      corev1.Protocol
 		want          bool
 	}{
 		{

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -148,7 +148,7 @@ func TestIsClusterIPSet(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := IsClusterIPSet(&tc.inp)
-			assert.Equal(t, res, tc.expOut)
+			assert.Equal(t, tc.expOut, res)
 		})
 	}
 }
@@ -229,7 +229,7 @@ func TestServiceTypeHasClusterIP(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := ServiceTypeHasClusterIP(&tc.inp)
-			assert.Equal(t, res, tc.expOut)
+			assert.Equal(t, tc.expOut, res)
 		})
 	}
 }
@@ -272,7 +272,7 @@ func TestServiceTypeHasNodePort(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := ServiceTypeHasNodePort(&tc.inp)
-			assert.Equal(t, res, tc.expOut)
+			assert.Equal(t, tc.expOut, res)
 		})
 	}
 }
@@ -329,7 +329,7 @@ func TestGetNodePrimaryIP(t *testing.T) {
 			if tc.expErr {
 				assert.Error(t, e)
 			} else {
-				assert.Equal(t, res, tc.expOut)
+				assert.Equal(t, tc.expOut, res)
 			}
 		})
 	}

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -15,7 +15,6 @@ import (
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
@@ -31,7 +30,7 @@ func TestParseSubnets(t *testing.T) {
 	}{
 		{
 			desc:     "multiple subnets layer 3 topology",
-			topology: types.Layer3Topology,
+			topology: ovntypes.Layer3Topology,
 			subnets:  "192.168.1.1/26/28, fda6::/48",
 			expectedSubnets: []config.CIDRNetworkEntry{
 				{
@@ -46,11 +45,11 @@ func TestParseSubnets(t *testing.T) {
 		},
 		{
 			desc:     "empty subnets layer 3 topology",
-			topology: types.Layer3Topology,
+			topology: ovntypes.Layer3Topology,
 		},
 		{
 			desc:     "multiple subnets and excludes layer 2 topology",
-			topology: types.Layer2Topology,
+			topology: ovntypes.Layer2Topology,
 			subnets:  "192.168.1.1/26, fda6::/48",
 			excludes: "192.168.1.38/32, fda6::38/128",
 			expectedSubnets: []config.CIDRNetworkEntry{
@@ -65,25 +64,25 @@ func TestParseSubnets(t *testing.T) {
 		},
 		{
 			desc:     "empty subnets layer 2 topology",
-			topology: types.Layer2Topology,
+			topology: ovntypes.Layer2Topology,
 		},
 		{
 			desc:        "invalid formatted excludes layer 2 topology",
-			topology:    types.Layer2Topology,
+			topology:    ovntypes.Layer2Topology,
 			subnets:     "192.168.1.1/26",
 			excludes:    "192.168.1.1/26/32",
 			expectError: true,
 		},
 		{
 			desc:        "invalid not contained excludes layer 2 topology",
-			topology:    types.Layer2Topology,
+			topology:    ovntypes.Layer2Topology,
 			subnets:     "fda6::/48",
 			excludes:    "fda7::38/128",
 			expectError: true,
 		},
 		{
 			desc:     "multiple subnets and excludes localnet topology",
-			topology: types.LocalnetTopology,
+			topology: ovntypes.LocalnetTopology,
 			subnets:  "192.168.1.1/26, fda6::/48",
 			excludes: "192.168.1.38/32, fda6::38/128",
 			expectedSubnets: []config.CIDRNetworkEntry{
@@ -98,18 +97,18 @@ func TestParseSubnets(t *testing.T) {
 		},
 		{
 			desc:     "empty subnets localnet topology",
-			topology: types.LocalnetTopology,
+			topology: ovntypes.LocalnetTopology,
 		},
 		{
 			desc:        "invalid formatted excludes localnet topology",
-			topology:    types.LocalnetTopology,
+			topology:    ovntypes.LocalnetTopology,
 			subnets:     "fda6::/48",
 			excludes:    "fda6::1/48/128",
 			expectError: true,
 		},
 		{
 			desc:        "invalid not contained excludes localnet topology",
-			topology:    types.LocalnetTopology,
+			topology:    ovntypes.LocalnetTopology,
 			subnets:     "192.168.1.1/26",
 			excludes:    "192.168.2.38/32",
 			expectError: true,
@@ -1063,7 +1062,7 @@ func TestSubnetOverlapCheck(t *testing.T) {
 	_, cidr6, _ := net.ParseCIDR("fe00::/16")
 	_, svcCidr4, _ := net.ParseCIDR("172.30.0.0/16")
 	_, svcCidr6, _ := net.ParseCIDR("fe01::/16")
-	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{cidr4, 24}, {cidr6, 64}}
+	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 24}, {CIDR: cidr6, HostSubnetLength: 64}}
 	config.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCidr4, svcCidr6}
 	config.Gateway.V4MasqueradeSubnet = "169.254.169.0/29"
 	config.Gateway.V6MasqueradeSubnet = "fd69::/125"

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -587,7 +587,7 @@ func TestJoinSubnets(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			netInfo, err := NewNetInfo(test.inputNetConf)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(netInfo.JoinSubnets()).To(gomega.Equal(test.expectedSubnets))
 			if netInfo.TopologyType() != ovntypes.LocalnetTopology {
 				g.Expect(netInfo.JoinSubnetV4()).To(gomega.Equal(test.expectedSubnets[0]))
@@ -689,7 +689,7 @@ func TestIsPrimaryNetwork(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			netInfo, err := NewNetInfo(test.inputNetConf)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(netInfo.IsPrimaryNetwork()).To(gomega.Equal(test.expectedPrimary))
 		})
 	}
@@ -742,7 +742,7 @@ func TestIsDefault(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			netInfo, err := NewNetInfo(test.inputNetConf)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(netInfo.IsDefault()).To(gomega.Equal(test.expectedDefaultVal))
 		})
 	}
@@ -821,7 +821,7 @@ func TestGetPodNADToNetworkMapping(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			netInfo, err := NewNetInfo(test.inputNetConf)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			if test.inputNetConf.NADName != "" {
 				mutableNetInfo := NewMutableNetInfo(netInfo)
 				mutableNetInfo.AddNADs(test.inputNetConf.NADName)
@@ -1016,7 +1016,7 @@ func TestGetPodNADToNetworkMappingWithActiveNetwork(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			netInfo, err := NewNetInfo(test.inputNetConf)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			if test.inputNetConf.NADName != "" {
 				mutableNetInfo := NewMutableNetInfo(netInfo)
 				mutableNetInfo.AddNADs(test.inputNetConf.NADName)
@@ -1026,7 +1026,7 @@ func TestGetPodNADToNetworkMappingWithActiveNetwork(t *testing.T) {
 			var primaryUDNNetInfo NetInfo
 			if test.inputPrimaryUDNConfig != nil {
 				primaryUDNNetInfo, err = NewNetInfo(test.inputPrimaryUDNConfig)
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 				if test.inputPrimaryUDNConfig.NADName != "" {
 					mutableNetInfo := NewMutableNetInfo(primaryUDNNetInfo)
 					mutableNetInfo.AddNADs(test.inputPrimaryUDNConfig.NADName)
@@ -1252,7 +1252,7 @@ func TestNewNetInfo(t *testing.T) {
 			g := gomega.NewWithT(t)
 			_, err := NewNetInfo(inputNetConf)
 			if test.expectedError == nil {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			} else {
 				g.Expect(err).To(gomega.MatchError(test.expectedError.Error()))
 			}

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 
-	kapi "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -982,7 +982,7 @@ func TestDeleteConntrack(t *testing.T) {
 		errExp                   bool
 		inputIPStr               string
 		inputPort                int32
-		inputProtocol            kapi.Protocol
+		inputProtocol            corev1.Protocol
 		labels                   [][]byte
 		onRetArgsNetLinkLibOpers []ovntest.TestifyMockHelper
 	}{
@@ -1008,7 +1008,7 @@ func TestDeleteConntrack(t *testing.T) {
 		{
 			desc:          "Valid IPv4 address input with UDP protocol",
 			inputIPStr:    "192.168.1.14",
-			inputProtocol: kapi.ProtocolUDP,
+			inputProtocol: corev1.ProtocolUDP,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "ConntrackDeleteFilter", OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily", "*netlink.ConntrackFilter"}, RetArgList: []interface{}{uint(1), nil}},
 			},
@@ -1016,7 +1016,7 @@ func TestDeleteConntrack(t *testing.T) {
 		{
 			desc:          "Valid IPv4 address input with SCTP protocol",
 			inputIPStr:    "192.168.1.14",
-			inputProtocol: kapi.ProtocolSCTP,
+			inputProtocol: corev1.ProtocolSCTP,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "ConntrackDeleteFilter", OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily", "*netlink.ConntrackFilter"}, RetArgList: []interface{}{uint(1), nil}},
 			},
@@ -1024,7 +1024,7 @@ func TestDeleteConntrack(t *testing.T) {
 		{
 			desc:          "Valid IPv4 address input with TCP protocol",
 			inputIPStr:    "192.168.1.14",
-			inputProtocol: kapi.ProtocolTCP,
+			inputProtocol: corev1.ProtocolTCP,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "ConntrackDeleteFilter", OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily", "*netlink.ConntrackFilter"}, RetArgList: []interface{}{uint(1), nil}},
 			},
@@ -1041,7 +1041,7 @@ func TestDeleteConntrack(t *testing.T) {
 		{
 			desc:          "Valid IPv6 address input with valid port input and valid Layer 4 protocol and labels",
 			inputIPStr:    "fffb::1",
-			inputProtocol: kapi.ProtocolSCTP,
+			inputProtocol: corev1.ProtocolSCTP,
 			inputPort:     9999,
 			labels:        [][]byte{{3, 4, 61, 141, 207, 170}, {0x2}},
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +38,7 @@ func TestGetFamily(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := getFamily(tc.input)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -77,7 +78,7 @@ func TestLinkByName(t *testing.T) {
 			res, err := LinkByName(tc.input)
 			t.Log(res, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				assert.NotNil(t, res)
 			}
@@ -131,7 +132,7 @@ func TestLinkSetUp(t *testing.T) {
 			res, err := LinkSetUp(tc.input)
 			t.Log(res, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				assert.NotNil(t, res)
 			}
@@ -232,9 +233,9 @@ func TestLinkAddrFlush(t *testing.T) {
 			err := LinkAddrFlush(tc.input)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -305,9 +306,9 @@ func TestLinkAddrExist(t *testing.T) {
 			flag, err := LinkAddrExist(tc.inputLink, tc.inputAddrToMatch)
 			t.Log(flag, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -428,9 +429,9 @@ func TestSyncAddresses(t *testing.T) {
 			err := SyncAddresses(tc.inputLink, tc.inputNewAddrs)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -497,9 +498,9 @@ func TestLinkAddrAdd(t *testing.T) {
 			err := LinkAddrAdd(tc.inputLink, tc.inputNewAddr, tc.inputFlags, 0, 0)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -635,9 +636,9 @@ func TestLinkRoutesDel(t *testing.T) {
 			err := LinkRoutesDel(tc.inputLink, tc.inputSubnets)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -698,9 +699,9 @@ func TestLinkRoutesAdd(t *testing.T) {
 			err := LinkRoutesAdd(tc.inputLink, tc.inputGwIP, tc.inputSubnets, 0, nil)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -801,12 +802,12 @@ func TestLinkRouteExists(t *testing.T) {
 			route, err := LinkRouteGetByDstAndGw(tc.inputLink, tc.inputGwIP, tc.inputSubnet)
 			t.Log(route, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			if tc.outBoolFlag {
-				assert.True(t, route != nil)
+				assert.NotNil(t, route)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -860,9 +861,9 @@ func TestLinkNeighAdd(t *testing.T) {
 			err := LinkNeighAdd(tc.inputLink, tc.inputNeigIP, tc.inputMacAddr)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -958,9 +959,9 @@ func TestLinkNeighExists(t *testing.T) {
 			flag, err := LinkNeighExists(tc.inputLink, tc.inputNeigIP, tc.inputMacAddr)
 			t.Log(flag, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			if tc.outBoolFlag {
 				assert.True(t, flag)
@@ -1055,9 +1056,9 @@ func TestDeleteConntrack(t *testing.T) {
 
 			err := DeleteConntrack(tc.inputIPStr, tc.inputPort, tc.inputProtocol, netlink.ConntrackReplyAnyIP, tc.labels)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 		})
@@ -1068,9 +1069,9 @@ func TestDeleteConntrack(t *testing.T) {
 
 			err := DeleteConntrack(tc.inputIPStr, tc.inputPort, tc.inputProtocol, netlink.ConntrackOrigDstIP, tc.labels)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 		})
@@ -1176,12 +1177,12 @@ func TestGetIPv6OnSubnet(t *testing.T) {
 			ip, err := GetIPv6OnSubnet(tc.inputIface, tc.inputIP)
 			t.Log(ip, err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			if tc.expectedIP != nil {
-				assert.Equal(t, ip, tc.expectedIP)
+				assert.Equal(t, tc.expectedIP, ip)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -1263,8 +1264,8 @@ func TestGetMTUOfInterfaceWithAddress(t *testing.T) {
 			ovntest.ProcessMockFnList(&exisitngMockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
 			_, mtu, err := GetIFNameAndMTUForAddress(tc.interfaceAddress)
-			assert.Equal(t, err != nil, tc.wantError)
-			assert.Equal(t, mtu, tc.wantMTU)
+			assert.Equal(t, tc.wantError, err != nil)
+			assert.Equal(t, tc.wantMTU, mtu)
 			mockNetLinkOps.AssertExpectations(t)
 			exisitngMockLink.AssertExpectations(t)
 		})
@@ -1302,7 +1303,7 @@ func TestIsAddressReservedForInternalUse(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := IsAddressReservedForInternalUse(tc.input)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -8,6 +8,7 @@ import (
 
 	iputils "github.com/containernetworking/plugins/pkg/ip"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
@@ -112,7 +113,7 @@ func TestGetOVSPortMACAddress(t *testing.T) {
 			res, err := GetOVSPortMACAddress(tc.input)
 			t.Log(res, err)
 			if tc.errExpected {
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 			mockKexecIface.AssertExpectations(t)
 			mockExecRunner.AssertExpectations(t)
@@ -141,7 +142,7 @@ func TestIPFamilyName(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := IPFamilyName(tc.input)
 			t.Log(res)
-			assert.Equal(t, res, tc.expOut)
+			assert.Equal(t, tc.expOut, res)
 		})
 	}
 }
@@ -283,7 +284,7 @@ func TestJoinHostPortInt32(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := JoinHostPortInt32(tc.inpHost, tc.inpPort)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -310,7 +311,7 @@ func TestIPAddrToHWAddr(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := IPAddrToHWAddr(tc.inpIP)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -344,7 +345,7 @@ func TestJoinIPs(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := JoinIPs(tc.inpIPList, tc.inpSeparator)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -378,7 +379,7 @@ func TestJoinIPNets(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := JoinIPNets(tc.inpIPNetList, tc.inpSeparator)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -412,7 +413,7 @@ func TestJoinIPNetIPs(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := JoinIPNetIPs(tc.inpIPNetList, tc.inpSeparator)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -465,7 +466,7 @@ func TestContainsCIDR(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			res := ContainsCIDR(tc.inpIPNet1, tc.inpIPNet2)
 			t.Log(res)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }

--- a/go-controller/pkg/util/nicstobridge_test.go
+++ b/go-controller/pkg/util/nicstobridge_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -152,7 +153,7 @@ func TestGetNicName(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Equal(t, res, tc.outputExp)
+				assert.Equal(t, tc.outputExp, res)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -233,9 +234,9 @@ func TestSaveIPAddress(t *testing.T) {
 			err := saveIPAddress(tc.inpNewLink, tc.inpOldLink, tc.inpAddrs)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -308,9 +309,9 @@ func TestDelAddRoute(t *testing.T) {
 			err := delAddRoute(tc.inpOldLink, tc.inpNewLink, tc.inpRoute)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -392,9 +393,9 @@ func TestSaveRoute(t *testing.T) {
 			err := saveRoute(tc.inpOldLink, tc.inpNewLink, tc.inpRoutes)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
@@ -557,11 +558,11 @@ func TestNicToBridge(t *testing.T) {
 			res, err := NicToBridge(tc.inpIface)
 			t.Log(res, err)
 			if tc.errExp {
-				assert.Error(t, err)
-				assert.Equal(t, len(res), 0)
+				require.Error(t, err)
+				assert.Empty(t, res)
 			} else {
-				assert.Nil(t, err)
-				assert.Greater(t, len(res), 0)
+				require.NoError(t, err)
+				assert.NotEmpty(t, res)
 			}
 			mockKexecIface.AssertExpectations(t)
 			mockExecRunner.AssertExpectations(t)
@@ -1155,9 +1156,9 @@ func TestBridgeToNic(t *testing.T) {
 			err := BridgeToNic(tc.inpBridge)
 			t.Log(err)
 			if tc.errExp {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockKexecIface.AssertExpectations(t)
 			mockExecRunner.AssertExpectations(t)

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -280,19 +279,19 @@ func TestSetL3GatewayConfig(t *testing.T) {
 func TestParseNodeL3GatewayAnnotation(t *testing.T) {
 	tests := []struct {
 		desc      string
-		inpNode   *v1.Node
+		inpNode   *corev1.Node
 		errAssert bool
 		errMatch  error
 	}{
 		{
 			desc:      "error: annotation not found for node",
-			inpNode:   &v1.Node{},
+			inpNode:   &corev1.Node{},
 			errAssert: true,
 			errMatch:  fmt.Errorf("%s annotation not found for node", OvnNodeL3GatewayConfig),
 		},
 		{
 			desc: "error: fail to unmarshal l3 gateway config annotations",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac_address":"}}`},
 				},
@@ -302,7 +301,7 @@ func TestParseNodeL3GatewayAnnotation(t *testing.T) {
 		},
 		{
 			desc: "error: annotation for network not found",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/l3-gateway-config": `{"nondefault":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`},
 				},
@@ -312,7 +311,7 @@ func TestParseNodeL3GatewayAnnotation(t *testing.T) {
 		},
 		{
 			desc: "error: nod chassis ID annotation not found",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`},
 				},
@@ -322,7 +321,7 @@ func TestParseNodeL3GatewayAnnotation(t *testing.T) {
 		},
 		{
 			desc: "success: parse completed",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
@@ -350,18 +349,18 @@ func TestParseNodeL3GatewayAnnotation(t *testing.T) {
 func TestNodeL3GatewayAnnotationChanged(t *testing.T) {
 	tests := []struct {
 		desc    string
-		oldNode *v1.Node
-		newNode *v1.Node
+		oldNode *corev1.Node
+		newNode *corev1.Node
 		result  bool
 	}{
 		{
 			desc: "true: annotation changed",
-			oldNode: &v1.Node{
+			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
 			},
-			newNode: &v1.Node{
+			newNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
@@ -372,14 +371,14 @@ func TestNodeL3GatewayAnnotationChanged(t *testing.T) {
 		},
 		{
 			desc: "true: annotation's node IP field changed",
-			newNode: &v1.Node{
+			newNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.3/24", "next-hop":"169.255.33.1"}}`,
 					},
 				},
 			},
-			oldNode: &v1.Node{
+			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
@@ -390,14 +389,14 @@ func TestNodeL3GatewayAnnotationChanged(t *testing.T) {
 		},
 		{
 			desc: "false: annotation didn't change",
-			newNode: &v1.Node{
+			newNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
 					},
 				},
 			},
-			oldNode: &v1.Node{
+			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
@@ -418,19 +417,19 @@ func TestNodeL3GatewayAnnotationChanged(t *testing.T) {
 func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 	tests := []struct {
 		desc        string
-		inpNode     v1.Node
+		inpNode     corev1.Node
 		errExpected bool
 		expOutput   bool
 		netName     string
 	}{
 		{
 			desc:      "mac address annotation not found for node, however, does not return error",
-			inpNode:   v1.Node{},
+			inpNode:   corev1.Node{},
 			expOutput: false,
 		},
 		{
 			desc: "success: parse mac address for given netName",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-mgmt-port-mac-addresses": "{\"default\":\"96:8f:e8:25:a2:e5\",\"blue\":\"d6:bc:85:32:30:fb\",\"red\":\"4a:ea:1d:8d:8f:8c\"}"},
 				},
@@ -440,7 +439,7 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 		},
 		{
 			desc: "error: parse mac address error",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-mgmt-port-mac-addresses": "{\"default\":\"96:8f:e8:25:a2:\",\"blue\":\"1\",\"red\":\"2\"}"},
 				},
@@ -450,7 +449,7 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 		},
 		{
 			desc: "error: parse mac address error since value of secondary network is invalid",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-mgmt-port-mac-addresses": "{\"default\":\"96:8f:e8:25:a2:\",\"blue\":\"1\",\"red\":\"2\"}"},
 				},
@@ -460,7 +459,7 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 		},
 		{
 			desc: "error: parse mac address error since network doesn't exist on the annotation",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-mgmt-port-mac-addresses": "{\"default\":\"96:8f:e8:25:a2:\",\"blue\":\"1\",\"red\":\"2\"}"},
 				},
@@ -488,18 +487,18 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
 	tests := []struct {
 		desc        string
-		inpNode     v1.Node
+		inpNode     corev1.Node
 		errExpected bool
 		expOutput   bool
 	}{
 		{
 			desc:      "Gateway router LPR IP address annotation not found for node, however, does not return error",
-			inpNode:   v1.Node{},
+			inpNode:   corev1.Node{},
 			expOutput: false,
 		},
 		{
 			desc: "success: Gateway router parse LPR IP address",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16"}`},
 				},
@@ -508,7 +507,7 @@ func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
 		},
 		{
 			desc: "success: Gateway router parse LPR IP address dual stack",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16", "ipv6":"fd:98::/64"}`},
 				},
@@ -517,7 +516,7 @@ func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
 		},
 		{
 			desc: "error: Gateway router parse LPR IP address error",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5"}`},
 				},
@@ -544,19 +543,19 @@ func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
 func TestParseNodeGatewayRouterJoinAddrs(t *testing.T) {
 	tests := []struct {
 		desc        string
-		inpNode     v1.Node
+		inpNode     corev1.Node
 		netName     string
 		errExpected bool
 		expOutput   bool
 	}{
 		{
 			desc:      "Gateway router LPR IP address annotation not found for node, however, does not return error",
-			inpNode:   v1.Node{},
+			inpNode:   corev1.Node{},
 			expOutput: false,
 		},
 		{
 			desc: "success: Gateway router parse LPR IP address",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddrs": `{"default":{"ipv4":"100.64.0.4/16"}}`},
 				},
@@ -566,7 +565,7 @@ func TestParseNodeGatewayRouterJoinAddrs(t *testing.T) {
 		},
 		{
 			desc: "success: Gateway router parse LPR IP address dual stack",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddrs": `{"default":{"ipv4":"100.64.0.5/16","ipv6":"fd:98::/64"}}`},
 				},
@@ -576,7 +575,7 @@ func TestParseNodeGatewayRouterJoinAddrs(t *testing.T) {
 		},
 		{
 			desc: "success: Gateway router parse LPR IP address dual stack for the right network name",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddrs": `{"default":{"ipv4":"100.64.0.5/16","ipv6":"fd:98::/64"},"l3-network":{"ipv4":"100.65.0.5/16","ipv6":"fd:99::/64"}}`},
 				},
@@ -586,7 +585,7 @@ func TestParseNodeGatewayRouterJoinAddrs(t *testing.T) {
 		},
 		{
 			desc: "error: Gateway router parse LPR IP address dual stack cannot find the requested network name",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddrs": `{"default":{"ipv4":"100.64.0.5/16","ipv6":"fd:98::/64"},"l3-network":{"ipv4":"100.65.0.5/16","ipv6":"fd:99::/64"}}`},
 				},
@@ -596,7 +595,7 @@ func TestParseNodeGatewayRouterJoinAddrs(t *testing.T) {
 		},
 		{
 			desc: "error: Gateway router parse LPR IP address error",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddrs": `{"default":{"ipv4":"100.64.0.5"}}`},
 				},
@@ -714,17 +713,17 @@ func TestSetGatewayMTUSupport(t *testing.T) {
 func TestParseNodeGatewayMTUSupport(t *testing.T) {
 	tests := []struct {
 		desc    string
-		inpNode *v1.Node
+		inpNode *corev1.Node
 		res     bool
 	}{
 		{
 			desc:    "annotation not found for node and true",
-			inpNode: &v1.Node{},
+			inpNode: &corev1.Node{},
 			res:     true,
 		},
 		{
 			desc: "parse completed and true",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/gateway-mtu-support": "true",
@@ -735,7 +734,7 @@ func TestParseNodeGatewayMTUSupport(t *testing.T) {
 		},
 		{
 			desc: "parse completed and false",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/gateway-mtu-support": "false",
@@ -746,7 +745,7 @@ func TestParseNodeGatewayMTUSupport(t *testing.T) {
 		},
 		{
 			desc: "parse invalid value completed and true",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/gateway-mtu-support": "tru",
@@ -781,7 +780,7 @@ func TestGetNetworkID(t *testing.T) {
 		{
 			desc: "with bad network ID annotations should return and error and invalid network ID",
 			nodes: []*corev1.Node{
-				&v1.Node{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"k8s.ovn.org/network-ids": "not a map",
@@ -796,14 +795,14 @@ func TestGetNetworkID(t *testing.T) {
 		{
 			desc: "with multiple networks annotation should return expected network ID and no error",
 			nodes: []*corev1.Node{
-				&v1.Node{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"k8s.ovn.org/network-ids": `{"rednet": "5"}`,
 						},
 					},
 				},
-				&v1.Node{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"k8s.ovn.org/network-ids": `{"yellownet": "6", "bluenet": "3"}`,
@@ -831,20 +830,20 @@ func TestGetNetworkID(t *testing.T) {
 func TestParseUDNLayer2NodeGRLRPTunnelIDs(t *testing.T) {
 	tests := []struct {
 		desc        string
-		inpNode     *v1.Node
+		inpNode     *corev1.Node
 		inpNetName  string
 		res         int
 		errExpected bool
 	}{
 		{
 			desc:       "annotation not found for node and invalidID",
-			inpNode:    &v1.Node{},
+			inpNode:    &corev1.Node{},
 			inpNetName: "rednet",
 			res:        -1,
 		},
 		{
 			desc: "parse completed and validID",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids": `{"rednet":"5"}`,
@@ -857,7 +856,7 @@ func TestParseUDNLayer2NodeGRLRPTunnelIDs(t *testing.T) {
 		},
 		{
 			desc: "parse completed and invalid value",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids": `blah`,
@@ -870,7 +869,7 @@ func TestParseUDNLayer2NodeGRLRPTunnelIDs(t *testing.T) {
 		},
 		{
 			desc: "multiple networks; parse completed and validID",
-			inpNode: &v1.Node{
+			inpNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids": `{"rednet":"5", "bluenet":"8"}`,

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,7 +199,7 @@ func TestL3GatewayConfig_UnmarshalJSON(t *testing.T) {
 				assert.Contains(t, e.Error(), tc.errMatch.Error())
 			} else {
 				t.Log(l3GwCfg)
-				assert.Equal(t, l3GwCfg, tc.expOut)
+				assert.Equal(t, tc.expOut, l3GwCfg)
 			}
 		})
 	}
@@ -269,7 +270,7 @@ func TestSetL3GatewayConfig(t *testing.T) {
 			e := SetL3GatewayConfig(tc.inpNodeAnnotator, &tc.inputL3GwCfg)
 			if tc.errExpected {
 				t.Log(e)
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockAnnotator.AssertExpectations(t)
 		})
@@ -474,7 +475,7 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 			cfg, e := ParseNodeManagementPortMACAddresses(&tc.inpNode, tc.netName)
 			if tc.errExpected {
 				t.Log(e)
-				assert.Error(t, e)
+				require.Error(t, e)
 				assert.Nil(t, cfg)
 			}
 			if tc.expOutput {
@@ -530,7 +531,7 @@ func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
 			cfg, e := ParseNodeGatewayRouterLRPAddr(&tc.inpNode)
 			if tc.errExpected {
 				t.Log(e)
-				assert.Error(t, e)
+				require.Error(t, e)
 				assert.Nil(t, cfg)
 			}
 			if tc.expOutput {
@@ -611,7 +612,7 @@ func TestParseNodeGatewayRouterJoinAddrs(t *testing.T) {
 			cfg, e := ParseNodeGatewayRouterJoinAddrs(&tc.inpNode, tc.netName)
 			if tc.errExpected {
 				t.Log(e)
-				assert.Error(t, e)
+				require.Error(t, e)
 				assert.Nil(t, cfg)
 			}
 			if tc.expOutput {
@@ -652,7 +653,7 @@ func TestCreateNodeGatewayRouterLRPAddrsAnnotation(t *testing.T) {
 			res, err := UpdateNodeGatewayRouterLRPAddrsAnnotation(nil, tc.inpDefSubnetIps, types.DefaultNetworkName)
 			t.Log(res, err)
 			if tc.errExp {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.True(t, reflect.DeepEqual(res, tc.outExp))
 			}
@@ -703,7 +704,7 @@ func TestSetGatewayMTUSupport(t *testing.T) {
 			e := SetGatewayMTUSupport(tc.inpNodeAnnotator, tc.inputSet)
 			if tc.errExpected {
 				t.Log(e)
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockAnnotator.AssertExpectations(t)
 		})
@@ -820,9 +821,9 @@ func TestGetNetworkID(t *testing.T) {
 			if tc.expectedError != nil {
 				assert.Contains(t, obtainedError.Error(), tc.expectedError.Error())
 			} else {
-				assert.NoError(t, obtainedError)
+				require.NoError(t, obtainedError)
 			}
-			assert.Equal(t, obtainedNetworkID, tc.expectedNetworkID)
+			assert.Equal(t, tc.expectedNetworkID, obtainedNetworkID)
 		})
 	}
 }
@@ -886,7 +887,7 @@ func TestParseUDNLayer2NodeGRLRPTunnelIDs(t *testing.T) {
 			res, err := ParseUDNLayer2NodeGRLRPTunnelIDs(tc.inpNode, tc.inpNetName)
 			if tc.errExpected {
 				t.Log(err)
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 			assert.Equal(t, tc.res, res)
 		})

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	kexec "k8s.io/utils/exec"
 
@@ -83,7 +84,7 @@ func TestRunningPlatform(t *testing.T) {
 			if tc.expErr != nil {
 				assert.Contains(t, err.Error(), tc.expErr.Error())
 			} else {
-				assert.Equal(t, res, tc.expOut)
+				assert.Equal(t, tc.expOut, res)
 			}
 		})
 	}
@@ -142,7 +143,7 @@ func TestRunOVNretry(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, e.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, e)
+				require.NoError(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -268,7 +269,7 @@ func TestGetNbOVSDBArgs(t *testing.T) {
 				defer resetScheme(preValOvnNBScheme)
 			}
 			res := getNbOVSDBArgs(tc.inpCmdStr, tc.inpVarArgs)
-			assert.Equal(t, res, tc.outExp)
+			assert.Equal(t, tc.outExp, res)
 		})
 	}
 }
@@ -347,7 +348,7 @@ func TestRunOVNNorthAppCtl(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -429,7 +430,7 @@ func TestRunOVNControllerAppCtl(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -509,7 +510,7 @@ func TestRunOvsVswitchdAppCtl(t *testing.T) {
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -556,7 +557,7 @@ func TestDefaultExecRunner_RunCmd(t *testing.T) {
 			}
 			_, _, e := runCmdExecRunner.RunCmd(tc.cmd, tc.cmdPath, tc.envVars, tc.cmdArg)
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockCmd.AssertExpectations(t)
 		})
 	}
@@ -592,7 +593,7 @@ func TestSetExec(t *testing.T) {
 				runner = &execHelper{exec: mockKexecIface}
 			}
 			e := SetExec(mockKexecIface)
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockKexecIface.AssertExpectations(t)
 		})
 	}
@@ -632,7 +633,7 @@ func TestSetExecWithoutOVS(t *testing.T) {
 			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgs)
 
 			e := SetExecWithoutOVS(mockKexecIface)
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockKexecIface.AssertExpectations(t)
 		})
 	}
@@ -672,7 +673,7 @@ func TestSetSpecificExec(t *testing.T) {
 			}
 
 			e := SetSpecificExec(mockKexecIface, tc.fnArg)
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockKexecIface.AssertExpectations(t)
 		})
 	}
@@ -718,7 +719,7 @@ func TestRunCmd(t *testing.T) {
 
 			_, _, e := runCmd(mockCmd, tc.cmdPath, tc.cmdArg)
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockCmd.AssertExpectations(t)
 		})
 	}
@@ -792,7 +793,7 @@ func TestRun(t *testing.T) {
 
 			_, _, e := run(tc.cmdPath, tc.cmdArg)
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockCmd.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -862,7 +863,7 @@ func TestRunWithEnvVars(t *testing.T) {
 
 			_, _, e := runWithEnvVars(tc.cmdPath, tc.envArgs, tc.cmdArg)
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockCmd.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -903,7 +904,7 @@ func TestRunOVSOfctl(t *testing.T) {
 
 			_, _, e := RunOVSOfctl()
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -996,7 +997,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0
 			ports, err := GetOpenFlowPorts("breth0", tc.portNumbers)
 
 			// make sure that there's no error
-			assert.Equal(t, err, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, err)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 
@@ -1040,7 +1041,7 @@ func TestRunOVSVsctl(t *testing.T) {
 
 			_, _, e := RunOVSVsctl()
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -1084,7 +1085,7 @@ func TestRunOVSAppctlWithTimeout(t *testing.T) {
 
 			_, _, e := RunOVSAppctlWithTimeout(tc.timeout)
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -1125,7 +1126,7 @@ func TestRunOVSAppctl(t *testing.T) {
 
 			_, _, e := RunOVSAppctl()
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -1169,7 +1170,7 @@ func TestRunOVNAppctlWithTimeout(t *testing.T) {
 
 			_, _, e := RunOVNAppctlWithTimeout(tc.timeout)
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -1214,7 +1215,7 @@ func TestRunOVNNbctlWithTimeout(t *testing.T) {
 			_, _, e := RunOVNNbctlWithTimeout(tc.timeout)
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1257,7 +1258,7 @@ func TestRunOVNNbctl(t *testing.T) {
 			_, _, e := RunOVNNbctl()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1303,7 +1304,7 @@ func TestRunOVNSbctlWithTimeout(t *testing.T) {
 			_, _, e := RunOVNSbctlWithTimeout(tc.timeout)
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1346,7 +1347,7 @@ func TestRunOVNSbctl(t *testing.T) {
 			_, _, e := RunOVNSbctl()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1389,7 +1390,7 @@ func TestRunOVSDBClient(t *testing.T) {
 			_, _, e := RunOVSDBClient()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1432,7 +1433,7 @@ func TestRunOVSDBTool(t *testing.T) {
 			_, _, e := RunOVSDBTool()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1475,7 +1476,7 @@ func TestRunOVSDBClientOVNNB(t *testing.T) {
 			_, _, e := RunOVSDBClientOVNNB("list-dbs")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1518,7 +1519,7 @@ func TestRunOVNNBAppCtl(t *testing.T) {
 			_, _, e := RunOVNNBAppCtl()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1561,7 +1562,7 @@ func TestRunOVNSBAppCtl(t *testing.T) {
 			_, _, e := RunOVNSBAppCtl()
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1597,7 +1598,7 @@ func TestRunIP(t *testing.T) {
 
 			_, _, e := RunIP()
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -1632,7 +1633,7 @@ func TestRunSysctl(t *testing.T) {
 
 			_, _, e := RunSysctl("-w", "net.ipv4.conf.eth0.rp_filter=2")
 
-			assert.Equal(t, e, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, e)
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})
@@ -1678,7 +1679,7 @@ func TestAddOFFlowWithSpecificAction(t *testing.T) {
 			_, _, e := AddOFFlowWithSpecificAction("somename", "someaction")
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1725,7 +1726,7 @@ func TestReplaceOFFlows(t *testing.T) {
 			_, _, e := ReplaceOFFlows("somename", []string{})
 
 			if tc.expectedErr != nil {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1780,7 +1781,7 @@ func TestGetOVNDBServerInfo(t *testing.T) {
 			_, e := GetOVNDBServerInfo(15, "nb", "OVN_Northbound")
 
 			if tc.expectedErr {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
@@ -1862,7 +1863,7 @@ func TestDetectSCTPSupport(t *testing.T) {
 			_, e := DetectSCTPSupport()
 
 			if tc.expectedErr {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -9,6 +9,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -331,7 +332,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			res1, e := GetPodIPsOfNetwork(tc.inpPod, tc.networkInfo)
 			t.Log(res1, e)
 			if tc.errAssert {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else if tc.errMatch != nil {
 				if errors.Is(tc.errMatch, ErrNoPodIPFound) {
 					assert.ErrorIs(t, e, ErrNoPodIPFound)
@@ -466,10 +467,10 @@ func TestUnmarshalUDNOpenPortsAnnotation(t *testing.T) {
 				UDNOpenPortsAnnotationName: tc.input,
 			})
 			if tc.errSubstr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errSubstr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.result, res)
 			}
 		})

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -10,7 +10,7 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -237,7 +237,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 	)
 	tests := []struct {
 		desc        string
-		inpPod      *v1.Pod
+		inpPod      *corev1.Pod
 		networkInfo NetInfo
 		errAssert   bool
 		errMatch    error
@@ -251,7 +251,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 		},*/
 		{
 			desc: "test when pod annotation is non-nil for the default cluster network",
-			inpPod: &v1.Pod{
+			inpPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.1/24"],"mac_address":"0a:58:fd:98:00:01"}}`},
 				},
@@ -261,14 +261,14 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 		},
 		{
 			desc:        "test when pod.status.PodIP is empty",
-			inpPod:      &v1.Pod{},
+			inpPod:      &corev1.Pod{},
 			networkInfo: &DefaultNetInfo{},
 			errMatch:    ErrNoPodIPFound,
 		},
 		{
 			desc: "test when pod.status.PodIP is non-empty",
-			inpPod: &v1.Pod{
-				Status: v1.PodStatus{
+			inpPod: &corev1.Pod{
+				Status: corev1.PodStatus{
 					PodIP: "192.168.1.15",
 				},
 			},
@@ -277,10 +277,10 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 		},
 		{
 			desc: "test when pod.status.PodIPs is non-empty",
-			inpPod: &v1.Pod{
-				Status: v1.PodStatus{
-					PodIPs: []v1.PodIP{
-						{"192.168.1.15"},
+			inpPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					PodIPs: []corev1.PodIP{
+						{IP: "192.168.1.15"},
 					},
 				},
 			},
@@ -289,10 +289,10 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 		},
 		{
 			desc: "test path when an entry in pod.status.PodIPs is malformed",
-			inpPod: &v1.Pod{
-				Status: v1.PodStatus{
-					PodIPs: []v1.PodIP{
-						{"192.168.1."},
+			inpPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					PodIPs: []corev1.PodIP{
+						{IP: "192.168.1."},
 					},
 				},
 			},
@@ -301,7 +301,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 		},
 		{
 			desc: "test when pod annotation is non-nil for a secondary network",
-			inpPod: &v1.Pod{
+			inpPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q, "namespace": %q}]`, secondaryNetworkName, namespace),
@@ -314,7 +314,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 		},
 		{
 			desc: "test when pod annotation is non-nil for a secondary network",
-			inpPod: &v1.Pod{
+			inpPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q, "namespace": %q}]`, secondaryNetworkName, namespace),

--- a/go-controller/pkg/util/pod_test.go
+++ b/go-controller/pkg/util/pod_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	kubemocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	v1mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
@@ -72,10 +72,10 @@ func TestUpdatePodWithAllocationOrRollback(t *testing.T) {
 				rollbackDone = true
 			}
 
-			pod := &v1.Pod{}
+			pod := &corev1.Pod{}
 
 			var allocated bool
-			allocate := func(pod *v1.Pod) (*v1.Pod, func(), error) {
+			allocate := func(pod *corev1.Pod) (*corev1.Pod, func(), error) {
 				allocated = true
 				if tt.allocateErr {
 					return pod, rollback, errors.New("Allocate error")
@@ -98,7 +98,7 @@ func TestUpdatePodWithAllocationOrRollback(t *testing.T) {
 				kubeMock.On("UpdatePodStatus", pod).Return(nil)
 			}
 
-			err := UpdatePodWithRetryOrRollback(podListerMock, kubeMock, &v1.Pod{}, allocate)
+			err := UpdatePodWithRetryOrRollback(podListerMock, kubeMock, &corev1.Pod{}, allocate)
 
 			if (err != nil) != tt.expectErr {
 				t.Errorf("UpdatePodWithAllocationOrRollback() error = %v, expectErr %v", err, tt.expectErr)

--- a/go-controller/pkg/util/subnet_annotations_unit_test.go
+++ b/go-controller/pkg/util/subnet_annotations_unit_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -68,7 +68,7 @@ func TestCreateSubnetAnnotation(t *testing.T) {
 }
 
 func TestSetSubnetAnnotation(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
+	fakeClient := fake.NewSimpleClientset(&corev1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
 	testAnnotator := kube.NewNodeAnnotator(k, "")
 	tests := []struct {
@@ -99,7 +99,7 @@ func TestSetSubnetAnnotation(t *testing.T) {
 func TestParseSubnetAnnotation(t *testing.T) {
 	tests := []struct {
 		desc        string
-		inpNode     v1.Node
+		inpNode     corev1.Node
 		annName     string
 		errExpected bool
 	}{
@@ -107,7 +107,7 @@ func TestParseSubnetAnnotation(t *testing.T) {
 			desc:        "incorrect annotation",
 			annName:     "blah",
 			errExpected: true,
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
 					Annotations: map[string]string{
@@ -119,7 +119,7 @@ func TestParseSubnetAnnotation(t *testing.T) {
 		{
 			desc:    "correct annotation with one subnet",
 			annName: ovnNodeSubnets,
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
 					Annotations: map[string]string{
@@ -131,7 +131,7 @@ func TestParseSubnetAnnotation(t *testing.T) {
 		{
 			desc:    "parse as dual-stack",
 			annName: ovnNodeSubnets,
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
 					Annotations: map[string]string{
@@ -144,7 +144,7 @@ func TestParseSubnetAnnotation(t *testing.T) {
 			desc:        "error:cannot parse as single or dual stack",
 			annName:     ovnNodeSubnets,
 			errExpected: true,
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
 					Annotations: map[string]string{
@@ -157,7 +157,7 @@ func TestParseSubnetAnnotation(t *testing.T) {
 			desc:        "error: annotation has no default network",
 			annName:     ovnNodeSubnets,
 			errExpected: true,
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
 					Annotations: map[string]string{
@@ -185,18 +185,18 @@ func TestParseSubnetAnnotation(t *testing.T) {
 func TestNodeSubnetAnnotationChanged(t *testing.T) {
 	tests := []struct {
 		desc    string
-		oldNode *v1.Node
-		newNode *v1.Node
+		oldNode *corev1.Node
+		newNode *corev1.Node
 		result  bool
 	}{
 		{
 			desc: "true: annotation changed",
-			oldNode: &v1.Node{
+			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
 			},
-			newNode: &v1.Node{
+			newNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
@@ -207,14 +207,14 @@ func TestNodeSubnetAnnotationChanged(t *testing.T) {
 		},
 		{
 			desc: "true: annotation's value changed",
-			newNode: &v1.Node{
+			newNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
 					},
 				},
 			},
-			oldNode: &v1.Node{
+			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.2.0/24\"}",
@@ -225,14 +225,14 @@ func TestNodeSubnetAnnotationChanged(t *testing.T) {
 		},
 		{
 			desc: "false: annotation didn't change",
-			newNode: &v1.Node{
+			newNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
 					},
 				},
 			},
-			oldNode: &v1.Node{
+			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
@@ -283,7 +283,7 @@ func TestCreateNodeHostSubnetAnnotation(t *testing.T) {
 }
 
 func TestSetNodeHostSubnetAnnotation(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
+	fakeClient := fake.NewSimpleClientset(&corev1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
 	testAnnotator := kube.NewNodeAnnotator(k, "")
 
@@ -311,7 +311,7 @@ func TestSetNodeHostSubnetAnnotation(t *testing.T) {
 }
 
 func TestDeleteNodeHostSubnetAnnotation(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset(&v1.NodeList{})
+	fakeClient := fake.NewSimpleClientset(&corev1.NodeList{})
 	k := &kube.Kube{KClient: fakeClient}
 	testAnnotator := kube.NewNodeAnnotator(k, "")
 
@@ -325,7 +325,7 @@ func TestDeleteNodeHostSubnetAnnotation(t *testing.T) {
 		},
 	}
 	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(*testing.T) {
 			DeleteNodeHostSubnetAnnotation(tc.inpNodeAnnotator)
 		})
 	}
@@ -334,12 +334,12 @@ func TestDeleteNodeHostSubnetAnnotation(t *testing.T) {
 func TestParseNodeHostSubnetAnnotation(t *testing.T) {
 	tests := []struct {
 		desc    string
-		inpNode v1.Node
+		inpNode corev1.Node
 		errExp  bool
 	}{
 		{
 			desc: "tests function coverage, success path",
-			inpNode: v1.Node{
+			inpNode: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
 					Annotations: map[string]string{

--- a/go-controller/pkg/util/subnet_annotations_unit_test.go
+++ b/go-controller/pkg/util/subnet_annotations_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +61,7 @@ func TestCreateSubnetAnnotation(t *testing.T) {
 			mapRes := map[string]string{}
 			e := updateSubnetAnnotation(mapRes, tc.inpAnnotName, types.DefaultNetworkName, defSubList)
 			if tc.expectedErr {
-				assert.Error(t, e)
+				require.Error(t, e)
 			}
 			t.Log(mapRes[tc.inpAnnotName], e)
 		})
@@ -90,7 +91,7 @@ func TestSetSubnetAnnotation(t *testing.T) {
 			err := setSubnetAnnotation(tc.inpNodeAnnotator, tc.inpAnnotName, tc.inpDefSubnetIps)
 			t.Log(err)
 			if tc.errExp {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 		})
 	}
@@ -176,7 +177,7 @@ func TestParseSubnetAnnotation(t *testing.T) {
 			} else {
 				ipList := ipListMap[types.DefaultNetworkName]
 				t.Log(ipList)
-				assert.Greater(t, len(ipList), 0)
+				assert.NotEmpty(t, ipList)
 			}
 		})
 	}
@@ -274,7 +275,7 @@ func TestCreateNodeHostSubnetAnnotation(t *testing.T) {
 			res, err := UpdateNodeHostSubnetAnnotation(nil, tc.inpDefSubnetIps, types.DefaultNetworkName)
 			t.Log(res, err)
 			if tc.errExp {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.True(t, reflect.DeepEqual(res, tc.outExp))
 			}
@@ -304,7 +305,7 @@ func TestSetNodeHostSubnetAnnotation(t *testing.T) {
 			err := SetNodeHostSubnetAnnotation(tc.inpNodeAnnotator, tc.inpDefSubnetIps)
 			t.Log(err)
 			if tc.errExp {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 		})
 	}
@@ -354,7 +355,7 @@ func TestParseNodeHostSubnetAnnotation(t *testing.T) {
 			res, err := ParseNodeHostSubnetAnnotation(&tc.inpNode, types.DefaultNetworkName)
 			t.Log(res, err)
 			if tc.errExp {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.NotNil(t, res)
 			}

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -11,6 +11,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,9 +100,9 @@ func TestGetNodeChassisID(t *testing.T) {
 
 			ret, e := GetNodeChassisID()
 			if tc.errExpected {
-				assert.Error(t, e)
+				require.Error(t, e)
 			} else {
-				assert.Greater(t, len(ret), 0)
+				assert.NotEmpty(t, ret)
 			}
 			mockExecRunner.AssertExpectations(t)
 			mockCmd.AssertExpectations(t)
@@ -250,7 +251,7 @@ func TestFilterIPsSlice(t *testing.T) {
 
 func TestGenerateId(t *testing.T) {
 	id := GenerateId(10)
-	assert.Equal(t, 10, len(id))
+	assert.Len(t, id, 10)
 	matchesPattern, _ := regexp.MatchString("([a-zA-Z0-9-]*)", id)
 	assert.True(t, matchesPattern)
 }

--- a/go-controller/vendor/github.com/stretchr/testify/require/doc.go
+++ b/go-controller/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,29 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// # Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//
+//	import (
+//	  "testing"
+//	  "github.com/stretchr/testify/require"
+//	)
+//
+//	func TestSomething(t *testing.T) {
+//
+//	  var a string = "Hello"
+//	  var b string = "Hello"
+//
+//	  require.Equal(t, a, b, "The two words should be the same.")
+//
+//	}
+//
+// # Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/go-controller/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/go-controller/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs"

--- a/go-controller/vendor/github.com/stretchr/testify/require/require.go
+++ b/go-controller/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,2060 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Condition(t, comp, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Conditionf(t, comp, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	assert.Contains(t, "Hello World", "World")
+//	assert.Contains(t, ["Hello", "World"], "World")
+//	assert.Contains(t, {"Hello": "World"}, "Hello")
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Contains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Containsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	assert.Empty(t, obj)
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Empty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	assert.Emptyf(t, obj, "error message %s", "formatted")
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Emptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equal asserts that two objects are equal.
+//
+//	assert.Equal(t, 123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equal(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	assert.EqualError(t, err,  expectedErrorString)
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValues asserts that two objects are equal or convertible to the same types
+// and equal.
+//
+//	assert.EqualValues(t, uint32(123), int32(123))
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the same types
+// and equal.
+//
+//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equalf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if assert.Error(t, err) {
+//		   assert.Equal(t, expectedError, err)
+//	  }
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Error(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if assert.Errorf(t, err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedErrorf, err)
+//	  }
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Errorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventually(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithT(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithTf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventuallyf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	assert.Exactly(t, int32(123), int64(123))
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactly(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactlyf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Fail(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNow(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNowf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Failf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// False asserts that the specified value is false.
+//
+//	assert.False(t, myBool)
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.False(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	assert.Falsef(t, myBool, "error message %s", "formatted")
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Falsef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	assert.Greater(t, 2, 1)
+//	assert.Greater(t, float64(2), float64(1))
+//	assert.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greater(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	assert.GreaterOrEqual(t, 2, 1)
+//	assert.GreaterOrEqual(t, 2, 2)
+//	assert.GreaterOrEqual(t, "b", "a")
+//	assert.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greaterf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCode(t, handler, method, url, values, statuscode, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCodef(t, handler, method, url, values, statuscode, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	assert.IsDecreasing(t, []int{2, 1, 0})
+//	assert.IsDecreasing(t, []float{2, 1})
+//	assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	assert.IsIncreasing(t, []int{1, 2, 3})
+//	assert.IsIncreasing(t, []float{1, 2})
+//	assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	assert.IsNonDecreasing(t, []int{1, 1, 2})
+//	assert.IsNonDecreasing(t, []float{1, 2})
+//	assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	assert.IsNonIncreasing(t, []int{2, 1, 1})
+//	assert.IsNonIncreasing(t, []float{2, 1})
+//	assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsType(t, expectedType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsTypef(t, expectedType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	assert.Len(t, mySlice, 3)
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Len(t, object, length, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lenf(t, object, length, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Less asserts that the first element is less than the second
+//
+//	assert.Less(t, 1, 2)
+//	assert.Less(t, float64(1), float64(2))
+//	assert.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Less(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	assert.LessOrEqual(t, 1, 2)
+//	assert.LessOrEqual(t, 2, 2)
+//	assert.LessOrEqual(t, "a", "b")
+//	assert.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
+//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lessf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negative asserts that the specified element is negative
+//
+//	assert.Negative(t, -1)
+//	assert.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	assert.Negativef(t, -1, "error message %s", "formatted")
+//	assert.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negativef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Never(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Neverf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	assert.Nil(t, err)
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	assert.Nilf(t, err, "error message %s", "formatted")
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if assert.NoError(t, err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoError(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoErrorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	assert.NotContains(t, "Hello World", "Earth")
+//	assert.NotContains(t, ["Hello", "World"], "Earth")
+//	assert.NotContains(t, {"Hello": "World"}, "Earth")
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContainsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if assert.NotEmpty(t, obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmpty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	assert.NotEqual(t, obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	assert.NotEqualValues(t, obj1, obj2)
+func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	assert.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	assert.NotNil(t, err)
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	assert.NotNilf(t, err, "error message %s", "formatted")
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	assert.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	assert.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	assert.NotSame(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSame(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSamef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubset asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	assert.NotSubset(t, [1, 3, 4], [1, 2])
+//	assert.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	assert.Panics(t, func(){ GoCrazy() })
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithError(t, errString, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithErrorf(t, errString, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positive asserts that the specified element is positive
+//
+//	assert.Positive(t, 1)
+//	assert.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	assert.Positivef(t, 1, "error message %s", "formatted")
+//	assert.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positivef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	assert.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	assert.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Same(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Samef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subset asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	assert.Subset(t, [1, 2, 3], [1, 2])
+//	assert.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subsetf asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// True asserts that the specified value is true.
+//
+//	assert.True(t, myBool)
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.True(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Truef asserts that the specified value is true.
+//
+//	assert.Truef(t, myBool, "error message %s", "formatted")
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Truef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRange(t, actual, start, end, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRangef(t, actual, start, end, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zero asserts that i is the zero value for its type.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zerof asserts that i is the zero value for its type.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}

--- a/go-controller/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/go-controller/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,0 +1,6 @@
+{{.Comment}}
+func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
+	t.FailNow()
+}

--- a/go-controller/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/go-controller/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,1622 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	a.Empty(obj)
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	a.Emptyf(obj, "error message %s", "formatted")
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//	a.Equal(123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValuesf(a.t, expected, actual, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertible to the same types
+// and equal.
+//
+//	a.EqualValues(uint32(123), int32(123))
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the same types
+// and equal.
+//
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.Error(err) {
+//		   assert.Equal(t, expectedError, err)
+//	  }
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Error(a.t, err, msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, err, target, msg, args...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.Errorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedErrorf, err)
+//	  }
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Errorf(a.t, err, msg, args...)
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithT(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 1*time.Second, 10*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	a.Exactly(int32(123), int64(123))
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//	a.False(myBool)
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	a.Falsef(myBool, "error message %s", "formatted")
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greaterf(a.t, e1, e2, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	a.Len(mySlice, 3)
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//	a.Negative(-1)
+//	a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negativef(a.t, e, msg, args...)
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Never(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Neverf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	a.Nil(err)
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	a.Nilf(err, "error message %s", "formatted")
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExists(a.t, path, msgAndArgs...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExistsf(a.t, path, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExists(a.t, path, msgAndArgs...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExistsf(a.t, path, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	a.NotEqual(obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValues(obj1, obj2)
+func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIsf(a.t, err, target, msg, args...)
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	a.NotNil(err)
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	a.NotNilf(err, "error message %s", "formatted")
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanics(func(){ RemainCalm() })
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	a.NotSame(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSame(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSamef(a.t, expected, actual, msg, args...)
+}
+
+// NotSubset asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panics(func(){ GoCrazy() })
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithError(a.t, errString, f, msgAndArgs...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithErrorf(a.t, errString, f, msg, args...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//	a.Positive(1)
+//	a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positivef(a.t, e, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Samef(a.t, expected, actual, msg, args...)
+}
+
+// Subset asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//	a.True(myBool)
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//	a.Truef(myBool, "error message %s", "formatted")
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRangef(a.t, actual, start, end, msg, args...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zerof(a.t, i, msg, args...)
+}

--- a/go-controller/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
+++ b/go-controller/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentWithoutT "a"}}
+func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) {
+	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	{{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
+}

--- a/go-controller/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/go-controller/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,29 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+type tHelper interface {
+	Helper()
+}
+
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{})
+
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{})
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -441,6 +441,7 @@ github.com/stretchr/objx
 ## explicit; go 1.17
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
+github.com/stretchr/testify/require
 # github.com/urfave/cli/v2 v2.27.2
 ## explicit; go 1.18
 github.com/urfave/cli/v2


### PR DESCRIPTION
Enable linting for unit tests, add test specific linters.

I suggest the reviewer to do a leap of faith and not do thorough review of the changes, 99% percent of them are suggested or automatically applied by the linters.

Some highlights:

- Numerous fixes of incorrect use of `Eventually` (passing a value instead of a function).
- Numerous fixes of ignored errors, in some cases tests passing for the incorrect reasons.
- Numerous fixes to assertions and presentation of failures
- Numerous fixes on usage of test helpers (`GinkgoRecover`, `t.Helper`, ...) 

I would suggest normal attention to these changes that some level of refactoring involved:
`go-controller/pkg/node/gateway_localnet_linux_test.go`
`go-controller/pkg/node/egress_service_test.go`

