### PR TITLE
Remove default route if UDN network is advertised on its own VRF

### DIFF
--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -81,6 +82,12 @@ type UserDefinedNetworkGateway struct {
 	// reconcile channel to signal reconciliation of the gateway on network
 	// configuration changes
 	reconcile chan struct{}
+
+	// vrfTableId holds the route table ID corresponding to management port interface of the network
+	vrfTableId int
+
+	// gwInterfaceIndex holds the link index of gateway interface
+	gwInterfaceIndex int
 }
 
 // UTILS Needed for UDN (also leveraged for default netInfo) in bridgeConfiguration
@@ -250,19 +257,29 @@ func NewUserDefinedNetworkGateway(netInfo util.NetInfo, node *corev1.Node, nodeL
 		return nil, fmt.Errorf("unable to dereference default node network controller gateway object")
 	}
 
+	if gw.openflowManager == nil {
+		return nil, fmt.Errorf("openflow manager has not been provided for network: %s", netInfo.GetNetworkName())
+	}
+	intfName := gw.openflowManager.defaultBridge.getGatewayIface()
+	link, err := util.GetNetLinkOps().LinkByName(intfName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get link for %s, error: %v", intfName, err)
+	}
+
 	return &UserDefinedNetworkGateway{
-		NetInfo:       netInfo,
-		node:          node,
-		nodeLister:    nodeLister,
-		kubeInterface: kubeInterface,
-		vrfManager:    vrfManager,
-		masqCTMark:    masqCTMark,
-		pktMark:       pktMark,
-		v4MasqIPs:     v4MasqIPs,
-		v6MasqIPs:     v6MasqIPs,
-		gateway:       gw,
-		ruleManager:   ruleManager,
-		reconcile:     make(chan struct{}, 1),
+		NetInfo:          netInfo,
+		node:             node,
+		nodeLister:       nodeLister,
+		kubeInterface:    kubeInterface,
+		vrfManager:       vrfManager,
+		masqCTMark:       masqCTMark,
+		pktMark:          pktMark,
+		v4MasqIPs:        v4MasqIPs,
+		v6MasqIPs:        v6MasqIPs,
+		gateway:          gw,
+		ruleManager:      ruleManager,
+		reconcile:        make(chan struct{}, 1),
+		gwInterfaceIndex: link.Attrs().Index,
 	}, nil
 }
 
@@ -317,21 +334,23 @@ func (udng *UserDefinedNetworkGateway) addMarkChain() error {
 // AddNetwork will be responsible to create all plumbings
 // required by this UDN on the gateway side
 func (udng *UserDefinedNetworkGateway) AddNetwork() error {
+	if udng.openflowManager == nil {
+		return fmt.Errorf("openflow manager has not been provided for network: %s", udng.NetInfo.GetNetworkName())
+	}
 	// port is created first and its MAC address configured. The IP(s) on that link are added after enslaving to a VRF device (addUDNManagementPortIPs)
 	// because IPv6 addresses are removed by the kernel (if not link local) when enslaved to a VRF device.
-	// Add the routes after setting the IP(s) to ensure that the default subnet route towards the mgmt network exists.
+	// Add the routes(AddVRFRoutes) after setting the IP(s) to ensure that the default subnet route towards the mgmt network exists.
 	mplink, err := udng.addUDNManagementPort()
 	if err != nil {
 		return fmt.Errorf("could not create management port netdevice for network %s: %w", udng.GetNetworkName(), err)
 	}
 	vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
-	vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
-	routes, err := udng.computeRoutesForUDN(vrfTableId, mplink)
+	routes, err := udng.computeRoutesForUDN(mplink)
 	if err != nil {
 		return fmt.Errorf("failed to compute routes for network %s, err: %v", udng.GetNetworkName(), err)
 	}
-	if err = udng.vrfManager.AddVRF(vrfDeviceName, mplink.Attrs().Name, uint32(vrfTableId), nil); err != nil {
-		return fmt.Errorf("could not add VRF %d for network %s, err: %v", vrfTableId, udng.GetNetworkName(), err)
+	if err = udng.vrfManager.AddVRF(vrfDeviceName, mplink.Attrs().Name, uint32(udng.vrfTableId), nil); err != nil {
+		return fmt.Errorf("could not add VRF %d for network %s, err: %v", udng.vrfTableId, udng.GetNetworkName(), err)
 	}
 	if err = udng.addUDNManagementPortIPs(mplink); err != nil {
 		return fmt.Errorf("unable to add management port IP(s) for link %s, for network %s: %w", mplink.Attrs().Name, udng.GetNetworkName(), err)
@@ -349,43 +368,40 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 	if err := addRPFilterLooseModeForManagementPort(mgmtPortName); err != nil {
 		return fmt.Errorf("could not set loose mode for reverse path filtering on management port %s: %v", mgmtPortName, err)
 	}
-	if udng.openflowManager != nil {
-		nodeSubnets, err := udng.getLocalSubnets()
-		if err != nil {
-			return fmt.Errorf("failed to get node subnets for network %s: %w", udng.GetNetworkName(), err)
-		}
-		if err = udng.openflowManager.addNetwork(udng.NetInfo, nodeSubnets, udng.masqCTMark, udng.pktMark, udng.v6MasqIPs, udng.v4MasqIPs); err != nil {
-			return fmt.Errorf("could not add network %s: %v", udng.GetNetworkName(), err)
-		}
 
-		waiter := newStartupWaiterWithTimeout(waitForPatchPortTimeout)
-		readyFunc := func() (bool, error) {
-			if err := setBridgeNetworkOfPorts(udng.openflowManager.defaultBridge, udng.GetNetworkName()); err != nil {
-				klog.V(3).Infof("Failed to set network %s's openflow ports for default bridge; error: %v", udng.GetNetworkName(), err)
+	nodeSubnets, err := udng.getLocalSubnets()
+	if err != nil {
+		return fmt.Errorf("failed to get node subnets for network %s: %w", udng.GetNetworkName(), err)
+	}
+	if err = udng.openflowManager.addNetwork(udng.NetInfo, nodeSubnets, udng.masqCTMark, udng.pktMark, udng.v6MasqIPs, udng.v4MasqIPs); err != nil {
+		return fmt.Errorf("could not add network %s: %v", udng.GetNetworkName(), err)
+	}
+
+	waiter := newStartupWaiterWithTimeout(waitForPatchPortTimeout)
+	readyFunc := func() (bool, error) {
+		if err := setBridgeNetworkOfPorts(udng.openflowManager.defaultBridge, udng.GetNetworkName()); err != nil {
+			klog.V(3).Infof("Failed to set network %s's openflow ports for default bridge; error: %v", udng.GetNetworkName(), err)
+			return false, nil
+		}
+		if udng.openflowManager.externalGatewayBridge != nil {
+			if err := setBridgeNetworkOfPorts(udng.openflowManager.externalGatewayBridge, udng.GetNetworkName()); err != nil {
+				klog.V(3).Infof("Failed to set network %s's openflow ports for secondary bridge; error: %v", udng.GetNetworkName(), err)
 				return false, nil
 			}
-			if udng.openflowManager.externalGatewayBridge != nil {
-				if err := setBridgeNetworkOfPorts(udng.openflowManager.externalGatewayBridge, udng.GetNetworkName()); err != nil {
-					klog.V(3).Infof("Failed to set network %s's openflow ports for secondary bridge; error: %v", udng.GetNetworkName(), err)
-					return false, nil
-				}
-			}
-			return true, nil
 		}
-		postFunc := func() error {
-			if err := udng.gateway.Reconcile(); err != nil {
-				return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", udng.GetNetworkName(), err)
-			}
-			return nil
-		}
-		waiter.AddWait(readyFunc, postFunc)
-		if err := waiter.Wait(); err != nil {
-			return err
-		}
-	} else {
-		klog.Warningf("Openflow manager has not been invoked for network %s; we will skip programming flows"+
-			"on the bridge for this network.", udng.NetInfo.GetNetworkName())
+		return true, nil
 	}
+	postFunc := func() error {
+		if err := udng.gateway.Reconcile(); err != nil {
+			return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", udng.GetNetworkName(), err)
+		}
+		return nil
+	}
+	waiter.AddWait(readyFunc, postFunc)
+	if err := waiter.Wait(); err != nil {
+		return err
+	}
+
 	if err := udng.addMarkChain(); err != nil {
 		return fmt.Errorf("failed to add the service masquerade chain: %w", err)
 	}
@@ -471,6 +487,8 @@ func (udng *UserDefinedNetworkGateway) addUDNManagementPort() (netlink.Link, err
 		return nil, fmt.Errorf("failed to set the link up for interface %s while plumbing network %s, err: %v",
 			interfaceName, udng.GetNetworkName(), err)
 	}
+	vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
+	udng.vrfTableId = vrfTableId
 	klog.V(3).Infof("Setup management port link %s for network %s succeeded", interfaceName, udng.GetNetworkName())
 
 	// STEP3
@@ -552,15 +570,7 @@ func (udng *UserDefinedNetworkGateway) deleteUDNManagementPort() error {
 
 // computeRoutesForUDN returns a list of routes programmed into a given UDN's VRF
 // when adding new routes please leave a sample comment on how that route looks like
-func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(vrfTableId int, mpLink netlink.Link) ([]netlink.Route, error) {
-	nextHops, intfName, err := getGatewayNextHops()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get the gateway next hops for node %s, err: %v", udng.node.Name, err)
-	}
-	link, err := util.GetNetLinkOps().LinkByName(intfName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get link for %s, error: %v", intfName, err)
-	}
+func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) ([]netlink.Route, error) {
 	networkMTU := udng.NetInfo.MTU()
 	if networkMTU == 0 {
 		networkMTU = config.Default.MTU
@@ -576,31 +586,22 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(vrfTableId int, mpLin
 			gwIP = config.Gateway.MasqueradeIPs.V6DummyNextHopMasqueradeIP
 		}
 		retVal = append(retVal, netlink.Route{
-			LinkIndex: link.Attrs().Index,
+			LinkIndex: udng.gwInterfaceIndex,
 			Dst:       serviceSubnet,
 			MTU:       networkMTU,
 			Gw:        gwIP,
-			Table:     vrfTableId,
+			Table:     udng.vrfTableId,
 		})
 	}
 
 	// Route2: Add default route: default via 172.18.0.1 dev breth0 mtu 1400
 	// necessary for UDN CNI and host-networked pods default traffic to go to node's gatewayIP
-	var defaultAnyCIDR *net.IPNet
-	for _, nextHop := range nextHops {
-		isV6 := utilnet.IsIPv6(nextHop)
-		_, defaultAnyCIDR, _ = net.ParseCIDR("0.0.0.0/0")
-		if isV6 {
-			_, defaultAnyCIDR, _ = net.ParseCIDR("::/0")
-		}
-		retVal = append(retVal, netlink.Route{
-			LinkIndex: link.Attrs().Index,
-			Dst:       defaultAnyCIDR,
-			MTU:       networkMTU,
-			Gw:        nextHop,
-			Table:     vrfTableId,
-		})
+	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
+	defaultRoute, err := udng.getDefaultRoute(isNetworkAdvertised)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add default route for network %s, err: %v", udng.GetNetworkName(), err)
 	}
+	retVal = append(retVal, defaultRoute...)
 
 	// Route3: Add MasqueradeRoute for reply traffic route: 169.254.169.12 dev ovn-k8s-mpX mtu 1400
 	// necessary for reply traffic towards UDN CNI pods to go into OVN
@@ -613,7 +614,7 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(vrfTableId int, mpLin
 			LinkIndex: mpLink.Attrs().Index,
 			Dst:       masqIPv4,
 			MTU:       networkMTU,
-			Table:     vrfTableId,
+			Table:     udng.vrfTableId,
 		})
 	}
 
@@ -626,7 +627,7 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(vrfTableId int, mpLin
 			LinkIndex: mpLink.Attrs().Index,
 			Dst:       masqIPv6,
 			MTU:       networkMTU,
-			Table:     vrfTableId,
+			Table:     udng.vrfTableId,
 		})
 	}
 
@@ -654,7 +655,7 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(vrfTableId int, mpLin
 				Mask: util.GetIPFullMask(etpLocalMasqueradeIP),
 			},
 			Gw:    gwIP.IP,
-			Table: vrfTableId,
+			Table: udng.vrfTableId,
 		})
 		if udng.NetInfo.TopologyType() == types.Layer3Topology {
 			for _, clusterSubnet := range udng.Subnets() {
@@ -663,13 +664,46 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(vrfTableId int, mpLin
 						LinkIndex: mpLink.Attrs().Index,
 						Dst:       clusterSubnet.CIDR,
 						Gw:        gwIP.IP,
-						Table:     vrfTableId,
+						Table:     udng.vrfTableId,
 					})
 				}
 			}
 		}
 	}
 
+	return retVal, nil
+}
+
+func (udng *UserDefinedNetworkGateway) getDefaultRoute(isNetworkAdvertised bool) ([]netlink.Route, error) {
+	vrfs := udng.GetPodNetworkAdvertisedOnNodeVRFs(udng.node.Name)
+	// If the network is advertised on a non default VRF then we should only consider routes received from external BGP
+	// device and not send any traffic based on default route similar to one present in default VRF. This is more important
+	// for VRF-Lite usecase where we need traffic to leave from vlan device instead of default gateway interface.
+	if isNetworkAdvertised && !slices.Contains(vrfs, types.DefaultNetworkName) {
+		return nil, nil
+	}
+
+	networkMTU := udng.NetInfo.MTU()
+	if networkMTU == 0 {
+		networkMTU = config.Default.MTU
+	}
+
+	var retVal []netlink.Route
+	var defaultAnyCIDR *net.IPNet
+	for _, nextHop := range udng.gateway.openflowManager.defaultBridge.nextHops {
+		isV6 := utilnet.IsIPv6(nextHop)
+		_, defaultAnyCIDR, _ = net.ParseCIDR("0.0.0.0/0")
+		if isV6 {
+			_, defaultAnyCIDR, _ = net.ParseCIDR("::/0")
+		}
+		retVal = append(retVal, netlink.Route{
+			LinkIndex: udng.gwInterfaceIndex,
+			Dst:       defaultAnyCIDR,
+			MTU:       networkMTU,
+			Gw:        nextHop,
+			Table:     udng.vrfTableId,
+		})
+	}
 	return retVal, nil
 }
 
@@ -710,7 +744,7 @@ func (udng *UserDefinedNetworkGateway) getV6MasqueradeIP() (*net.IPNet, error) {
 // 2000:	from all to 10.132.0.0/14 lookup 1007
 // 2000:	from all fwmark 0x1001 lookup 1009
 // 2000:	from all to 10.134.0.0/14 lookup 1009
-func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(vrfTableId int) ([]netlink.Rule, []netlink.Rule, error) {
+func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules() ([]netlink.Rule, []netlink.Rule, error) {
 	var addIPRules []netlink.Rule
 	var delIPRules []netlink.Rule
 	var masqIPRules []netlink.Rule
@@ -726,20 +760,20 @@ func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(vrfTableId int) ([
 	}
 
 	if masqIPv4 != nil {
-		addIPRules = append(addIPRules, generateIPRuleForPacketMark(udng.pktMark, false, uint(vrfTableId)))
-		masqIPRules = append(masqIPRules, generateIPRuleForMasqIP(masqIPv4.IP, false, uint(vrfTableId)))
+		addIPRules = append(addIPRules, generateIPRuleForPacketMark(udng.pktMark, false, uint(udng.vrfTableId)))
+		masqIPRules = append(masqIPRules, generateIPRuleForMasqIP(masqIPv4.IP, false, uint(udng.vrfTableId)))
 		for _, subnet := range udng.Subnets() {
 			if utilnet.IsIPv4CIDR(subnet.CIDR) {
-				subnetIPRules = append(subnetIPRules, generateIPRuleForUDNSubnet(subnet.CIDR, false, uint(vrfTableId)))
+				subnetIPRules = append(subnetIPRules, generateIPRuleForUDNSubnet(subnet.CIDR, false, uint(udng.vrfTableId)))
 			}
 		}
 	}
 	if masqIPv6 != nil {
-		addIPRules = append(addIPRules, generateIPRuleForPacketMark(udng.pktMark, true, uint(vrfTableId)))
-		masqIPRules = append(masqIPRules, generateIPRuleForMasqIP(masqIPv6.IP, true, uint(vrfTableId)))
+		addIPRules = append(addIPRules, generateIPRuleForPacketMark(udng.pktMark, true, uint(udng.vrfTableId)))
+		masqIPRules = append(masqIPRules, generateIPRuleForMasqIP(masqIPv6.IP, true, uint(udng.vrfTableId)))
 		for _, subnet := range udng.Subnets() {
 			if utilnet.IsIPv6CIDR(subnet.CIDR) {
-				subnetIPRules = append(subnetIPRules, generateIPRuleForUDNSubnet(subnet.CIDR, true, uint(vrfTableId)))
+				subnetIPRules = append(subnetIPRules, generateIPRuleForUDNSubnet(subnet.CIDR, true, uint(udng.vrfTableId)))
 			}
 		}
 	}
@@ -848,6 +882,10 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 		return fmt.Errorf("error while updating ip rule for UDN %s: %s", udng.GetNetworkName(), err)
 	}
 
+	if err := udng.updateUDNVRFIPRoute(isNetworkAdvertised); err != nil {
+		return fmt.Errorf("error while updating ip route for UDN %s: %s", udng.GetNetworkName(), err)
+	}
+
 	// add below OpenFlows based on the gateway mode and whether the network is advertised or not:
 	// table=1, n_packets=0, n_bytes=0, priority=16,ip,nw_dst=128.192.0.2 actions=LOCAL (Both gateway modes)
 	// table=1, n_packets=0, n_bytes=0, priority=15,ip,nw_dst=128.192.0.0/14 actions=output:3 (shared gateway mode)
@@ -861,13 +899,7 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 // updateUDNVRFIPRule updates IP rules for a network depending on whether the
 // network is advertised or not
 func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRule() error {
-	interfaceName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(udng.GetNetworkID()))
-	mplink, err := util.LinkByName(interfaceName)
-	if err != nil {
-		return fmt.Errorf("unable to get link for %s, error: %v", interfaceName, err)
-	}
-	vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
-	addIPRules, deleteIPRules, err := udng.constructUDNVRFIPRules(vrfTableId)
+	addIPRules, deleteIPRules, err := udng.constructUDNVRFIPRules()
 	if err != nil {
 		return fmt.Errorf("unable to get iprules for network %s, err: %v", udng.GetNetworkName(), err)
 	}
@@ -881,6 +913,40 @@ func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRule() error {
 		if err = udng.ruleManager.Delete(rule); err != nil {
 			return fmt.Errorf("unable to delete iprule for network %s, err: %v", udng.GetNetworkName(), err)
 		}
+	}
+	return nil
+}
+
+// Add or remove default route from a vrf device based on the network is
+// advertised on its own network or default network
+func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRoute(isNetworkAdvertised bool) error {
+	vrfs := udng.GetPodNetworkAdvertisedOnNodeVRFs(udng.node.Name)
+	if isNetworkAdvertised && !slices.Contains(vrfs, types.DefaultNetworkName) {
+		if err := udng.removeDefaultRouteFromVRF(); err != nil {
+			return fmt.Errorf("error while removing default route from VRF %s corresponding to network %s: %s",
+				util.GetNetworkVRFName(udng.NetInfo), udng.GetNetworkName(), err)
+		}
+	} else if !isNetworkAdvertised || slices.Contains(vrfs, types.DefaultNetworkName) {
+		defaultRoute, err := udng.getDefaultRoute(isNetworkAdvertised)
+		if err != nil {
+			return fmt.Errorf("unable to get default route for network %s, err: %v", udng.GetNetworkName(), err)
+		}
+		if err = udng.vrfManager.AddVRFRoutes(util.GetNetworkVRFName(udng.NetInfo), defaultRoute); err != nil {
+			return fmt.Errorf("error while adding default route to VRF %s corresponding to network %s, err: %v",
+				util.GetNetworkVRFName(udng.NetInfo), udng.GetNetworkName(), err)
+		}
+	}
+	return nil
+}
+
+func (udng *UserDefinedNetworkGateway) removeDefaultRouteFromVRF() error {
+	vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
+	defaultRoute, err := udng.getDefaultRoute(false)
+	if err != nil {
+		return fmt.Errorf("unable to get default route for network %s, err: %v", udng.GetNetworkName(), err)
+	}
+	if err = udng.vrfManager.DeleteVRFRoutes(vrfDeviceName, defaultRoute); err != nil {
+		return fmt.Errorf("unable to delete routes for network %s, err: %v", udng.GetNetworkName(), err)
 	}
 	return nil
 }

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -101,11 +101,13 @@ func (c *Controller) addRoute(r netlink.Route) error {
 		// already managed - nothing to do
 		return nil
 	}
-	link, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
-	if err != nil {
-		return fmt.Errorf("failed to apply route (%s) because unable to get link: %v", r.String(), err)
+	if r.LinkIndex != 0 {
+		_, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
+		if err != nil {
+			return fmt.Errorf("failed to apply route (%s) because unable to get link: %v", r.String(), err)
+		}
 	}
-	if err := c.applyRoute(link, r.Gw, r.Dst, r.MTU, r.Src, r.Table); err != nil {
+	if err := c.applyRoute(r.LinkIndex, r.Gw, r.Dst, r.MTU, r.Src, r.Table, r.Priority, r.Type, r.Scope); err != nil {
 		return fmt.Errorf("failed to apply route (%s): %v", r.String(), err)
 	}
 	klog.Infof("Route Manager: completed adding route: %s", r.String())
@@ -118,15 +120,17 @@ func (c *Controller) delRoute(r netlink.Route) error {
 	c.Lock()
 	defer c.Unlock()
 	klog.Infof("Route Manager: attempting to delete route: %s", r.String())
-	link, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
-	if err != nil {
-		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
-			delete(c.store, r.LinkIndex)
-			return nil
+	if r.LinkIndex != 0 {
+		_, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
+		if err != nil {
+			if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+				delete(c.store, r.LinkIndex)
+				return nil
+			}
+			return fmt.Errorf("failed to delete route (%s) because unable to get link: %v", r.String(), err)
 		}
-		return fmt.Errorf("failed to delete route (%s) because unable to get link: %v", r.String(), err)
 	}
-	if err := c.netlinkDelRoute(link, r.Dst, r.Table); err != nil {
+	if err := c.netlinkDelRoute(r.LinkIndex, r.Dst, r.Table); err != nil {
 		return fmt.Errorf("failed to delete route (%s): %v", r.String(), err)
 	}
 	managedRoutes, ok := c.store[r.LinkIndex]
@@ -171,12 +175,15 @@ func (c *Controller) processNetlinkEvent(ru netlink.RouteUpdate) error {
 	}
 	for _, managedRoute := range managedRoutes {
 		if RoutePartiallyEqual(managedRoute, ru.Route) {
-			link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
-			if err != nil {
-				klog.Errorf("Route Manager: failed to restore route because unable to get link by index %d: %v", managedRoute.LinkIndex, err)
-				continue
+			if managedRoute.LinkIndex != 0 {
+				_, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
+				if err != nil {
+					klog.Errorf("Route Manager: failed to restore route because unable to get link by index %d: %v", managedRoute.LinkIndex, err)
+					continue
+				}
 			}
-			if err = c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
+			if err := c.applyRoute(managedRoute.LinkIndex, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table,
+				managedRoute.Priority, managedRoute.Type, managedRoute.Scope); err != nil {
 				klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)
 			}
 		}
@@ -184,14 +191,15 @@ func (c *Controller) processNetlinkEvent(ru netlink.RouteUpdate) error {
 	return nil
 }
 
-func (c *Controller) applyRoute(link netlink.Link, gwIP net.IP, subnet *net.IPNet, mtu int, src net.IP, table int) error {
-	filterRoute, filterMask := filterRouteByDstAndTable(link.Attrs().Index, subnet, table)
+func (c *Controller) applyRoute(linkIndex int, gwIP net.IP, subnet *net.IPNet, mtu int, src net.IP,
+	table, priority, rtype int, scope netlink.Scope) error {
+	filterRoute, filterMask := filterRouteByDstAndTable(linkIndex, subnet, table)
 	existingRoutes, err := util.GetNetLinkOps().RouteListFiltered(getNetlinkIPFamily(subnet), filterRoute, filterMask)
 	if err != nil {
 		return fmt.Errorf("failed to list filtered routes: %v", err)
 	}
 	if len(existingRoutes) == 0 {
-		return c.netlinkAddRoute(link, gwIP, subnet, mtu, src, table)
+		return c.netlinkAddRoute(linkIndex, gwIP, subnet, mtu, src, table, priority, rtype, scope)
 	}
 	netlinkRoute := &existingRoutes[0]
 	if netlinkRoute.MTU != mtu || !src.Equal(netlinkRoute.Src) || !gwIP.Equal(netlinkRoute.Gw) {
@@ -207,10 +215,11 @@ func (c *Controller) applyRoute(link netlink.Link, gwIP net.IP, subnet *net.IPNe
 	return nil
 }
 
-func (c *Controller) netlinkAddRoute(link netlink.Link, gwIP net.IP, subnet *net.IPNet, mtu int, srcIP net.IP, table int) error {
+func (c *Controller) netlinkAddRoute(linkIndex int, gwIP net.IP, subnet *net.IPNet,
+	mtu int, srcIP net.IP, table, priority, rtype int, scope netlink.Scope) error {
 	newNlRoute := &netlink.Route{
 		Dst:       subnet,
-		LinkIndex: link.Attrs().Index,
+		LinkIndex: linkIndex,
 		Scope:     netlink.SCOPE_UNIVERSE,
 		Table:     table,
 	}
@@ -223,21 +232,31 @@ func (c *Controller) netlinkAddRoute(link netlink.Link, gwIP net.IP, subnet *net
 	if mtu != 0 {
 		newNlRoute.MTU = mtu
 	}
+	if priority != 0 {
+		newNlRoute.Priority = priority
+	}
+	if rtype != 0 {
+		newNlRoute.Type = rtype
+	}
+	if scope != netlink.Scope(0) {
+		newNlRoute.Scope = scope
+	}
 	err := util.GetNetLinkOps().RouteAdd(newNlRoute)
 	if err != nil {
-		return fmt.Errorf("failed to add route (gw: %v, subnet %v, mtu %d, src IP %v): %v", gwIP, subnet, mtu, srcIP, err)
+		return fmt.Errorf("failed to add route (linkIndex: %d gw: %v, subnet %v, mtu %d, src IP %v): %v",
+			newNlRoute.LinkIndex, gwIP, subnet, mtu, srcIP, err)
 	}
 	return nil
 }
 
-func (c *Controller) netlinkDelRoute(link netlink.Link, subnet *net.IPNet, table int) error {
+func (c *Controller) netlinkDelRoute(linkIndex int, subnet *net.IPNet, table int) error {
 	if subnet == nil {
 		return fmt.Errorf("cannot delete route with no valid subnet")
 	}
-	filter, mask := filterRouteByDstAndTable(link.Attrs().Index, subnet, table)
+	filter, mask := filterRouteByDstAndTable(linkIndex, subnet, table)
 	existingRoutes, err := util.GetNetLinkOps().RouteListFiltered(netlink.FAMILY_ALL, filter, mask)
 	if err != nil {
-		return fmt.Errorf("failed to get routes for link %s: %v", link.Attrs().Name, err)
+		return fmt.Errorf("failed to get routes for link %d: %v", linkIndex, err)
 	}
 	for _, existingRoute := range existingRoutes {
 		if err = util.GetNetLinkOps().RouteDel(&existingRoute); err != nil {
@@ -286,16 +305,19 @@ func (c *Controller) sync() {
 				}
 			}
 			if !found {
-				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
-				if err != nil {
-					if util.GetNetLinkOps().IsLinkNotFoundError(err) {
-						deletedLinkIndexes = append(deletedLinkIndexes, linkIndex)
-					} else {
-						klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+				if managedRoute.LinkIndex != 0 {
+					_, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
+					if err != nil {
+						if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+							deletedLinkIndexes = append(deletedLinkIndexes, linkIndex)
+						} else {
+							klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+						}
+						continue
 					}
-					continue
 				}
-				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
+				if err := c.applyRoute(managedRoute.LinkIndex, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table,
+					managedRoute.Priority, managedRoute.Type, managedRoute.Scope); err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)
 				}
 			}
@@ -353,5 +375,8 @@ func RoutePartiallyEqual(r, x netlink.Route) bool {
 		r.Gw.Equal(x.Gw) &&
 		r.Table == x.Table &&
 		r.Flags == x.Flags &&
-		r.MTU == x.MTU
+		r.MTU == x.MTU &&
+		r.Type == x.Type &&
+		r.Priority == x.Priority &&
+		r.Scope == x.Scope
 }

--- a/go-controller/pkg/node/routemanager/route_manager_test.go
+++ b/go-controller/pkg/node/routemanager/route_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	utilsnet "k8s.io/utils/net"
 
@@ -95,7 +96,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 
 	ginkgo.Context("add route", func() {
 		ginkgo.It("applies default route in custom table", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: customTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: customTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, customTableID)
@@ -103,7 +104,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("applies default route with gateway in custom table", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Gw: loIP, Table: customTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Gw: loIP, Table: customTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, customTableID)
@@ -111,7 +112,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("applies route with subnet, gateway IP, src IP, MTU", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Gw: loGWIP, MTU: loMTU, Src: loIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Gw: loGWIP, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -119,7 +120,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("applies route with subnets, gateway IP, src IP", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Src: loIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -127,7 +128,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("applies route with subnets, gateway IP", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -135,7 +136,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("applies route with subnets", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -143,9 +144,9 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("route exists, has different mtu and is updated", func() {
-			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID}
+			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRoute(testNS, route)).Should(gomega.Succeed())
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loAlternativeMTU, Src: loIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loAlternativeMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -153,9 +154,9 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("route exists, has different src and is updated", func() {
-			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIP, Table: MainTableID}
+			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRoute(testNS, route)).Should(gomega.Succeed())
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -163,7 +164,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("two equal routes, different tables", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: 5}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: 5, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			validateRoute := func(testNS ns.NetNS, r netlink.Route, tableID int) func() bool {
 				return func() bool {
@@ -187,7 +188,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 
 	ginkgo.Context("del route", func() {
 		ginkgo.It("del route with dst", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -199,7 +200,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("del route with dst and gateway", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -211,7 +212,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("del route with dst, gateway and MTU", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, MTU: loMTU, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, MTU: loMTU, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -223,12 +224,12 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("del route amongst multiple managed routes present", func() {
-			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID}
+			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, rAlt)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, MainTableID)
 			}, time.Second).Should(gomega.BeTrue())
-			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID}
+			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, rDefault)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRoutesInTable(testNS, []netlink.Route{rDefault, rAlt}, loLink.Attrs().Index, MainTableID)
@@ -243,12 +244,12 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("del route and ignores unmanaged route", func() {
-			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID}
+			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRoute(testNS, rAlt)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, MainTableID)
 			}, time.Second).Should(gomega.BeTrue())
-			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID}
+			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, rDefault)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRoutesInTable(testNS, []netlink.Route{rDefault, rAlt}, loLink.Attrs().Index, MainTableID)
@@ -260,7 +261,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("del default route in custom route table", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: customTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: customTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, customTableID)
@@ -270,7 +271,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 
 	ginkgo.Context("runtime sync", func() {
 		ginkgo.It("reapplies managed route that was removed (gw IP, mtu, src IP)", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -287,7 +288,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("reapplies managed route that was removed (mtu, src IP)", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -304,7 +305,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("reapplies managed route that was removed because link is down", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
 				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
@@ -339,7 +340,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 				if err = netlink.LinkSetUp(link); err != nil {
 					return err
 				}
-				r := netlink.Route{LinkIndex: link.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID}
+				r := netlink.Route{LinkIndex: link.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID, Type: unix.RTN_UNICAST}
 				if err = rm.Add(r); err != nil {
 					return err
 				}

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -5,21 +5,29 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
+	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	factoryMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory/mocks"
 	kubemocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/managementport"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
@@ -51,9 +59,11 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		fexec = ovntest.NewFakeExec()
 		Expect(util.SetExec(fexec)).To(Succeed())
 		ovntest.AnnotateNADWithNetworkID(networkID, nad)
+		ovntest.AddLink("breth0")
 	})
 	AfterEach(func() {
 		util.ResetRunner()
+		ovntest.DelLink("breth0")
 	})
 
 	It("ensure UDNGateway is not invoked when feature gate is OFF", func() {
@@ -105,7 +115,8 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		NetInfo, err := util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
 		getCreationFakeCommands(fexec, "ovn-k8s-mp3", mgtPortMAC, NetInfo.GetNetworkName(), "worker1", NetInfo.MTU())
-		controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, nil, nil, &gateway{})
+		ofm := getDummyOpenflowManager()
+		controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, nil, nil, &gateway{openflowManager: ofm})
 		Expect(err).NotTo(HaveOccurred())
 		err = controller.Start(context.Background())
 		Expect(err).To(HaveOccurred()) // we don't have the gateway pieces setup so its expected to fail here
@@ -152,8 +163,9 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 		fexec            *ovntest.FakeExec
 		testNS           ns.NetNS
 		vrf              *vrfmanager.Controller
+		routeManager     *routemanager.Controller
 		ipRulesManager   *iprulemanager.Controller
-		v4NodeSubnet     = "10.128.0.0/24"
+		v4NodeSubnet     = "100.128.0.0/24"
 		v6NodeSubnet     = "ae70::66/112"
 		mgtPort          = fmt.Sprintf("%s%d", types.K8sMgmtIntfNamePrefix, netID)
 		gatewayInterface = "eth0"
@@ -161,6 +173,8 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 		stopCh           chan struct{}
 		wg               *sync.WaitGroup
 		kubeMock         kubemocks.Interface
+		v4NodeIP         = "192.168.1.10/24"
+		v6NodeIP         = "fc00:f853:ccd:e793::3/64"
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -186,7 +200,12 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			if err != nil {
 				return err
 			}
-			addr, _ = netlink.ParseAddr("10.0.0.5/24")
+			addr, _ = netlink.ParseAddr(v4NodeIP)
+			err = netlink.AddrAdd(link, addr)
+			if err != nil {
+				return err
+			}
+			addr, _ = netlink.ParseAddr(v6NodeIP)
 			err = netlink.AddrAdd(link, addr)
 			if err != nil {
 				return err
@@ -196,7 +215,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 		Expect(err).NotTo(HaveOccurred())
 		wg = &sync.WaitGroup{}
 		stopCh = make(chan struct{})
-		routeManager := routemanager.NewController()
+		routeManager = routemanager.NewController()
 		wg.Add(1)
 		go func() {
 			defer GinkgoRecover()
@@ -244,12 +263,14 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 	ovntest.OnSupportedPlatformsIt("ensure UDNGateway and VRFManager and IPRulesManager are invoked for Primary UDNs when feature gate is ON", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
-		config.Gateway.NextHop = "10.0.0.11"
+		config.Gateway.NextHop = "192.168.1.13"
 		config.Gateway.Interface = gatewayInterface
 		config.Gateway.V6MasqueradeSubnet = "fd69::/112"
-		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
 		config.IPv6Mode = true
 		config.IPv4Mode = true
+		config.Gateway.NodeportEnable = true
+		ifAddrs := ovntest.MustParseIPNets(v4NodeIP, v6NodeIP)
 
 		By("creating necessary mocks")
 		factoryMock := factoryMocks.NodeWatchFactory{}
@@ -257,8 +278,15 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					"k8s.ovn.org/network-ids":  fmt.Sprintf("{\"%s\": \"%d\"}", netName, netID),
-					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet)},
+					"k8s.ovn.org/network-ids":       fmt.Sprintf("{\"%s\": \"%d\"}", netName, netID),
+					"k8s.ovn.org/node-subnets":      fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet),
+					"k8s.ovn.org/host-cidrs":        fmt.Sprintf("[\"%s\", \"%s\"]", v4NodeIP, v6NodeIP),
+					"k8s.ovn.org/l3-gateway-config": "{\"default\": {}}",
+				},
+			},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: strings.Split(v4NodeIP, "/")[0]},
+				{Type: corev1.NodeInternalIP, Address: strings.Split(v6NodeIP, "/")[0]}},
 			},
 		}
 		nodeList := []*corev1.Node{node}
@@ -270,6 +298,51 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 		nodeInformer.On("Lister").Return(&nodeLister)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		nodenft.SetFakeNFTablesHelper()
+		util.SetFakeIPTablesHelpers()
+
+		kubeFakeClient := fake.NewSimpleClientset(
+			&corev1.NodeList{
+				Items: []corev1.Node{*node},
+			},
+		)
+		fakeClient := &util.OVNNodeClientset{
+			KubeClient:               kubeFakeClient,
+			NetworkAttchDefClient:    nadfake.NewSimpleClientset(),
+			UserDefinedNetworkClient: udnfakeclient.NewSimpleClientset(),
+		}
+
+		nodeAnnotatorMock := &kubemocks.Annotator{}
+		nodeAnnotatorMock.On("Delete", mock.Anything).Return(nil)
+		nodeAnnotatorMock.On("Set", mock.Anything, map[string]*util.L3GatewayConfig{
+			types.DefaultNetworkName: {
+				ChassisID:   "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",
+				BridgeID:    "breth0",
+				InterfaceID: "breth0_worker1",
+				MACAddress:  ovntest.MustParseMAC("00:00:00:55:66:99"),
+				IPAddresses: ifAddrs,
+				VLANID:      ptr.To(uint(0)),
+			}}).Return(nil)
+		nodeAnnotatorMock.On("Set", mock.Anything, mock.Anything).Return(nil)
+		nodeAnnotatorMock.On("Run").Return(nil)
+		kubeMock.On("SetAnnotationsOnNode", node.Name, map[string]interface{}{
+			"k8s.ovn.org/node-masquerade-subnet": "{\"ipv4\":\"169.254.0.0/17\",\"ipv6\":\"fd69::/112\"}",
+		}).Return(nil)
+		kubeMock.On("SetAnnotationsOnNode", node.Name, map[string]interface{}{
+			"k8s.ovn.org/host-cidrs":          "[\"192.168.1.10/24\",\"fc00:f853:ccd:e793::3/64\"]",
+			"k8s.ovn.org/l3-gateway-config":   "{\"default\":{\"mode\":\"\"}}",
+			"k8s.ovn.org/node-primary-ifaddr": "{\"ipv4\":\"192.168.1.10/24\",\"ipv6\":\"fc00:f853:ccd:e793::3/64\"}",
+		}).Return(nil)
+
+		wf, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		wg := &sync.WaitGroup{}
+		defer func() {
+			wf.Shutdown()
+			wg.Wait()
+		}()
+		err = wf.Start()
+
+		Expect(err).NotTo(HaveOccurred())
 
 		By("creating NAD for primary UDN")
 		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
@@ -280,20 +353,78 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 		_, ipNet, err := net.ParseCIDR(v4NodeSubnet)
 		Expect(err).NotTo(HaveOccurred())
 		mgtPortMAC = util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipNet).IP).String()
-		By("creating secondary network controller for user defined primary network")
-		cnnci := CommonNodeNetworkControllerInfo{name: nodeName, watchFactory: &factoryMock}
-		controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, vrf, ipRulesManager, &gateway{})
+		// Make Management port
+		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
+		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", routeManager, NetInfo)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(controller.gateway).To(Not(BeNil()))
-		Expect(controller.gateway.ruleManager).To(Not(BeNil()))
-		controller.gateway.kubeInterface = &kubeMock
 
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
+			// need this for getGatewayNextHops
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovs-vsctl --timeout=15 port-to-br eth0",
+				Output: "breth0",
+			})
+			setManagementPortFakeCommands(fexec, nodeName)
+			setUpGatewayFakeOVSCommands(fexec)
 			getCreationFakeCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, NetInfo.MTU())
-			getVRFCreationFakeOVSCommands(fexec)
 			getRPFilterLooseModeFakeCommands(fexec)
+			setUpUDNOpenflowManagerFakeOVSCommands(fexec)
 			getDeletionFakeOVSCommands(fexec, mgtPort)
+
+			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
+
+			// create dummy management interface
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: types.K8sMgmtIntfName,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = mp.Start(stopCh)
+			Expect(err).NotTo(HaveOccurred())
+
+			// make preparations for creating openflow manager in DNCC which can be used for SNCC
+			localGw, err := newGateway(
+				nodeName,
+				ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet),
+				gatewayNextHops,
+				gatewayIntf,
+				"",
+				ifAddrs,
+				nodeAnnotatorMock,
+				mp,
+				&kubeMock,
+				wf,
+				routeManager,
+				nil,
+				networkmanager.Default().Interface(),
+				config.GatewayModeLocal,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			stop := make(chan struct{})
+			wg := &sync.WaitGroup{}
+			err = localGw.initFunc()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(localGw.Init(stop, wg)).To(Succeed())
+			// we cannot start the shared gw directly because it will spawn a goroutine that may not be bound to the test netns
+			// Start does two things, starts nodeIPManager which spawns a go routine and also starts openflow manager by spawning a go routine
+			//sharedGw.Start()
+			localGw.nodeIPManager.sync()
+			// we cannot start openflow manager directly because it spawns a go routine
+			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
+			err = localGw.openflowManager.updateBridgeFlowCache(localGw.nodeIPManager.ListAddresses())
+			Expect(err).NotTo(HaveOccurred())
+			localGw.openflowManager.syncFlows()
+
+			By("creating secondary network controller for user defined primary network")
+			cnnci := CommonNodeNetworkControllerInfo{name: nodeName, watchFactory: &factoryMock}
+			controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, vrf, ipRulesManager, localGw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(controller.gateway).To(Not(BeNil()))
+			Expect(controller.gateway.ruleManager).To(Not(BeNil()))
+			controller.gateway.kubeInterface = &kubeMock
 
 			By("starting secondary network controller for user defined primary network")
 			err = controller.Start(context.Background())

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -2,6 +2,7 @@ package vrfmanager
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -295,6 +296,54 @@ func (vrfm *Controller) AddVRFRoutes(name string, routes []netlink.Route) error 
 	vrfDev.routes = append(vrfDev.routes, routes...)
 
 	return vrfm.sync(vrfDev)
+}
+
+// DeleteVRFRoutes deletes a set of routes from a VRF
+func (vrfm *Controller) DeleteVRFRoutes(name string, routes []netlink.Route) error {
+	vrfm.mu.Lock()
+	defer vrfm.mu.Unlock()
+
+	vrfLink, err := util.GetNetLinkOps().LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve VRF device %s, err: %v", name, err)
+	}
+
+	vrf, ok := vrfm.vrfs[vrfLink.Attrs().Index]
+	if !ok {
+		return fmt.Errorf("failed to find VRF %s", name)
+	}
+	type route struct {
+		LinkIndex int
+		Dst       string
+		Table     int
+	}
+	deleteRoutesRequested := sets.New[route]()
+	for _, r := range routes {
+		deleteRoutesRequested.Insert(route{
+			LinkIndex: r.LinkIndex,
+			Dst:       r.Dst.String(),
+			Table:     r.Table,
+		})
+	}
+
+	vrf.routes = slices.DeleteFunc(vrf.routes, func(r netlink.Route) bool {
+		if err != nil {
+			return false
+		}
+		delete := deleteRoutesRequested.Has(
+			route{
+				LinkIndex: r.LinkIndex,
+				Dst:       r.Dst.String(),
+				Table:     r.Table,
+			})
+		if !delete {
+			return false
+		}
+		err = vrfm.routeManager.Del(r)
+		return err == nil
+	})
+	vrfm.vrfs[vrfLink.Attrs().Index] = vrf
+	return err
 }
 
 // Repair deletes stale VRF device(s) on the host. This helps remove

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -25,6 +25,9 @@ const (
 	PhysicalNetworkName     = "physnet"
 	PhysicalNetworkExGwName = "exgwphysnet"
 
+	// LoopbackInterfaceIndex is the link index corresponding to loopback interface
+	LoopbackInterfaceIndex = 1
+
 	// LocalNetworkName is the name that maps to an OVS bridge that provides
 	// access to local service
 	LocalNetworkName = "locnet"


### PR DESCRIPTION
Add or remove default route from a vrf device based on the network is advertised on its own network or default network.

Default route from a VRF corresponding to a UDN does not get removed if the network is advertised on default VRF.

default via 172.18.0.1 dev breth0 mtu 1400

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
