### PR TITLE
Import BGP routes to UDN when EgressIP is advertised

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -714,11 +714,6 @@ func (c *Controller) generateFRRConfiguration(
 			continue
 		}
 
-		// we won't do imports if the pod network is not advertised
-		if !advertisements.Has(ratypes.PodNetwork) {
-			continue
-		}
-
 		// before handling imports, lets normalize the VRF for the default
 		// network: when doing imports, the default VRF is is referred to as
 		// "default" instead of ""

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -551,7 +551,8 @@ func TestController_reconcile(t *testing.T) {
 					Routers: []*testRouter{
 						{ASN: 1, VRF: "red", Prefixes: []string{"1.0.1.3/32", "172.100.0.16/32"}, Neighbors: []*testNeighbor{
 							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.0.1.3/32", "172.100.0.16/32"}},
-						}},
+						}, Imports: []string{"blue"}},
+						{ASN: 1, VRF: "blue", Imports: []string{"red"}},
 					}},
 			},
 			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},


### PR DESCRIPTION
BGP routes will be imported to the UDN VRF and GR, when EgressIP for the UDN is advertised to the default VRF. This ensures that the egress traffic can find the right egress route.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

1. Create a CUDN

2. Create a namespace that uses the CUDN as the primary network.

3. Create an EIP that selects the pods in the namespace

4. Create an RA that selects the CUDN and only advertises the EIP to the default VRF

5. Create a FRRConfiguration that can connect to an external BGP router. The BGP router is different from the default route of the node.

6. Create a test pod in the namespace. And try to curl an external host that is only reachable via the BGP router.
