### PR TITLE
Add allow-stateless ACLs for advertised L2 UDNs

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -373,10 +373,6 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 			return nil, nil, fmt.Errorf("%w: selected network %q has unsupported topology %q", errConfig, networkName, network.TopologyType())
 		}
 
-		if config.Gateway.Mode == config.GatewayModeLocal && network.TopologyType() == types.Layer2Topology {
-			return nil, nil, fmt.Errorf("%w: BGP is currently not supported for Layer2 networks in local gateway mode, network: %s", errConfig, network.GetNetworkName())
-		}
-
 		if advertisements.Has(ratypes.EgressIP) && network.TopologyType() == types.Layer2Topology {
 			return nil, nil, fmt.Errorf("%w: EgressIP advertisement is currently not supported for Layer2 networks, network: %s", errConfig, network.GetNetworkName())
 		}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -746,6 +746,14 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *corev1.Node, swit
 	var v4Subnet *net.IPNet
 	addresses := macAddress.String()
 	mgmtPortIPs := []net.IP{}
+
+	if config.Gateway.Mode == config.GatewayModeLocal &&
+		bnc.TopologyType() == types.Layer2Topology &&
+		util.IsPodNetworkAdvertisedAtNode(bnc.GetNetInfo(), node.Name) {
+		if err := bnc.addNetworkSubnetAllowACL(node.Name, switchName, hostSubnets); err != nil {
+			return nil, err
+		}
+	}
 	for _, hostSubnet := range hostSubnets {
 		mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 		addresses += " " + mgmtIfAddr.IP.String()

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -515,7 +515,10 @@ func (oc *SecondaryLayer2NetworkController) Stop() {
 func (oc *SecondaryLayer2NetworkController) Reconcile(netInfo util.NetInfo) error {
 	return oc.BaseNetworkController.reconcile(
 		netInfo,
-		func(node string) { oc.gatewaysFailed.Store(node, true) },
+		func(node string) {
+			oc.gatewaysFailed.Store(node, true)
+			oc.mgmtPortFailed.Store(node, true)
+		},
 	)
 }
 

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -95,7 +95,8 @@ const (
 	PrimaryUDNAllowPriority = 1001
 	// Default deny acl rule priority
 	PrimaryUDNDenyPriority = 1000
-
+	// UDN subnet allow acl priority used for enabling assymetric traffic for L2 networks in LGW with BGP
+	UDNSubnetAllowPriority = 999
 	// ACL Tiers
 	// Tier 0 is called Primary as it is evaluated before any other feature-related Tiers.
 	// Currently used for User Defined Network Feature.

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -297,11 +297,6 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				Values:   []string{f.Namespace.Name},
 			}}}
 
-			if IsGatewayModeLocal() && cudnTemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 {
-				e2eskipper.Skipf(
-					"BGP for L2 networks on LGW is currently unsupported",
-				)
-			}
 			// Create CUDN
 			ginkgo.By("create ClusterUserDefinedNetwork")
 			udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
@@ -534,9 +529,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 		var ra *rav1.RouteAdvertisements
 
 		ginkgo.BeforeEach(func() {
-			if cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 && isLocalGWModeEnabled() {
-				e2eskipper.Skipf("Advertising Layer2 UDNs is not currently supported in LGW")
-			}
 			ginkgo.By("Configuring primary UDN namespaces")
 			var err error
 			udnNamespaceA, err = f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
@@ -674,9 +666,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 		})
 
 		ginkgo.AfterEach(func() {
-			if cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 && isLocalGWModeEnabled() {
-				return
-			}
 			gomega.Expect(f.ClientSet.CoreV1().Pods(udnNamespaceA.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
 			gomega.Expect(f.ClientSet.CoreV1().Pods(udnNamespaceB.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
 


### PR DESCRIPTION
Based on: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5130

With BGP layer2 networks we advertise the whole subnet from every node, this naturally causes asymmetric routing which breaks in local gateway mode due to OVN dropping packets with an invalid conntrack state. 

Example flow:
```mermaid
flowchart TD    
    External ~~~  ovn-worker
    External ~~~ ovn-worker2
    subgraph ovn-worker2
        C1[eth0] --> C2[mpX- DROP]
    end
    subgraph ovn-worker
        A1[pod] --> A2[mpX]
        A2 --> A3[eth0]
    end
    A3 -- SYN --> External
    External -- SYN/ACK --> C1
```

OVN drops the traffic due to allow-related ACLs that cause the assymetric reply to be commited to conntrack and then dropped since the state is invalid:
```
recirc_id(0x1f50),in_port(9),ct_state(-new-est-rpl+inv+trk),ct_mark(0/0x1),eth(),eth_type(0x0800),ipv4(frag=no), packets:2, bytes:148, used:0.712s, flags:S., actions:drop
```

To work around the issue this PR is adding two `allow-stateless` ACLs that avoid committing to conntrack for the traffic going to and from pod subnet  through the management port.

**The remaining concern is that this change will affect network policy enforcement, I've picked the priority that is below our default deny to avoid that but I would like some extra eyes on this.** 

kudos to @dceara for all the help with this!