### PR TITLE
Support network segmentation via helm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -424,6 +424,7 @@ jobs:
         # num-nodes-per-zone : "<integer value>"
         # forwarding : ["", "disable-forwarding"]
         # dns-name-resolver : ["", "enable-dns-name-resolver"]
+        # network-segmentation : ["", "enable-network-segmentation"]
         # traffic-flow-tests : "<tests range. i.e. 1-24>"
         include:
           - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
@@ -441,7 +442,7 @@ jobs:
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "multi-homing-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "multi-homing-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "network-segmentation": "enable-network-segmentation"}
           - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "compact-mode",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
@@ -451,18 +452,18 @@ jobs:
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3"}
-          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
+          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3", "network-segmentation": "enable-network-segmentation"}
+          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3", "network-segmentation": "enable-network-segmentation"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "bgp", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default"}
-          - {"target": "bgp", "ha": "noHA", "gateway-mode": "shared",  "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default"}
-          - {"target": "traffic-flow-test-only","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24"}
-          - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "bgp", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation"}
+          - {"target": "bgp", "ha": "noHA", "gateway-mode": "shared",  "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation"}
+          - {"target": "traffic-flow-test-only","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24", "network-segmentation": "enable-network-segmentation"}
+          - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
@@ -477,7 +478,7 @@ jobs:
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
       ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'multi-homing-helm' || matrix.target == 'traffic-flow-test-only' || matrix.routeadvertisements != '' }}"
-      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' || matrix.target == 'tools' || matrix.target == 'kv-live-migration' || matrix.target == 'traffic-flow-test-only' || matrix.target == 'bgp' }}"
+      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' || matrix.network-segmentation == 'enable-network-segmentation' }}"
       DISABLE_UDN_HOST_ISOLATION: "true"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -32,6 +32,11 @@ if_error_exit() {
     fi
 }
 
+set_common_default_params() {
+  KIND_IMAGE=${KIND_IMAGE:-kindest/node}
+  K8S_VERSION=${K8S_VERSION:-v1.32.3}
+}
+
 run_kubectl() {
   local retries=0
   local attempts=10

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -11,6 +11,7 @@ export OCI_BIN=${KIND_EXPERIMENTAL_PROVIDER:-docker}
 source "${DIR}/kind-common"
 
 set_default_params() {
+  set_common_default_params
 
   # Set default values
   export KIND_CONFIG=${KIND_CONFIG:-}
@@ -326,7 +327,7 @@ networking:
 EOT
 
     kind delete clusters $KIND_CLUSTER_NAME ||:
-    kind create cluster --name $KIND_CLUSTER_NAME --config "${KIND_CONFIG}" --retain
+    kind create cluster --name $KIND_CLUSTER_NAME --image "${KIND_IMAGE}":"${K8S_VERSION}" --config "${KIND_CONFIG}" --retain
     kind load docker-image --name $KIND_CLUSTER_NAME $OVN_IMAGE
 
     # When using HA, label nodes to host db.

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -25,6 +25,7 @@ set_default_params() {
   export OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   export KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
   export ENABLE_MULTI_NET=${ENABLE_MULTI_NET:-false}
+  export ENABLE_NETWORK_SEGMENTATION=${ENABLE_NETWORK_SEGMENTATION:-false}
   export KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
   export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
   export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:helm'}
@@ -95,32 +96,34 @@ usage() {
     echo "       [ -pl  | --install-cni-plugins ]"
     echo "       [ -ikv | --install-kubevirt ]"
     echo "       [ -mne | --multi-network-enable ]"
+    echo "       [ -nse | --network-segmentation-enable ]"
     echo "       [ -wk  | --num-workers <num> ]"
     echo "       [ -ic  | --enable-interconnect]"
     echo "       [ -npz | --node-per-zone ]"
     echo "       [ -cn  | --cluster-name ]"
     echo "       [ -h ]"
     echo ""
-    echo "--delete                            Delete current cluster"
-    echo "-cf  | --config-file                Name of the KIND configuration file"
-    echo "-kt  | --keep-taint                 Do not remove taint components"
-    echo "                                    DEFAULT: Remove taint components"
-    echo "-me  | --multicast-enabled          Enable multicast. DEFAULT: Disabled"
-    echo "-ho  | --hybrid-enabled             Enable hybrid overlay. DEFAULT: Disabled"
-    echo "-obs | --observability              Enable observability. DEFAULT: Disabled"
-    echo "-el  | --ovn-empty-lb-events        Enable empty-lb-events generation for LB without backends. DEFAULT: Disabled"
-    echo "-ii  | --install-ingress            Flag to install Ingress Components."
-    echo "                                    DEFAULT: Don't install ingress components."
-    echo "-mlb | --install-metallb            Install metallb to test service type LoadBalancer deployments"
-    echo "-pl  | --install-cni-plugins        Install CNI plugins"
-    echo "-ikv | --install-kubevirt           Install kubevirt"
-    echo "-mne | --multi-network-enable       Enable multi networks. DEFAULT: Disabled"
-    echo "-ha  | --ha-enabled                 Enable high availability. DEFAULT: HA Disabled"
-    echo "-wk  | --num-workers                Number of worker nodes. DEFAULT: 2 workers"
-    echo "-cn  | --cluster-name               Configure the kind cluster's name"
-    echo "-dns | --enable-dnsnameresolver     Enable DNSNameResolver for resolving the DNS names used in the DNS rules of EgressFirewall."
-    echo "-ic  | --enable-interconnect        Enable interconnect with each node as a zone (only valid if OVN_HA is false)"
-    echo "-npz | --nodes-per-zone             Specify number of nodes per zone (Default 0, which means global zone; >0 means interconnect zone, where 1 for single-node zone, >1 for multi-node zone). If this value > 1, then (total k8s nodes (workers + 1) / num of nodes per zone) should be zero."
+    echo "--delete                             Delete current cluster"
+    echo "-cf  | --config-file                 Name of the KIND configuration file"
+    echo "-kt  | --keep-taint                  Do not remove taint components"
+    echo "                                     DEFAULT: Remove taint components"
+    echo "-me  | --multicast-enabled           Enable multicast. DEFAULT: Disabled"
+    echo "-ho  | --hybrid-enabled              Enable hybrid overlay. DEFAULT: Disabled"
+    echo "-obs | --observability               Enable observability. DEFAULT: Disabled"
+    echo "-el  | --ovn-empty-lb-events         Enable empty-lb-events generation for LB without backends. DEFAULT: Disabled"
+    echo "-ii  | --install-ingress             Flag to install Ingress Components."
+    echo "                                     DEFAULT: Don't install ingress components."
+    echo "-mlb | --install-metallb             Install metallb to test service type LoadBalancer deployments"
+    echo "-pl  | --install-cni-plugins         Install CNI plugins"
+    echo "-ikv | --install-kubevirt            Install kubevirt"
+    echo "-mne | --multi-network-enable        Enable multi networks. DEFAULT: Disabled"
+    echo "-nse | --network-segmentation-enable Enable network segmentation. DEFAULT: Disabled"
+    echo "-ha  | --ha-enabled                  Enable high availability. DEFAULT: HA Disabled"
+    echo "-wk  | --num-workers                 Number of worker nodes. DEFAULT: 2 workers"
+    echo "-cn  | --cluster-name                Configure the kind cluster's name"
+    echo "-dns | --enable-dnsnameresolver      Enable DNSNameResolver for resolving the DNS names used in the DNS rules of EgressFirewall."
+    echo "-ic  | --enable-interconnect         Enable interconnect with each node as a zone (only valid if OVN_HA is false)"
+    echo "-npz | --nodes-per-zone              Specify number of nodes per zone (Default 0, which means global zone; >0 means interconnect zone, where 1 for single-node zone, >1 for multi-node zone). If this value > 1, then (total k8s nodes (workers + 1) / num of nodes per zone) should be zero."
     echo ""
 
 }
@@ -128,67 +131,69 @@ usage() {
 parse_args() {
     while [ "$1" != "" ]; do
         case $1 in
-            --delete )                          delete
-                                                exit
-                                                ;;
-            -cf | --config-file )               shift
-                                                if test ! -f "$1"; then
-                                                    echo "$1 does not  exist"
-                                                    usage
-                                                    exit 1
-                                                fi
-                                                KIND_CONFIG=$1
-                                                ;;
-            -kt | --keep-taint )                KIND_REMOVE_TAINT=false
-                                                ;;
-            -me | --multicast-enabled)          OVN_MULTICAST_ENABLE=true
-                                                ;;
-            -ho | --hybrid-enabled )            OVN_HYBRID_OVERLAY_ENABLE=true
-                                                ;;
-            -obs | --observability )            OVN_OBSERV_ENABLE=true
-                                                ;;
-            -el | --ovn-empty-lb-events )       OVN_EMPTY_LB_EVENTS=true
-                                                ;;
-            -ii | --install-ingress )           KIND_INSTALL_INGRESS=true
-                                                ;;
-            -mlb | --install-metallb )          KIND_INSTALL_METALLB=true
-                                                ;;
-            -pl | --install-cni-plugins )       KIND_INSTALL_PLUGINS=true
-                                                ;;
-            -ikv | --install-kubevirt)          KIND_INSTALL_KUBEVIRT=true
-                                                ;;
-            -mne | --multi-network-enable )     ENABLE_MULTI_NET=true
-                                                ;;
-            -ha | --ha-enabled )                OVN_HA=true
-                                                KIND_NUM_MASTER=3
-                                                ;;
-            -wk | --num-workers )               shift
-                                                if ! [[ "$1" =~ ^[0-9]+$ ]]; then
-                                                    echo "Invalid num-workers: $1"
-                                                    usage
-                                                    exit 1
-                                                fi
-                                                KIND_NUM_WORKER=$1
-                                                ;;
-            -cn | --cluster-name )              shift
-                                                KIND_CLUSTER_NAME=$1
-                                                # Setup KUBECONFIG
-                                                set_default_params
-                                                ;;
-            -dns | --enable-dnsnameresolver )   OVN_ENABLE_DNSNAMERESOLVER=true
-                                                ;;
-            -ic | --enable-interconnect )       OVN_ENABLE_INTERCONNECT=true
-                                                ;;
-            -npz | --nodes-per-zone )           shift
-                                                if ! [[ "$1" =~ ^[0-9]+$ ]]; then
-                                                    echo "Invalid num-nodes-per-zone: $1"
-                                                    usage
-                                                    exit 1
-                                                fi
-                                                KIND_NUM_NODES_PER_ZONE=$1
-                                                ;;
-            * )                                 usage
-                                                exit 1
+            --delete )                            delete
+                                                  exit
+                                                  ;;
+            -cf | --config-file )                 shift
+                                                  if test ! -f "$1"; then
+                                                      echo "$1 does not  exist"
+                                                      usage
+                                                      exit 1
+                                                  fi
+                                                  KIND_CONFIG=$1
+                                                  ;;
+            -kt | --keep-taint )                  KIND_REMOVE_TAINT=false
+                                                  ;;
+            -me | --multicast-enabled)            OVN_MULTICAST_ENABLE=true
+                                                  ;;
+            -ho | --hybrid-enabled )              OVN_HYBRID_OVERLAY_ENABLE=true
+                                                  ;;
+            -obs | --observability )              OVN_OBSERV_ENABLE=true
+                                                  ;;
+            -el | --ovn-empty-lb-events )         OVN_EMPTY_LB_EVENTS=true
+                                                  ;;
+            -ii | --install-ingress )             KIND_INSTALL_INGRESS=true
+                                                  ;;
+            -mlb | --install-metallb )            KIND_INSTALL_METALLB=true
+                                                  ;;
+            -pl | --install-cni-plugins )         KIND_INSTALL_PLUGINS=true
+                                                  ;;
+            -ikv | --install-kubevirt)            KIND_INSTALL_KUBEVIRT=true
+                                                  ;;
+            -mne | --multi-network-enable )       ENABLE_MULTI_NET=true
+                                                  ;;
+            -nse | --network-segmentation-enable) ENABLE_NETWORK_SEGMENTATION=true
+                                                  ;;
+            -ha | --ha-enabled )                  OVN_HA=true
+                                                  KIND_NUM_MASTER=3
+                                                  ;;
+            -wk | --num-workers )                 shift
+                                                  if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+                                                      echo "Invalid num-workers: $1"
+                                                      usage
+                                                      exit 1
+                                                  fi
+                                                  KIND_NUM_WORKER=$1
+                                                  ;;
+            -cn | --cluster-name )                shift
+                                                  KIND_CLUSTER_NAME=$1
+                                                  # Setup KUBECONFIG
+                                                  set_default_params
+                                                  ;;
+            -dns | --enable-dnsnameresolver )     OVN_ENABLE_DNSNAMERESOLVER=true
+                                                  ;;
+            -ic | --enable-interconnect )         OVN_ENABLE_INTERCONNECT=true
+                                                  ;;
+            -npz | --nodes-per-zone )             shift
+                                                  if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+                                                      echo "Invalid num-nodes-per-zone: $1"
+                                                      usage
+                                                      exit 1
+                                                  fi
+                                                  KIND_NUM_NODES_PER_ZONE=$1
+                                                  ;;
+            * )                                   usage
+                                                  exit 1
         esac
         shift
     done
@@ -211,6 +216,7 @@ print_params() {
      echo "KIND_CLUSTER_NAME = $KIND_CLUSTER_NAME"
      echo "KIND_REMOVE_TAINT = $KIND_REMOVE_TAINT"
      echo "ENABLE_MULTI_NET = $ENABLE_MULTI_NET"
+     echo "ENABLE_NETWORK_SEGMENTATION = $ENABLE_NETWORK_SEGMENTATION"
      echo "OVN_IMAGE = $OVN_IMAGE"
      echo "KIND_NUM_MASTER = $KIND_NUM_MASTER"
      echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
@@ -391,7 +397,8 @@ create_ovn_kubernetes() {
                           --set tags.ovnkube-db=$(if [ "${OVN_HA}" == "false" ]; then echo "true"; else echo "false"; fi)"
     fi
     echo "value_file=${value_file}"
-    helm install ovn-kubernetes . -f ${value_file} \
+    cmd=$(cat <<EOF
+helm install ovn-kubernetes . -f "${value_file}" \
           --set k8sAPIServer=${API_URL} \
           --set podNetwork="${NET_CIDR_IPV4}/24" \
           --set serviceNetwork=${SVC_CIDR_IPV4} \
@@ -402,11 +409,16 @@ create_ovn_kubernetes() {
           --set global.enableAdminNetworkPolicy=true \
           --set global.enableMulticast=$(if [ "${OVN_MULTICAST_ENABLE}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableMultiNetwork=$(if [ "${ENABLE_MULTI_NET}" == "true" ]; then echo "true"; else echo "false"; fi) \
+          --set global.enableNetworkSegmentation=$(if [ "${ENABLE_NETWORK_SEGMENTATION}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableHybridOverlay=$(if [ "${OVN_HYBRID_OVERLAY_ENABLE}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableObservability=$(if [ "${OVN_OBSERV_ENABLE}" == "true" ]; then echo "true"; else echo "false"; fi) \
-        --set global.emptyLbEvents=$(if [ "${OVN_EMPTY_LB_EVENTS}" == "true" ]; then echo "true"; else echo "false"; fi) \
+          --set global.emptyLbEvents=$(if [ "${OVN_EMPTY_LB_EVENTS}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableDNSNameResolver=$(if [ "${OVN_ENABLE_DNSNAMERESOLVER}" == "true" ]; then echo "true"; else echo "false"; fi) \
           ${ovnkube_db_options}
+EOF
+       )
+    echo "${cmd}"
+    eval "${cmd}"
 }
 
 delete() {

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -512,6 +512,8 @@ set_openssl_binary() {
 }
 
 set_default_params() {
+  set_common_default_params
+
   # Set default values
   # Used for multi cluster setups
   KIND_CREATE=${KIND_CREATE:-true}
@@ -528,8 +530,6 @@ set_default_params() {
     MANIFEST_OUTPUT_DIR="${DIR}/../dist/yaml/${KIND_CLUSTER_NAME}"
   fi
   RUN_IN_CONTAINER=${RUN_IN_CONTAINER:-false}
-  KIND_IMAGE=${KIND_IMAGE:-kindest/node}
-  K8S_VERSION=${K8S_VERSION:-v1.32.3}
   OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-shared}
   KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
   KIND_INSTALL_METALLB=${KIND_INSTALL_METALLB:-false}

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -334,6 +334,15 @@ false
 			<td>Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes</td>
 		</tr>
 		<tr>
+			<td>global.enableNetworkSegmentation</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to use user defined networks (UDN) feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
 			<td>global.enableMulticast</td>
 			<td>string</td>
 			<td><pre lang="json">

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -124,6 +124,8 @@ spec:
           value: {{ default "" .Values.global.enableEgressQos | quote }}
         - name: OVN_MULTI_NETWORK_ENABLE
           value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: {{ default "" .Values.global.enableNetworkSegmentation | quote }}
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
@@ -74,6 +74,7 @@ rules:
           - egressfirewalls
           - egressqoses
           - userdefinednetworks
+          - clusteruserdefinednetworks
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.ovn.org"]
       resources:
@@ -81,6 +82,9 @@ rules:
           - egressservices/status
           - userdefinednetworks
           - userdefinednetworks/status
+          - clusteruserdefinednetworks
+          - clusteruserdefinednetworks/status
+          - clusteruserdefinednetworks/finalizers
       verbs: [ "patch", "update" ]
     - apiGroups: [""]
       resources:

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -234,6 +234,8 @@ spec:
           value: {{ default "" .Values.global.enableEgressQos | quote }}
         - name: OVN_MULTI_NETWORK_ENABLE
           value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: {{ default "" .Values.global.enableNetworkSegmentation | quote }}
         - name: OVN_EGRESSSERVICE_ENABLE
           value: {{ default "" .Values.global.enableEgressService | quote }}
         - name: OVN_HYBRID_OVERLAY_NET_CIDR

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/rbac-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/rbac-ovnkube-master.yaml
@@ -83,6 +83,8 @@ rules:
           - egressqoses
           - egressservices
           - adminpolicybasedexternalroutes
+          - userdefinednetworks
+          - clusteruserdefinednetworks
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.cni.cncf.io"]
       resources:
@@ -92,7 +94,11 @@ rules:
     - apiGroups: ["k8s.cni.cncf.io"]
       resources:
           - network-attachment-definitions
-      verbs: ["patch"]
+      verbs: [ "patch", "update" ]
+    - apiGroups: [ "k8s.cni.cncf.io" ]
+      resources:
+      - network-attachment-definitions
+      verbs: [ "create", "delete" ]
     - apiGroups: ["policy.networking.k8s.io"]
       resources:
           - adminnetworkpolicies/status
@@ -106,6 +112,11 @@ rules:
           - egressservices/status
           - adminpolicybasedexternalroutes/status
           - egressqoses/status
+          - userdefinednetworks
+          - userdefinednetworks/status
+          - clusteruserdefinednetworks
+          - clusteruserdefinednetworks/status
+          - clusteruserdefinednetworks/finalizers
       verbs: [ "patch", "update" ]
     - apiGroups: [""]
       resources:

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -227,6 +227,8 @@ spec:
           value: {{ default "" .Values.global.lFlowCacheLimitKb | quote }}
         - name: OVN_MULTI_NETWORK_ENABLE
           value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: {{ default "" .Values.global.enableNetworkSegmentation | quote }}
         - name: OVN_ENABLE_INTERCONNECT
           value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -412,6 +412,8 @@ spec:
           value: {{ default "" .Values.global.lFlowCacheLimitKb | quote }}
         - name: OVN_MULTI_NETWORK_ENABLE
           value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: {{ default "" .Values.global.enableNetworkSegmentation | quote }}
         - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
           value: {{ default "" .Values.global.nodeMgmtPortNetdev | quote }}
         - name: OVN_EMPTY_LB_EVENTS

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -311,6 +311,8 @@ spec:
           value: {{ default "" .Values.global.enableEgressQos | quote }}
         - name: OVN_MULTI_NETWORK_ENABLE
           value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: {{ default "" .Values.global.enableNetworkSegmentation | quote }}
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_clusteruserdefinednetworks.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_clusteruserdefinednetworks.yaml
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_routeadvertisements.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_routeadvertisements.yaml
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_routeadvertisements.yaml.j2

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_userdefinednetworks.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_userdefinednetworks.yaml
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -181,6 +181,8 @@ rules:
           - egressqoses
           - egressservices
           - adminpolicybasedexternalroutes
+          - userdefinednetworks
+          - clusteruserdefinednetworks
       verbs: [ "get", "list", "watch" ]
     {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
     - apiGroups: ["certificates.k8s.io"]

--- a/helm/ovn-kubernetes/values-multi-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-multi-node-zone.yaml
@@ -72,6 +72,8 @@ global:
   enableMulticast: ""
   # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes
   enableMultiNetwork: false
+  # -- Configure to use user defined networks (UDN) feature with ovn-kubernetes
+  enableNetworkSegmentation: false
   # -- Configure to enable IPsec
   enableIpsec: false
   # -- Use SSL transport to NB/SB db and northd

--- a/helm/ovn-kubernetes/values-no-ic.yaml
+++ b/helm/ovn-kubernetes/values-no-ic.yaml
@@ -66,6 +66,8 @@ global:
   enableMulticast: ""
   # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes
   enableMultiNetwork: false
+  # -- Configure to use user defined networks (UDN) feature with ovn-kubernetes
+  enableNetworkSegmentation: false
   # -- Configure to enable IPsec
   enableIpsec: false
   # -- Use SSL transport to NB/SB db and northd

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -72,6 +72,8 @@ global:
   enableMulticast: ""
   # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes
   enableMultiNetwork: false
+  # -- Configure to use user defined networks (UDN) feature with ovn-kubernetes
+  enableNetworkSegmentation: false
   # -- Configure to enable IPsec
   enableIpsec: false
   # -- Use SSL transport to NB/SB db and northd

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -59,7 +59,7 @@ sudo mv kubernetes/test/bin/ginkgo /usr/local/bin/ginkgo
 rm kubernetes-test-linux-${ARCH}.tar.gz
 
 if [ "$USE_HELM" == true ]; then
-    HELM_VERSION="v3.14.2"
+    HELM_VERSION="v3.17.2"
 	# to get latest stable version: https://github.com/helm/helm/releases
     curl -L  https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz -o helm-linux-${ARCH}.tar.gz
 	tar xvzf helm-linux-${ARCH}.tar.gz


### PR DESCRIPTION
This PR includes changes needed in order to support deploying ovn-kubernetes via helm with UDN feature.

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5147

```
❯ cd contrib && ./kind-helm.sh --help | grep -C2 -i segm
       [ -ikv | --install-kubevirt ]
       [ -mne | --multi-network-enable ]
       [ -nse | --network-segmentation-enable ]    <---- new 
       [ -wk  | --num-workers <num> ]
       [ -ic  | --enable-interconnect]
--
-ikv | --install-kubevirt            Install kubevirt
-mne | --multi-network-enable        Enable multi networks. DEFAULT: Disabled
-nse | --network-segmentation-enable Enable network segmentation. DEFAULT: Disabled
-ha  | --ha-enabled                  Enable high availability. DEFAULT: HA Disabled
-wk  | --num-workers                 Number of worker nodes. DEFAULT: 2 workers 


❯ ./kind-helm.sh -ic -mne -nse
...
helm install ovn-kubernetes . -f "values-single-node-zone.yaml"  \
--set global.enableMultiNetwork=true  \
--set global.enableNetworkSegmentation=true  \      <=== NEW VALUE!!!
...

❯ helm ls
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ovn-kubernetes  default         1               2025-03-25 21:24:53.92383979 +0000 UTC  deployed        ovn-kubernetes-1.0.0    1.0.0



❯ cat ~/udn.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: udn-test
  labels:
    k8s.ovn.org/primary-user-defined-network: ""
---
apiVersion: k8s.ovn.org/v1
kind: UserDefinedNetwork
metadata:
  name: l3-primary
  namespace: udn-test
spec:
  topology: Layer3
  layer3:
    role: Primary
    subnets:
    - cidr: 10.20.0.0/16



❯ PODS=($(kubectl get pods -n ovn-kubernetes -o name | grep ovnkube-node | cut -d/ -f2)) ; \
for POD in "${PODS[@]}"; do
  echo -n "$POD  "
  kubectl -n ovn-kubernetes logs -c ovnkube-controller "$POD" > ~/x
  grep 'forbidden: User' ~/x > ~/rbac_errors.txt
  wc -l ~/rbac_errors.txt
done

ovnkube-node-84zsm  0 /home/vagrant/rbac_errors.txt
ovnkube-node-nf47x  0 /home/vagrant/rbac_errors.txt
ovnkube-node-rpxsf  0 /home/vagrant/rbac_errors.txt


❯ PODS=( $(kubectl -n ovn-kubernetes get pods -o jsonpath='{.items[*].metadata.name}' -l 'name in (ovnkube-control-plane,ovnkube-identity)') ) ; \
for POD in "${PODS[@]}"; do
  echo -n "$POD  "
  kubectl -n ovn-kubernetes logs "$POD" > ~/x
  grep 'forbidden: User' ~/x > ~/rbac_errors.txt
  wc -l ~/rbac_errors.txt
done

ovnkube-control-plane-69d89866bb-dhpfq  0 /home/vagrant/rbac_errors.txt
ovnkube-identity-777b5545fd-hsnnk  0 /home/vagrant/rbac_errors.txt



❯ k create -f ~/udn.yaml
namespace/udn-test created
userdefinednetwork.k8s.ovn.org/l3-primary created


❯ k get UserDefinedNetwork -A -oyaml
apiVersion: v1
items:
- apiVersion: k8s.ovn.org/v1
  kind: UserDefinedNetwork
  metadata:
    creationTimestamp: "2025-03-25T21:17:21Z"
    finalizers:
    - k8s.ovn.org/user-defined-network-protection
    generation: 1
    name: l3-primary
    namespace: udn-test
    resourceVersion: "1839"
    uid: b5508b42-4e71-44c2-b588-f74c23669e4c
  spec:
    layer3:
      role: Primary
      subnets:
      - cidr: 10.20.0.0/16
    topology: Layer3
  status:
    conditions:
    - lastTransitionTime: "2025-03-25T21:17:21Z"
      message: NetworkAttachmentDefinition has been created
      reason: NetworkAttachmentDefinitionCreated
      status: "True"
      type: NetworkCreated
    - lastTransitionTime: "2025-03-25T21:17:21Z"
      message: Network allocation succeeded for all synced nodes.
      reason: NetworkAllocationSucceeded
      status: "True"
      type: NetworkAllocationSucceeded
kind: List
metadata:
  resourceVersion: ""
  ```