### PR TITLE
Block local processes from accessing advertised UDNs

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -69,6 +69,14 @@ const (
 	// nftablesUDNMarkExternalIPsV4Map, nftablesUDNMarkExternalIPsV6Map
 	nftablesUDNServiceMarkChain = "udn-service-mark"
 
+	// nftablesUDNBGPOutputChain is a base chain used for blocking the local processes
+	// from accessing any of the advertised UDN networks
+	nftablesUDNBGPOutputChain = "udn-bgp-drop"
+
+	// nftablesAdvertisedUDNsSetV[4|6] is a set containing advertised UDN subnets
+	nftablesAdvertisedUDNsSetV4 = "advertised-udn-subnets-v4"
+	nftablesAdvertisedUDNsSetV6 = "advertised-udn-subnets-v6"
+
 	// nftablesUDNMarkNodePortsMap is a verdict maps containing
 	// localNodeIP / protocol / port keys indicating traffic that
 	// should be marked with a UDN specific value, which is used to direct the traffic
@@ -2457,6 +2465,11 @@ func newNodePortWatcher(
 				return nil, fmt.Errorf("unable to configure UDN nftables: %w", err)
 			}
 		}
+		if util.IsRouteAdvertisementsEnabled() {
+			if err := configureAdvertisedUDNIsolationNFTables(); err != nil {
+				return nil, fmt.Errorf("unable to configure UDN isolation nftables: %w", err)
+			}
+		}
 	}
 
 	var subnets []*net.IPNet
@@ -2918,4 +2931,75 @@ func getIPv(ipnet *net.IPNet) string {
 		prefix = "ipv6"
 	}
 	return prefix
+}
+
+// configureAdvertisedUDNIsolationNFTables configures nftables to drop traffic generated locally towards advertised UDN subnets.
+// It sets up a nftables chain named nftablesUDNBGPOutputChain in the output hook with filter priority which drops
+// traffic originating from the local node destined to nftablesAdvertisedUDNsSet.
+// It creates nftablesAdvertisedUDNsSet[v4|v6] set which stores the subnets.
+// Results in:
+//
+//	set advertised-udn-subnets-v4 {
+//	  type ipv4_addr
+//	  flags interval
+//	  comment "advertised UDN V4 subnets"
+//	}
+//	set advertised-udn-subnets-v6 {
+//	  type ipv6_addr
+//	  flags interval
+//	  comment "advertised UDN V6 subnets"
+//	}
+//	chain udn-bgp-drop {
+//	  comment "Drop traffic generated locally towards advertised UDN subnets"
+//	   type filter hook output priority filter; policy accept;
+//	   ip daddr @advertised-udn-subnets-v4 counter packets 0 bytes 0 drop
+//	   ip6 daddr @advertised-udn-subnets-v6 counter packets 0 bytes 0 drop
+//	 }
+func configureAdvertisedUDNIsolationNFTables() error {
+	counterIfDebug := ""
+	if config.Logging.Level > 4 {
+		counterIfDebug = "counter"
+	}
+
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+	tx := nft.NewTransaction()
+	tx.Add(&knftables.Chain{
+		Name:    nftablesUDNBGPOutputChain,
+		Comment: knftables.PtrTo("Drop traffic generated locally towards advertised UDN subnets"),
+
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.OutputHook),
+		Priority: knftables.PtrTo(knftables.FilterPriority),
+	})
+	tx.Flush(&knftables.Chain{Name: nftablesUDNBGPOutputChain})
+
+	// TODO: clean up any stale entries in advertised-udn-subnets-v[4|6]
+	set := &knftables.Set{
+		Name:    nftablesAdvertisedUDNsSetV4,
+		Comment: knftables.PtrTo("advertised UDN V4 subnets"),
+		Type:    "ipv4_addr",
+		Flags:   []knftables.SetFlag{knftables.IntervalFlag},
+	}
+	tx.Add(set)
+
+	set = &knftables.Set{
+		Name:    nftablesAdvertisedUDNsSetV6,
+		Comment: knftables.PtrTo("advertised UDN V6 subnets"),
+		Type:    "ipv6_addr",
+		Flags:   []knftables.SetFlag{knftables.IntervalFlag},
+	}
+	tx.Add(set)
+
+	tx.Add(&knftables.Rule{
+		Chain: nftablesUDNBGPOutputChain,
+		Rule:  knftables.Concat(fmt.Sprintf("ip daddr @%s", nftablesAdvertisedUDNsSetV4), counterIfDebug, "drop"),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: nftablesUDNBGPOutputChain,
+		Rule:  knftables.Concat(fmt.Sprintf("ip6 daddr @%s", nftablesAdvertisedUDNsSetV6), counterIfDebug, "drop"),
+	})
+	return nft.Run(context.TODO(), tx)
 }

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -573,7 +573,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnB.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
 
 			ginkgo.By("Selecting 3 schedulable nodes")
-			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
+			nodes, err = e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
 
@@ -602,6 +602,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			pod.Namespace = udnNamespaceB.Name
 			pod.Labels = map[string]string{"network": cudnB.Name}
 			podNetB = e2epod.PodClientNS(f, udnNamespaceB.Name).CreateSync(context.TODO(), pod)
+			framework.Logf("created pod %s/%s", podNetB.Namespace, podNetB.Name)
 
 			svc.Name = fmt.Sprintf("service-%s", cudnB.Name)
 			svc.Namespace = pod.Namespace
@@ -743,9 +744,16 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					framework.Logf("Connectivity check successful:'%s' -> %s", client, targetAddress)
 					return out, nil
 				}
+				clientName, clientNamespace, dst, expectedOutput, expectErr := connInfo(0)
 
-				gomega.Eventually(func() error {
-					clientName, clientNamespace, dst, expectedOutput, expectErr := connInfo(0)
+				asyncAssertion := gomega.Eventually
+				timeout := time.Second * 30
+				if expectErr {
+					// When the connectivity check is expected to fail it should be failing consistently
+					asyncAssertion = gomega.Consistently
+					timeout = time.Second * 15
+				}
+				asyncAssertion(func() error {
 					out, err := checkConnectivity(clientName, clientNamespace, dst)
 					if expectErr != (err != nil) {
 						return fmt.Errorf("expected connectivity check to return error(%t), got %v, output %v", expectErr, err, out)
@@ -769,7 +777,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						}
 					}
 					return nil
-				}, 30*time.Second).Should(gomega.BeNil())
+				}, timeout).Should(gomega.BeNil())
 			},
 			ginkgo.Entry("pod to pod on the same network and same node should work",
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
@@ -795,34 +803,28 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					framework.ExpectNoError(err)
 					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", clientPodStatus.IPs[ipFamilyIndex].IP.String(), false
 				}),
-			ginkgo.Entry("pod to pod on different networks and same node not should work",
-				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
-					// podsNetA[2] and podNetB are on the same node
-					clientPod := podsNetA[2]
-					srvPod := podNetB
+			// TODO: Enable the following tests once pod-pod on different advertised networks isolation is addressed
+			//ginkgo.Entry("pod to pod on different networks and same node should not work",
+			//	func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+			//		// podsNetA[2] and podNetB are on the same node
+			//		clientPod := podsNetA[2]
+			//		srvPod := podNetB
+			//
+			//		srvPodStatus, err := userDefinedNetworkStatus(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
+			//		framework.ExpectNoError(err)
+			//		return clientPod.Name, clientPod.Namespace, net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", curlConnectionTimeoutCode, true
+			//	}),
 
-					srvPodStatus, err := userDefinedNetworkStatus(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
-					framework.ExpectNoError(err)
-					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", curlConnectionTimeoutCode, true
-				}),
-
-			ginkgo.Entry("pod to pod on different networks and different nodes not should work",
-				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
-					// podsNetA[0] and podNetB are on different nodes
-					clientPod := podsNetA[0]
-					srvPod := podNetB
-
-					srvPodStatus, err := userDefinedNetworkStatus(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
-					framework.ExpectNoError(err)
-					retErr := true
-					out := curlConnectionTimeoutCode
-					if cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
-						// FIXME: L3 - pod to pod on different networks and different nodes should NOT work
-						retErr = false
-						out = ""
-					}
-					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", out, retErr
-				}),
+			//ginkgo.Entry("pod to pod on different networks and different nodes should not work",
+			//	func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+			//		// podsNetA[0] and podNetB are on different nodes
+			//		clientPod := podsNetA[0]
+			//		srvPod := podNetB
+			//
+			//		srvPodStatus, err := userDefinedNetworkStatus(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
+			//		framework.ExpectNoError(err)
+			//		return clientPod.Name, clientPod.Namespace, net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", curlConnectionTimeoutCode, true
+			//	}),
 			ginkgo.Entry("pod in the default network should not be able to access a UDN service",
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 					return podNetDefault.Name, podNetDefault.Namespace, net.JoinHostPort(svcNetA.Spec.ClusterIPs[ipFamilyIndex], "8080") + "/clientip", curlConnectionTimeoutCode, true
@@ -853,11 +855,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 
 					srvPodStatus, err := userDefinedNetworkStatus(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
 					framework.ExpectNoError(err)
-					// FIXME: L3 - curl returns code 7, the request works partially
-					// The client starts a connection from the default VRF. An IP rule sends this traffic into a specific VRF to reach the server pod.
-					// When the server pod replies (SYN-ACK), the reply packet is handled by the VRF. This stack doesn't contain the original client socket information,
-					// so it sees no active connection matching the reply and terminates the attempt with a RST.
-					return clientNode, "", net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", "", true
+					return clientNode, "", net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", curlConnectionTimeoutCode, true
 				}),
 			ginkgo.Entry("host to a different node UDN pod should not work",
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
@@ -867,14 +865,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 
 					srvPodStatus, err := userDefinedNetworkStatus(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
 					framework.ExpectNoError(err)
-					retErr := true
-					out := curlConnectionTimeoutCode
-					if cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
-						// FIXME: L3 - host to UDN pod on different node should not work
-						retErr = false
-						out = ""
-					}
-					return clientNode, "", net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", out, retErr
+					return clientNode, "", net.JoinHostPort(srvPodStatus.IPs[ipFamilyIndex].IP.String(), "8080") + "/clientip", curlConnectionTimeoutCode, true
 				}),
 		)
 


### PR DESCRIPTION
The PR is based on https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5167. 

An important caveat is that these rules will also block the VRF from accessing the UDN subnets.