### PR TITLE
Fix the commands for image build in the docs and script.

### DIFF
--- a/dist/READMEcontainer.md
+++ b/dist/READMEcontainer.md
@@ -84,7 +84,7 @@ kubelet.
 
 $ cd images && make
 builds the default centos based image from  Dockerfile
-$  make fedora
+$ make fedora-image
 builds the image with the fedora 
 
 Once the image is built it must be tagged and pushed to a docker image repo

--- a/docs/developer-guide/image-build.md
+++ b/docs/developer-guide/image-build.md
@@ -21,8 +21,8 @@ To build images locally, use the following [Makefile](https://github.com/ovn-kub
 
 ```bash
 $ cd dist/images
-$ make fedora
-$ make ubuntu
+$ make fedora-image
+$ make ubuntu-image
 ```
 
 The build will create an image called ovn-kube-fedora:latest or ovn-kube-ubuntu:latest, which can be re-tagged.

--- a/docs/installation/launching-ovn-kubernetes-on-kind.md
+++ b/docs/installation/launching-ovn-kubernetes-on-kind.md
@@ -44,7 +44,7 @@ Build the image for fedora and launch the KIND Deployment
 
 ```
 $ pushd dist/images
-$ make fedora
+$ make fedora-image
 $ popd
 
 $ pushd contrib
@@ -70,7 +70,7 @@ $ OCI_BIN=podman
 Then build,
 
 ```
-$ make fedora
+$ make fedora-image
 $ popd
 ```
 
@@ -319,7 +319,7 @@ $ cd go-controller/
 $ make
 
 $ cd ../dist/images/
-$ make fedora
+$ make fedora-image
 
 $ cd ../../contrib/
 $ KIND_IPV4_SUPPORT=false KIND_IPV6_SUPPORT=true ./kind.sh
@@ -423,7 +423,7 @@ $ cd go-controller/
 $ make
 
 $ cd ../dist/images/
-$ make fedora
+$ make fedora-image
 
 $ cd ../../contrib/
 $ KIND_IPV4_SUPPORT=true KIND_IPV6_SUPPORT=true K8S_VERSION=v1.31.0 ./kind.sh

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -64,7 +64,7 @@ networking:
 - Optional: build local image and load it into Kind nodes
 ```
 # cd dist/images
-# make ubuntu
+# make ubuntu-image
 # docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 # kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```

--- a/docs/observability/ovn-observability.md
+++ b/docs/observability/ovn-observability.md
@@ -45,8 +45,8 @@ As of Aug 2024, the kernel need to be built from the source, therefore to try th
 - rebuild the kernel with the current master branch from [Linus' tree](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git)
   - to rebuild on fedora: https://docs.fedoraproject.org/en-US/quick-docs/kernel-build-custom/#_building_a_vanilla_upstream_kernel
 - Build an ovn-kubernetes image that uses the latest OVS/OVN code:
-`OVS_BRANCH=main make -C dist/images fedora-dev`
-- Start kind with that image, use `-ov localhost/ovn-kube-fedora-dev:latest` flag with `kind.sh` script.
+`OVS_BRANCH=main make -C dist/images fedora-dev-local-gw-deployment`
+- Start kind with that image, use `-ov localhost/ovn-daemonset-fedora:latest` flag with `kind.sh` script.
 
 ## Workflow Description
 

--- a/helm/basic-deploy.sh
+++ b/helm/basic-deploy.sh
@@ -50,7 +50,7 @@ if [[ "$BUILD_IMAGE" == "true" ]]; then
   # Build image
   echo "Building Docker image..."
   pushd ../dist/images
-  make ubuntu
+  make ubuntu-image
   popd
   docker tag ovn-kube-ubuntu:latest $IMG
 else

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -84,7 +84,7 @@ networking:
 - Optional: build local image and load it into Kind nodes
 ```
 # cd dist/images
-# make ubuntu
+# make ubuntu-image
 # docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 # kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -87,7 +87,7 @@ networking:
 - Optional: build local image and load it into Kind nodes
 ```
 # cd dist/images
-# make ubuntu
+# make ubuntu-image
 # docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 # kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

It seems that the build commands for container images of ubuntu and fedora were changed in the https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4899, but this did not seem to be reflected in the docs and script, so fix it.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
