### PR TITLE
Add support to advertise EIPs for UDNs

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -57,11 +57,14 @@ var (
 
 // Controller reconciles RouteAdvertisements
 type Controller struct {
-	eipLister  egressiplisters.EgressIPLister
-	frrLister  frrlisters.FRRConfigurationLister
-	nadLister  nadlisters.NetworkAttachmentDefinitionLister
-	nodeLister corelisters.NodeLister
-	raLister   ralisters.RouteAdvertisementsLister
+	wf *factory.WatchFactory
+
+	eipLister       egressiplisters.EgressIPLister
+	frrLister       frrlisters.FRRConfigurationLister
+	nadLister       nadlisters.NetworkAttachmentDefinitionLister
+	nodeLister      corelisters.NodeLister
+	raLister        ralisters.RouteAdvertisementsLister
+	namespaceLister corelisters.NamespaceLister
 
 	frrClient frrclientset.Interface
 	nadClient nadclientset.Interface
@@ -72,6 +75,7 @@ type Controller struct {
 	nadController  controllerutil.Controller
 	nodeController controllerutil.Controller
 	raController   controllerutil.Controller
+	nsController   controllerutil.Controller
 
 	nm networkmanager.Interface
 }
@@ -83,15 +87,17 @@ func NewController(
 	ovnClient *util.OVNClusterManagerClientset,
 ) *Controller {
 	c := &Controller{
-		eipLister:  wf.EgressIPInformer().Lister(),
-		frrLister:  wf.FRRConfigurationsInformer().Lister(),
-		nadLister:  wf.NADInformer().Lister(),
-		nodeLister: wf.NodeCoreInformer().Lister(),
-		raLister:   wf.RouteAdvertisementsInformer().Lister(),
-		frrClient:  ovnClient.FRRClient,
-		nadClient:  ovnClient.NetworkAttchDefClient,
-		raClient:   ovnClient.RouteAdvertisementsClient,
-		nm:         nm,
+		wf:              wf,
+		eipLister:       wf.EgressIPInformer().Lister(),
+		frrLister:       wf.FRRConfigurationsInformer().Lister(),
+		nadLister:       wf.NADInformer().Lister(),
+		nodeLister:      wf.NodeCoreInformer().Lister(),
+		raLister:        wf.RouteAdvertisementsInformer().Lister(),
+		namespaceLister: wf.NamespaceInformer().Lister(),
+		frrClient:       ovnClient.FRRClient,
+		nadClient:       ovnClient.NetworkAttchDefClient,
+		raClient:        ovnClient.RouteAdvertisementsClient,
+		nm:              nm,
 	}
 
 	handleError := func(key string, errorstatus error) error {
@@ -153,13 +159,23 @@ func NewController(
 
 	eipConfig := &controllerutil.ControllerConfig[eiptypes.EgressIP]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
-		Reconcile:      c.reconcileEgressIP,
+		Reconcile:      c.reconcileEgressIPs,
 		Threadiness:    1,
 		Informer:       wf.EgressIPInformer().Informer(),
 		Lister:         wf.EgressIPInformer().Lister().List,
 		ObjNeedsUpdate: egressIPNeedsUpdate,
 	}
 	c.eipController = controllerutil.NewController("clustermanager routeadvertisements egressip controller", eipConfig)
+
+	nsConfig := &controllerutil.ControllerConfig[corev1.Namespace]{
+		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		Reconcile:      c.reconcileEgressIPs,
+		Threadiness:    1,
+		Informer:       wf.NamespaceInformer().Informer(),
+		Lister:         wf.NamespaceInformer().Lister().List,
+		ObjNeedsUpdate: nsNeedsUpdate,
+	}
+	c.nsController = controllerutil.NewController("clustermanager routeadvertisements namespace controller", nsConfig)
 
 	return c
 }
@@ -171,6 +187,7 @@ func (c *Controller) Start() error {
 		c.frrController,
 		c.nadController,
 		c.nodeController,
+		c.nsController,
 		c.raController,
 	)
 }
@@ -181,20 +198,33 @@ func (c *Controller) Stop() {
 		c.frrController,
 		c.nadController,
 		c.nodeController,
+		c.nsController,
 		c.raController,
 	)
-	klog.Infof("Cluster manager routeadvertisements stoppedu")
+	klog.Infof("Cluster manager routeadvertisements stopped")
 }
 
 func (c *Controller) ReconcileNetwork(_ string, old, new util.NetInfo) {
-	// This controller already listens on NAD events however we skip NADs
-	// pointing to networks that network manager is still not aware of; so we
-	// only need to signal the reconciliation of new networks. Reconcile one of
-	// the NADs of the network to do s
-	if new == nil || old != nil {
-		return
+	// This controller already listens on NAD events but there is two additional
+	// scenarios we need to cover for:
+	// - for newly created networks, we need to wait until network manager is
+	// aware of them.
+	// - if the namespaces served by a network change.
+	oldNamespaces, newNamespaces := sets.New[string](), sets.New[string]()
+	if old != nil {
+		oldNamespaces.Insert(old.GetNADNamespaces()...)
 	}
-	c.nadController.Reconcile(new.GetNADs()[0])
+	if new != nil {
+		newNamespaces.Insert(new.GetNADNamespaces()...)
+	}
+	if new != nil && !newNamespaces.Equal(oldNamespaces) {
+		// we use one of the NADs of the network to reconcile it
+		c.nadController.Reconcile(new.GetNADs()[0])
+		// if the namespaces served by a network changed, it is possible that
+		// those namespaces are served or no longer served by the default
+		// network, so reconcile it as well
+		c.nadController.Reconcile(config.Kubernetes.OVNConfigNamespace + "/" + types.DefaultNetworkName)
+	}
 }
 
 // Reconcile RouteAdvertisements. For each selected FRRConfiguration and node,
@@ -206,7 +236,8 @@ func (c *Controller) ReconcileNetwork(_ string, old, new util.NetInfo) {
 //
 // - If EgressIP advertisements are enabled, the generated FRRConfiguration will
 // announce from the node the EgressIPs allocated to it on the matching target
-// VRFs.
+// VRFs. Selected EgressIP are those that serve the same namespaces as the
+// selected networks. Target VRF `auto` is not supported for EgressIPs.
 //
 // - If pod network advertisements are enabled, the generated FRRConfiguration
 // will import the target VRFs on the selected networks as required.
@@ -222,7 +253,7 @@ func (c *Controller) ReconcileNetwork(_ string, old, new util.NetInfo) {
 // Finally, it will update the status of the RouteAdvertisements.
 //
 // The controller processes selected events of RouteAdvertisements,
-// FRRConfigurations, Nodes, EgressIPs and NADs.
+// FRRConfigurations, Nodes, EgressIPs, NADs and namespaces.
 func (c *Controller) reconcile(name string) error {
 	startTime := time.Now()
 	klog.V(5).Infof("Syncing routeadvertisements %q", name)
@@ -292,6 +323,11 @@ type selectedNetworks struct {
 func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) ([]*frrtypes.FRRConfiguration, []*nadtypes.NetworkAttachmentDefinition, error) {
 	if ra == nil {
 		return nil, nil, nil
+	}
+
+	advertisements := sets.New(ra.Spec.Advertisements...)
+	if advertisements.Has(ratypes.EgressIP) && ra.Spec.TargetVRF == "auto" {
+		return nil, nil, fmt.Errorf("%w: advertising EgressIP not supported with TargetVRF set to 'auto'", errConfig)
 	}
 
 	// if we are matching on the well known default network label, create an
@@ -369,7 +405,6 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 	if err != nil {
 		return nil, nil, err
 	}
-	advertisements := sets.New(ra.Spec.Advertisements...)
 	if !nodeSelector.Empty() && advertisements.Has(ratypes.PodNetwork) {
 		return nil, nil, fmt.Errorf("%w: node selector cannot be specified if pod network is advertised", errConfig)
 	}
@@ -444,15 +479,15 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 
 	// helper to gather egress ips and cache during reconcile
 	// TODO perhaps cache across reconciles as well
-	var nodeEgressIPs map[string][]string
-	getEgressIPs := func(nodeName string) ([]string, error) {
-		if nodeEgressIPs == nil {
-			nodeEgressIPs, err = c.getEgressIPsByNode()
+	var eipsByNodesByNetworks map[string]map[string]sets.Set[string]
+	getEgressIPsByNode := func(nodeName string) (map[string]sets.Set[string], error) {
+		if eipsByNodesByNetworks == nil {
+			eipsByNodesByNetworks, err = c.getEgressIPsByNodesByNetworks(networkSet)
 			if err != nil {
 				return nil, err
 			}
 		}
-		return nodeEgressIPs[nodeName], nil
+		return eipsByNodesByNetworks[nodeName], nil
 	}
 
 	// helper to gather host subnets and egress ips as prefixes
@@ -469,13 +504,11 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 		// gather EgressIPs
 		var eips []string
 		if advertisements.Has(ratypes.EgressIP) {
-			if network != types.DefaultNetworkName {
-				return nil, fmt.Errorf("%w: can't advertise EgressIP in selected non default network %q: %w", errConfig, network, err)
-			}
-			eips, err = getEgressIPs(nodeName)
+			eipsByNode, err := getEgressIPsByNode(nodeName)
 			if err != nil {
 				return nil, err
 			}
+			eips = eipsByNode[network].UnsortedList()
 		}
 
 		prefixes := make([]string, 0, len(subnets)+len(eips))
@@ -500,8 +533,13 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 			// ordered
 			slices.Sort(selectedNetworks.hostNetworkSubnets[network])
 		}
-		// ordered
-		slices.Sort(selectedNetworks.hostSubnets)
+		// order, dedup
+		selectedNetworks.hostSubnets = sets.List(sets.New(selectedNetworks.hostSubnets...))
+
+		// if there is no prefixes to advertise for this node, skip it
+		if len(selectedNetworks.hostSubnets) == 0 {
+			continue
+		}
 
 		matchedNetworks := sets.New[string]()
 		for _, frrConfig := range frrConfigs {
@@ -985,26 +1023,69 @@ func (c *Controller) getOrCreateDefaultNetworkNAD() (*nadtypes.NetworkAttachment
 	)
 }
 
-// getEgressIPsByNode iterates all existing egress IPs and returns them indexed
-// by node
-func (c *Controller) getEgressIPsByNode() (map[string][]string, error) {
+// getEgressIPsByNodesByNetworks iterates all existing egress IPs that apply to
+// any of the provided networks and returns a "node -> network -> eips"
+// map.
+func (c *Controller) getEgressIPsByNodesByNetworks(networks sets.Set[string]) (map[string]map[string]sets.Set[string], error) {
+	eipsByNodesByNetworks := map[string]map[string]sets.Set[string]{}
+	addEgressIPsByNodesByNetwork := func(eipsByNodes map[string]string, network string) {
+		for node, eip := range eipsByNodes {
+			if eipsByNodesByNetworks[node] == nil {
+				eipsByNodesByNetworks[node] = map[string]sets.Set[string]{}
+			}
+			if eipsByNodesByNetworks[node][network] == nil {
+				eipsByNodesByNetworks[node][network] = sets.New[string]()
+			}
+			eipsByNodesByNetworks[node][network].Insert(eip)
+		}
+	}
+
+	addEgressIPsByNodesByNetworkSelector := func(eipsByNodes map[string]string, namespaceSelector *metav1.LabelSelector) error {
+		nsSelector, err := metav1.LabelSelectorAsSelector(namespaceSelector)
+		if err != nil {
+			return err
+		}
+		selected, err := c.namespaceLister.List(nsSelector)
+		if err != nil {
+			return err
+		}
+		for _, namespace := range selected {
+			namespaceNetwork := c.nm.GetActiveNetworkForNamespaceFast(namespace.Name)
+			networkName := namespaceNetwork.GetNetworkName()
+			if networks.Has(networkName) {
+				addEgressIPsByNodesByNetwork(eipsByNodes, networkName)
+			}
+		}
+		return nil
+	}
+
 	eips, err := c.eipLister.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	eipsByNode := map[string][]string{}
 	for _, eip := range eips {
+		eipsByNodes := make(map[string]string, len(eip.Status.Items))
 		for _, item := range eip.Status.Items {
-			if item.EgressIP == "" {
+			// skip unassigned EIPs
+			if item.EgressIP == "" || item.Node == "" {
 				continue
 			}
+
 			ip := item.EgressIP + util.GetIPFullMaskString(item.EgressIP)
-			eipsByNode[item.Node] = append(eipsByNode[item.Node], ip)
+			eipsByNodes[item.Node] = ip
+		}
+		if len(eipsByNodes) == 0 {
+			continue
+		}
+
+		err = addEgressIPsByNodesByNetworkSelector(eipsByNodes, &eip.Spec.NamespaceSelector)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	return eipsByNode, nil
+	return eipsByNodesByNetworks, nil
 }
 
 // isOwnUpdate checks if an object was updated by us last, as indicated by its
@@ -1055,12 +1136,13 @@ func nadNeedsUpdate(oldObj, newObj *nadtypes.NetworkAttachmentDefinition) bool {
 func nodeNeedsUpdate(oldObj, newObj *corev1.Node) bool {
 	return oldObj == nil || newObj == nil ||
 		!reflect.DeepEqual(oldObj.Labels, newObj.Labels) ||
-		util.NodeSubnetAnnotationChanged(oldObj, newObj)
+		util.NodeSubnetAnnotationChanged(oldObj, newObj) ||
+		oldObj.Annotations[util.OvnNodeIfAddr] != newObj.Annotations[util.OvnNodeIfAddr]
 }
 
 func egressIPNeedsUpdate(oldObj, newObj *eiptypes.EgressIP) bool {
-	if oldObj != nil && newObj != nil && reflect.DeepEqual(oldObj.Status, newObj.Status) {
-		return false
+	if oldObj != nil && newObj != nil {
+		return !reflect.DeepEqual(oldObj.Status, newObj.Status) || !reflect.DeepEqual(oldObj.Spec.NamespaceSelector, newObj.Spec.NamespaceSelector)
 	}
 	if oldObj != nil && len(oldObj.Status.Items) > 0 {
 		return true
@@ -1069,6 +1151,12 @@ func egressIPNeedsUpdate(oldObj, newObj *eiptypes.EgressIP) bool {
 		return true
 	}
 	return false
+}
+
+func nsNeedsUpdate(oldObj, newObj *corev1.Namespace) bool {
+	// we only care about label changes, added/deleted namespaces served by a
+	// UDN will already be reflected in a network update
+	return oldObj != nil && newObj != nil && !reflect.DeepEqual(oldObj.Labels, newObj.Labels)
 }
 
 func (c *Controller) reconcileFRRConfiguration(key string) error {
@@ -1133,7 +1221,7 @@ func (c *Controller) reconcileNAD(key string) error {
 	return nil
 }
 
-func (c *Controller) reconcileEgressIP(_ string) error {
+func (c *Controller) reconcileEgressIPs(string) error {
 	// reconcile RAs that advertise EIPs
 	ras, err := c.raLister.List(labels.Everything())
 	if err != nil {

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -80,14 +80,42 @@ func (tra testRA) RouteAdvertisements() *ratypes.RouteAdvertisements {
 	return ra
 }
 
+var (
+	nodePrimaryAddr = map[string]string{
+		"node": "1.0.1.100/24",
+	}
+	nodePrimaryAddrIPv6 = map[string]string{
+		"node": "fd03::ffff:0100:0050/64",
+	}
+)
+
+type testNamespace struct {
+	Name   string
+	Labels map[string]string
+}
+
+func (tn testNamespace) Namespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   tn.Name,
+			Labels: tn.Labels,
+		},
+	}
+}
+
 type testNode struct {
-	Name              string
-	Generation        int
-	Labels            map[string]string
-	SubnetsAnnotation string
+	Name                     string
+	Generation               int
+	Labels                   map[string]string
+	PrimaryAddressAnnotation string
+	SubnetsAnnotation        string
 }
 
 func (tn testNode) Node() *corev1.Node {
+	primaryAddressAnnotation := tn.PrimaryAddressAnnotation
+	if primaryAddressAnnotation == "" {
+		primaryAddressAnnotation = "{\"ipv4\":\"" + nodePrimaryAddr[tn.Name] + "\", \"ipv6\":\"" + nodePrimaryAddrIPv6[tn.Name] + "\"}"
+	}
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       tn.Name,
@@ -95,6 +123,7 @@ func (tn testNode) Node() *corev1.Node {
 			Generation: int64(tn.Generation),
 			Annotations: map[string]string{
 				"k8s.ovn.org/node-subnets": tn.SubnetsAnnotation,
+				util.OvnNodeIfAddr:         primaryAddressAnnotation,
 			},
 		},
 	}
@@ -210,9 +239,10 @@ func (tf testFRRConfig) FRRConfiguration() *frrapi.FRRConfiguration {
 }
 
 type testEIP struct {
-	Name       string
-	Generation int
-	EIPs       map[string]string
+	Name              string
+	Generation        int
+	NamespaceSelector map[string]string
+	EIPs              map[string]string
 }
 
 func (te testEIP) EgressIP() *eiptypes.EgressIP {
@@ -220,6 +250,11 @@ func (te testEIP) EgressIP() *eiptypes.EgressIP {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       te.Name,
 			Generation: int64(te.Generation),
+		},
+		Spec: eiptypes.EgressIPSpec{
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: te.NamespaceSelector,
+			},
 		},
 		Status: eiptypes.EgressIPStatus{
 			Items: []eiptypes.EgressIPStatusItem{},
@@ -333,6 +368,7 @@ func TestController_reconcile(t *testing.T) {
 		frrConfigs           []*testFRRConfig
 		nads                 []*testNAD
 		nodes                []*testNode
+		namespaces           []*testNamespace
 		eips                 []*testEIP
 		reconcile            string
 		wantErr              bool
@@ -442,8 +478,8 @@ func TestController_reconcile(t *testing.T) {
 			expectNADAnnotations: map[string]map[string]string{"red": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}, "blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
 		},
 		{
-			name: "reconciles eip RouteAdvertisement for a single FRR config, node, default network and non default target VRF",
-			ra:   &testRA{Name: "ra", TargetVRF: "red", AdvertiseEgressIPs: true},
+			name: "reconciles eip RouteAdvertisement for a single FRR config, node, non default network and non default target VRF",
+			ra:   &testRA{Name: "ra", TargetVRF: "red", AdvertiseEgressIPs: true, NetworkSelector: map[string]string{"selected": "true"}},
 			frrConfigs: []*testFRRConfig{
 				{
 					Name:      "frrConfig",
@@ -455,8 +491,24 @@ func TestController_reconcile(t *testing.T) {
 					},
 				},
 			},
-			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\"}"}},
-			eips:                 []*testEIP{{Name: "eip", EIPs: map[string]string{"node": "1.0.1.1"}}},
+			nads: []*testNAD{
+				{Name: "default", Namespace: "ovn-kubernetes", Network: "default"},
+				{Name: "red", Namespace: "red", Network: "cluster.udn.red", Topology: "layer3", Subnet: "1.2.0.0/16"},
+				{Name: "blue", Namespace: "blue", Network: "cluster.udn.blue", Topology: "layer3", Subnet: "1.3.0.0/16", Labels: map[string]string{"selected": "true"}},
+			},
+			nodes: []*testNode{
+				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.1.0/24\", \"cluster.udn.red\":\"1.2.1.0/24\", \"cluster.udn.blue\":\"1.3.1.0/24\"}"},
+			},
+			namespaces: []*testNamespace{
+				{Name: "default", Labels: map[string]string{"selected": "default"}},
+				{Name: "red", Labels: map[string]string{"selected": "red"}},
+				{Name: "blue", Labels: map[string]string{"selected": "blue"}},
+			},
+			eips: []*testEIP{
+				{Name: "eip1", EIPs: map[string]string{"node": "172.100.0.16"}, NamespaceSelector: map[string]string{"selected": "blue"}}, // secondary interface EIP also advertised
+				{Name: "eip2", EIPs: map[string]string{"node": "1.0.1.2"}, NamespaceSelector: map[string]string{"selected": "red"}},       // namespace served by unselected network, ignored
+				{Name: "eip3", EIPs: map[string]string{"node": "1.0.1.3"}, NamespaceSelector: map[string]string{"selected": "blue"}},
+			},
 			reconcile:            "ra",
 			expectAcceptedStatus: metav1.ConditionTrue,
 			expectFRRConfigs: []*testFRRConfig{
@@ -465,12 +517,12 @@ func TestController_reconcile(t *testing.T) {
 					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
 					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
 					Routers: []*testRouter{
-						{ASN: 1, VRF: "red", Prefixes: []string{"1.0.1.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.0.1.1/32"}},
+						{ASN: 1, VRF: "red", Prefixes: []string{"1.0.1.3/32", "172.100.0.16/32"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.0.1.3/32", "172.100.0.16/32"}},
 						}},
 					}},
 			},
-			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
 		},
 		{
 			name: "reconciles a RouteAdvertisement updating the generated FRRConfigurations if needed",
@@ -721,28 +773,6 @@ func TestController_reconcile(t *testing.T) {
 			expectAcceptedStatus: metav1.ConditionFalse,
 		},
 		{
-			name: "fails to reconcile if egress IPs are advertised for non-default network",
-			ra:   &testRA{Name: "ra", AdvertiseEgressIPs: true, NetworkSelector: map[string]string{"selected": "true"}},
-			nads: []*testNAD{
-				{Name: "red", Namespace: "red", Network: "red", Topology: "layer3", Labels: map[string]string{"selected": "true"}},
-			},
-			frrConfigs: []*testFRRConfig{
-				{
-					Name:      "frrConfig",
-					Namespace: frrNamespace,
-					Routers: []*testRouter{
-						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100"},
-						}},
-					},
-				},
-			},
-			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"red\":\"1.1.0.0/24\"}"}},
-			eips:                 []*testEIP{{Name: "eip", EIPs: map[string]string{"node": "1.0.1.1"}}},
-			reconcile:            "ra",
-			expectAcceptedStatus: metav1.ConditionFalse,
-		},
-		{
 			name: "fails to reconcile if a selectd FRRConfiguration has no matching VRF",
 			ra:   &testRA{Name: "ra", TargetVRF: "red", AdvertisePods: true},
 			frrConfigs: []*testFRRConfig{
@@ -761,11 +791,11 @@ func TestController_reconcile(t *testing.T) {
 			expectAcceptedStatus: metav1.ConditionFalse,
 		},
 		{
-			name: "fails to reconcile if not all VRFs were matched on auto",
+			name: "fails to reconcile if not all VRFs were matched with 'auto' target VRF",
 			ra:   &testRA{Name: "ra", TargetVRF: "auto", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
 			nads: []*testNAD{
-				{Name: "red", Namespace: "red", Network: "red", Labels: map[string]string{"selected": "true"}},
-				{Name: "blue", Namespace: "blue", Network: "blue", Labels: map[string]string{"selected": "true"}},
+				{Name: "red", Namespace: "red", Network: "red", Topology: "layer3", Labels: map[string]string{"selected": "true"}},
+				{Name: "blue", Namespace: "blue", Network: "blue", Topology: "layer3", Labels: map[string]string{"selected": "true"}},
 			},
 			frrConfigs: []*testFRRConfig{
 				{
@@ -783,10 +813,10 @@ func TestController_reconcile(t *testing.T) {
 			expectAcceptedStatus: metav1.ConditionFalse,
 		},
 		{
-			name: "fails to reconcile if network names are too long to fit as a VFR name",
-			ra:   &testRA{Name: "ra", TargetVRF: "auto", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			name: "fails to reconcile if EgressIP is advertised with 'auto' target VRF",
+			ra:   &testRA{Name: "ra", TargetVRF: "auto", AdvertiseEgressIPs: true, NetworkSelector: map[string]string{"selected": "true"}},
 			nads: []*testNAD{
-				{Name: "red", Namespace: "red", Network: util.GenerateCUDNNetworkName("red.name.too.long"), Labels: map[string]string{"selected": "true"}},
+				{Name: "red", Namespace: "red", Network: "red", Topology: "layer3", Labels: map[string]string{"selected": "true"}},
 			},
 			frrConfigs: []*testFRRConfig{
 				{
@@ -799,28 +829,7 @@ func TestController_reconcile(t *testing.T) {
 					},
 				},
 			},
-			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"cluster_udn_red.name.too.long\":\"1.1.0.0/24\"}"}},
-			reconcile:            "ra",
-			expectAcceptedStatus: metav1.ConditionFalse,
-		},
-		{
-			name: "fails to reconcile if network is not a cluster UDN",
-			ra:   &testRA{Name: "ra", TargetVRF: "auto", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
-			nads: []*testNAD{
-				{Name: "red", Namespace: "red", Network: "red", Labels: map[string]string{"selected": "true"}},
-			},
-			frrConfigs: []*testFRRConfig{
-				{
-					Name:      "frrConfig",
-					Namespace: frrNamespace,
-					Routers: []*testRouter{
-						{ASN: 1, VRF: "red", Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100"},
-						}},
-					},
-				},
-			},
-			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"red\":\"1.1.0.0/24\"}"}},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"red\":\"1.1.0.0/24\""}},
 			reconcile:            "ra",
 			expectAcceptedStatus: metav1.ConditionFalse,
 		},
@@ -867,8 +876,7 @@ func TestController_reconcile(t *testing.T) {
 			fakeClientset := util.GetOVNClientset().GetClusterManagerClientset()
 			addGenerateNameReactor[*frrfake.Clientset](fakeClientset.FRRClient)
 
-			// create test objects (we could initialize these objects with the
-			// clients but at least for the NADs iit doesn't work)
+			// create test objects
 			if tt.ra != nil {
 				_, err := fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), tt.ra.RouteAdvertisements(), metav1.CreateOptions{})
 				g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -893,6 +901,11 @@ func TestController_reconcile(t *testing.T) {
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 
+			for _, namespace := range tt.namespaces {
+				_, err := fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace.Namespace(), metav1.CreateOptions{})
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+
 			for _, eip := range tt.eips {
 				_, err := fakeClientset.EgressIPClient.K8sV1().EgressIPs().Create(context.Background(), eip.EgressIP(), metav1.CreateOptions{})
 				g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -911,6 +924,14 @@ func TestController_reconcile(t *testing.T) {
 				defaultNAD, err = c.getOrCreateDefaultNetworkNAD()
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 			}
+			// prime the default network NAD namespace
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.Kubernetes.OVNConfigNamespace,
+				},
+			}
+			_, err = fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// update it with the annotation that network manager would set
 			defaultNAD.Annotations = map[string]string{types.OvnNetworkNameAnnotation: types.DefaultNetworkName}
@@ -1143,6 +1164,18 @@ func TestUpdates(t *testing.T) {
 			expectedReconcile: []string{"ra1", "ra3"},
 		},
 		{
+			name:              "reconciles all RAs that advertise EIPs on updated EIP status",
+			oldObject:         &testEIP{Name: "eip", EIPs: map[string]string{"node": "ip"}},
+			newObject:         &testEIP{Name: "eip", EIPs: map[string]string{"node": "ip"}, NamespaceSelector: map[string]string{"selected": "true"}},
+			expectedReconcile: []string{"ra1", "ra3"},
+		},
+		{
+			name:              "reconciles all RAs that advertise EIPs on updated namespace labels",
+			oldObject:         &testNamespace{Name: "ns1", Labels: map[string]string{"selected": "true"}},
+			newObject:         &testNamespace{Name: "ns1"},
+			expectedReconcile: []string{"ra1", "ra3"},
+		},
+		{
 			name:      "does not reconcile RAs on new EIP with no status",
 			newObject: &testEIP{Name: "eip"},
 		},
@@ -1178,6 +1211,12 @@ func TestUpdates(t *testing.T) {
 			name:              "reconciles all RAs on updated Node subnet annotation",
 			oldObject:         &testNode{Name: "eip"},
 			newObject:         &testNode{Name: "eip", SubnetsAnnotation: "subnets"},
+			expectedReconcile: []string{"ra1", "ra2", "ra3"},
+		},
+		{
+			name:              "reconciles all RAs on updated Node primary address annotation",
+			oldObject:         &testNode{Name: "eip", PrimaryAddressAnnotation: "old"},
+			newObject:         &testNode{Name: "eip", PrimaryAddressAnnotation: "new"},
 			expectedReconcile: []string{"ra1", "ra2", "ra3"},
 		},
 		{
@@ -1250,6 +1289,8 @@ func TestUpdates(t *testing.T) {
 					_, err = fakeClientset.EgressIPClient.K8sV1().EgressIPs().Create(context.Background(), t.EgressIP(), metav1.CreateOptions{})
 				case *testNode:
 					_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), t.Node(), metav1.CreateOptions{})
+				case *testNamespace:
+					_, err = fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(), t.Namespace(), metav1.CreateOptions{})
 				}
 				return err
 			}
@@ -1264,6 +1305,8 @@ func TestUpdates(t *testing.T) {
 					_, err = fakeClientset.EgressIPClient.K8sV1().EgressIPs().Update(context.Background(), t.EgressIP(), metav1.UpdateOptions{})
 				case *testNode:
 					_, err = fakeClientset.KubeClient.CoreV1().Nodes().Update(context.Background(), t.Node(), metav1.UpdateOptions{})
+				case *testNamespace:
+					_, err = fakeClientset.KubeClient.CoreV1().Namespaces().Update(context.Background(), t.Namespace(), metav1.UpdateOptions{})
 				}
 				return err
 			}
@@ -1278,6 +1321,8 @@ func TestUpdates(t *testing.T) {
 					err = fakeClientset.EgressIPClient.K8sV1().EgressIPs().Delete(context.Background(), t.Name, metav1.DeleteOptions{})
 				case *testNode:
 					err = fakeClientset.KubeClient.CoreV1().Nodes().Delete(context.Background(), t.Name, metav1.DeleteOptions{})
+				case *testNamespace:
+					err = fakeClientset.KubeClient.CoreV1().Namespaces().Delete(context.Background(), t.Name, metav1.DeleteOptions{})
 				}
 				return err
 			}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -1044,6 +1044,12 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 	}
 
 	if util.IsRouteAdvertisementsEnabled() {
+		wf.informers[NamespaceType], err = newQueuedInformer(eventQueueSize, NamespaceType, wf.iFactory.Core().V1().Namespaces().Informer(),
+			wf.stopChan, defaultNumEventQueues)
+		if err != nil {
+			return nil, err
+		}
+
 		wf.raFactory = routeadvertisementsinformerfactory.NewSharedInformerFactory(ovnClientset.RouteAdvertisementsClient, resyncInterval)
 		// make sure shared informer is created for a factory, so on wf.raFactory.Start() it is initialized and caches are synced.
 		wf.raFactory.K8s().V1().RouteAdvertisements().Informer()

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -20,7 +20,21 @@ const (
 // Interface is the main package entrypoint and provides network related
 // information to the rest of the project.
 type Interface interface {
+	// GetActiveNetworkForNamespace returns a copy of the primary network for
+	// the namespace if any or the default network otherwise. If there is a
+	// primary UDN defined but the NAD has not been processed yet, returns
+	// ErrNetworkControllerTopologyNotManaged. Used for controllers that are not
+	// capable of reconciling primary network changes. If unsure, use this one
+	// and not GetActiveNetworkForNamespaceFast.
 	GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error)
+
+	// GetActiveNetworkForNamespaceFast returns the primary network for the
+	// namespace if any or the default network otherwise. It is faster than
+	// GetActiveNetworkForNamespace because it does not copy the network and it
+	// does not verify against UDNs. However, it is recommended to be used only
+	// by controllers capable of reconciling primary network changes. If unsure,
+	// use GetActiveNetworkForNamespace.
+	GetActiveNetworkForNamespaceFast(namespace string) util.NetInfo
 
 	// GetNetwork returns the network of the given name or nil if unknown
 	GetNetwork(name string) util.NetInfo
@@ -169,6 +183,10 @@ func (nm defaultNetworkManager) Stop() {}
 
 func (nm defaultNetworkManager) GetActiveNetworkForNamespace(string) (util.NetInfo, error) {
 	return &util.DefaultNetInfo{}, nil
+}
+
+func (nm defaultNetworkManager) GetActiveNetworkForNamespaceFast(string) util.NetInfo {
+	return &util.DefaultNetInfo{}
 }
 
 func (nm defaultNetworkManager) GetNetwork(name string) util.NetInfo {


### PR DESCRIPTION
Add support to advertise EIPs for UDNs in cluster manager
RouteAdvertisements controller. 

Selected Egress IPs are those that 
- are served on the same namespaces as where the selected
  networks are serving, and
- are assigned to a selected node
- ~~are on the default network subnet for that node~~

Egress IPs, just as with Pod IPs, will be advertised on routers
on the target VRF on the selected nodes.

`auto` is not supported as target VRF for Egress IPs.

**Better** support for Egress IPs on subnets other that the default network
node subnet, **including support** VRF-Lite interface subnets, is left for a future
exercise. We would need cluster manager to be able to:
- map non VRF-Lite interface subnets to the proper BGP sessions
- tell apart VRF-Lite interface subnets from other secondary interface 
  subnets
