### PR TITLE
Convert to DaemonSet and fix update strategy of ovnkube-identity pods

### DIFF
--- a/dist/templates/ovnkube-identity.yaml.j2
+++ b/dist/templates/ovnkube-identity.yaml.j2
@@ -1,7 +1,7 @@
 # ovnkube-identity
 # starts ovnkube-identity
 # it is run on the master(s).
-kind: Deployment
+kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ovnkube-identity
@@ -9,18 +9,16 @@ metadata:
   namespace: ovn-kubernetes
   annotations:
     kubernetes.io/description: |
-      This Deployment launches the ovnkube-identity networking component.
+      This DaemonSet launches the ovnkube-identity networking component on control-plane nodes.
 spec:
-  progressDeadlineSeconds: 600
-  replicas: {{ ovn_master_count | default(1|int) }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: ovnkube-identity
-  strategy:
+  updateStrategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 100%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -35,20 +33,9 @@ spec:
       serviceAccountName: ovnkube-identity
       hostNetwork: true
       dnsPolicy: Default
-
-      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
-      # only one instance of ovnkube-control-plane pod per node
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - "linux"
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+        kubernetes.io/os: "linux"
       containers:
       - name: ovnkube-identity
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -2,7 +2,7 @@
 # ovnkube-identity
 # starts ovnkube-identity
 # it is run on the master(s).
-kind: Deployment
+kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ovnkube-identity
@@ -10,18 +10,16 @@ metadata:
   namespace: ovn-kubernetes
   annotations:
     kubernetes.io/description: |
-      This Deployment launches the ovnkube-identity networking component.
+      This DaemonSet launches the ovnkube-identity networking component on control-plane nodes.
 spec:
-  progressDeadlineSeconds: 600
-  replicas: {{ default 1 .Values.replicas }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: ovnkube-identity
-  strategy:
+  updateStrategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 100%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -40,9 +38,9 @@ spec:
       serviceAccountName: ovnkube-identity
       hostNetwork: true
       dnsPolicy: Default
-      {{- if .Values.affinity }}
-      affinity: {{ toYaml .Values.affinity | nindent 8 }}
-      {{- end }}
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+        kubernetes.io/os: "linux"
       containers:
       - name: ovnkube-identity
         image: {{ include "getImage" . }}

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
@@ -1,29 +1,4 @@
-replicas: 1
 logLevel: 4
 logFileMaxSize: 100
 logFileMaxBackups: 5
 logFileMaxAge: 5
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-## Required to be scheduled on a linux node and only one instance of ovnkube-identity pod per node
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: node-role.kubernetes.io/control-plane
-              operator: Exists
-            - key: kubernetes.io/os
-              operator: In
-              values:
-                - "linux"
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-            - key: name
-              operator: In
-              values:
-                - ovnkube-identity
-        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Ovnkube-identity pods should run on all control-plane nodes and require that a newly created pod is fully functional before the old one can be terminated and hence require additional pods during upgrades

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
