### PR TITLE
E2Es: reduce the amount of env vars

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -77,7 +77,11 @@ func setupHostRedirectPod(f *framework.Framework, node *v1.Node, exContainerName
 
 	// setup redirect iptables rule in node
 	ipTablesArgs := []string{"PREROUTING", "-t", "nat", "--dst", redirectIP, "-j", "REDIRECT"}
-	updateIPTablesRulesForNode("insert", node.Name, ipTablesArgs, isIPv6)
+	ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+	if err != nil {
+		return fmt.Errorf("failed to determine ovn-kubernetes namespace name: %v", err)
+	}
+	updateIPTablesRulesForNode(f.ClientSet.CoreV1().Namespaces(), "insert", ovnKubeNs, node.Name, ipTablesArgs, isIPv6)
 
 	command := []string{
 		"bash", "-c",
@@ -656,7 +660,7 @@ func restartOVNKubeNodePodsInParallel(clientset kubernetes.Interface, namespace 
 	for _, n := range nodeNames {
 		nodeName := n
 		restartFuncs = append(restartFuncs, func() error {
-			return restartOVNKubeNodePod(clientset, ovnNamespace, nodeName)
+			return restartOVNKubeNodePod(clientset, namespace, nodeName)
 		})
 	}
 
@@ -665,18 +669,21 @@ func restartOVNKubeNodePodsInParallel(clientset kubernetes.Interface, namespace 
 
 // getOVNKubePodLogsFiltered retrieves logs from ovnkube-node pods and filters logs lines according to filteringRegexp
 func getOVNKubePodLogsFiltered(clientset kubernetes.Interface, namespace, nodeName, filteringRegexp string) (string, error) {
-	ovnKubeNodePods, err := clientset.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+	ovnKubeNodePods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "name=ovnkube-node",
 		FieldSelector: "spec.nodeName=" + nodeName,
 	})
 	if err != nil {
 		return "", fmt.Errorf("getOVNKubePodLogsFiltered: error while getting ovnkube-node pods: %w", err)
 	}
-
-	logs, err := e2epod.GetPodLogs(context.TODO(), clientset, ovnNamespace, ovnKubeNodePods.Items[0].Name, getNodeContainerName())
+	ovnKubeNs, err := getOVNKubeNamespaceName(clientset.CoreV1().Namespaces())
+	if err != nil {
+		return "", fmt.Errorf("failed to determine ovn-kubernetes namespace name: %v", err)
+	}
+	logs, err := e2epod.GetPodLogs(context.TODO(), clientset, ovnKubeNs, ovnKubeNodePods.Items[0].Name, getNodeContainerName(clientset.CoreV1().Namespaces()))
 	if err != nil {
 		return "", fmt.Errorf("getOVNKubePodLogsFiltered: error while getting ovnkube-node [%s/%s] logs: %w",
-			ovnNamespace, ovnKubeNodePods.Items[0].Name, err)
+			namespace, ovnKubeNodePods.Items[0].Name, err)
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(logs))
@@ -697,13 +704,13 @@ func getOVNKubePodLogsFiltered(clientset kubernetes.Interface, namespace, nodeNa
 	return filteredLogs, nil
 }
 
-func findOvnKubeControlPlaneNode(controlPlanePodName, leaseName string) (string, error) {
+func findOvnKubeControlPlaneNode(namespace, controlPlanePodName, leaseName string) (string, error) {
 
-	ovnkubeControlPlaneNode, err := e2ekubectl.RunKubectl(ovnNamespace, "get", "leases", leaseName,
+	ovnkubeControlPlaneNode, err := e2ekubectl.RunKubectl(namespace, "get", "leases", leaseName,
 		"-o", "jsonpath='{.spec.holderIdentity}'")
 
 	framework.ExpectNoError(err, fmt.Sprintf("Unable to retrieve leases (%s)"+
-		"from %s %v", leaseName, ovnNamespace, err))
+		"from %s %v", leaseName, namespace, err))
 
 	framework.Logf(fmt.Sprintf("master instance of %s is running on node %s", controlPlanePodName, ovnkubeControlPlaneNode))
 	// Strip leading and trailing quotes if present
@@ -740,7 +747,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		if isInterconnectEnabled() {
 			controlPlanePodName = "ovnkube-control-plane"
 			// in "one node per zone" config, ovnkube-controller doesn't create leader election lease
-			if !singleNodePerZone() {
+			if !singleNodePerZone(f.ClientSet.CoreV1().Namespaces()) {
 				controlPlaneLeaseName = "ovn-kubernetes-master-ovn-control-plane"
 			} else {
 				controlPlaneLeaseName = "ovn-kubernetes-master"
@@ -749,8 +756,9 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 			controlPlanePodName = "ovnkube-master"
 			controlPlaneLeaseName = "ovn-kubernetes-master"
 		}
-
-		controlPlanePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		controlPlanePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.Background(), metav1.ListOptions{
 			LabelSelector: "name=" + controlPlanePodName,
 		})
 		framework.ExpectNoError(err)
@@ -801,12 +809,14 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		}()
 
 		ginkgo.By("Checking that TCP redirect connection entry in conntrack before ovnkube-node restart")
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 		gomega.Eventually(func() int {
-			return pokeConntrackEntries(nodeName, redirectIP, "tcp", nil)
+			return pokeConntrackEntries(nodeName, ovnKubeNs, redirectIP, "tcp", nil)
 		}, "10s", "1s").ShouldNot(gomega.Equal(0))
 
 		ginkgo.By("Deleting ovn-kube pod on node " + nodeName)
-		err = restartOVNKubeNodePod(f.ClientSet, ovnNamespace, nodeName)
+		err = restartOVNKubeNodePod(f.ClientSet, ovnKubeNs, nodeName)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Ensuring there were no connectivity errors")
@@ -817,14 +827,15 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 
 		ginkgo.By("Checking that TCP redirect connection entry in conntrack remained after ovnkube-node restart")
 		gomega.Consistently(func() int {
-			return pokeConntrackEntries(nodeName, redirectIP, "tcp", nil)
+			return pokeConntrackEntries(nodeName, ovnKubeNs, redirectIP, "tcp", nil)
 		}, "5s", "500ms").ShouldNot(gomega.Equal(0))
 	})
 
 	ginkgo.It("should provide Internet connection continuously when pod running master instance of ovnkube-control-plane is killed", func() {
 		ginkgo.By(fmt.Sprintf("Running container which tries to connect to %s in a loop", extDNSIP))
-
-		ovnKubeControlPlaneNode, err := findOvnKubeControlPlaneNode(controlPlanePodName, controlPlaneLeaseName)
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		ovnKubeControlPlaneNode, err := findOvnKubeControlPlaneNode(ovnKubeNs, controlPlanePodName, controlPlaneLeaseName)
 		framework.ExpectNoError(err, fmt.Sprintf("unable to find current master of %s cluster %v", controlPlanePodName, err))
 		podChan, errChan := make(chan *v1.Pod), make(chan error)
 		go func() {
@@ -840,7 +851,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 
 		time.Sleep(5 * time.Second)
 
-		podClient := f.ClientSet.CoreV1().Pods(ovnNamespace)
+		podClient := f.ClientSet.CoreV1().Pods(ovnKubeNs)
 
 		podList, err := podClient.List(context.Background(), metav1.ListOptions{
 			LabelSelector: "name=" + controlPlanePodName,
@@ -856,7 +867,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		}
 
 		ginkgo.By("Deleting ovnkube control plane pod " + podName)
-		deletePodWithWaitByName(context.TODO(), f.ClientSet, podName, ovnNamespace)
+		deletePodWithWaitByName(context.TODO(), f.ClientSet, podName, ovnKubeNs)
 		framework.Logf("Deleted ovnkube control plane pod %q", podName)
 
 		ginkgo.By("Ensuring there were no connectivity errors")
@@ -868,8 +879,9 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 
 	ginkgo.It("should provide Internet connection continuously when all pods are killed on node running master instance of ovnkube-control-plane", func() {
 		ginkgo.By(fmt.Sprintf("Running container which tries to connect to %s in a loop", extDNSIP))
-
-		ovnKubeControlPlaneNode, err := findOvnKubeControlPlaneNode(controlPlanePodName, controlPlaneLeaseName)
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		ovnKubeControlPlaneNode, err := findOvnKubeControlPlaneNode(ovnKubeNs, controlPlanePodName, controlPlaneLeaseName)
 		framework.ExpectNoError(err, fmt.Sprintf("unable to find current master of %s cluster %v", controlPlanePodName, err))
 
 		podChan, errChan := make(chan *v1.Pod), make(chan error)
@@ -902,7 +914,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 				!strings.HasPrefix(pod.Name, "ovnkube-identity") &&
 				!strings.HasPrefix(pod.Name, "ovs-node") {
 				framework.Logf("%q", pod.Namespace)
-				err = deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				err = deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnKubeNs)
 				framework.ExpectNoError(err, fmt.Sprintf("failed to delete pod %s", pod.Name))
 				framework.Logf("Deleted control plane pod %q", pod.Name)
 			}
@@ -931,12 +943,13 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		time.Sleep(5 * time.Second)
 
 		podClient := f.ClientSet.CoreV1().Pods("")
-
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 		podList, _ := podClient.List(context.Background(), metav1.ListOptions{})
 		for _, pod := range podList.Items {
 			if strings.HasPrefix(pod.Name, controlPlanePodName) && !strings.HasPrefix(pod.Name, "ovs-node") {
 				framework.Logf("%q", pod.Namespace)
-				err = deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnNamespace)
+				err = deletePodWithWaitByName(context.TODO(), f.ClientSet, pod.Name, ovnKubeNs)
 				framework.ExpectNoError(err, fmt.Sprintf("failed to delete pod %s", pod.Name))
 				framework.Logf("Deleted control plane pod %q", pod.Name)
 			}
@@ -992,8 +1005,10 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 				framework.Failf("could not reset MTU of interface: %s", err)
 			}
 
+			ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+			framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 			// restart ovnkube-node pod
-			if err := restartOVNKubeNodePod(f.ClientSet, ovnNamespace, testNodeName); err != nil {
+			if err := restartOVNKubeNodePod(f.ClientSet, ovnKubeNs, testNodeName); err != nil {
 				framework.Failf("could not restart ovnkube-node pod: %s", err)
 			}
 
@@ -1007,9 +1022,10 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 			if err != nil {
 				framework.Failf("could not set MTU of interface: %s", err)
 			}
-
+			ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+			framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 			// restart ovnkube-node pod to trigger mtu validation
-			if err := restartOVNKubeNodePod(f.ClientSet, ovnNamespace, testNodeName); err == nil || err != wait.ErrWaitTimeout {
+			if err := restartOVNKubeNodePod(f.ClientSet, ovnKubeNs, testNodeName); err == nil || err != wait.ErrWaitTimeout {
 				if err == nil {
 					framework.Failf("ovnkube-node pod restarted correctly, but wasn't supposed to: %s", err)
 				}
@@ -1031,9 +1047,10 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 			if err != nil {
 				framework.Failf("could not set MTU of interface: %s", err)
 			}
-
+			ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+			framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 			// restart ovnkube-node pod to trigger mtu validation
-			if err := restartOVNKubeNodePod(f.ClientSet, ovnNamespace, testNodeName); err != nil {
+			if err := restartOVNKubeNodePod(f.ClientSet, ovnKubeNs, testNodeName); err != nil {
 				framework.Failf("could not restart ovnkube-node pod: %s", err)
 			}
 
@@ -1959,7 +1976,9 @@ var _ = ginkgo.Describe("e2e br-int flow monitoring export validation", func() {
 
 			ginkgo.By(fmt.Sprintf("Configuring ovnkube-node to use the new %s collector target", protocolStr))
 			setEnv := map[string]string{ovnEnvVar: addressAndPort}
-			setUnsetTemplateContainerEnv(f.ClientSet, ovnNamespace, "daemonset/ovnkube-node", getNodeContainerName(), setEnv)
+			ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should be able to get ovn-kubernetes namespace")
+			setUnsetTemplateContainerEnv(f.ClientSet, ovnKubeNs, "daemonset/ovnkube-node", getNodeContainerName(f.ClientSet.CoreV1().Namespaces()), setEnv)
 
 			ginkgo.By(fmt.Sprintf("Checking that the collector container received %s data", protocolStr))
 			keyword := keywordInLogs[protocol]
@@ -1989,9 +2008,9 @@ var _ = ginkgo.Describe("e2e br-int flow monitoring export validation", func() {
 				protocolStr, keyword))
 
 			ginkgo.By(fmt.Sprintf("Unsetting %s variable in ovnkube-node daemonset", ovnEnvVar))
-			setUnsetTemplateContainerEnv(f.ClientSet, ovnNamespace, "daemonset/ovnkube-node", getNodeContainerName(), nil, ovnEnvVar)
+			setUnsetTemplateContainerEnv(f.ClientSet, ovnKubeNs, "daemonset/ovnkube-node", getNodeContainerName(f.ClientSet.CoreV1().Namespaces()), nil, ovnEnvVar)
 
-			ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+			ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: "name=ovnkube-node",
 			})
 			if err != nil {
@@ -2002,9 +2021,9 @@ var _ = ginkgo.Describe("e2e br-int flow monitoring export validation", func() {
 
 				execOptions := e2epod.ExecOptions{
 					Command:       []string{"ovs-vsctl", "find", strings.ToLower(protocolStr)},
-					Namespace:     ovnNamespace,
+					Namespace:     ovnKubeNs,
 					PodName:       ovnKubeNodePod.Name,
-					ContainerName: getNodeContainerName(),
+					ContainerName: getNodeContainerName(f.ClientSet.CoreV1().Namespaces()),
 					CaptureStdout: true,
 					CaptureStderr: true,
 				}
@@ -2144,7 +2163,9 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 
 	fileExistsOnPod := func(f *framework.Framework, namespace string, pod *v1.Pod, file string) bool {
 		containerFlag := fmt.Sprintf("-c=%s", pod.Spec.Containers[0].Name)
-		_, err := e2ekubectl.RunKubectl(ovnNamespace, "exec", pod.Name, containerFlag, "--", "ls", file)
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		_, err = e2ekubectl.RunKubectl(ovnKubeNs, "exec", pod.Name, containerFlag, "--", "ls", file)
 		if err == nil {
 			return true
 		}
@@ -2176,7 +2197,9 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 
 	deleteFileFromPod := func(f *framework.Framework, namespace string, pod *v1.Pod, file string) {
 		containerFlag := fmt.Sprintf("-c=%s", pod.Spec.Containers[0].Name)
-		e2ekubectl.RunKubectl(ovnNamespace, "exec", pod.Name, containerFlag, "--", "rm", file)
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		e2ekubectl.RunKubectl(ovnKubeNs, "exec", pod.Name, containerFlag, "--", "rm", file)
 		if fileExistsOnPod(f, namespace, pod, file) {
 			framework.Failf("Error: failed to delete file %s", file)
 		}
@@ -2285,24 +2308,25 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 			}
 
 			// Start the db disruption - delete the db files and delete the db-pod in order to emulate the cluster/pod restart
-
+			ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+			framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 			// Retrieve the DB pod
-			dbPod, err := f.ClientSet.CoreV1().Pods(ovnNamespace).Get(context.Background(), db_pod_name, metav1.GetOptions{})
+			dbPod, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).Get(context.Background(), db_pod_name, metav1.GetOptions{})
 			framework.ExpectNoError(err, fmt.Sprintf("unable to get pod: %s, err: %v", db_pod_name, err))
 
 			// Check that all files are on the db pod
 			framework.Logf("make sure that all the db files are on db pod %s", dbPod.Name)
-			if !allFilesExistOnPod(f, ovnNamespace, dbPod, allDBFiles) {
+			if !allFilesExistOnPod(f, ovnKubeNs, dbPod, allDBFiles) {
 				framework.Failf("Error: db files not found")
 			}
 			// Delete the db files from the db-pod
 			framework.Logf("deleting db files from db pod")
 			for _, db_file := range DBFileNamesToDelete {
-				deleteFileFromPod(f, ovnNamespace, dbPod, db_file)
+				deleteFileFromPod(f, ovnKubeNs, dbPod, db_file)
 			}
 			// Delete the db-pod in order to emulate the cluster/pod restart
 			framework.Logf("deleting db pod %s", dbPod.Name)
-			deletePod(f, ovnNamespace, dbPod.Name)
+			deletePod(f, ovnKubeNs, dbPod.Name)
 
 			framework.Logf("wait for db pod to finish full restart")
 			waitForPodToFinishFullRestart(f, dbPod)
@@ -2310,7 +2334,7 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 			// Check db files existence
 			// Check that all files are on pod
 			framework.Logf("make sure that all the db files are on db pod %s", dbPod.Name)
-			if !allFilesExistOnPod(f, ovnNamespace, dbPod, allDBFiles) {
+			if !allFilesExistOnPod(f, ovnKubeNs, dbPod, allDBFiles) {
 				framework.Failf("Error: db files not found")
 			}
 
@@ -2346,8 +2370,9 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 				"No separate db pods in muliple zones interconnect deployment",
 			)
 		}
-
-		dbDeployment := getDeployment(f, ovnNamespace, "ovnkube-db")
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		dbDeployment := getDeployment(f, ovnKubeNs, "ovnkube-db")
 		dbPods, err := e2edeployment.GetPodsForDeployment(context.TODO(), f.ClientSet, dbDeployment)
 		if err != nil {
 			framework.Failf("Error: Failed to get pods, err: %v", err)
@@ -2366,7 +2391,7 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 			framework.Logf("deleting db pod: %v", dbPodName)
 			// Delete the db-pod in order to emulate the pod restart
 			dbPod.Status.Message = "check"
-			deletePod(f, ovnNamespace, dbPodName)
+			deletePod(f, ovnKubeNs, dbPodName)
 		}
 
 		framework.Logf("wait for all the Deployment to become ready again after pod deletion")
@@ -2380,7 +2405,9 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 	})
 
 	ginkgo.It("Should validate connectivity before and after deleting all the db-pods at once in HA mode", func() {
-		dbPods, err := e2epod.GetPods(context.TODO(), f.ClientSet, ovnNamespace, map[string]string{"name": databasePodPrefix})
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		dbPods, err := e2epod.GetPods(context.TODO(), f.ClientSet, ovnKubeNs, map[string]string{"name": databasePodPrefix})
 		if err != nil {
 			framework.Failf("Error: Failed to get pods, err: %v", err)
 		}
@@ -2397,7 +2424,7 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 			framework.Logf("deleting db pod: %v", dbPodName)
 			// Delete the db-pod in order to emulate the pod restart
 			dbPod.Status.Message = "check"
-			deletePod(f, ovnNamespace, dbPodName)
+			deletePod(f, ovnKubeNs, dbPodName)
 		}
 
 		framework.Logf("wait for all the pods to finish full restart")

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1524,7 +1524,7 @@ runcmd:
 					namespace:          namespace,
 					name:               "net1",
 					topology:           td.topology,
-					cidr:               correctCIDRFamily(cidrIPv4, cidrIPv6),
+					cidr:               correctCIDRFamily(fr.ClientSet, cidrIPv4, cidrIPv6),
 					allowPersistentIPs: true,
 					role:               td.role,
 				})
@@ -1533,15 +1533,17 @@ runcmd:
 				By("setting up the localnet underlay")
 				nodes := ovsPods(clientSet)
 				Expect(nodes).NotTo(BeEmpty())
+				ovnKubeNs, err := getOVNKubeNamespaceName(fr.ClientSet.CoreV1().Namespaces())
+				Expect(err).ShouldNot(HaveOccurred(), "failed to retrieve ovn-kubernetes namespace")
 				DeferCleanup(func() {
 					if e2eframework.TestContext.DeleteNamespace && (e2eframework.TestContext.DeleteNamespaceOnFailure || !CurrentSpecReport().Failed()) {
 						By("tearing down the localnet underlay")
-						Expect(teardownUnderlay(nodes)).To(Succeed())
+						Expect(teardownUnderlay(nodes, ovnKubeNs)).To(Succeed())
 					}
 				})
 
 				const secondaryInterfaceName = "eth1"
-				Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+				Expect(setupUnderlay(nodes, ovnKubeNs, secondaryInterfaceName, netConfig)).To(Succeed())
 			}
 
 			By("Creating NetworkAttachmentDefinition")
@@ -1665,7 +1667,7 @@ runcmd:
 				checkNorthSouthEgressICMPTraffic(vmi, []string{externalContainerIPV4Address, externalContainerIPV6Address}, step)
 			}
 
-			if td.role == "primary" && td.test.description == liveMigrate.description && isIPv4Supported() && isInterconnectEnabled() {
+			if td.role == "primary" && td.test.description == liveMigrate.description && isIPv4Supported(fr.ClientSet) && isInterconnectEnabled() {
 				step = by(vm.Name, fmt.Sprintf("Checking IPv4 gateway cached mac after %s %s", td.resource.description, td.test.description))
 				Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
 
@@ -1794,7 +1796,7 @@ runcmd:
 					namespace: namespace,
 					name:      "net1",
 					topology:  "layer2",
-					cidr:      correctCIDRFamily(cidrIPv4, cidrIPv6),
+					cidr:      correctCIDRFamily(fr.ClientSet, cidrIPv4, cidrIPv6),
 					role:      "primary",
 					mtu:       1300,
 				})
@@ -1838,7 +1840,7 @@ runcmd:
 				Get(context.Background(), config.Kubernetes.DNSServiceName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			if isIPv4Supported() {
+			if isIPv4Supported(fr.ClientSet) {
 				expectedIP, err := matchIPv4StringFamily(primaryUDNNetworkStatus.IPs)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1866,7 +1868,7 @@ runcmd:
 				Expect(primaryUDNValueForDevice("GENERAL.MTU")).To(ConsistOf("1300"))
 			}
 
-			if isIPv6Supported() {
+			if isIPv6Supported(fr.ClientSet) {
 				expectedIP, err := matchIPv6StringFamily(primaryUDNNetworkStatus.IPs)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(primaryUDNValueFor).

--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -18,23 +19,24 @@ const (
 	del        = "del-br"
 )
 
-func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmentConfig) error {
+func setupUnderlay(ovsPods []v1.Pod, ovnKubeNs, portName string, nadConfig networkAttachmentConfig) error {
 	for _, ovsPod := range ovsPods {
-		if err := addOVSBridge(ovsPod.Name, bridgeName); err != nil {
+		if err := addOVSBridge(ovnKubeNs, ovsPod.Name, bridgeName); err != nil {
 			return err
 		}
 
 		if nadConfig.vlanID > 0 {
-			if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, nadConfig.vlanID); err != nil {
+			if err := ovsEnableVLANAccessPort(ovnKubeNs, ovsPod.Name, bridgeName, portName, nadConfig.vlanID); err != nil {
 				return err
 			}
 		} else {
-			if err := ovsAttachPortToBridge(ovsPod.Name, bridgeName, portName); err != nil {
+			if err := ovsAttachPortToBridge(ovnKubeNs, ovsPod.Name, bridgeName, portName); err != nil {
 				return err
 			}
 		}
 
 		if err := configureBridgeMappings(
+			ovnKubeNs,
 			ovsPod.Name,
 			defaultNetworkBridgeMapping(),
 			bridgeMapping(nadConfig.networkName, bridgeName),
@@ -45,13 +47,13 @@ func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmen
 	return nil
 }
 
-func ovsRemoveSwitchPort(ovsPods []v1.Pod, portName string, newVLANID int) error {
+func ovsRemoveSwitchPort(ovsPods []v1.Pod, ovnKubeNs, portName string, newVLANID int) error {
 	for _, ovsPod := range ovsPods {
-		if err := ovsRemoveVLANAccessPort(ovsPod.Name, bridgeName, portName); err != nil {
+		if err := ovsRemoveVLANAccessPort(ovnKubeNs, ovsPod.Name, bridgeName, portName); err != nil {
 			return fmt.Errorf("failed to remove old VLAN port: %v", err)
 		}
 
-		if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, newVLANID); err != nil {
+		if err := ovsEnableVLANAccessPort(ovnKubeNs, ovsPod.Name, bridgeName, portName, newVLANID); err != nil {
 			return fmt.Errorf("failed to add new VLAN port: %v", err)
 		}
 	}
@@ -59,9 +61,9 @@ func ovsRemoveSwitchPort(ovsPods []v1.Pod, portName string, newVLANID int) error
 	return nil
 }
 
-func teardownUnderlay(ovsPods []v1.Pod) error {
+func teardownUnderlay(ovsPods []v1.Pod, ovnKubeNs string) error {
 	for _, ovsPod := range ovsPods {
-		if err := removeOVSBridge(ovsPod.Name, bridgeName); err != nil {
+		if err := removeOVSBridge(ovnKubeNs, ovsPod.Name, bridgeName); err != nil {
 			return err
 		}
 	}
@@ -72,7 +74,9 @@ func ovsPods(clientSet clientset.Interface) []v1.Pod {
 	const (
 		ovsNodeLabel = "app=ovs-node"
 	)
-	pods, err := clientSet.CoreV1().Pods(ovnNamespace).List(
+	ovnKubeNs, err := getOVNKubeNamespaceName(clientSet.CoreV1().Namespaces())
+	framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+	pods, err := clientSet.CoreV1().Pods(ovnKubeNs).List(
 		context.Background(),
 		metav1.ListOptions{LabelSelector: ovsNodeLabel},
 	)
@@ -82,32 +86,32 @@ func ovsPods(clientSet clientset.Interface) []v1.Pod {
 	return pods.Items
 }
 
-func addOVSBridge(ovnNodeName string, bridgeName string) error {
-	_, err := runCommand(ovsBridgeCommand(ovnNodeName, add, bridgeName)...)
+func addOVSBridge(ovnKubeNs, ovnNodeName string, bridgeName string) error {
+	_, err := runCommand(ovsBridgeCommand(ovnKubeNs, ovnNodeName, add, bridgeName)...)
 	if err != nil {
 		return fmt.Errorf("failed to ADD OVS bridge %s: %v", bridgeName, err)
 	}
 	return nil
 }
 
-func removeOVSBridge(ovnNodeName string, bridgeName string) error {
-	_, err := runCommand(ovsBridgeCommand(ovnNodeName, del, bridgeName)...)
+func removeOVSBridge(ovnKubeNs, ovnNodeName string, bridgeName string) error {
+	_, err := runCommand(ovsBridgeCommand(ovnKubeNs, ovnNodeName, del, bridgeName)...)
 	if err != nil {
 		return fmt.Errorf("failed to DELETE OVS bridge %s: %v", bridgeName, err)
 	}
 	return nil
 }
 
-func ovsBridgeCommand(ovnNodeName string, addOrDeleteCmd string, bridgeName string) []string {
+func ovsBridgeCommand(ovnKubeNs, ovnNodeName string, addOrDeleteCmd string, bridgeName string) []string {
 	return []string{
-		"kubectl", "-n", ovnNamespace, "exec", ovnNodeName, "--",
+		"kubectl", "-n", ovnKubeNs, "exec", ovnNodeName, "--",
 		"ovs-vsctl", addOrDeleteCmd, bridgeName,
 	}
 }
 
-func ovsAttachPortToBridge(ovsNodeName string, bridgeName string, portName string) error {
+func ovsAttachPortToBridge(ovnKubeNs, ovsNodeName string, bridgeName string, portName string) error {
 	cmd := []string{
-		"kubectl", "-n", ovnNamespace, "exec", ovsNodeName, "--",
+		"kubectl", "-n", ovnKubeNs, "exec", ovsNodeName, "--",
 		"ovs-vsctl", "add-port", bridgeName, portName,
 	}
 
@@ -118,9 +122,9 @@ func ovsAttachPortToBridge(ovsNodeName string, bridgeName string, portName strin
 	return nil
 }
 
-func ovsEnableVLANAccessPort(ovsNodeName string, bridgeName string, portName string, vlanID int) error {
+func ovsEnableVLANAccessPort(ovnKubeNs, ovsNodeName string, bridgeName string, portName string, vlanID int) error {
 	cmd := []string{
-		"kubectl", "-n", ovnNamespace, "exec", ovsNodeName, "--",
+		"kubectl", "-n", ovnKubeNs, "exec", ovsNodeName, "--",
 		"ovs-vsctl", "add-port", bridgeName, portName, fmt.Sprintf("tag=%d", vlanID), "vlan_mode=access",
 	}
 
@@ -131,9 +135,9 @@ func ovsEnableVLANAccessPort(ovsNodeName string, bridgeName string, portName str
 	return nil
 }
 
-func ovsRemoveVLANAccessPort(ovsNodeName string, bridgeName string, portName string) error {
+func ovsRemoveVLANAccessPort(ovnKubeNs, ovsNodeName string, bridgeName string, portName string) error {
 	cmd := []string{
-		"kubectl", "-n", ovnNamespace, "exec", ovsNodeName, "--",
+		"kubectl", "-n", ovnKubeNs, "exec", ovsNodeName, "--",
 		"ovs-vsctl", "del-port", bridgeName, portName,
 	}
 
@@ -167,9 +171,9 @@ func Map[T, V any](items []T, fn func(T) V) []V {
 	return result
 }
 
-func configureBridgeMappings(ovnNodeName string, mappings ...BridgeMapping) error {
+func configureBridgeMappings(ovnKubeNs, ovnNodeName string, mappings ...BridgeMapping) error {
 	mappingsString := fmt.Sprintf("external_ids:ovn-bridge-mappings=%s", BridgeMappings(mappings).String())
-	cmd := []string{"kubectl", "-n", ovnNamespace, "exec", ovnNodeName,
+	cmd := []string{"kubectl", "-n", ovnKubeNs, "exec", ovnNodeName,
 		"--", "ovs-vsctl", "set", "open", ".", mappingsString,
 	}
 	_, err := runCommand(cmd...)

--- a/test/e2e/multi_node_zones_interconnect.go
+++ b/test/e2e/multi_node_zones_interconnect.go
@@ -38,9 +38,10 @@ func changeNodeZone(node *v1.Node, zone string, cs clientset.Interface) error {
 
 	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
 	framework.ExpectNoError(err)
-
+	ovnKubeNs, err := getOVNKubeNamespaceName(cs.CoreV1().Namespaces())
+	framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 	// Restart the ovnkube-node on this node
-	err = restartOVNKubeNodePod(cs, ovnNamespace, node.Name)
+	err = restartOVNKubeNodePod(cs, ovnKubeNs, node.Name)
 	framework.ExpectNoError(err)
 
 	// Verify that the node is moved to the expected zone

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -19,6 +19,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	utilsnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
@@ -29,14 +30,31 @@ func netCIDR(netCIDR string, netPrefixLengthPerNode int) string {
 	return fmt.Sprintf("%s/%d", netCIDR, netPrefixLengthPerNode)
 }
 
+func joinCIDRs(cidr ...string) string {
+	return strings.Join(cidr, ",")
+}
+
+func filterUnsupportedCIDRs(cs clientset.Interface, cidrs string) string {
+	cidrsSplit := strings.Split(cidrs, ",")
+	var ipv4CIDR, ipv6CIDR []string
+	for _, cidr := range cidrsSplit {
+		if utilsnet.IsIPv6CIDRString(cidr) {
+			ipv6CIDR = append(ipv6CIDR, cidr)
+		} else {
+			ipv4CIDR = append(ipv4CIDR, cidr)
+		}
+	}
+	return correctCIDRFamily(cs, strings.Join(ipv4CIDR, ","), strings.Join(ipv6CIDR, ","))
+}
+
 // takes ipv4 and ipv6 cidrs and returns the correct type for the cluster under test
-func correctCIDRFamily(ipv4CIDR, ipv6CIDR string) string {
+func correctCIDRFamily(cs clientset.Interface, ipv4CIDR, ipv6CIDR string) string {
 	// dual stack cluster
-	if isIPv6Supported() && isIPv4Supported() {
+	if isIPv6Supported(cs) && isIPv4Supported(cs) {
 		return strings.Join([]string{ipv4CIDR, ipv6CIDR}, ",")
 	}
 	// is an ipv6 only cluster
-	if isIPv6Supported() {
+	if isIPv6Supported(cs) {
 		return ipv6CIDR
 	}
 

--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -59,6 +59,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 					) {
 						By("creating the network")
 						netConfig.namespace = f.Namespace.Name
+						netConfig.cidr = filterUnsupportedCIDRs(cs, netConfig.cidr)
 						Expect(createNetworkFn(netConfig)).To(Succeed())
 
 						replicas := int32(3)
@@ -120,7 +121,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						false,
@@ -130,7 +131,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						false,
@@ -140,7 +141,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						true,
@@ -150,7 +151,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						true,
@@ -190,6 +191,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						Expect(err).NotTo(HaveOccurred())
 						By("creating the network")
 						netConfig.namespace = defaultNetNamespace.Name
+						netConfig.cidr = filterUnsupportedCIDRs(cs, netConfig.cidr)
 						Expect(createNetworkFn(netConfig)).To(Succeed())
 
 						replicas := int32(3)
@@ -228,7 +230,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "secondary",
 						},
 					),
@@ -237,7 +239,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "secondary",
 						},
 					),

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -105,6 +105,7 @@ var _ = Describe("Network Segmentation: services", func() {
 				clientNode := nodes.Items[1].Name // when client runs on a different node than the server
 
 				By("Creating the attachment configuration")
+				netConfigParams.cidr = filterUnsupportedCIDRs(cs, netConfigParams.cidr)
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
 				netConfig.namespace = f.Namespace.Name
 				_, err = nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
@@ -251,7 +252,9 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				// in OVNK in CLBO state https://issues.redhat.com/browse/OCPBUGS-41499
 				if netConfigParams.topology == "layer3" { // no need to run it for layer 2 as well
 					By("Restart ovnkube-node on one node and verify that the new ovnkube-node pod goes to the running state")
-					err = restartOVNKubeNodePod(cs, ovnNamespace, clientNode)
+					ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+					framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+					err = restartOVNKubeNodePod(cs, ovnKubeNs, clientNode)
 					Expect(err).NotTo(HaveOccurred())
 				}
 			},
@@ -261,7 +264,7 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 					role:     "primary",
 				},
 			),
@@ -270,7 +273,7 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer2",
-					cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     joinCIDRs(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 					role:     "primary",
 				},
 			),

--- a/test/e2e/node_ip_mac_migration.go
+++ b/test/e2e/node_ip_mac_migration.go
@@ -221,8 +221,9 @@ spec:
 					err := migrateWorkerNodeIP(workerNode.Name, migrationWorkerNodeIP, workerNodeIPs[ipAddrFamily],
 						true)
 					Expect(err).NotTo(HaveOccurred())
-
-					ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+					ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+					framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+					ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 						LabelSelector: "app=ovnkube-node",
 						FieldSelector: "spec.nodeName=" + workerNode.Name,
 					})
@@ -232,7 +233,7 @@ spec:
 
 					Eventually(func() bool {
 						By("waiting for the ovn-encap-ip to be reconfigured")
-						return isOVNEncapIPReady(workerNode.Name, workerNodeIPs[ipAddrFamily], ovnkubePodWorkerNode.Name)
+						return isOVNEncapIPReady(workerNode.Name, workerNodeIPs[ipAddrFamily], ovnKubeNs, ovnkubePodWorkerNode.Name)
 					}, pollingTimeout, pollingInterval).Should(BeTrue())
 
 					err = deletePodWithWait(context.TODO(), f.ClientSet, &ovnkubePodWorkerNode)
@@ -258,8 +259,9 @@ spec:
 
 							By("Setting rollbackNeeded to true")
 							rollbackNeeded = true
-
-							ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+							ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+							framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+							ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 								LabelSelector: "app=ovnkube-node",
 								FieldSelector: "spec.nodeName=" + workerNode.Name,
 							})
@@ -269,7 +271,7 @@ spec:
 
 							Eventually(func() bool {
 								By("waiting for the ovn-encap-ip to be reconfigured")
-								return isOVNEncapIPReady(workerNode.Name, migrationWorkerNodeIP, ovnkubePodWorkerNode.Name)
+								return isOVNEncapIPReady(workerNode.Name, migrationWorkerNodeIP, ovnKubeNs, ovnkubePodWorkerNode.Name)
 							}, pollingTimeout, pollingInterval).Should(BeTrue())
 
 							By(fmt.Sprintf("Sleeping for %d seconds to give things time to settle", settleTimeout))
@@ -358,8 +360,9 @@ spec:
 
 							By("Setting rollbackNeeded to true")
 							rollbackNeeded = true
-
-							ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+							ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+							framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+							ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 								LabelSelector: "app=ovnkube-node",
 								FieldSelector: "spec.nodeName=" + workerNode.Name,
 							})
@@ -369,7 +372,7 @@ spec:
 
 							Eventually(func() bool {
 								By("waiting for the ovn-encap-ip to be reconfigured")
-								return isOVNEncapIPReady(workerNode.Name, migrationWorkerNodeIP, ovnkubePodWorkerNode.Name)
+								return isOVNEncapIPReady(workerNode.Name, migrationWorkerNodeIP, ovnKubeNs, ovnkubePodWorkerNode.Name)
 							}, pollingTimeout, pollingInterval).Should(BeTrue())
 
 							By(fmt.Sprintf("Sleeping for %d seconds to give things time to settle", settleTimeout))
@@ -438,7 +441,9 @@ spec:
 					assignedNodePort = svc.Spec.Ports[0].NodePort
 
 					// find the ovn-kube node pod on this node
-					pods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+					ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+					framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+					pods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 						LabelSelector: "app=ovnkube-node",
 						FieldSelector: "spec.nodeName=" + workerNode.Name,
 					})
@@ -487,8 +492,9 @@ spec:
 
 							By("Setting rollbackNeeded to true")
 							rollbackNeeded = true
-
-							ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+							ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+							framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+							ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 								LabelSelector: "app=ovnkube-node",
 								FieldSelector: "spec.nodeName=" + workerNode.Name,
 							})
@@ -498,7 +504,7 @@ spec:
 
 							Eventually(func() bool {
 								By("waiting for the ovn-encap-ip to be reconfigured")
-								return isOVNEncapIPReady(workerNode.Name, migrationWorkerNodeIP, ovnkubePodWorkerNode.Name)
+								return isOVNEncapIPReady(workerNode.Name, migrationWorkerNodeIP, ovnKubeNs, ovnkubePodWorkerNode.Name)
 							}, pollingTimeout, pollingInterval).Should(BeTrue())
 
 							By(fmt.Sprintf("Sleeping for %d seconds to give things time to settle", settleTimeout))
@@ -537,7 +543,9 @@ spec:
 	When("when MAC address changes", func() {
 		BeforeEach(func() {
 			By("Storing original MAC")
-			ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+			ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+			framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+			ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: "app=ovnkube-node",
 				FieldSelector: "spec.nodeName=" + workerNode.Name,
 			})
@@ -859,9 +867,9 @@ func isAddressReachableFromContainer(containerName, targetIP string) (bool, erro
 	return false, nil
 }
 
-func isOVNEncapIPReady(nodeName, nodeIP, ovnkubePodName string) bool {
+func isOVNEncapIPReady(nodeName, nodeIP, ovnkubeNamespaceName, ovnkubePodName string) bool {
 	framework.Logf("Verifying ovn-encap-ip for node %s", nodeName)
-	cmd := []string{"kubectl", "-n", ovnNamespace, "exec", ovnkubePodName, "-c", "ovn-controller",
+	cmd := []string{"kubectl", "-n", ovnkubeNamespaceName, "exec", ovnkubePodName, "-c", "ovn-controller",
 		"--", "ovs-vsctl", "get", "open_vswitch", ".", "external-ids:ovn-encap-ip"}
 	output, err := runCommand(cmd...)
 	if err != nil {

--- a/test/e2e/ovspinning.go
+++ b/test/e2e/ovspinning.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var _ = ginkgo.Describe("OVS CPU affinity pinning", func() {
@@ -15,15 +16,16 @@ var _ = ginkgo.Describe("OVS CPU affinity pinning", func() {
 
 		_, err := runCommand(containerRuntime, "exec", nodeWithEnabledOvsAffinityPinning, "bash", "-c", "echo 1 > /etc/openvswitch/enable_dynamic_cpu_affinity")
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		restartOVNKubeNodePodsInParallel(f.ClientSet, ovnKubeNs, "ovn-worker", "ovn-worker2")
 
-		restartOVNKubeNodePodsInParallel(f.ClientSet, ovnNamespace, "ovn-worker", "ovn-worker2")
-
-		enabledNodeLogs, err := getOVNKubePodLogsFiltered(f.ClientSet, ovnNamespace, "ovn-worker2", ".*ovspinning_linux.go.*$")
+		enabledNodeLogs, err := getOVNKubePodLogsFiltered(f.ClientSet, ovnKubeNs, "ovn-worker2", ".*ovspinning_linux.go.*$")
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Expect(enabledNodeLogs).To(gomega.ContainSubstring("Starting OVS daemon CPU pinning"))
 
-		disabledNodeLogs, err := getOVNKubePodLogsFiltered(f.ClientSet, ovnNamespace, "ovn-worker", ".*ovspinning_linux.go.*$")
+		disabledNodeLogs, err := getOVNKubePodLogsFiltered(f.ClientSet, ovnKubeNs, "ovn-worker", ".*ovspinning_linux.go.*$")
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(disabledNodeLogs).To(gomega.ContainSubstring("OVS CPU affinity pinning disabled"))
 	})

--- a/test/e2e/pod.go
+++ b/test/e2e/pod.go
@@ -95,11 +95,11 @@ var _ = ginkgo.Describe("Pod to external server PMTUD", func() {
 				agntHostCmds,
 			)
 
-			if isIPv4Supported() {
+			if isIPv4Supported(f.ClientSet) {
 				serverNodeInternalIPs = append(serverNodeInternalIPs, externalIpv4)
 			}
 
-			if isIPv6Supported() {
+			if isIPv6Supported(f.ClientSet) {
 				serverNodeInternalIPs = append(serverNodeInternalIPs, externalIpv6)
 			}
 
@@ -198,12 +198,14 @@ var _ = ginkgo.Describe("Pod to external server PMTUD", func() {
 							}
 							return nil
 						}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+						ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+						framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 						// Flushing the IP route cache will remove any routes in the cache
 						// that are a result of receiving a "need to frag" packet. Let's
 						// flush this on all 3 nodes else we will run into the
 						// bug: https://issues.redhat.com/browse/OCPBUGS-7609.
 						// TODO: Revisit this once https://bugzilla.redhat.com/show_bug.cgi?id=2169839 is fixed.
-						ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+						ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 							LabelSelector: "name=ovnkube-node",
 						})
 						if err != nil {
@@ -215,7 +217,7 @@ var _ = ginkgo.Describe("Pod to external server PMTUD", func() {
 							if isInterconnectEnabled() {
 								containerName = "ovnkube-controller"
 							}
-							_, err := e2ekubectl.RunKubectl(ovnNamespace, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
+							_, err := e2ekubectl.RunKubectl(ovnKubeNs, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
 								"ip", "route", "flush", "cache")
 							framework.ExpectNoError(err, "Flushing the ip route cache failed")
 						}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -133,7 +133,9 @@ var _ = ginkgo.Describe("Services", func() {
 
 		ginkgo.By("Connecting to the service from another host-network pod on node " + nodeName)
 		// find the ovn-kube node pod on this node
-		pods, err := cs.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		pods, err := cs.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "app=ovnkube-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
 		})
@@ -483,12 +485,14 @@ var _ = ginkgo.Describe("Services", func() {
 								}
 								return nil
 							}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+							ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+							framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
 							// Flushing the IP route cache will remove any routes in the cache
 							// that are a result of receiving a "need to frag" packet. Let's
 							// flush this on all 3 nodes else we will run into the
 							// bug: https://issues.redhat.com/browse/OCPBUGS-7609.
 							// TODO: Revisit this once https://bugzilla.redhat.com/show_bug.cgi?id=2169839 is fixed.
-							ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+							ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 								LabelSelector: "name=ovnkube-node",
 							})
 							if err != nil {
@@ -504,7 +508,7 @@ var _ = ginkgo.Describe("Services", func() {
 								arguments := []string{"exec", ovnKubeNodePod.Name, "--container", containerName, "--"}
 								sepFlush := strings.Split(flushCmd, " ")
 								arguments = append(arguments, sepFlush...)
-								_, err := e2ekubectl.RunKubectl(ovnNamespace, arguments...)
+								_, err := e2ekubectl.RunKubectl(ovnKubeNs, arguments...)
 								framework.ExpectNoError(err, "Flushing the ip route cache failed")
 							}
 						}
@@ -566,7 +570,9 @@ var _ = ginkgo.Describe("Services", func() {
 		framework.ExpectNoError(err)
 		node := nodes.Items[0]
 		nodeName := node.Name
-		pods, err := cs.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+		pods, err := cs.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "app=ovnkube-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
 		})
@@ -606,7 +612,7 @@ var _ = ginkgo.Describe("Services", func() {
 		framework.ExpectNoError(err)
 		cleanupFn = func() {
 			// initial pod used for host command may be deleted at this point, refetch
-			pods, err := cs.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
+			pods, err := cs.CoreV1().Pods(ovnKubeNs).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: "app=ovnkube-node",
 				FieldSelector: "spec.nodeName=" + nodeName,
 			})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -26,18 +26,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/debug"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	testutils "k8s.io/kubernetes/test/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
 	utilnet "k8s.io/utils/net"
 )
 
 const (
-	ovnNamespace   = "ovn-kubernetes"
 	ovnNodeSubnets = "k8s.ovn.org/node-subnets"
 	// ovnNodeZoneNameAnnotation is the node annotation name to store the node zone name.
 	ovnNodeZoneNameAnnotation = "k8s.ovn.org/zone-name"
@@ -641,6 +642,19 @@ func getMACAddressesForNetwork(container, network string) string {
 	return strings.TrimSuffix(macAddr, "\n")
 }
 
+func getOVNKubeNamespaceName(nsClient typedcorev1.NamespaceInterface) (string, error) {
+	namespaces, err := nsClient.List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list namepaces: %v", err)
+	}
+	for _, ns := range namespaces.Items {
+		if strings.Contains(ns.Name, "ovn-kubernetes") {
+			return ns.Name, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find OVN-Kubernetes namespace name")
+}
+
 // waitClusterHealthy ensures we have a given number of ovn-k worker and master nodes,
 // as well as all nodes are healthy
 func waitClusterHealthy(f *framework.Framework, numControlPlanePods int, controlPlanePodName string) error {
@@ -664,8 +678,11 @@ func waitClusterHealthy(f *framework.Framework, numControlPlanePods int, control
 			framework.Logf("Not enough schedulable nodes, have %d want %d", len(afterNodes.Items), numNodes)
 			return false, nil
 		}
-
-		podClient := f.ClientSet.CoreV1().Pods(ovnNamespace)
+		ovnKubeNs, err := getOVNKubeNamespaceName(f.ClientSet.CoreV1().Namespaces())
+		if err != nil {
+			return false, fmt.Errorf("failed to find ovn-kubernetes namespace: %v", err)
+		}
+		podClient := f.ClientSet.CoreV1().Pods(ovnKubeNs)
 		// Ensure all nodes are running and healthy
 		podList, err := podClient.List(context.Background(), metav1.ListOptions{
 			LabelSelector: "app=ovnkube-node",
@@ -1122,7 +1139,7 @@ func countACLLogs(targetNodeName string, policyNameRegex string, expectedACLVerd
 func getTemplateContainerEnv(namespace, resource, container, key string) string {
 	args := []string{"get", resource,
 		"-o=jsonpath='{.spec.template.spec.containers[?(@.name==\"" + container + "\")].env[?(@.name==\"" + key + "\")].value}'"}
-	value := e2ekubectl.RunKubectlOrDie(ovnNamespace, args...)
+	value := e2ekubectl.RunKubectlOrDie(namespace, args...)
 	return strings.Trim(value, "'")
 }
 
@@ -1148,7 +1165,7 @@ func setUnsetTemplateContainerEnv(c kubernetes.Interface, namespace, resource, c
 
 // allowOrDropNodeInputTrafficOnPort ensures or deletes a drop iptables
 // input rule for the specified node, protocol and port
-func allowOrDropNodeInputTrafficOnPort(op, nodeName, protocol, port string) {
+func allowOrDropNodeInputTrafficOnPort(nsClient typedcorev1.NamespaceInterface, op, ovnKubeNs, nodeName, protocol, port string) {
 	ipTablesArgs := []string{"INPUT", "-p", protocol, "--dport", port, "-j", "DROP"}
 	switch op {
 	case "Allow":
@@ -1158,20 +1175,20 @@ func allowOrDropNodeInputTrafficOnPort(op, nodeName, protocol, port string) {
 	default:
 		framework.Failf("unsupported op %s", op)
 	}
-	updateIPTablesRulesForNode(op, nodeName, ipTablesArgs, false)
-	updateIPTablesRulesForNode(op, nodeName, ipTablesArgs, true)
+	updateIPTablesRulesForNode(nsClient, op, ovnKubeNs, nodeName, ipTablesArgs, false)
+	updateIPTablesRulesForNode(nsClient, op, ovnKubeNs, nodeName, ipTablesArgs, true)
 }
 
-func updateIPTablesRulesForNode(op, nodeName string, ipTablesArgs []string, ipv6 bool) {
+func updateIPTablesRulesForNode(nsClient typedcorev1.NamespaceInterface, op, ovnKubeNs, nodeName string, ipTablesArgs []string, ipv6 bool) {
 	args := []string{"get", "pods", "--selector=app=ovnkube-node", "--field-selector", fmt.Sprintf("spec.nodeName=%s", nodeName), "-o", "jsonpath={.items..metadata.name}"}
-	ovnKubePodName := e2ekubectl.RunKubectlOrDie(ovnNamespace, args...)
+	ovnKubePodName := e2ekubectl.RunKubectlOrDie(ovnKubeNs, args...)
 	iptables := "iptables"
 	if ipv6 {
 		iptables = "ip6tables"
 	}
 
-	args = []string{"exec", ovnKubePodName, "-c", getNodeContainerName(), "--", iptables, "--check"}
-	_, err := e2ekubectl.RunKubectl(ovnNamespace, append(args, ipTablesArgs...)...)
+	args = []string{"exec", ovnKubePodName, "-c", getNodeContainerName(nsClient), "--", iptables, "--check"}
+	_, err := e2ekubectl.RunKubectl(ovnKubeNs, append(args, ipTablesArgs...)...)
 	// errors known to be equivalent to not found
 	notFound1 := "No chain/target/match by that name"
 	notFound2 := "does a matching rule exist in that chain?"
@@ -1186,9 +1203,9 @@ func updateIPTablesRulesForNode(op, nodeName string, ipTablesArgs []string, ipv6
 		// rule is already there
 		return
 	}
-	args = []string{"exec", ovnKubePodName, "-c", getNodeContainerName(), "--", iptables, "--" + op}
+	args = []string{"exec", ovnKubePodName, "-c", getNodeContainerName(nsClient), "--", iptables, "--" + op}
 	framework.Logf("%s %s rule: %q on node %s", op, iptables, strings.Join(ipTablesArgs, ","), nodeName)
-	e2ekubectl.RunKubectlOrDie(ovnNamespace, append(args, ipTablesArgs...)...)
+	e2ekubectl.RunKubectlOrDie(ovnKubeNs, append(args, ipTablesArgs...)...)
 }
 
 func randStr(n int) string {
@@ -1201,14 +1218,22 @@ func randStr(n int) string {
 	return string(b)
 }
 
-func isIPv4Supported() bool {
-	val, present := os.LookupEnv("KIND_IPV4_SUPPORT")
-	return present && val == "true"
+func isIPv4Supported(cs clientset.Interface) bool {
+	v4, _ := getSupportedIPFamilies(cs)
+	return v4
 }
 
-func isIPv6Supported() bool {
-	val, present := os.LookupEnv("KIND_IPV6_SUPPORT")
-	return present && val == "true"
+func isIPv6Supported(cs clientset.Interface) bool {
+	_, v6 := getSupportedIPFamilies(cs)
+	return v6
+}
+
+func getSupportedIPFamilies(cs clientset.Interface) (bool, bool) {
+	nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), cs, e2eservice.MaxNodesForEndpointsTests)
+	framework.ExpectNoError(err)
+	v4NodeAddrs := e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeInternalIP, v1.IPv4Protocol)
+	v6NodeAddrs := e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeInternalIP, v1.IPv6Protocol)
+	return len(v4NodeAddrs) > 0, len(v6NodeAddrs) > 0
 }
 
 func isInterconnectEnabled() bool {
@@ -1231,10 +1256,13 @@ func isLocalGWModeEnabled() bool {
 	return present && val == "local"
 }
 
-func singleNodePerZone() bool {
+func singleNodePerZone(nsClient typedcorev1.NamespaceInterface) bool {
 	if singleNodePerZoneResult == nil {
+		ovnKubeNs, err := getOVNKubeNamespaceName(nsClient)
+		framework.ExpectNoError(err, "failed to get ovn-kubernetes namespace")
+
 		args := []string{"get", "pods", "--selector=app=ovnkube-node", "-o", "jsonpath={.items[0].spec.containers[*].name}"}
-		containerNames := e2ekubectl.RunKubectlOrDie(ovnNamespace, args...)
+		containerNames := e2ekubectl.RunKubectlOrDie(ovnKubeNs, args...)
 		result := true
 		for _, containerName := range strings.Split(containerNames, " ") {
 			if containerName == "ovnkube-node" {
@@ -1247,8 +1275,8 @@ func singleNodePerZone() bool {
 	return *singleNodePerZoneResult
 }
 
-func getNodeContainerName() string {
-	if singleNodePerZone() {
+func getNodeContainerName(nsClient typedcorev1.NamespaceInterface) string {
+	if singleNodePerZone(nsClient) {
 		return "ovnkube-controller"
 	}
 	return "ovnkube-node"


### PR DESCRIPTION
Using env vars is troublesome to config the e2es.
We should be inspecting the cluster under test and trying to figure out what config/features are available.

This is by no means a full conversion but enough to unblock me downstream.

