### PR TITLE
Fix UDN nftables mark chain cleanup

### DIFF
--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -310,7 +310,9 @@ func (udng *UserDefinedNetworkGateway) delMarkChain() error {
 	chain := &knftables.Chain{
 		Name: GetUDNMarkChain(fmt.Sprintf("0x%x", udng.pktMark)),
 	}
-	tx.Flush(chain)
+	// Delete would return an error if we tried to delete a chain that didn't exist, so
+	// we do an Add first (which is a no-op if the chain already exists) and then Delete.
+	tx.Add(chain)
 	tx.Delete(chain)
 	return nft.Run(context.TODO(), tx)
 }


### PR DESCRIPTION
There is no need to flush the chain before removing it.
Additionally handle the case where the chain was already removed.

Found by @jcaamano here: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when deleting network chains to prevent errors if a chain does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->