### PR TITLE
Update github runners to use the new kernel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -495,7 +495,6 @@ jobs:
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'multi-homing-helm' || matrix.target == 'traffic-flow-test-only' || matrix.routeadvertisements != '' }}"
       ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' || matrix.network-segmentation == 'enable-network-segmentation' }}"
-      DISABLE_UDN_HOST_ISOLATION: "true"
       PLATFORM_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       PLATFORM_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
   # separate job for parallelism
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
 
   build-master:
     name: Build-master
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     # Create a cache for the built master image
     - name: Restore master image cache
@@ -156,7 +156,7 @@ jobs:
 
   build-pr:
     name: Build-PR
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     # Create a cache for the build PR image
     - name: Restore PR image cache
@@ -271,7 +271,7 @@ jobs:
   ovn-upgrade-e2e:
     name: Upgrade OVN from Master to PR branch based image
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs:
       - build-master
@@ -319,10 +319,9 @@ jobs:
         sudo rm -rf /usr/local/lib/android/sdk
         sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
-          azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+          azure-cli firefox \
           google-chrome-stable \
-          llvm-* microsoft-edge-stable mono-* \
-          msbuild mysql-server-core-* php-* php7* \
+          llvm-* microsoft-edge-stable \
           powershell temurin-* zulu-*
         # clean unused packages
         sudo apt-get autoclean
@@ -422,7 +421,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # 30 mins for kind, 180 mins for control-plane tests, 10 minutes for all other steps
     timeout-minutes: 220
     strategy:
@@ -525,10 +524,9 @@ jobs:
         sudo rm -rf /usr/local/lib/android/sdk
         sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
-          azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+          azure-cli firefox \
           google-chrome-stable \
-          llvm-* microsoft-edge-stable mono-* \
-          msbuild mysql-server-core-* php-* php7* \
+          llvm-* microsoft-edge-stable \
           powershell temurin-* zulu-*
         # clean unused packages
         sudo apt-get autoclean
@@ -712,7 +710,7 @@ jobs:
   e2e-dual-conversion:
     name: e2e-dual-conversion
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -761,10 +759,9 @@ jobs:
         sudo rm -rf /usr/local/lib/android/sdk
         sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
-          azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+          azure-cli firefox \
           google-chrome-stable \
-          llvm-* microsoft-edge-stable mono-* \
-          msbuild mysql-server-core-* php-* php7* \
+          llvm-* microsoft-edge-stable \
           powershell temurin-* zulu-*
         # clean unused packages
         sudo apt-get autoclean

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -2162,7 +2162,6 @@ ovnkube-controller-with-node() {
     --nodeport \
     --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
     --pidfile ${OVN_RUNDIR}/ovnkube-controller-with-node.pid \
-    --disable-udn-host-isolation \
     --zone ${ovn_zone} &
 
   wait_for_event attempts=3 process_ready ovnkube-controller-with-node
@@ -2814,7 +2813,6 @@ ovn-node() {
         --nodeport \
         --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
         --pidfile ${OVN_RUNDIR}/ovnkube.pid \
-        --disable-udn-host-isolation \
         --zone ${ovn_zone} &
 
   wait_for_event attempts=3 process_ready ovnkube

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -425,18 +425,15 @@ type OVNKubernetesFeatureConfig struct {
 	EnableNetworkSegmentation       bool `gcfg:"enable-network-segmentation"`
 	EnablePreconfiguredUDNAddresses bool `gcfg:"enable-preconfigured-udn-addresses"`
 	EnableRouteAdvertisements       bool `gcfg:"enable-route-advertisements"`
-	// This feature requires a kernel fix https://github.com/torvalds/linux/commit/7f3287db654395f9c5ddd246325ff7889f550286
-	// to work on a kind cluster. Flag allows to disable it for current CI, will be turned on when github runners have this fix.
-	DisableUDNHostIsolation      bool `gcfg:"disable-udn-host-isolation"`
-	EnableMultiNetworkPolicy     bool `gcfg:"enable-multi-networkpolicy"`
-	EnableStatelessNetPol        bool `gcfg:"enable-stateless-netpol"`
-	EnableInterconnect           bool `gcfg:"enable-interconnect"`
-	EnableMultiExternalGateway   bool `gcfg:"enable-multi-external-gateway"`
-	EnablePersistentIPs          bool `gcfg:"enable-persistent-ips"`
-	EnableDNSNameResolver        bool `gcfg:"enable-dns-name-resolver"`
-	EnableServiceTemplateSupport bool `gcfg:"enable-svc-template-support"`
-	EnableObservability          bool `gcfg:"enable-observability"`
-	EnableNetworkQoS             bool `gcfg:"enable-network-qos"`
+	EnableMultiNetworkPolicy        bool `gcfg:"enable-multi-networkpolicy"`
+	EnableStatelessNetPol           bool `gcfg:"enable-stateless-netpol"`
+	EnableInterconnect              bool `gcfg:"enable-interconnect"`
+	EnableMultiExternalGateway      bool `gcfg:"enable-multi-external-gateway"`
+	EnablePersistentIPs             bool `gcfg:"enable-persistent-ips"`
+	EnableDNSNameResolver           bool `gcfg:"enable-dns-name-resolver"`
+	EnableServiceTemplateSupport    bool `gcfg:"enable-svc-template-support"`
+	EnableObservability             bool `gcfg:"enable-observability"`
+	EnableNetworkQoS                bool `gcfg:"enable-network-qos"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -1086,12 +1083,6 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use MultiNetworkPolicy CRD feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableMultiNetworkPolicy,
 		Value:       OVNKubernetesFeature.EnableMultiNetworkPolicy,
-	},
-	&cli.BoolFlag{
-		Name:        "disable-udn-host-isolation",
-		Usage:       "Configure to disable UDN host isolation with ovn-kubernetes.",
-		Destination: &cliConfig.OVNKubernetesFeature.DisableUDNHostIsolation,
-		Value:       OVNKubernetesFeature.DisableUDNHostIsolation,
 	},
 	&cli.BoolFlag{
 		Name:        "enable-network-segmentation",

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -150,7 +150,7 @@ func newDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, sto
 		routeManager: routeManager,
 		ovsClient:    ovsClient,
 	}
-	if util.IsNetworkSegmentationSupportEnabled() && !config.OVNKubernetesFeature.DisableUDNHostIsolation {
+	if util.IsNetworkSegmentationSupportEnabled() {
 		c.udnHostIsolationManager = NewUDNHostIsolationManager(config.IPv4Mode, config.IPv6Mode,
 			cnnci.watchFactory.PodCoreInformer(), cnnci.name, cnnci.recorder)
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1144,11 +1144,6 @@ func isInterconnectEnabled() bool {
 	return present && val == "true"
 }
 
-func isUDNHostIsolationDisabled() bool {
-	val, present := os.LookupEnv("DISABLE_UDN_HOST_ISOLATION")
-	return present && val == "true"
-}
-
 func isNetworkSegmentationEnabled() bool {
 	val, present := os.LookupEnv("ENABLE_NETWORK_SEGMENTATION")
 	return present && val == "true"


### PR DESCRIPTION
Issue: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5187

Re-enable udn-host-isolation tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline to use Ubuntu 24.04 runners and simplified package removal steps.
  * Removed the ability to configure or disable UDN host isolation via CLI flags or configuration files.

* **Refactor**
  * Simplified internal logic by always enabling UDN host isolation when network segmentation support is enabled.

* **Tests**
  * Updated end-to-end tests to always verify host isolation behavior, removing conditional checks based on host isolation settings.
  * Improved node IP address migration by reversing the order of IP address removal and addition for smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->