### PR TITLE
routeimport: account for CUDN network name prefix

### DIFF
--- a/go-controller/pkg/ovn/routeimport/route_import.go
+++ b/go-controller/pkg/ovn/routeimport/route_import.go
@@ -264,8 +264,8 @@ func (c *controller) syncLinkUpdate(update *netlink.LinkUpdate) {
 	c.Lock()
 	defer c.Unlock()
 
-	// for CUDNs, VRF name equals network name
-	network := c.networks[vrf.Name]
+	// for CUDNs, VRF name equals network name sans prefix
+	network := c.networks[util.GenerateCUDNNetworkName(vrf.Name)]
 	// but if we got an ID, this can't be a CUDN, it's a UDN.
 	if networkID != types.InvalidID {
 		network = c.networks[c.networkIDs[networkID]]

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -369,7 +369,7 @@ func Test_controller_syncLinkUpdate(t *testing.T) {
 			expectTables: map[int]int{1000: 1},
 		},
 		{
-			name: "does reconcile on link updates with actual changes",
+			name: "does reconcile on link updates with actual changes for generated VRF names",
 			fields: fields{
 				networkIDs: map[int]string{1: "udn"},
 				networks:   map[string]util.NetInfo{"udn": udn},
@@ -381,6 +381,20 @@ func Test_controller_syncLinkUpdate(t *testing.T) {
 			},
 			expectTables:     map[int]int{1001: 1},
 			expectReconciles: []string{"udn"},
+		},
+		{
+			name: "does reconcile on link updates with actual changes for network VRF names",
+			fields: fields{
+				networkIDs: map[int]string{1: types.CUDNPrefix + "udn"},
+				networks:   map[string]util.NetInfo{types.CUDNPrefix + "udn": udn},
+				tables:     map[int]int{1000: 1},
+			},
+			args: args{&netlink.LinkUpdate{
+				Header: unix.NlMsghdr{Type: unix.RTM_NEWLINK},
+				Link:   &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: "udn"}, Table: 1001}},
+			},
+			expectTables:     map[int]int{1001: 1},
+			expectReconciles: []string{types.CUDNPrefix + "udn"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Route import for CUDNs with names <= 15 characters would fail when the route import controller becomes aware of the network before the VRF exists. 
The VRF name is the same as the CUDN name but the logic did not account for the "cluster_udn_" prefix that is added to the network name.
