### PR TITLE
UDN Isolation with BGP: Remove support for receiving advertised routes from remote nodes

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -932,6 +932,11 @@ func RemoveLoadBalancersFromLogicalRouterOps(nbClient libovsdbclient.Client, ops
 	return ops, err
 }
 
+func getNATMutableFields(nat *nbdb.NAT) []interface{} {
+	return []interface{}{&nat.Type, &nat.ExternalIP, &nat.LogicalIP, &nat.LogicalPort, &nat.ExternalMAC,
+		&nat.ExternalIDs, &nat.Match, &nat.Options, &nat.ExternalPortRange, &nat.GatewayPort, &nat.Priority}
+}
+
 func buildNAT(
 	natType nbdb.NATType,
 	externalIP string,
@@ -1152,7 +1157,7 @@ func CreateOrUpdateNATsOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation
 		}
 		opModel := operationModel{
 			Model:          inputNat,
-			OnModelUpdates: onModelUpdatesAllNonDefault(),
+			OnModelUpdates: getNATMutableFields(inputNat),
 			ErrNotFound:    false,
 			BulkOp:         false,
 			DoAfter:        func() { router.Nat = append(router.Nat, inputNat.UUID) },
@@ -1280,7 +1285,7 @@ func UpdateNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, nats ..
 		opModel := []operationModel{
 			{
 				Model:          nat,
-				OnModelUpdates: onModelUpdatesAllNonDefault(),
+				OnModelUpdates: getNATMutableFields(nat),
 				ErrNotFound:    true,
 				BulkOp:         false,
 			},

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -1035,7 +1035,7 @@ func BuildDNATAndSNATWithMatch(
 // isEquivalentNAT checks if the `searched` NAT is equivalent to `existing`.
 // Returns true if the UUID is set in `searched` and matches the UUID of `existing`.
 // Otherwise, perform the following checks:
-//   - Compare the Type and Match fields.
+//   - Compare the Type.
 //   - Compare ExternalIP if it is set in `searched`.
 //   - Compare LogicalIP if the Type in `searched` is SNAT.
 //   - Compare LogicalPort if it is set in `searched`.
@@ -1047,10 +1047,6 @@ func isEquivalentNAT(existing *nbdb.NAT, searched *nbdb.NAT) bool {
 	}
 
 	if searched.Type != existing.Type {
-		return false
-	}
-
-	if searched.Match != existing.Match {
 		return false
 	}
 

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -349,13 +349,12 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 			bridgeMacAddress, mod_vlan_id, defaultNetConfig.OfPortPatch))
 
 	// table 2, priority 200, dispatch from UDN -> Host -> OVN. These packets have
-	// already been SNATed to the UDN's masq IP or have been marked with the UDN's packet mark.
+	// already been SNATed to the UDN's masquerade IP or have been marked with the UDN's packet mark.
 	if config.IPv4Mode {
 		for _, netConfig := range b.patchedNetConfigs() {
 			if netConfig.IsDefaultNetwork() {
 				continue
 			}
-			srcIPOrSubnet := netConfig.V4MasqIPs.ManagementPort.IP.String()
 			if util.IsRouteAdvertisementsEnabled() && netConfig.Advertised.Load() {
 				var udnAdvertisedSubnets []*net.IPNet
 				for _, clusterEntry := range netConfig.Subnets {
@@ -368,9 +367,14 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 					klog.Infof("Unable to determine IPV4 UDN subnet for the provided family isIPV6: %v", err)
 					continue
 				}
-
-				// Use the filtered subnets for the flow compute instead of the masqueradeIP
-				srcIPOrSubnet = matchingIPFamilySubnet.String()
+				// In addition to the masqueradeIP based flows, we also need the podsubnet based flows for
+				// advertised networks since UDN pod to clusterIP is unSNATed and we need this traffic to be taken into
+				// the correct patch port of it's own network where it's a deadend if the clusterIP is not part of
+				// that UDN network and works if it is part of the UDN network.
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=200, table=2, ip, ip_src=%s, "+
+						"actions=drop",
+						nodetypes.DefaultOpenFlowCookie, matchingIPFamilySubnet.String()))
 			}
 			// Drop traffic coming from the masquerade IP or the UDN subnet(for advertised UDNs) to ensure that
 			// isolation between networks is enforced. This handles the case where a pod on the UDN subnet is sending traffic to
@@ -378,7 +382,7 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, ip, ip_src=%s, "+
 					"actions=drop",
-					nodetypes.DefaultOpenFlowCookie, srcIPOrSubnet))
+					nodetypes.DefaultOpenFlowCookie, netConfig.V4MasqIPs.ManagementPort.IP.String()))
 
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=250, table=2, ip, pkt_mark=%s, "+
@@ -393,7 +397,6 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 			if netConfig.IsDefaultNetwork() {
 				continue
 			}
-			srcIPOrSubnet := netConfig.V6MasqIPs.ManagementPort.IP.String()
 			if util.IsRouteAdvertisementsEnabled() && netConfig.Advertised.Load() {
 				var udnAdvertisedSubnets []*net.IPNet
 				for _, clusterEntry := range netConfig.Subnets {
@@ -407,13 +410,15 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 					continue
 				}
 
-				// Use the filtered subnets for the flow compute instead of the masqueradeIP
-				srcIPOrSubnet = matchingIPFamilySubnet.String()
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=200, table=2, ip6, ipv6_src=%s, "+
+						"actions=drop",
+						nodetypes.DefaultOpenFlowCookie, matchingIPFamilySubnet.String()))
 			}
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, ip6, ipv6_src=%s, "+
 					"actions=drop",
-					nodetypes.DefaultOpenFlowCookie, srcIPOrSubnet))
+					nodetypes.DefaultOpenFlowCookie, netConfig.V6MasqIPs.ManagementPort.IP.String()))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=250, table=2, ip6, pkt_mark=%s, "+
 					"actions=set_field:%s->eth_dst,output:%s",

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1515,23 +1515,32 @@ func (nc *DefaultNodeNetworkController) WatchNodes() error {
 func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error {
 	var nftElems []*knftables.Element
 	var addrs []string
-	for _, address := range node.Status.Addresses {
-		if address.Type != corev1.NodeInternalIP {
-			continue
-		}
-		nodeIP := net.ParseIP(address.Address)
-		if nodeIP == nil {
-			continue
-		}
 
+	// Use GetNodeAddresses to get all node IPs (including current node for openflow)
+	ipsv4, ipsv6, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, node)
+	if err != nil {
+		return fmt.Errorf("failed to get node addresses for node %q: %w", node.Name, err)
+	}
+
+	// Process IPv4 addresses
+	for _, nodeIP := range ipsv4 {
 		addrs = append(addrs, nodeIP.String())
 		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
-		if utilnet.IsIPv4(nodeIP) {
+		// Only add to nftables if this is remote node
+		if node.Name != nc.name {
 			nftElems = append(nftElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv4,
 				Key: []string{nodeIP.String()},
 			})
-		} else {
+		}
+	}
+
+	// Process IPv6 addresses
+	for _, nodeIP := range ipsv6 {
+		addrs = append(addrs, nodeIP.String())
+		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
+		// Only add to nftables if this is remote node
+		if node.Name != nc.name {
 			nftElems = append(nftElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv6,
 				Key: []string{nodeIP.String()},
@@ -1578,17 +1587,17 @@ func removePMTUDNodeNFTRules(nodeIPs []net.IP) error {
 func (nc *DefaultNodeNetworkController) deleteNode(node *corev1.Node) {
 	gw := nc.Gateway.(*gateway)
 	gw.openflowManager.deleteFlowsByKey(getPMTUDKey(node.Name))
-	ipsToRemove := make([]net.IP, 0)
-	for _, address := range node.Status.Addresses {
-		if address.Type != corev1.NodeInternalIP {
-			continue
-		}
-		nodeIP := net.ParseIP(address.Address)
-		if nodeIP == nil {
-			continue
-		}
-		ipsToRemove = append(ipsToRemove, nodeIP)
+
+	// Use GetNodeAddresses to get node IPs
+	ipsv4, ipsv6, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, node)
+	if err != nil {
+		klog.Errorf("Failed to get node addresses for node %q: %v", node.Name, err)
+		return
 	}
+
+	ipsToRemove := make([]net.IP, 0, len(ipsv4)+len(ipsv6))
+	ipsToRemove = append(ipsToRemove, ipsv4...)
+	ipsToRemove = append(ipsToRemove, ipsv6...)
 
 	klog.Infof("Deleting NFT elements for node: %s", node.Name)
 	if err := removePMTUDNodeNFTRules(ipsToRemove); err != nil {
@@ -1610,27 +1619,28 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 		if node.Name == nc.name {
 			continue
 		}
-		for _, address := range node.Status.Addresses {
-			if address.Type != corev1.NodeInternalIP {
-				continue
-			}
-			nodeIP := net.ParseIP(address.Address)
-			if nodeIP == nil {
-				continue
-			}
 
-			// Remove IPs from NFT sets
-			if utilnet.IsIPv4(nodeIP) {
-				keepNFTSetElemsV4 = append(keepNFTSetElemsV4, &knftables.Element{
-					Set: types.NFTRemoteNodeIPsv4,
-					Key: []string{nodeIP.String()},
-				})
-			} else {
-				keepNFTSetElemsV6 = append(keepNFTSetElemsV6, &knftables.Element{
-					Set: types.NFTRemoteNodeIPsv6,
-					Key: []string{nodeIP.String()},
-				})
-			}
+		// Use GetNodeAddresses to get node IPs
+		ipsv4, ipsv6, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, node)
+		if err != nil {
+			klog.Errorf("Failed to get node addresses for node %q: %v", node.Name, err)
+			continue
+		}
+
+		// Process IPv4 addresses
+		for _, nodeIP := range ipsv4 {
+			keepNFTSetElemsV4 = append(keepNFTSetElemsV4, &knftables.Element{
+				Set: types.NFTRemoteNodeIPsv4,
+				Key: []string{nodeIP.String()},
+			})
+		}
+
+		// Process IPv6 addresses
+		for _, nodeIP := range ipsv6 {
+			keepNFTSetElemsV6 = append(keepNFTSetElemsV6, &knftables.Element{
+				Set: types.NFTRemoteNodeIPsv6,
+				Key: []string{nodeIP.String()},
+			})
 		}
 	}
 	if err := recreateNFTSet(types.NFTRemoteNodeIPsv4, keepNFTSetElemsV4); err != nil {

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -188,7 +188,7 @@ func NewDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, net
 
 	nc.initRetryFrameworkForNode()
 
-	err = setupPMTUDNFTSets()
+	err = setupRemoteNodeNFTSets()
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup PMTUD nftables sets: %w", err)
 	}
@@ -1528,12 +1528,12 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
 		if utilnet.IsIPv4(nodeIP) {
 			nftElems = append(nftElems, &knftables.Element{
-				Set: types.NFTNoPMTUDRemoteNodeIPsv4,
+				Set: types.NFTRemoteNodeIPsv4,
 				Key: []string{nodeIP.String()},
 			})
 		} else {
 			nftElems = append(nftElems, &knftables.Element{
-				Set: types.NFTNoPMTUDRemoteNodeIPsv6,
+				Set: types.NFTRemoteNodeIPsv6,
 				Key: []string{nodeIP.String()},
 			})
 		}
@@ -1557,12 +1557,12 @@ func removePMTUDNodeNFTRules(nodeIPs []net.IP) error {
 		// Remove IPs from NFT sets
 		if utilnet.IsIPv4(nodeIP) {
 			nftElems = append(nftElems, &knftables.Element{
-				Set: types.NFTNoPMTUDRemoteNodeIPsv4,
+				Set: types.NFTRemoteNodeIPsv4,
 				Key: []string{nodeIP.String()},
 			})
 		} else {
 			nftElems = append(nftElems, &knftables.Element{
-				Set: types.NFTNoPMTUDRemoteNodeIPsv6,
+				Set: types.NFTRemoteNodeIPsv6,
 				Key: []string{nodeIP.String()},
 			})
 		}
@@ -1622,21 +1622,21 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 			// Remove IPs from NFT sets
 			if utilnet.IsIPv4(nodeIP) {
 				keepNFTSetElemsV4 = append(keepNFTSetElemsV4, &knftables.Element{
-					Set: types.NFTNoPMTUDRemoteNodeIPsv4,
+					Set: types.NFTRemoteNodeIPsv4,
 					Key: []string{nodeIP.String()},
 				})
 			} else {
 				keepNFTSetElemsV6 = append(keepNFTSetElemsV6, &knftables.Element{
-					Set: types.NFTNoPMTUDRemoteNodeIPsv6,
+					Set: types.NFTRemoteNodeIPsv6,
 					Key: []string{nodeIP.String()},
 				})
 			}
 		}
 	}
-	if err := recreateNFTSet(types.NFTNoPMTUDRemoteNodeIPsv4, keepNFTSetElemsV4); err != nil {
+	if err := recreateNFTSet(types.NFTRemoteNodeIPsv4, keepNFTSetElemsV4); err != nil {
 		errors = append(errors, err)
 	}
-	if err := recreateNFTSet(types.NFTNoPMTUDRemoteNodeIPsv6, keepNFTSetElemsV6); err != nil {
+	if err := recreateNFTSet(types.NFTRemoteNodeIPsv6, keepNFTSetElemsV6); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -38,18 +38,18 @@ import (
 
 const v4PMTUDNFTRules = `
 add table inet ovn-kubernetes
-add rule inet ovn-kubernetes no-pmtud ip daddr @no-pmtud-remote-node-ips-v4 meta l4proto icmp icmp type 3 icmp code 4 counter drop
+add rule inet ovn-kubernetes no-pmtud ip daddr @remote-node-ips-v4 meta l4proto icmp icmp type 3 icmp code 4 counter drop
 add chain inet ovn-kubernetes no-pmtud { type filter hook output priority 0 ; comment "Block egress needs frag/packet too big to remote k8s nodes" ; }
-add set inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { type ipv4_addr ; comment "Block egress ICMP needs frag to remote Kubernetes nodes" ; }
-add set inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { type ipv6_addr ; comment "Block egress ICMPv6 packet too big to remote Kubernetes nodes" ; }
+add set inet ovn-kubernetes remote-node-ips-v4 { type ipv4_addr ; comment "Block egress ICMP needs frag to remote Kubernetes nodes" ; }
+add set inet ovn-kubernetes remote-node-ips-v6 { type ipv6_addr ; comment "Block egress ICMPv6 packet too big to remote Kubernetes nodes" ; }
 `
 
 const v6PMTUDNFTRules = `
 add table inet ovn-kubernetes
-add rule inet ovn-kubernetes no-pmtud meta l4proto icmpv6 icmpv6 type 2 icmpv6 code 0 ip6 daddr @no-pmtud-remote-node-ips-v6 counter drop
+add rule inet ovn-kubernetes no-pmtud meta l4proto icmpv6 icmpv6 type 2 icmpv6 code 0 ip6 daddr @remote-node-ips-v6 counter drop
 add chain inet ovn-kubernetes no-pmtud { type filter hook output priority 0 ; comment "Block egress needs frag/packet too big to remote k8s nodes" ; }
-add set inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { type ipv4_addr ; comment "Block egress ICMP needs frag to remote Kubernetes nodes" ; }
-add set inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { type ipv6_addr ; comment "Block egress ICMPv6 packet too big to remote Kubernetes nodes" ; }
+add set inet ovn-kubernetes remote-node-ips-v4 { type ipv4_addr ; comment "Block egress ICMP needs frag to remote Kubernetes nodes" ; }
+add set inet ovn-kubernetes remote-node-ips-v6 { type ipv6_addr ; comment "Block egress ICMPv6 packet too big to remote Kubernetes nodes" ; }
 `
 
 var _ = Describe("Node", func() {
@@ -806,7 +806,7 @@ var _ = Describe("Node", func() {
 					cnnci := NewCommonNodeNetworkControllerInfo(kubeFakeClient, fakeClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
 					nc = newDefaultNodeNetworkController(cnnci, stop, wg, routeManager, nil)
 					nc.initRetryFrameworkForNode()
-					err = setupPMTUDNFTSets()
+					err = setupRemoteNodeNFTSets()
 					Expect(err).NotTo(HaveOccurred())
 					err = setupPMTUDNFTChain()
 					Expect(err).NotTo(HaveOccurred())
@@ -830,7 +830,7 @@ var _ = Describe("Node", func() {
 					err = nc.WatchNodes()
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v4PMTUDNFTRules + `
-add element inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { 169.254.254.61 }
+add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.254.61 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -911,7 +911,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { 169.254.254.61 }
 					cnnci := NewCommonNodeNetworkControllerInfo(kubeFakeClient, fakeClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
 					nc = newDefaultNodeNetworkController(cnnci, stop, wg, routeManager, nil)
 					nc.initRetryFrameworkForNode()
-					err = setupPMTUDNFTSets()
+					err = setupRemoteNodeNFTSets()
 					Expect(err).NotTo(HaveOccurred())
 					err = setupPMTUDNFTChain()
 					Expect(err).NotTo(HaveOccurred())
@@ -935,7 +935,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { 169.254.254.61 }
 					err = nc.WatchNodes()
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v4PMTUDNFTRules + `
-add element inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { 169.254.253.61 }
+add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.253.61 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -1058,7 +1058,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { 169.254.253.61 }
 					cnnci := NewCommonNodeNetworkControllerInfo(kubeFakeClient, fakeClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
 					nc = newDefaultNodeNetworkController(cnnci, stop, wg, routeManager, nil)
 					nc.initRetryFrameworkForNode()
-					err = setupPMTUDNFTSets()
+					err = setupRemoteNodeNFTSets()
 					Expect(err).NotTo(HaveOccurred())
 					err = setupPMTUDNFTChain()
 					Expect(err).NotTo(HaveOccurred())
@@ -1082,7 +1082,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v4 { 169.254.253.61 }
 					err = nc.WatchNodes()
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v6PMTUDNFTRules + `
-add element inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { 2001:db8:1::4 }
+add element inet ovn-kubernetes remote-node-ips-v6 { 2001:db8:1::4 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -1162,7 +1162,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { 2001:db8:1::4 }
 					cnnci := NewCommonNodeNetworkControllerInfo(kubeFakeClient, fakeClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
 					nc = newDefaultNodeNetworkController(cnnci, stop, wg, routeManager, nil)
 					nc.initRetryFrameworkForNode()
-					err = setupPMTUDNFTSets()
+					err = setupRemoteNodeNFTSets()
 					Expect(err).NotTo(HaveOccurred())
 					err = setupPMTUDNFTChain()
 					Expect(err).NotTo(HaveOccurred())
@@ -1186,7 +1186,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { 2001:db8:1::4 }
 					err = nc.WatchNodes()
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v6PMTUDNFTRules + `
-add element inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { 2002:db8:1::4 }
+add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -1323,7 +1323,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { 2002:db8:1::4 }
 					cnnci := NewCommonNodeNetworkControllerInfo(kubeFakeClient, fakeClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
 					nc = newDefaultNodeNetworkController(cnnci, stop, wg, routeManager, nil)
 					nc.initRetryFrameworkForNode()
-					err = setupPMTUDNFTSets()
+					err = setupRemoteNodeNFTSets()
 					Expect(err).NotTo(HaveOccurred())
 					err = setupPMTUDNFTChain()
 					Expect(err).NotTo(HaveOccurred())
@@ -1444,7 +1444,7 @@ add element inet ovn-kubernetes no-pmtud-remote-node-ips-v6 { 2002:db8:1::4 }
 					cnnci := NewCommonNodeNetworkControllerInfo(kubeFakeClient, fakeClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
 					nc = newDefaultNodeNetworkController(cnnci, stop, wg, routeManager, nil)
 					nc.initRetryFrameworkForNode()
-					err = setupPMTUDNFTSets()
+					err = setupRemoteNodeNFTSets()
 					Expect(err).NotTo(HaveOccurred())
 					err = setupPMTUDNFTChain()
 					Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -755,6 +755,9 @@ var _ = Describe("Node", func() {
 					node := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: nodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", nodeIP+"/24"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -769,6 +772,9 @@ var _ = Describe("Node", func() {
 					otherNode := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: remoteNodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", otherNodeIP+"/24"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -860,6 +866,9 @@ add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.254.61 }
 					node := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: nodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", nodeIP+"/24"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -874,6 +883,9 @@ add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.254.61 }
 					otherNode := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: remoteNodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", otherSubnetNodeIP+"/24"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -1007,6 +1019,9 @@ add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.253.61 }
 					node := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: nodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", nodeIP+"/64"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -1021,6 +1036,9 @@ add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.253.61 }
 					otherNode := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: remoteNodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", otherNodeIP+"/64"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -1111,6 +1129,9 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2001:db8:1::4 }
 					node := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: nodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", nodeIP+"/64"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{
@@ -1125,6 +1146,9 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2001:db8:1::4 }
 					otherNode := corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: remoteNodeName,
+							Annotations: map[string]string{
+								util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", otherSubnetNodeIP+"/64"),
+							},
 						},
 						Status: corev1.NodeStatus{
 							Addresses: []corev1.NodeAddress{

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -522,8 +522,8 @@ func (g *gateway) updateSNATRules() error {
 	subnets := util.IPsToNetworkIPs(g.nodeIPManager.mgmtPort.GetAddresses()...)
 
 	if g.GetDefaultPodNetworkAdvertised() || config.Gateway.Mode != config.GatewayModeLocal {
-		return delLocalGatewayPodSubnetNATRules(subnets...)
+		return delLocalGatewayPodSubnetNFTRules()
 	}
 
-	return addLocalGatewayPodSubnetNATRules(subnets...)
+	return addLocalGatewayPodSubnetNFTRules(subnets...)
 }

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -521,9 +521,9 @@ func (g *gateway) addAllServices() []error {
 func (g *gateway) updateSNATRules() error {
 	subnets := util.IPsToNetworkIPs(g.nodeIPManager.mgmtPort.GetAddresses()...)
 
-	if g.GetDefaultPodNetworkAdvertised() || config.Gateway.Mode != config.GatewayModeLocal {
+	if config.Gateway.Mode != config.GatewayModeLocal {
 		return delLocalGatewayPodSubnetNFTRules()
 	}
 
-	return addLocalGatewayPodSubnetNFTRules(subnets...)
+	return addOrUpdateLocalGatewayPodSubnetNFTRules(g.GetDefaultPodNetworkAdvertised(), subnets...)
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -80,6 +80,17 @@ add chain inet ovn-kubernetes udn-service-prerouting { type filter hook prerouti
 add rule inet ovn-kubernetes udn-service-prerouting iifname != %s jump udn-service-mark
 add chain inet ovn-kubernetes udn-service-output { type filter hook output priority -150 ; comment "UDN services packet mark - Output" ; }
 add rule inet ovn-kubernetes udn-service-output jump udn-service-mark
+add chain inet ovn-kubernetes ovn-kube-udn-masq { comment "OVN UDN masquerade" ; }
+add rule inet ovn-kubernetes ovn-kube-udn-masq ip saddr != 169.254.169.0/29 ip daddr != 172.16.1.0/24 ip saddr 169.254.169.0/24 masquerade
+add rule inet ovn-kubernetes ovn-kube-local-gw-masq jump ovn-kube-udn-masq
+`
+
+const baseLGWNFTablesRules = `
+add rule inet ovn-kubernetes ovn-kube-local-gw-masq ip saddr 169.254.169.1 masquerade
+add chain inet ovn-kubernetes ovn-kube-local-gw-masq { type nat hook postrouting priority 100 ; comment "OVN local gateway masquerade" ; }
+add rule inet ovn-kubernetes ovn-kube-local-gw-masq jump ovn-kube-pod-subnet-masq
+add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
+add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq
 `
 
 func getBaseNFTRules(mgmtPort string) string {
@@ -88,6 +99,10 @@ func getBaseNFTRules(mgmtPort string) string {
 		ret += fmt.Sprintf(baseUDNNFTRulesFmt, mgmtPort)
 	}
 	return ret
+}
+
+func getBaseLGWNFTablesRules(mgmtPort string) string {
+	return getBaseNFTRules(mgmtPort) + baseLGWNFTablesRules
 }
 
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
@@ -1350,10 +1365,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				"OVN-KUBE-EXTERNALIP": []string{
 					fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 				},
-				"POSTROUTING": []string{
-					"-s 169.254.169.1 -j MASQUERADE",
-					"-s 10.1.1.0/24 -j MASQUERADE",
-				},
 				"OVN-KUBE-ETP": []string{},
 				"OVN-KUBE-ITP": []string{},
 			},
@@ -1379,16 +1390,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				"OVN-KUBE-ITP": []string{},
 			},
 		}
-		if util.IsNetworkSegmentationSupportEnabled() {
-			expectedTables["nat"]["POSTROUTING"] = append(expectedTables["nat"]["POSTROUTING"],
-				"-j OVN-KUBE-UDN-MASQUERADE",
-			)
-			expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"] = append(expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"],
-				"-s 169.254.169.0/29 -j RETURN",     // this guarantees we don't SNAT default network masqueradeIPs
-				"-d 172.16.1.0/24 -j RETURN",        // this guarantees we don't SNAT service traffic
-				"-s 169.254.169.0/24 -j MASQUERADE", // this guarantees we SNAT all UDN MasqueradeIPs traffic leaving the node
-			)
-		}
 		f4 := iptV4.(*util.FakeIPTables)
 		err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
 			Table: "filter",
@@ -1405,7 +1406,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		err = f6.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedNFT := getBaseNFTRules(types.K8sMgmtIntfName)
+		expectedNFT := getBaseLGWNFTablesRules(types.K8sMgmtIntfName)
 		err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -87,7 +87,7 @@ add rule inet ovn-kubernetes ovn-kube-local-gw-masq jump ovn-kube-udn-masq
 
 const baseLGWNFTablesRules = `
 add rule inet ovn-kubernetes ovn-kube-local-gw-masq ip saddr 169.254.169.1 masquerade
-add chain inet ovn-kubernetes ovn-kube-local-gw-masq { type nat hook postrouting priority 100 ; comment "OVN local gateway masquerade" ; }
+add chain inet ovn-kubernetes ovn-kube-local-gw-masq { type nat hook postrouting priority 101 ; comment "OVN local gateway masquerade" ; }
 add rule inet ovn-kubernetes ovn-kube-local-gw-masq jump ovn-kube-pod-subnet-masq
 add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
 add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -6,12 +6,14 @@ package node
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -26,6 +28,13 @@ import (
 // ordering dependency between two rules (especially, in any case where it's necessary to
 // use an "accept" rule to override a later "drop" rule), then those rules will need to
 // either both be iptables or both be nftables.
+
+// nftables chain names
+const (
+	nftablesLocalGatewayMasqChain = "ovn-kube-local-gw-masq"
+	nftablesPodSubnetMasqChain    = "ovn-kube-pod-subnet-masq"
+	nftablesUDNMasqChain          = "ovn-kube-udn-masq"
+)
 
 // getNoSNATNodePortRules returns elements to add to the "mgmtport-no-snat-nodeports"
 // set to prevent SNAT of sourceIP when passing through the management port, for an
@@ -185,4 +194,294 @@ func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNCo
 		rules = append(rules, getUDNExternalIPsMarkNFTRules(svcPort, util.GetExternalAndLBIPs(service), netConfig)...)
 	}
 	return rules
+}
+
+// getLocalGatewayPodSubnetMasqueradeNFTRule creates a rule for masquerading traffic from the pod subnet CIDR
+// in local gateway node in a seperate chain which is then called from local gateway masquerade chain.
+//
+//	chain ovn-kube-pod-subnet-masq {
+//		ip saddr 10.244.0.0/24 masquerade
+//		ip6 saddr fd00:10:244:1::/64 masquerade
+//	}
+func getLocalGatewayPodSubnetMasqueradeNFTRule(cidr *net.IPNet) (*knftables.Rule, error) {
+	// Create the rule for masquerading traffic from the CIDR
+	ipPrefix := "ip"
+	if utilnet.IsIPv6CIDR(cidr) {
+		ipPrefix = "ip6"
+	}
+
+	rule := &knftables.Rule{
+		Rule: knftables.Concat(
+			ipPrefix, "saddr", cidr,
+			"masquerade",
+		),
+		Chain: nftablesPodSubnetMasqChain,
+	}
+
+	return rule, nil
+}
+
+// getLocalGatewayNATNFTRules returns the nftables rules for local gateway NAT including masquerade IP rule,
+// pod subnet rules, and UDN masquerade rules (if network segmentation is enabled).
+// This function supports dual-stack by accepting multiple CIDRs and generating rules for all IP families.
+//
+//	chain ovn-kube-local-gw-masq {
+//		comment "OVN local gateway masquerade"
+//		type nat hook postrouting priority srcnat; policy accept;
+//		ip saddr 169.254.0.1 masquerade
+//		ip6 saddr fd69::1 masquerade
+//		jump ovn-kube-pod-subnet-masq
+//		jump ovn-kube-udn-masq
+//	}
+func getLocalGatewayNATNFTRules(cidrs ...*net.IPNet) ([]*knftables.Rule, error) {
+	var rules []*knftables.Rule
+
+	// Process each CIDR to support dual-stack
+	for _, cidr := range cidrs {
+		// Determine IP version and masquerade IP
+		isIPv6 := utilnet.IsIPv6CIDR(cidr)
+		var masqueradeIP net.IP
+		var ipPrefix string
+		if isIPv6 {
+			masqueradeIP = config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP
+			ipPrefix = "ip6"
+		} else {
+			masqueradeIP = config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP
+			ipPrefix = "ip"
+		}
+
+		// Rule1: Masquerade IP rule for the main chain
+		masqRule := &knftables.Rule{
+			Chain: nftablesLocalGatewayMasqChain,
+			Rule: knftables.Concat(
+				ipPrefix, "saddr", masqueradeIP,
+				"masquerade",
+			),
+		}
+		rules = append(rules, masqRule)
+
+		// Rule2: Pod subnet NAT rule for the pod subnet chain
+		podSubnetRule, err := getLocalGatewayPodSubnetMasqueradeNFTRule(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create pod subnet masquerade rule: %w", err)
+		}
+		rules = append(rules, podSubnetRule)
+	}
+
+	// Rule 3: UDN masquerade rules (if network segmentation is enabled)
+	if util.IsNetworkSegmentationSupportEnabled() {
+		if config.IPv4Mode {
+			udnRules, err := getUDNMasqueradeNFTRules(utilnet.IPv4)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create IPv4 UDN masquerade rules: %w", err)
+			}
+			rules = append(rules, udnRules...)
+		}
+		if config.IPv6Mode {
+			udnRules, err := getUDNMasqueradeNFTRules(utilnet.IPv6)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create IPv6 UDN masquerade rules: %w", err)
+			}
+			rules = append(rules, udnRules...)
+		}
+	}
+
+	return rules, nil
+}
+
+// getUDNMasqueradeNFTRules returns the nftables rules for UDN masquerade.
+// Chain creation is handled separately by setupLocalGatewayNATNFTRules.
+//
+//	chain ovn-kube-udn-masq {
+//		comment "OVN UDN masquerade"
+//		ip saddr != 169.254.0.0/29 ip daddr != 10.96.0.0/16 ip saddr 169.254.0.0/17 masquerade
+//		ip6 saddr != fd69::/125 ip daddr != fd00:10:96::/112 ip6 saddr fd69::/112 masquerade
+//	}
+func getUDNMasqueradeNFTRules(ipFamily utilnet.IPFamily) ([]*knftables.Rule, error) {
+	var rules []*knftables.Rule
+
+	// Determine subnet and IP family
+	srcUDNMasqueradePrefix := config.Gateway.V4MasqueradeSubnet
+	ipPrefix := "ip"
+	if ipFamily == utilnet.IPv6 {
+		srcUDNMasqueradePrefix = config.Gateway.V6MasqueradeSubnet
+		ipPrefix = "ip6"
+	}
+
+	// Calculate reserved masquerade prefix (first 8 IPs)
+	_, ipnet, err := net.ParseCIDR(srcUDNMasqueradePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse UDN masquerade subnet: %w", err)
+	}
+	_, prefixLen := ipnet.Mask.Size()
+	defaultNetworkReservedMasqueradePrefix := fmt.Sprintf("%s/%d", ipnet.IP.String(), prefixLen-3)
+
+	// Rule: RETURN for reserved masquerade prefix and service CIDRs
+	// rest of the traffic is masqueraded
+
+	for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+		if utilnet.IPFamilyOfCIDR(svcCIDR) != ipFamily {
+			continue
+		}
+		masqueradeRule := &knftables.Rule{
+			Chain: nftablesUDNMasqChain,
+			Rule: knftables.Concat(
+				ipPrefix, "saddr", "!=", defaultNetworkReservedMasqueradePrefix, // this guarantees we don't SNAT default network masqueradeIPs
+				ipPrefix, "daddr", "!=", svcCIDR, // this guarantees we don't SNAT service traffic
+				ipPrefix, "saddr", srcUDNMasqueradePrefix, // this guarantees we SNAT all UDN MasqueradeIPs traffic leaving the node
+				"masquerade",
+			),
+		}
+		rules = append(rules, masqueradeRule)
+	}
+
+	return rules, nil
+}
+
+// initLocalGatewayNFTNATRules sets up nftables rules for local gateway NAT functionality
+// This function supports dual-stack by accepting multiple CIDRs and generating rules for all IP families
+func initLocalGatewayNFTNATRules(cidrs ...*net.IPNet) error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get nftables helper: %w", err)
+	}
+
+	// Create transaction and apply all chains and rules
+	tx := nft.NewTransaction()
+
+	// Create main local gateway masquerade chain
+	localGwMasqChain := &knftables.Chain{
+		Name:     nftablesLocalGatewayMasqChain,
+		Comment:  knftables.PtrTo("OVN local gateway masquerade"),
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.PostroutingHook),
+		Priority: knftables.PtrTo(knftables.SNATPriority),
+	}
+	tx.Add(localGwMasqChain)
+
+	// Create dedicated pod subnet masquerade chain
+	podSubnetMasqChain := &knftables.Chain{
+		Name: nftablesPodSubnetMasqChain,
+	}
+	tx.Add(podSubnetMasqChain)
+
+	// Create UDN masquerade chain only if network segmentation is enabled
+	var udnMasqChain *knftables.Chain
+	if util.IsNetworkSegmentationSupportEnabled() {
+		udnMasqChain = &knftables.Chain{
+			Name:    nftablesUDNMasqChain,
+			Comment: knftables.PtrTo("OVN UDN masquerade"),
+		}
+		tx.Add(udnMasqChain)
+	}
+
+	// Flush existing chains to ensure clean state
+	tx.Flush(localGwMasqChain)
+	tx.Flush(podSubnetMasqChain)
+	if util.IsNetworkSegmentationSupportEnabled() {
+		tx.Flush(udnMasqChain)
+	}
+
+	// Get the existing local gateway NAT rules
+	localGwRules, err := getLocalGatewayNATNFTRules(cidrs...)
+	if err != nil {
+		return fmt.Errorf("failed to get local gateway NAT rules: %w", err)
+	}
+
+	// Add the main local gateway NAT rules
+	for _, rule := range localGwRules {
+		tx.Add(rule)
+	}
+
+	// Add jump rule from main chain to pod subnet chain
+	jumpToPodSubnetRule := &knftables.Rule{
+		Chain: nftablesLocalGatewayMasqChain,
+		Rule: knftables.Concat(
+			"jump", nftablesPodSubnetMasqChain,
+		),
+	}
+	tx.Add(jumpToPodSubnetRule)
+
+	// Add jump rule to UDN chain only if network segmentation is enabled
+	if util.IsNetworkSegmentationSupportEnabled() {
+		jumpToUDNRule := &knftables.Rule{
+			Chain: nftablesLocalGatewayMasqChain,
+			Rule: knftables.Concat(
+				"jump", nftablesUDNMasqChain,
+			),
+		}
+		tx.Add(jumpToUDNRule)
+	}
+
+	err = nft.Run(context.TODO(), tx)
+	if err != nil {
+		return fmt.Errorf("failed to setup local gateway NAT nftables rules: %w", err)
+	}
+
+	return nil
+}
+
+// addLocalGatewayPodSubnetNFTRules adds nftables rules for pod subnet masquerading for multiple CIDRs
+// These rules are added to the dedicated pod subnet masquerade chain.
+func addLocalGatewayPodSubnetNFTRules(cidrs ...*net.IPNet) error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get nftables helper: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+
+	// Ensure the pod subnet chain exists
+	podSubnetChain := &knftables.Chain{
+		Name: nftablesPodSubnetMasqChain,
+	}
+	tx.Add(podSubnetChain)
+
+	// Flush the chain to remove all existing rules
+	tx.Flush(podSubnetChain)
+
+	for _, cidr := range cidrs {
+		rule, err := getLocalGatewayPodSubnetMasqueradeNFTRule(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to create nftables rules for CIDR %s: %w", cidr.String(), err)
+		}
+
+		// Add the rule
+		tx.Add(rule)
+	}
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to add pod subnet NAT rules: %w", err)
+	}
+
+	return nil
+}
+
+// delLocalGatewayPodSubnetNFTRules removes nftables rules for pod subnet masquerading for multiple CIDRs
+// Since we use a separate chain, we can simply flush it to remove all pod subnet rules.
+func delLocalGatewayPodSubnetNFTRules() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get nftables helper: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+
+	// In shared gateway mode, this chain might not exist if its
+	// not migration from local gateway mode. In that case, let's
+	// use the idiomatic way of adding the chain before trying to flush it.
+	// I anyways also have the knftables.IsNotFound() check in the caller later.
+	tx.Add(&knftables.Chain{
+		Name: nftablesPodSubnetMasqChain,
+	})
+
+	// Simply flush the dedicated pod subnet masquerade chain
+	// This removes all pod subnet masquerade rules at once
+	tx.Flush(&knftables.Chain{Name: nftablesPodSubnetMasqChain})
+
+	if err := nft.Run(context.TODO(), tx); err != nil && !knftables.IsNotFound(err) {
+		return fmt.Errorf("failed to delete pod subnet NAT rules: %w", err)
+	}
+
+	return nil
 }

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -203,16 +203,32 @@ func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNCo
 //		ip saddr 10.244.0.0/24 masquerade
 //		ip6 saddr fd00:10:244:1::/64 masquerade
 //	}
-func getLocalGatewayPodSubnetMasqueradeNFTRule(cidr *net.IPNet) (*knftables.Rule, error) {
+//
+// If isAdvertisedNetwork is true, masquerade only when destination matches remote node IPs.
+// Rules look like:
+// ip saddr 10.244.0.0/24 ip daddr @remote-node-ips-v4 masquerade
+// ip6 saddr fd00:10:244:1::/64 ip6 daddr @remote-node-ips-v6 masquerade
+func getLocalGatewayPodSubnetMasqueradeNFTRule(cidr *net.IPNet, isAdvertisedNetwork bool) (*knftables.Rule, error) {
 	// Create the rule for masquerading traffic from the CIDR
-	ipPrefix := "ip"
+	var ipPrefix string
+	var remoteNodeSetName string
 	if utilnet.IsIPv6CIDR(cidr) {
 		ipPrefix = "ip6"
+		remoteNodeSetName = types.NFTRemoteNodeIPsv6
+	} else {
+		ipPrefix = "ip"
+		remoteNodeSetName = types.NFTRemoteNodeIPsv4
 	}
 
+	// If network is advertised, only masquerade if destination is a remote node IP
+	var optionalDestRules []string
+	if isAdvertisedNetwork {
+		optionalDestRules = []string{ipPrefix, "daddr", "@", remoteNodeSetName}
+	}
 	rule := &knftables.Rule{
 		Rule: knftables.Concat(
 			ipPrefix, "saddr", cidr,
+			optionalDestRules,
 			"masquerade",
 		),
 		Chain: nftablesPodSubnetMasqChain,
@@ -261,7 +277,7 @@ func getLocalGatewayNATNFTRules(cidrs ...*net.IPNet) ([]*knftables.Rule, error) 
 		rules = append(rules, masqRule)
 
 		// Rule2: Pod subnet NAT rule for the pod subnet chain
-		podSubnetRule, err := getLocalGatewayPodSubnetMasqueradeNFTRule(cidr)
+		podSubnetRule, err := getLocalGatewayPodSubnetMasqueradeNFTRule(cidr, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create pod subnet masquerade rule: %w", err)
 		}
@@ -421,9 +437,12 @@ func initLocalGatewayNFTNATRules(cidrs ...*net.IPNet) error {
 	return nil
 }
 
-// addLocalGatewayPodSubnetNFTRules adds nftables rules for pod subnet masquerading for multiple CIDRs
+// addOrUpdateLocalGatewayPodSubnetNFTRules adds nftables rules for pod subnet masquerading for multiple CIDRs
 // These rules are added to the dedicated pod subnet masquerade chain.
-func addLocalGatewayPodSubnetNFTRules(cidrs ...*net.IPNet) error {
+// If the rules already exist, they are updated.
+// If isAdvertisedNetwork is true, the masquerade rules also get a destination match
+// that matches the remote node IP set.
+func addOrUpdateLocalGatewayPodSubnetNFTRules(isAdvertisedNetwork bool, cidrs ...*net.IPNet) error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("failed to get nftables helper: %w", err)
@@ -438,10 +457,12 @@ func addLocalGatewayPodSubnetNFTRules(cidrs ...*net.IPNet) error {
 	tx.Add(podSubnetChain)
 
 	// Flush the chain to remove all existing rules
+	// if network toggles between advertised and non-advertised, we need to flush the chain and re-add correct rules
 	tx.Flush(podSubnetChain)
 
+	// Add the new rules for each CIDR
 	for _, cidr := range cidrs {
-		rule, err := getLocalGatewayPodSubnetMasqueradeNFTRule(cidr)
+		rule, err := getLocalGatewayPodSubnetMasqueradeNFTRule(cidr, isAdvertisedNetwork)
 		if err != nil {
 			return fmt.Errorf("failed to create nftables rules for CIDR %s: %w", cidr.String(), err)
 		}

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -366,12 +366,18 @@ func initLocalGatewayNFTNATRules(cidrs ...*net.IPNet) error {
 	tx := nft.NewTransaction()
 
 	// Create main local gateway masquerade chain
+	// Use priority 101 instead of defaultknftables.SNATPriority (100) to ensure
+	// iptables egress IP rules in OVN-KUBE-EGRESS-IP-MULTI-NIC chain run first
+	// this also ensure for egress-services, the
+	// 	chain egress-services {
+	//	type nat hook postrouting priority srcnat; policy accept;
+	// is called before the local gateway masquerade chain
 	localGwMasqChain := &knftables.Chain{
 		Name:     nftablesLocalGatewayMasqChain,
 		Comment:  knftables.PtrTo("OVN local gateway masquerade"),
 		Type:     knftables.PtrTo(knftables.NATType),
 		Hook:     knftables.PtrTo(knftables.PostroutingHook),
-		Priority: knftables.PtrTo(knftables.SNATPriority),
+		Priority: knftables.PtrTo(knftables.BaseChainPriority("101")),
 	}
 	tx.Add(localGwMasqChain)
 

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -644,17 +644,20 @@ func (udng *UserDefinedNetworkGateway) getV6MasqueradeIP() (*net.IPNet, error) {
 
 // constructUDNVRFIPRules constructs rules that redirect matching packets
 // into the corresponding UDN VRF routing table.
-// If the network is not advertised, an example of the rules we set for a
-// network is:
-// 2000:   from all fwmark 0x1001 lookup 1007
-// 2000:   from all to 169.254.0.12 lookup 1007
-// 2000:   from all fwmark 0x1002 lookup 1009
-// 2000:   from all to 169.254.0.14 lookup 1009
-// If the network is advertised, an example of the rules we set for a network is:
+// If the network is not advertised, an example of the rules we set for two
+// networks is:
+// 2000:	from all fwmark 0x1001 lookup 1007
+// 2000:	from all to 169.254.0.12 lookup 1007
+// 2000:	from all fwmark 0x1002 lookup 1009
+// 2000:	from all to 169.254.0.14 lookup 1009
+// If the network is advertised, an example of the rules we set for two
+// networks is:
 // 2000:	from all fwmark 0x1001 lookup 1007
 // 2000:	from all to 10.132.0.0/14 lookup 1007
+// 2000:	from all to 169.254.0.12 lookup 1007
 // 2000:	from all fwmark 0x1001 lookup 1009
 // 2000:	from all to 10.134.0.0/14 lookup 1009
+// 2000:	from all to 169.254.0.14 lookup 1009
 func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(isNetworkAdvertised bool) ([]netlink.Rule, []netlink.Rule, error) {
 	var addIPRules []netlink.Rule
 	var delIPRules []netlink.Rule
@@ -693,7 +696,7 @@ func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(isNetworkAdvertise
 		delIPRules = append(delIPRules, subnetIPRules...)
 	default:
 		addIPRules = append(addIPRules, subnetIPRules...)
-		delIPRules = append(delIPRules, masqIPRules...)
+		addIPRules = append(addIPRules, masqIPRules...)
 	}
 	return addIPRules, delIPRules, nil
 }

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1625,7 +1625,6 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 			cidr := ""
 			if config.IPv4Mode {
 				cidr = "100.128.0.0/16/24"
-
 			}
 			if config.IPv4Mode && config.IPv6Mode {
 				cidr += ",ae70::/60/64"
@@ -1711,8 +1710,6 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					table:    1007,
 					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
 				},
-			},
-			deleteRules: []testRule{
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
@@ -1738,8 +1735,6 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					table:    1009,
 					dst:      *ovntest.MustParseIPNet("ae70::/60"),
 				},
-			},
-			deleteRules: []testRule{
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
@@ -1777,8 +1772,6 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					table:    1010,
 					dst:      *ovntest.MustParseIPNet("ae70::/60"),
 				},
-			},
-			deleteRules: []testRule{
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
@@ -1813,9 +1806,9 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 				cidr = "100.128.0.0/16/24"
 			}
 			if config.IPv4Mode && config.IPv6Mode {
-				cidr += ",ae70::/60"
+				cidr += ",ae70::/60/64"
 			} else if config.IPv6Mode {
-				cidr = "ae70::/60"
+				cidr = "ae70::/60/64"
 			}
 			nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 				types.Layer3Topology, cidr, types.NetworkRolePrimary)
@@ -1844,6 +1837,8 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 			udnGateway.vrfTableId = test.vrftableID
 			rules, delRules, err := udnGateway.constructUDNVRFIPRules(true)
 			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(rules).To(HaveLen(len(test.expectedRules)))
+			g.Expect(delRules).To(HaveLen(len(test.deleteRules)))
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1143,7 +1143,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(69))                                      // 18 UDN Flows and 5 advertisedUDN flows are added by default
+			Expect(flowMap["DEFAULT"]).To(HaveLen(71))                                      // 18 UDN Flows, 5 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -1166,7 +1166,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				// Check flows for default network service CIDR.
 				bridgeconfig.CheckDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
 
-				// Expect exactly one flow per advertised UDN for table 2 and table 0 for service isolation.
+				// Expect exactly two flow per advertised UDN for table 2 and table 0 for service isolation.
+				// but one of the flows used by advertised UDNs is already tracked and used by default UDNs hence not
+				// counted here but in the check above for default svc isolation flows.
 				bridgeconfig.CheckAdvertisedUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", svcCIDR, 2)
 			}
 

--- a/go-controller/pkg/node/node_nftables.go
+++ b/go-controller/pkg/node/node_nftables.go
@@ -13,8 +13,8 @@ import (
 
 const nftPMTUDChain = "no-pmtud"
 
-// setupPMTUDNFTSets sets up the NFT sets that contain remote Kubernetes node IPs
-func setupPMTUDNFTSets() error {
+// setupRemoteNodeNFTSets sets up the NFT sets that contain remote Kubernetes node IPs
+func setupRemoteNodeNFTSets() error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("failed to get nftables helper: %w", err)
@@ -22,12 +22,12 @@ func setupPMTUDNFTSets() error {
 
 	tx := nft.NewTransaction()
 	tx.Add(&knftables.Set{
-		Name:    types.NFTNoPMTUDRemoteNodeIPsv4,
+		Name:    types.NFTRemoteNodeIPsv4,
 		Comment: knftables.PtrTo("Block egress ICMP needs frag to remote Kubernetes nodes"),
 		Type:    "ipv4_addr",
 	})
 	tx.Add(&knftables.Set{
-		Name:    types.NFTNoPMTUDRemoteNodeIPsv6,
+		Name:    types.NFTRemoteNodeIPsv6,
 		Comment: knftables.PtrTo("Block egress ICMPv6 packet too big to remote Kubernetes nodes"),
 		Type:    "ipv6_addr",
 	})
@@ -68,7 +68,7 @@ func setupPMTUDNFTChain() error {
 		tx.Add(&knftables.Rule{
 			Chain: nftPMTUDChain,
 			Rule: knftables.Concat(
-				"ip daddr @"+types.NFTNoPMTUDRemoteNodeIPsv4,
+				"ip daddr @"+types.NFTRemoteNodeIPsv4,
 				"meta l4proto icmp",
 				"icmp type 3", // type 3 == Destination Unreachable
 				"icmp code 4", // code 4 indicates fragmentation needed
@@ -85,7 +85,7 @@ func setupPMTUDNFTChain() error {
 				"meta l4proto icmpv6", // match on ICMPv6 packets
 				"icmpv6 type 2",       // type 2 == Packet Too Big (PMTUD)
 				"icmpv6 code 0",       // code 0 for that message
-				"ip6 daddr @"+types.NFTNoPMTUDRemoteNodeIPsv6,
+				"ip6 daddr @"+types.NFTRemoteNodeIPsv6,
 				counterIfDebug,
 				"drop", // drop the packet
 			),

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -812,7 +812,7 @@ func (oc *BaseSecondaryNetworkController) allowPersistentIPs() bool {
 
 // buildUDNEgressSNAT is used to build the conditional SNAT required on L3 and L2 UDNs to
 // steer traffic correctly via mp0 when leaving OVN to the host
-func (bsnc *BaseSecondaryNetworkController) buildUDNEgressSNAT(localPodSubnets []*net.IPNet, outputPort string) ([]*nbdb.NAT, error) {
+func (bsnc *BaseSecondaryNetworkController) buildUDNEgressSNAT(localPodSubnets []*net.IPNet, outputPort string, isUDNAdvertised bool) ([]*nbdb.NAT, error) {
 	if len(localPodSubnets) == 0 {
 		return nil, nil // nothing to do
 	}
@@ -828,10 +828,11 @@ func (bsnc *BaseSecondaryNetworkController) buildUDNEgressSNAT(localPodSubnets [
 		types.TopologyExternalID: bsnc.TopologyType(),
 	}
 	for _, localPodSubnet := range localPodSubnets {
+		ipFamily := utilnet.IPv4
+		masqIP, err = udn.AllocateV4MasqueradeIPs(networkID)
 		if utilnet.IsIPv6CIDR(localPodSubnet) {
 			masqIP, err = udn.AllocateV6MasqueradeIPs(networkID)
-		} else {
-			masqIP, err = udn.AllocateV4MasqueradeIPs(networkID)
+			ipFamily = utilnet.IPv6
 		}
 		if err != nil {
 			return nil, err
@@ -839,10 +840,41 @@ func (bsnc *BaseSecondaryNetworkController) buildUDNEgressSNAT(localPodSubnets [
 		if masqIP == nil {
 			return nil, fmt.Errorf("masquerade IP cannot be empty network %s (%d): %v", bsnc.GetNetworkName(), networkID, err)
 		}
-		snats = append(snats, libovsdbops.BuildSNATWithMatch(&masqIP.ManagementPort.IP, localPodSubnet, outputPort,
-			extIDs, getMasqueradeManagementIPSNATMatch(dstMac.String())))
+		if !isUDNAdvertised {
+			snats = append(snats, libovsdbops.BuildSNATWithMatch(&masqIP.ManagementPort.IP, localPodSubnet, outputPort,
+				extIDs, getMasqueradeManagementIPSNATMatch(dstMac.String())))
+		} else {
+			// For advertised networks, we need to SNAT any traffic leaving the pods from these networks towards the node IPs
+			// in the cluster. In order to do such a conditional SNAT, we need an address set that contains the node IPs in the cluster.
+			// Given that egressIP feature already has an address set containing these nodeIPs owned by the default network controller, let's re-use it.
+			dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, DefaultNetworkControllerName)
+			addrSet, err := bsnc.addressSetFactory.GetAddressSet(dbIDs)
+			if err != nil {
+				return nil, fmt.Errorf("cannot ensure that addressSet %s exists: %w", NodeIPAddrSetName, err)
+			}
+			ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := addrSet.GetASHashNames()
+
+			snats = append(snats, libovsdbops.BuildSNATWithMatch(&masqIP.ManagementPort.IP, localPodSubnet, outputPort,
+				extIDs, fmt.Sprintf("%s && (%s)", getMasqueradeManagementIPSNATMatch(dstMac.String()),
+					getClusterNodesDestinationBasedSNATMatch(ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS, ipFamily))))
+		}
 	}
 	return snats, nil
+}
+
+func getMasqueradeManagementIPSNATMatch(dstMac string) string {
+	return fmt.Sprintf("eth.dst == %s", dstMac)
+}
+
+// getClusterNodesDestinationBasedSNATMatch creates destination-based SNAT match for the specified IP family
+func getClusterNodesDestinationBasedSNATMatch(ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS string, ipFamily utilnet.IPFamily) string {
+	var match string
+	if ipFamily == utilnet.IPv4 {
+		match = fmt.Sprintf("ip4.dst == $%s", ipv4ClusterNodeIPAS)
+	} else {
+		match = fmt.Sprintf("ip6.dst == $%s", ipv6ClusterNodeIPAS)
+	}
+	return match
 }
 
 func (bsnc *BaseSecondaryNetworkController) ensureDHCP(pod *corev1.Pod, podAnnotation *util.PodAnnotation, lsp *nbdb.LogicalSwitchPort) error {
@@ -865,10 +897,6 @@ func (bsnc *BaseSecondaryNetworkController) ensureDHCP(pod *corev1.Pod, podAnnot
 	opts = append(opts, kubevirt.WithIPv4DNSServer(ipv4DNSServer), kubevirt.WithIPv6DNSServer(ipv6DNSServer))
 
 	return kubevirt.EnsureDHCPOptionsForLSP(bsnc.controllerName, bsnc.nbClient, pod, podAnnotation.IPs, lsp, opts...)
-}
-
-func getMasqueradeManagementIPSNATMatch(dstMac string) string {
-	return fmt.Sprintf("eth.dst == %s", dstMac)
 }
 
 func (bsnc *BaseSecondaryNetworkController) requireDHCP(pod *corev1.Pod) bool {

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -8,10 +8,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -234,9 +236,41 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *corev1.Namespace
 				if err != nil {
 					errors = append(errors, err)
 				} else {
-					if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
-						errors = append(errors, err)
-					} else if err = addOrUpdatePodSNAT(oc.nbClient, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, podAnnotation.IPs); err != nil {
+					// Helper function to handle the complex SNAT operations
+					handleSNATOps := func() error {
+						extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName)
+						if err != nil {
+							return err
+						}
+
+						var ops []ovsdb.Operation
+						// Handle each pod IP individually since each IP family needs its own SNAT match
+						for _, podIP := range podAnnotation.IPs {
+							ipFamily := utilnet.IPv4
+							if utilnet.IsIPv6CIDR(podIP) {
+								ipFamily = utilnet.IPv6
+							}
+							snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(oc.nbClient, oc.GetNetInfo(), pod.Spec.NodeName, oc.isPodNetworkAdvertisedAtNode(pod.Spec.NodeName), ipFamily)
+							if err != nil {
+								return fmt.Errorf("failed to get SNAT match for node %s for network %s: %v", pod.Spec.NodeName, oc.GetNetworkName(), err)
+							}
+							ops, err = addOrUpdatePodSNATOps(oc.nbClient, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, []*net.IPNet{podIP}, snatMatch, ops)
+							if err != nil {
+								return err
+							}
+						}
+
+						// Execute all operations in a single transaction
+						if len(ops) > 0 {
+							_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+							if err != nil {
+								return fmt.Errorf("failed to update SNAT for pod %s on router %s: %v", pod.Name, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), err)
+							}
+						}
+						return nil
+					}
+
+					if err := handleSNATOps(); err != nil {
 						errors = append(errors, err)
 					}
 				}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
@@ -310,13 +311,26 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *corev1.Pod) (err error) 
 		if err != nil {
 			return err
 		}
-	} else if config.Gateway.DisableSNATMultipleGWs && !oc.isPodNetworkAdvertisedAtNode(pod.Spec.NodeName) {
+	} else if config.Gateway.DisableSNATMultipleGWs {
 		// Add NAT rules to pods if disable SNAT is set and does not have
 		// namespace annotations to go through external egress router
 		if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 			return err
-		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, podAnnotation.IPs, ops); err != nil {
-			return err
+		} else {
+			// Handle each pod IP individually since each IP family needs its own SNAT match
+			for _, podIP := range podAnnotation.IPs {
+				ipFamily := utilnet.IPv4
+				if utilnet.IsIPv6CIDR(podIP) {
+					ipFamily = utilnet.IPv6
+				}
+				snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(oc.nbClient, oc.GetNetInfo(), pod.Spec.NodeName, oc.isPodNetworkAdvertisedAtNode(pod.Spec.NodeName), ipFamily)
+				if err != nil {
+					return fmt.Errorf("failed to get SNAT match for node %s for network %s: %v", pod.Spec.NodeName, oc.GetNetworkName(), err)
+				}
+				if ops, err = addOrUpdatePodSNATOps(oc.nbClient, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, []*net.IPNet{podIP}, snatMatch, ops); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -857,7 +857,8 @@ func (oc *SecondaryLayer3NetworkController) addUpdateRemoteNodeEvent(node *corev
 	return err
 }
 
-// addNodeSubnetEgressSNAT adds the SNAT on each node's ovn-cluster-router in L3 networks
+// addOrUpdateUDNNodeSubnetEgressSNAT adds or updates the SNAT on each node's ovn-cluster-router in L3 networks for each UDN
+// Based on the isUDNAdvertised flag, the SNAT matches are slightly different
 // snat eth.dst == d6:cf:fd:2c:a6:44 169.254.0.12 10.128.0.0/24
 // snat eth.dst == d6:cf:fd:2c:a6:44 169.254.0.12 2010:100:200::/64
 // these SNATs are required for pod2Egress traffic in LGW mode and pod2SameNode traffic in SGW mode to function properly on UDNs
@@ -867,9 +868,12 @@ func (oc *SecondaryLayer3NetworkController) addUpdateRemoteNodeEvent(node *corev
 // externalIP = "169.254.0.12"; which is the masqueradeIP for this L3 UDN
 // so all in all we want to condionally SNAT all packets that are coming from pods hosted on this node,
 // which are leaving via UDN's mpX interface to the UDN's masqueradeIP.
-func (oc *SecondaryLayer3NetworkController) addUDNNodeSubnetEgressSNAT(localPodSubnets []*net.IPNet, node *corev1.Node) error {
+// If isUDNAdvertised is true, then we want to SNAT all packets that are coming from pods on this network
+// leaving towards nodeIPs on the cluster to masqueradeIP. If network is advertise then the SNAT looks like this:
+// "eth.dst == 0a:58:5d:5d:00:02 && (ip4.dst == $a712973235162149816)" "169.254.0.36" "93.93.0.0/24"
+func (oc *SecondaryLayer3NetworkController) addOrUpdateUDNNodeSubnetEgressSNAT(localPodSubnets []*net.IPNet, node *corev1.Node, isUDNAdvertised bool) error {
 	outputPort := types.RouterToSwitchPrefix + oc.GetNetworkScopedName(node.Name)
-	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort)
+	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort, isUDNAdvertised)
 	if err != nil {
 		return fmt.Errorf("failed to build UDN masquerade SNATs for network %q on node %q, err: %w",
 			oc.GetNetworkName(), node.Name, err)
@@ -882,28 +886,6 @@ func (oc *SecondaryLayer3NetworkController) addUDNNodeSubnetEgressSNAT(localPodS
 	}
 	if err := libovsdbops.CreateOrUpdateNATs(oc.nbClient, router, nats...); err != nil {
 		return fmt.Errorf("failed to update SNAT for node subnet on router: %q for network %q, error: %w",
-			oc.GetNetworkScopedClusterRouterName(), oc.GetNetworkName(), err)
-	}
-	return nil
-}
-
-// deleteUDNNodeSubnetEgressSNAT deletes SNAT rule from network specific
-// ovn_cluster_router depending on whether the network is advertised or not
-func (oc *SecondaryLayer3NetworkController) deleteUDNNodeSubnetEgressSNAT(localPodSubnets []*net.IPNet, node *corev1.Node) error {
-	outputPort := types.RouterToSwitchPrefix + oc.GetNetworkScopedName(node.Name)
-	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort)
-	if err != nil {
-		return fmt.Errorf("failed to build UDN masquerade SNATs for network %q on node %q, err: %w",
-			oc.GetNetworkName(), node.Name, err)
-	}
-	if len(nats) == 0 {
-		return nil // nothing to do
-	}
-	router := &nbdb.LogicalRouter{
-		Name: oc.GetNetworkScopedClusterRouterName(),
-	}
-	if err := libovsdbops.DeleteNATs(oc.nbClient, router, nats...); err != nil {
-		return fmt.Errorf("failed to delete SNAT for node subnet on router: %q for network %q, error: %w",
 			oc.GetNetworkScopedClusterRouterName(), oc.GetNetworkName(), err)
 	}
 	return nil
@@ -923,19 +905,17 @@ func (oc *SecondaryLayer3NetworkController) addNode(node *corev1.Node) ([]*net.I
 		return nil, err
 	}
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
-		if !util.IsPodNetworkAdvertisedAtNode(oc, node.Name) {
-			if err := oc.addUDNNodeSubnetEgressSNAT(hostSubnets, node); err != nil {
-				return nil, err
-			}
+		isUDNAdvertised := util.IsPodNetworkAdvertisedAtNode(oc, node.Name)
+		if err := oc.addOrUpdateUDNNodeSubnetEgressSNAT(hostSubnets, node, isUDNAdvertised); err != nil {
+			return nil, err
+		}
+		if !isUDNAdvertised {
 			if util.IsRouteAdvertisementsEnabled() {
 				if err := oc.deleteAdvertisedNetworkIsolation(node.Name); err != nil {
 					return nil, err
 				}
 			}
 		} else {
-			if err := oc.deleteUDNNodeSubnetEgressSNAT(hostSubnets, node); err != nil {
-				return nil, err
-			}
 			if err := oc.addAdvertisedNetworkIsolation(node.Name); err != nil {
 				return nil, err
 			}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -312,13 +312,13 @@ const (
 	// CUDNPrefix of all CUDN network names
 	CUDNPrefix = "cluster_udn_"
 
-	// NFTNoPMTUDRemoteNodeIPsv4 is a set used to track remote node IPs that do not belong to
+	// NFTRemoteNodeIPsv4 is a set used to track remote node v4IPs that do not belong to
 	// the local node's subnet.
-	NFTNoPMTUDRemoteNodeIPsv4 = "no-pmtud-remote-node-ips-v4"
+	NFTRemoteNodeIPsv4 = "remote-node-ips-v4"
 
-	// NFTNoPMTUDRemoteNodeIPsv6 is a set used to track remote node IPs that do not belong to
+	// NFTRemoteNodeIPsv6 is a set used to track remote node v6IPs that do not belong to
 	// the local node's subnet.
-	NFTNoPMTUDRemoteNodeIPsv6 = "no-pmtud-remote-node-ips-v6"
+	NFTRemoteNodeIPsv6 = "remote-node-ips-v6"
 
 	// Metrics
 	MetricOvnkubeNamespace               = "ovnkube"

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -82,7 +82,6 @@ type NetInfo interface {
 	GetNetworkScopedExtPortName(bridgeID, nodeName string) string
 	GetNetworkScopedLoadBalancerName(lbName string) string
 	GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string
-	GetNetworkScopedClusterSubnetSNATMatch(nodeName string) string
 
 	// GetNetInfo is an identity method used to get the specific NetInfo
 	// implementation
@@ -543,10 +542,6 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedLoadBalancerGroupName(lbGroupName s
 	return nInfo.GetNetworkScopedName(lbGroupName)
 }
 
-func (nInfo *DefaultNetInfo) GetNetworkScopedClusterSubnetSNATMatch(_ string) string {
-	return ""
-}
-
 func (nInfo *DefaultNetInfo) canReconcile(netInfo NetInfo) bool {
 	_, ok := netInfo.(*DefaultNetInfo)
 	return ok
@@ -736,13 +731,6 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedLoadBalancerName(lbName string) s
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string {
 	return nInfo.GetNetworkScopedName(lbGroupName)
-}
-
-func (nInfo *secondaryNetInfo) GetNetworkScopedClusterSubnetSNATMatch(nodeName string) string {
-	if nInfo.TopologyType() != types.Layer2Topology {
-		return ""
-	}
-	return fmt.Sprintf("outport == %q", types.GWRouterToExtSwitchPrefix+nInfo.GetNetworkScopedGWRouterName(nodeName))
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -980,7 +980,8 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					// pod -> node traffic should use the node's IP as the source for advertised UDNs.
 					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(hostNetworkPort)) + "/clientip", clientNodeIP, false
 				}),
-			ginkgo.Entry("UDN pod to the same node nodeport service in default network should work (should it? :)...)",
+			ginkgo.Entry("UDN pod to the same node nodeport service in default network should not work",
+				// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5410
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 					clientPod := podsNetA[0]
 					// podsNetA[0] is on nodes[0]. We need the same node. Let's hit the nodeport on nodes[0].
@@ -989,7 +990,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
 					nodePort := svcNetDefault.Spec.Ports[0].NodePort
 
-					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", curlConnectionTimeoutCode, true
 				}),
 			ginkgo.Entry("UDN pod to a different node nodeport service in default network should work",
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/label"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -626,7 +625,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				}
 
 				// create host networked Pods
-				_, err := createPod(f, node.Name+"-hostnet-ep", node.Name, f.Namespace.Name, []string{}, map[string]string{}, func(p *v1.Pod) {
+				_, err := createPod(f, node.Name+"-hostnet-ep", node.Name, f.Namespace.Name, []string{}, map[string]string{}, func(p *corev1.Pod) {
 					p.Spec.Containers[0].Args = args
 					p.Spec.HostNetwork = true
 				})
@@ -652,6 +651,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			svc.Spec.Ports = []corev1.ServicePort{{Port: 8080}}
 			familyPolicy := corev1.IPFamilyPolicyPreferDualStack
 			svc.Spec.IPFamilyPolicy = &familyPolicy
+			svc.Spec.Type = corev1.ServiceTypeNodePort
 			svcNetA, err = f.ClientSet.CoreV1().Services(pod.Namespace).Create(context.Background(), svc, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -675,6 +675,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			svc.Name = fmt.Sprintf("service-default")
 			svc.Namespace = "default"
 			svc.Spec.Selector = pod.Labels
+			svc.Spec.Type = corev1.ServiceTypeNodePort
 			svcNetDefault, err = f.ClientSet.CoreV1().Services(pod.Namespace).Create(context.Background(), svc, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -754,6 +755,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			}
 			if svcNetDefault != nil {
 				err = f.ClientSet.CoreV1().Services(svcNetDefault.Namespace).Delete(context.Background(), svcNetDefault.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				svcNetDefault = nil
 			}
 
@@ -954,11 +956,11 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					//    options [mss 1360,sackOK,TS val 3006752321 ecr 0,nop,wscale 7], length 0
 					// 10:59:55.352404 ovn-k8s-mp87 In  ifindex 186 0a:58:5d:5d:01:01 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 63, id 57264,
 					//    offset 0, flags [DF], proto TCP (6), length 60)
-					//    93.93.1.5.36363 > 172.18.0.2.25022: Flags [S], cksum 0xe0b7 (correct), seq 3879759281, win 65280,
+					//    169.154.169.12.36363 > 172.18.0.2.25022: Flags [S], cksum 0xe0b7 (correct), seq 3879759281, win 65280,
 					//    options [mss 1360,sackOK,TS val 3006752321 ecr 0,nop,wscale 7], length 0
 					// 10:59:55.352461 ovn-k8s-mp87 Out ifindex 186 0a:58:5d:5d:01:02 ethertype IPv4 (0x0800), length 60: (tos 0x0, ttl 64, id 0,
 					//    offset 0, flags [DF], proto TCP (6), length 40)
-					//    172.18.0.2.25022 > 93.93.1.5.36363: Flags [R.], cksum 0x609d (correct), seq 0, ack 3879759282, win 0, length 0
+					//    172.18.0.2.25022 > 169.154.169.12.36363: Flags [R.], cksum 0x609d (correct), seq 0, ack 3879759282, win 0, length 0
 					//    10:59:55.352927 319594f193d4d_3 Out ifindex 191 0a:58:5d:5d:01:02 ethertype IPv4 (0x0800), length 60: (tos 0x0, ttl 64, id 0,
 					//    offset 0, flags [DF], proto TCP (6), length 40)
 					//    172.18.0.2.25022 > 93.93.1.5.36363: Flags [R.], cksum 0x609d (correct), seq 0, ack 1, win 0, length 0
@@ -971,25 +973,90 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), podsNetA[2].Spec.NodeName, metav1.GetOptions{})
 					framework.ExpectNoError(err)
 					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
-					errBool := false
-					out := ""
-					if cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 {
-						// FIXME: this should be removed once we add the SNAT for pod->node traffic
-						// We now permit asymmetric traffic on LGW. This prevents the issue from occurring with IPv6.
-						// However, for IPv4 LGW rp_filter is still blocking the replies.
-						// The situation is different on SGW as we don't allow asymmetric traffic at all, which is why IPv6 traffic fails there too.
-						if ipFamilyIndex == ipFamilyV4 || !isLocalGWModeEnabled() {
-							// FIXME: fix assymmetry in L2 UDNs
-							// bad behaviour: packet is coming from other node -> entering eth0 -> bretho and here kernel drops the packet since
-							// rp_filter is set to 1 in breth0 and there is an iprule that sends the packet to mpX interface so kernel sees the packet
-							// having return path different from the incoming interface.
-							// The SNAT to nodeIP should fix this.
-							// this causes curl timeout with code 28
-							errBool = true
-							out = curlConnectionTimeoutCode
-						}
-					}
-					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(hostNetworkPort)) + "/hostname", out, errBool
+
+					clientNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					clientNodeIP := clientNode.Status.Addresses[ipFamilyIndex].Address
+					// pod -> node traffic should use the node's IP as the source for advertised UDNs.
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(hostNetworkPort)) + "/clientip", clientNodeIP, false
+				}),
+			ginkgo.Entry("UDN pod to the same node nodeport service in default network should work (should it? :)...)",
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					clientPod := podsNetA[0]
+					// podsNetA[0] is on nodes[0]. We need the same node. Let's hit the nodeport on nodes[0].
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[0].Name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
+					nodePort := svcNetDefault.Spec.Ports[0].NodePort
+
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+				}),
+			ginkgo.Entry("UDN pod to a different node nodeport service in default network should work",
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					clientPod := podsNetA[0]
+					// podsNetA[0] is on nodes[0]. We need a different node. podNetDefault is on nodes[1].
+					// The service is backed by podNetDefault. Let's hit the nodeport on nodes[2].
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[2].Name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
+					nodePort := svcNetDefault.Spec.Ports[0].NodePort
+
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+				}),
+			ginkgo.Entry("UDN pod to the same node nodeport service in same UDN network should work",
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					clientPod := podsNetA[0]
+					// The service is backed by pods in podsNetA.
+					// We want to hit the nodeport on the same node.
+					// client is on nodes[0]. Let's hit nodeport on nodes[0].
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[0].Name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
+					nodePort := svcNetA.Spec.Ports[0].NodePort
+
+					// The service can be backed by any of the pods in podsNetA, so we can't reliably check the output hostname.
+					// Just check that the connection is successful.
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+				}),
+			ginkgo.Entry("UDN pod to a different node nodeport service in same UDN network should work",
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					clientPod := podsNetA[0]
+					// The service is backed by pods in podsNetA.
+					// We want to hit the nodeport on a different node.
+					// client is on nodes[0]. Let's hit nodeport on nodes[2].
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[2].Name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
+					nodePort := svcNetA.Spec.Ports[0].NodePort
+
+					// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+				}),
+			ginkgo.Entry("UDN pod to the same node nodeport service in different UDN network should not work",
+				// FIXME: This test should work: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					clientPod := podsNetA[0]
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[0].Name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
+					nodePort := svcNetB.Spec.Ports[0].NodePort
+
+					// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", curlConnectionTimeoutCode, true
+				}),
+			ginkgo.Entry("UDN pod to a different node nodeport service in different UDN network should work",
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					clientPod := podsNetA[0]
+					// The service is backed by podNetB.
+					// We want to hit the nodeport on a different node from the client.
+					// client is on nodes[0]. Let's hit nodeport on nodes[2].
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[2].Name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					nodeIP := node.Status.Addresses[ipFamilyIndex].Address
+					nodePort := svcNetB.Spec.Ports[0].NodePort
+
+					// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
+					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
 				}),
 		)
 


### PR DESCRIPTION
CREDIT: To @trozet for suggesting the idea around SNATing all node related traffic to nodeIP for BGP and @jcaamano for coming up with design: https://issues.redhat.com/browse/OCPBUGS-56506?focusedId=27304963&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27304963

## 📑 Description

Today when default network or UDN networks are
advertised using RAs the nodes also learn the
routes of other nodes' pod subnets in the cluster.

Example snippet of exposing a UDN network on
default vrf (non-vrflite usecase):

```
root@ovn-worker2:/# ip r show table 1048
default via 172.18.0.1 dev breth0 mtu 1400
10.96.0.0/16 via 169.254.0.4 dev breth0 mtu 1400
10.244.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
10.244.2.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
103.103.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
103.103.1.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
169.254.0.3 via 203.203.1.1 dev ovn-k8s-mp12
169.254.0.34 dev ovn-k8s-mp12 mtu 1400
172.26.0.0/16 nhid 41 via 172.18.0.5 dev breth0 proto bgp metric 20
203.203.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
203.203.0.0/16 via 203.203.1.1 dev ovn-k8s-mp12
203.203.1.0/24 dev ovn-k8s-mp12 proto kernel scope link src 203.203.1.2
local 203.203.1.2 dev ovn-k8s-mp12 proto kernel scope host src 203.203.1.2
broadcast 203.203.1.255 dev ovn-k8s-mp12 proto kernel scope link src 203.203.1.2
203.203.2.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20

root@ovn-worker2:/# ip r show table 1046
default via 172.18.0.1 dev breth0 mtu 1400
10.96.0.0/16 via 169.254.0.4 dev breth0 mtu 1400
10.244.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
10.244.2.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
103.103.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
103.103.0.0/16 via 103.103.2.1 dev ovn-k8s-mp11
103.103.1.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
103.103.2.0/24 dev ovn-k8s-mp11 proto kernel scope link src 103.103.2.2
local 103.103.2.2 dev ovn-k8s-mp11 proto kernel scope host src 103.103.2.2
broadcast 103.103.2.255 dev ovn-k8s-mp11 proto kernel scope link src 103.103.2.2
169.254.0.3 via 103.103.2.1 dev ovn-k8s-mp11
169.254.0.32 dev ovn-k8s-mp11 mtu 1400
172.26.0.0/16 nhid 41 via 172.18.0.5 dev breth0 proto bgp metric 20
203.203.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
203.203.2.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
```

this happens because we import routes from the
default VRF:
```
      prefixes:
      - 103.103.0.0/24
      - 2014:100:200::/64
      - 2016:100:200::/64
      - 203.203.0.0/24
    - asn: 64512 imports: - vrf: default vrf: mp11-udn-vrf
    - asn: 64512 imports:
      - vrf: default vrf: mp12-udn-vrf nodeSelector: matchLabels: kubernetes.io/hostname: ovn-worker raw: {}

root@ovn-worker2:/# ip r
default via 172.18.0.1 dev breth0 mtu 1400
10.96.0.0/16 via 169.254.0.4 dev breth0 mtu 1400
10.244.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
10.244.2.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
103.103.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
103.103.1.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
169.254.0.3 via 203.203.1.1 dev ovn-k8s-mp12
169.254.0.34 dev ovn-k8s-mp12 mtu 1400
172.26.0.0/16 nhid 41 via 172.18.0.5 dev breth0 proto bgp metric 20
203.203.0.0/24 nhid 39 via 172.18.0.4 dev breth0 proto bgp metric 20
203.203.0.0/16 via 203.203.1.1 dev ovn-k8s-mp12
203.203.1.0/24 dev ovn-k8s-mp12 proto kernel scope link src 203.203.1.2
local 203.203.1.2 dev ovn-k8s-mp12 proto kernel scope host src 203.203.1.2
broadcast 203.203.1.255 dev ovn-k8s-mp12 proto kernel scope link src 203.203.1.2
203.203.2.0/24 nhid 40 via 172.18.0.3 dev breth0 proto bgp metric 20
```
which directly breaks UDN isolation and ovn-kubernetes is doing the routing.
* In the secure mode, we have ACLs that prevent this from happening: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5186
* However we have a new loose mode, https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5276 where there will not be any ACLs and OVNK will do the routing
* So this PR is specially applicable to the loose mode where we want the fabric router to route between UDNs NOT ovn-kubernetes
* In this PR we are going to remove the support for receiving routes from remote nodes in UDNs and default network. So advertising routes will only advertise routes and we will no longer make the nodes receive these routes. However in the future when we support overlay-mode with BGP, we will need to re-add these routes and design a better isolation model with UDNs within the cluster if that is desired.
* However when we do this, we will break pod to other node traffic (pod to same node doesn't work today for UDNs/advertisedUDNs anyways). So this means we break pod to kapi:6443 which is not desirable.
* Henceforth we will treat pod to nodes in the same cluster as "intra cluster traffic" for BGP and a design change is being made here to SNAT all such traffic to nodeIP and won't be "BGP aware"
* This PR will fix the broken UDN isolation case i.e UDNAPod->UDNBPod in loose mode and let fabric router do the routing if desired by the end-user
* This PR I am being told might/may deem https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4069 not necessary? But I am not so sure about that cause there was still that assymmetry around isolation with udn pod to nodeport but anyways this PR is supposed to fix etp=local/etp=cluster scenarios for nodeports with advertised BGP

## Additional information to reviewers

* @jcaamano also pointed out a corner case for kapi/dns clusterIP traffic to also be SNAT-ed to nodeIP which is a separate PR on top that will follow. - Mainly required for VRFLite scenario...
* UDNs today already also reuse the EIP nodeIP addresses sets that belong to default network controller w/o changing the externalIDs - meaning this address-set though owned by our central default network controller is already in use by other controllers - so I don't plan to change the ownership of that address-set - I know its icky to re-use the address-set used by another feature but we do this anyways in other places today.
* Secondly, EIP address-sets are created only when EIP feature is enabled..EIP feature is always enabled today and there is no way to disable this feature upstream to practically speaking we don't need to change logic to do it always? TODO: Rethink if we want to move its location to add/update nodes in central controller instead of doing it from egressNodes. I am happy to accommodate this change based on reviewer feedback - but this could also be a seperate effort.
* One more caveat is for SGW we use the EIP address sets for LGW we use the PMTUDRemoteNode NFT Set which means for SGW we include the localnodeIP and for LGW we only include remote nodeIPs as destinations -  I don't think its a big deal but its worth calling out this inconsistency
* ~This PR is only stopping route importing on UDNs not default network: This is intentionally a separate commit to preserve history. Initially we wanted to stop importing remote node routes for both default networks and UDNs. Later, we decided we will continue to import routes for default network but not for UDNs. Reasoning: UDN to UDN communication must happen via the fabric router and not be done by OVNK. So we want to stop importing routes in this case. However for default network to UDN network - its not exactly well defined. Is there a need to have UDN pods talk to default network or vice versa? Worst case as long as UDN network's importing is switched off, its not like
UDN pods can reach default network anyways within the cluster - so upto enduser to configure this on their side - hence we don't see the need to explicitly do it for default network as of today. TBD: Ask Tim,Jaime if there were more reasons for why we didn't want to do the same for defaultnetwork as well?~ for compatibility reasons and to fix ETP=local? nodeport case we are going to keep it the same on default network as well

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

E2E added.
TODO: In future add E2Es for nodeport etp=local test with bgp and also loadbalancers etp=local and etp=cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced nftables-based NAT masquerading for local gateways with dedicated chains for pod subnets and user-defined networks, supporting dual-stack.
  * Unified and improved SNAT rule management for user-defined networks with dynamic updates based on advertisement status.

* **Bug Fixes**
  * Fixed SNAT rule inconsistencies for advertised vs. non-advertised networks.
  * Corrected masquerade IP rule handling for advertised networks.

* **Refactor**
  * Simplified and consolidated SNAT creation, update, and deletion logic across multiple controllers.
  * Standardized nftables set and rule names related to remote node IPs.
  * Replaced manual IP address extraction with utility functions for better error handling.
  * Updated SNAT match handling to support per-IP-family granularity.
  * Removed deprecated iptables masquerade functions in favor of nftables implementations.
  * Removed logic related to BGP neighbor receive prefixes.

* **Tests**
  * Extended connectivity tests involving NodePort services and host-networked pods.
  * Updated expected flows and nftables rules in tests to reflect new masquerade and SNAT logic.
  * Enabled EgressIP feature flag in tests to validate related SNAT behaviors.

* **Chores**
  * Improved comments and documentation for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->