### PR TITLE
kind: Pin kubevirt to v1.4.0

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -324,7 +324,11 @@ install_kubevirt() {
     # vX.Y.Z - install specific stable (i.e v1.3.1)
     # nightly - install newest nightly
     # nightly tag - install specific nightly (i.e 20240910)
-    KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"stable"}
+    # KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"stable"}
+
+    # FIXME: kubevirt v1.5.0 is breaking live migration tcp connections at
+    #        at e2e tests, this pin to v1.4.0 wich is known to work
+    KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"v1.4.0"}
 
     for node in $(kubectl get node --no-headers  -o custom-columns=":metadata.name"); do
         $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"


### PR DESCRIPTION
## 📑 Description
The KubeVirt version v1.5.0 is breaking tcp connections at live migration during our e2e tests, this change ping kubevirt to last known good version v1.4.0

https://github.com/kubevirt/kubevirt/releases/tag/v1.5.0

Closes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5116

## How to verify it
NONE