### PR TITLE
Refactor routemanager

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -1332,7 +1332,7 @@ func routeDifference(routesA, routesB []netlink.Route) []netlink.Route {
 	for _, routeA := range routesA {
 		found = false
 		for _, routeB := range routesB {
-			if routemanager.RoutePartiallyEqual(routeA, routeB) {
+			if util.RouteEqual(&routeA, &routeB) {
 				found = true
 				break
 			}

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -1699,10 +1699,21 @@ func getNetlinkAddr(ip, netmask string) *netlink.Addr {
 // containsRoutes returns true if routes in routes1 are presents in routes routes2
 func containsRoutes(routes1 []netlink.Route, routes2 []netlink.Route) bool {
 	var found bool
+	eq := func(route1, route2 netlink.Route) bool {
+		// normalize fields that we don't set explicitly and just get set once
+		// the route is installed
+		if route1.Family == netlink.FAMILY_ALL {
+			route1.Family = route2.Family
+		}
+		if route1.Protocol == unix.RTPROT_UNSPEC {
+			route1.Protocol = route2.Protocol
+		}
+		return util.RouteEqual(&route1, &route2)
+	}
 	for _, route1 := range routes1 {
 		found = false
 		for _, route2 := range routes2 {
-			if routemanager.RoutePartiallyEqual(route1, route2) {
+			if eq(route1, route2) {
 				found = true
 				break
 			}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1756,8 +1756,7 @@ var _ = Describe("Gateway unit tests", func() {
 			netlinkMock.On("LinkByName", lnkAttr.Name).Return(lnk, nil)
 			netlinkMock.On("LinkByIndex", lnkAttr.Index).Return(lnk, nil)
 			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
-			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-			netlinkMock.On("RouteAdd", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			netlinkMock.On("RouteReplace", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			wg := &sync.WaitGroup{}
 			rm := routemanager.NewController()
 			util.SetNetLinkOpMockInst(netlinkMock)
@@ -1786,15 +1785,6 @@ var _ = Describe("Gateway unit tests", func() {
 				Name:  "ens1f0",
 				Index: 5,
 			}
-			previousRoute := &netlink.Route{
-				Dst:       ipnet,
-				LinkIndex: 5,
-				Scope:     netlink.SCOPE_UNIVERSE,
-				Gw:        gwIPs[0],
-				MTU:       config.Default.MTU - 100,
-				Src:       srcIP,
-			}
-
 			expectedRoute := &netlink.Route{
 				Dst:       ipnet,
 				LinkIndex: 5,
@@ -1802,13 +1792,13 @@ var _ = Describe("Gateway unit tests", func() {
 				Gw:        gwIPs[0],
 				MTU:       config.Default.MTU,
 				Src:       srcIP,
+				Table:     syscall.RT_TABLE_MAIN,
 			}
 
 			lnk.On("Attrs").Return(lnkAttr)
 			netlinkMock.On("LinkByName", lnkAttr.Name).Return(lnk, nil)
 			netlinkMock.On("LinkByIndex", lnkAttr.Index).Return(lnk, nil)
 			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
-			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{*previousRoute}, nil)
 			netlinkMock.On("RouteReplace", expectedRoute).Return(nil)
 			wg := &sync.WaitGroup{}
 			rm := routemanager.NewController()

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -3,6 +3,8 @@ package routemanager
 import (
 	"fmt"
 	"net"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -10,27 +12,31 @@ import (
 	"golang.org/x/sys/unix"
 
 	"k8s.io/klog/v2"
-	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-// MainTableID is the default routing table. IPRoute2 names the default routing table as 'main'
-const MainTableID = 254
+// key of a managed route, only one route allowed with the same key
+type key struct {
+	dst      string
+	table    int
+	priority int
+}
 
 type Controller struct {
 	*sync.Mutex
-	store map[int][]netlink.Route // key is link index
+	store map[key]*netlink.Route
 }
 
-// NewController manages routes which include adding and deletion of routes. It also manages restoration of managed routes.
-// Begin managing routes by calling Run() to start the manager.
-// Routes should be added via add(route) and deletion via del(route) functions only.
-// All other functions are used internally.
+// NewController manages routes which include adding and deletion of routes. It
+// also manages restoration of managed routes. Begin managing routes by calling
+// Run() to start the manager. Routes should be added via Add(route) and
+// deletion via Del(route) functions only. All other functions are used
+// internally.
 func NewController() *Controller {
 	return &Controller{
 		Mutex: &sync.Mutex{},
-		store: make(map[int][]netlink.Route),
+		store: make(map[key]*netlink.Route),
 	}
 }
 
@@ -51,105 +57,84 @@ func (c *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 			return
 		case newRouteEvent, ok := <-routeEventCh:
 			if !ok {
-				klog.Info("Route Manager: failed to read netlink route event - resubscribing")
+				klog.Warning("Route Manager: netlink route events subscription lost, resubscribing...")
 				subscribed, routeEventCh = subscribeNetlinkRouteEvents(stopCh)
 				continue
 			}
 			if err = c.processNetlinkEvent(newRouteEvent); err != nil {
 				// TODO: make util.GetNetLinkOps().IsLinkNotFoundError(err) smarter to unwrap error
 				// and use it here to log errors that are not IsLinkNotFoundError
-				klog.V(5).Infof("Route Manager: failed to process route update event (%s): %v", newRouteEvent.String(), err)
+				klog.Errorf("Route Manager: failed to process route update event %v: %v", newRouteEvent, err)
 			}
 		case <-ticker.C:
 			if !subscribed {
-				klog.Info("Route Manager: netlink route events aren't subscribed - resubscribing")
+				klog.Warning("Route Manager: netlink route events subscription lost, resubscribing...")
 				subscribed, routeEventCh = subscribeNetlinkRouteEvents(stopCh)
 			}
 			c.sync()
+			ticker.Reset(syncPeriod)
 		}
 	}
 }
 
-// Add submits a request to add a route
+// Add submits a request to add a route, instructing the kernel to replace a
+// previously existing route. Route manager will periodically sync to ensure the
+// provided route is installed and that no other routes with the same priority,
+// prefix and table tuple exist. Thus note that if the provided route is not a
+// replacement for an existing route, multiple routes with the same priority,
+// prefix and table tuple may exist until sync happens.
 func (c *Controller) Add(r netlink.Route) error {
-	if err := c.addRoute(r); err != nil {
-		return fmt.Errorf("route manager: failed to add route (%s): %w", r.String(), err)
-	}
-	return nil
+	c.Lock()
+	defer c.Unlock()
+	return c.addRoute(&r)
 }
 
-// Del submits a request to del a route
+// Del submits a request to delete and forget a route.
 func (c *Controller) Del(r netlink.Route) error {
-	if err := c.delRoute(r); err != nil {
-		return fmt.Errorf("route manager: failed to delete route (%s): %v", r.String(), err)
-	}
-	return nil
+	c.Lock()
+	defer c.Unlock()
+	return c.delRoute(&r)
 }
 
 // addRoute attempts to add the route and returns with error
 // if it fails to do so.
-func (c *Controller) addRoute(r netlink.Route) error {
-	c.Lock()
-	defer c.Unlock()
-	klog.Infof("Route Manager: attempting to add route: %s", r.String())
-	// If table is unspecified aka 0, then set it to main table ID. This is done by default when adding a route.
-	// Set it explicitly to aid comparison of routes.
-	if r.Table == 0 {
-		r.Table = MainTableID
+func (c *Controller) addRoute(r *netlink.Route) error {
+	r, err := validateAndNormalizeRoute(r)
+	if err != nil {
+		return err
 	}
-	if addedToStore := c.addRouteToStore(r); !addedToStore {
+	if c.hasRouteInStore(r) {
 		// already managed - nothing to do
 		return nil
 	}
-	if r.LinkIndex != 0 {
-		_, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
-		if err != nil {
-			return fmt.Errorf("failed to apply route (%s) because unable to get link: %v", r.String(), err)
-		}
+	err = c.netlinkAddRoute(r)
+	if err != nil {
+		return err
 	}
-	if err := c.applyRoute(r.LinkIndex, r.Gw, r.Dst, r.MTU, r.Src, r.Table, r.Priority, r.Type, r.Scope); err != nil {
-		return fmt.Errorf("failed to apply route (%s): %v", r.String(), err)
-	}
-	klog.Infof("Route Manager: completed adding route: %s", r.String())
+	c.addRouteToStore(r)
 	return nil
 }
 
 // delRoute attempts to remove the route and returns with error
 // if it fails to do so.
-func (c *Controller) delRoute(r netlink.Route) error {
-	c.Lock()
-	defer c.Unlock()
-	klog.Infof("Route Manager: attempting to delete route: %s", r.String())
-	if r.LinkIndex != 0 {
-		_, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
+func (c *Controller) delRoute(r *netlink.Route) error {
+	r, err := validateAndNormalizeRoute(r)
+	if err != nil {
+		return err
+	}
+	err = c.netlinkDelRoute(r)
+	if err != nil {
+		return err
+	}
+	// also remove the route we had in store if different
+	o := c.store[keyFromNetlink(r)]
+	if o != nil && !util.RouteEqual(r, o) {
+		err = c.netlinkDelRoute(o)
 		if err != nil {
-			if util.GetNetLinkOps().IsLinkNotFoundError(err) {
-				delete(c.store, r.LinkIndex)
-				return nil
-			}
-			return fmt.Errorf("failed to delete route (%s) because unable to get link: %v", r.String(), err)
+			return err
 		}
 	}
-	if err := c.netlinkDelRoute(r.LinkIndex, r.Dst, r.Table); err != nil {
-		return fmt.Errorf("failed to delete route (%s): %v", r.String(), err)
-	}
-	managedRoutes, ok := c.store[r.LinkIndex]
-	if !ok {
-		return nil
-	}
-	// remove route from existing routes
-	managedRoutesTemp := make([]netlink.Route, 0, len(managedRoutes))
-	for _, managedRoute := range managedRoutes {
-		if !RoutePartiallyEqual(managedRoute, r) {
-			managedRoutesTemp = append(managedRoutesTemp, managedRoute)
-		}
-	}
-	if len(managedRoutesTemp) == 0 {
-		delete(c.store, r.LinkIndex)
-	} else {
-		c.store[r.LinkIndex] = managedRoutesTemp
-	}
-	klog.Infof("Route Manager: deletion of routes for link complete: %s", r.String())
+	c.removeRouteFromStore(r)
 	return nil
 }
 
@@ -158,200 +143,141 @@ func (c *Controller) delRoute(r netlink.Route) error {
 func (c *Controller) processNetlinkEvent(ru netlink.RouteUpdate) error {
 	c.Lock()
 	defer c.Unlock()
-	if ru.Type == unix.RTM_NEWROUTE {
-		// An event resulting from `ip route change` will be seen as type RTM_NEWROUTE event and therefore this function will only
-		// log the changes and not attempt to restore the change. This will be accomplished by the sync function.
-		klog.Infof("Route Manager: netlink route addition event: %q", ru.String())
+	r := c.store[keyFromNetlink(&ru.Route)]
+	if r == nil {
 		return nil
 	}
-	if ru.Type != unix.RTM_DELROUTE {
-		return nil
-	}
-	klog.V(5).Infof("Route Manager: netlink route deletion event: %q", ru.String())
-	managedRoutes, ok := c.store[ru.LinkIndex]
-	if !ok {
-		// we don't manage this interface
-		return nil
-	}
-	for _, managedRoute := range managedRoutes {
-		if RoutePartiallyEqual(managedRoute, ru.Route) {
-			if managedRoute.LinkIndex != 0 {
-				_, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
-				if err != nil {
-					klog.Errorf("Route Manager: failed to restore route because unable to get link by index %d: %v", managedRoute.LinkIndex, err)
-					continue
-				}
-			}
-			if err := c.applyRoute(managedRoute.LinkIndex, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table,
-				managedRoute.Priority, managedRoute.Type, managedRoute.Scope); err != nil {
-				klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)
-			}
-		}
+	if ru.Type == unix.RTM_DELROUTE || !routePartiallyEqualWantedToExisting(r, &ru.Route) {
+		return c.netlinkAddRoute(r)
 	}
 	return nil
 }
 
-func (c *Controller) applyRoute(linkIndex int, gwIP net.IP, subnet *net.IPNet, mtu int, src net.IP,
-	table, priority, rtype int, scope netlink.Scope) error {
-	filterRoute, filterMask := filterRouteByDstAndTable(linkIndex, subnet, table)
-	existingRoutes, err := util.GetNetLinkOps().RouteListFiltered(getNetlinkIPFamily(subnet), filterRoute, filterMask)
+func (c *Controller) netlinkAddRoute(r *netlink.Route) error {
+	err := util.GetNetLinkOps().RouteReplace(r)
 	if err != nil {
-		return fmt.Errorf("failed to list filtered routes: %v", err)
+		return fmt.Errorf("failed to add route %s: %w", r, err)
 	}
-	if len(existingRoutes) == 0 {
-		return c.netlinkAddRoute(linkIndex, gwIP, subnet, mtu, src, table, priority, rtype, scope)
-	}
-	netlinkRoute := &existingRoutes[0]
-	if netlinkRoute.MTU != mtu || !src.Equal(netlinkRoute.Src) || !gwIP.Equal(netlinkRoute.Gw) {
-		netlinkRoute.MTU = mtu
-		netlinkRoute.Src = src
-		netlinkRoute.Gw = gwIP
-		err = util.GetNetLinkOps().RouteReplace(netlinkRoute)
-		if err != nil {
-			return fmt.Errorf("failed to replace route for subnet %s via gateway %s with mtu %d: %v",
-				subnet.String(), gwIP.String(), mtu, err)
-		}
-	}
+	klog.V(5).Infof("Route Manager: added route %s", r)
 	return nil
 }
 
-func (c *Controller) netlinkAddRoute(linkIndex int, gwIP net.IP, subnet *net.IPNet,
-	mtu int, srcIP net.IP, table, priority, rtype int, scope netlink.Scope) error {
-	newNlRoute := &netlink.Route{
-		Dst:       subnet,
-		LinkIndex: linkIndex,
-		Scope:     netlink.SCOPE_UNIVERSE,
-		Table:     table,
+func (c *Controller) netlinkDelRoute(r *netlink.Route) error {
+	err := util.GetNetLinkOps().RouteDel(r)
+	if err != nil && !isRouteNotFoundError(err) {
+		return fmt.Errorf("failed to delete route %s: %w", r, err)
 	}
-	if len(gwIP) > 0 {
-		newNlRoute.Gw = gwIP
-	}
-	if len(srcIP) > 0 {
-		newNlRoute.Src = srcIP
-	}
-	if mtu != 0 {
-		newNlRoute.MTU = mtu
-	}
-	if priority != 0 {
-		newNlRoute.Priority = priority
-	}
-	if rtype != 0 {
-		newNlRoute.Type = rtype
-	}
-	if scope != netlink.Scope(0) {
-		newNlRoute.Scope = scope
-	}
-	err := util.GetNetLinkOps().RouteAdd(newNlRoute)
-	if err != nil {
-		return fmt.Errorf("failed to add route (linkIndex: %d gw: %v, subnet %v, mtu %d, src IP %v): %v",
-			newNlRoute.LinkIndex, gwIP, subnet, mtu, srcIP, err)
-	}
-	return nil
-}
-
-func (c *Controller) netlinkDelRoute(linkIndex int, subnet *net.IPNet, table int) error {
-	if subnet == nil {
-		return fmt.Errorf("cannot delete route with no valid subnet")
-	}
-	filter, mask := filterRouteByDstAndTable(linkIndex, subnet, table)
-	existingRoutes, err := util.GetNetLinkOps().RouteListFiltered(netlink.FAMILY_ALL, filter, mask)
-	if err != nil {
-		return fmt.Errorf("failed to get routes for link %d: %v", linkIndex, err)
-	}
-	for _, existingRoute := range existingRoutes {
-		if err = util.GetNetLinkOps().RouteDel(&existingRoute); err != nil {
-			return err
-		}
-	}
+	klog.V(5).Infof("Route Manager: deleted route %s", r)
 	return nil
 }
 
 // addRouteToStore adds routes to the internal cache
 // Must be called with the controller locked
-func (c *Controller) addRouteToStore(r netlink.Route) bool {
-	existingRoutes, ok := c.store[r.LinkIndex]
-	if !ok {
-		c.store[r.LinkIndex] = []netlink.Route{r}
-		return true
-	}
-	for _, existingRoute := range existingRoutes {
-		if RoutePartiallyEqual(existingRoute, r) {
-			return false
-		}
-	}
-	c.store[r.LinkIndex] = append(existingRoutes, r)
-	return true
+func (c *Controller) addRouteToStore(r *netlink.Route) {
+	route := keyFromNetlink(r)
+	c.store[route] = r
 }
 
-// sync will iterate through all routes seen on a node and ensure any route manager managed routes are applied. Any additional
-// routes for this link are preserved. sync only inspects routes for links which we managed and ignore routes for non-managed links.
+// removeRouteFromStore removes route from the internal cache
+// Must be called with the controller locked
+func (c *Controller) removeRouteFromStore(r *netlink.Route) {
+	delete(c.store, keyFromNetlink(r))
+}
+
+// hasRouteInStore checks if a route with the same key is stored in the
+// internal cache as requested. Must be called with the controller locked
+func (c *Controller) hasRouteInStore(r *netlink.Route) bool {
+	route := c.store[keyFromNetlink(r)]
+	return route != nil && util.RouteEqual(r, route)
+}
+
+func validateAndNormalizeRoute(r *netlink.Route) (*netlink.Route, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil route provided")
+	}
+	if r.Table == unix.RT_TABLE_UNSPEC {
+		r.Table = unix.RT_TABLE_MAIN
+	}
+	return r, nil
+}
+
+func keyFromNetlink(r *netlink.Route) key {
+	return key{
+		dst:      r.Dst.String(),
+		table:    r.Table,
+		priority: r.Priority,
+	}
+}
+
+// sync will iterate through all routes seen on a node and ensure any route
+// manager managed routes are applied. Any conflicting additional routes are
+// removed. Other routes are preserved.
 func (c *Controller) sync() {
 	c.Lock()
 	defer c.Unlock()
-	deletedLinkIndexes := make([]int, 0)
-	for linkIndex, managedRoutes := range c.store {
-		for _, managedRoute := range managedRoutes {
-			filterRoute, filterMask := filterRouteByDstAndTable(linkIndex, managedRoute.Dst, managedRoute.Table)
-			existingRoutes, err := util.GetNetLinkOps().RouteListFiltered(netlink.FAMILY_ALL, filterRoute, filterMask)
+
+	var read, added, deleted int
+	start := time.Now()
+	defer func() {
+		klog.V(5).Infof("Route Manager: synced routes: stored[%d] read[%d] added[%d] deleted[%d], took %s",
+			len(c.store),
+			read,
+			added,
+			deleted,
+			time.Since(start),
+		)
+	}()
+
+	// there can be many routes on the system so make sure we list them as few
+	// times as possible
+	// note that RouteListFiltered dumps ALL routes, filtering happens on the
+	// client side
+	// we need to filter by table without specifying any table to get routes
+	// form all tables
+	filter := &netlink.Route{}
+	mask := netlink.RT_FILTER_TABLE
+	existing, err := util.GetNetLinkOps().RouteListFiltered(netlink.FAMILY_ALL, filter, mask)
+	if err != nil {
+		klog.Errorf("Route Manager: failed to list routes: %v", err)
+		return
+	}
+	read = len(existing)
+
+	existingAndTracked := map[key][]*netlink.Route{}
+	for _, r := range existing {
+		key := keyFromNetlink(&r)
+		wants := c.store[key]
+		if wants == nil {
+			continue
+		}
+		existingAndTracked[key] = append(existingAndTracked[key], &r)
+	}
+
+	for key, wants := range c.store {
+		existing := existingAndTracked[key]
+		if len(existing) == 1 && routePartiallyEqualWantedToExisting(wants, existing[0]) {
+			continue
+		}
+		// take the safe approach to delete routes before adding ours to make
+		// sure we don't end up deleting what we shouldn't
+		// deleting now may cause network blips until we add our route but
+		// nobody should be manipulating conflicting routes anyway
+		for _, r := range existing {
+			err := c.netlinkDelRoute(r)
 			if err != nil {
-				klog.Errorf("Route Manager: failed to list routes for link %d with route filter %s and mask filter %d: %v", linkIndex, filterRoute.String(), filterMask, err)
+				klog.Errorf("Route Manager: failed while syncing: %v", err)
 				continue
 			}
-			var found bool
-			for _, activeRoute := range existingRoutes {
-				if RoutePartiallyEqual(activeRoute, managedRoute) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				if managedRoute.LinkIndex != 0 {
-					_, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
-					if err != nil {
-						if util.GetNetLinkOps().IsLinkNotFoundError(err) {
-							deletedLinkIndexes = append(deletedLinkIndexes, linkIndex)
-						} else {
-							klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
-						}
-						continue
-					}
-				}
-				if err := c.applyRoute(managedRoute.LinkIndex, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table,
-					managedRoute.Priority, managedRoute.Type, managedRoute.Scope); err != nil {
-					klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)
-				}
-			}
+			klog.Warningf("Route Manager: removed unexpected route %s", r)
+			deleted++
 		}
+		err := c.netlinkAddRoute(wants)
+		if err != nil {
+			klog.Errorf("Route Manager: failed while syncing: %v", err)
+			continue
+		}
+		added++
 	}
-	for _, linkIndex := range deletedLinkIndexes {
-		klog.Infof("Route Manager: removing all routes associated with link index %d because link deleted", linkIndex)
-		delete(c.store, linkIndex)
-	}
-}
-
-func getNetlinkIPFamily(ipNet *net.IPNet) int {
-	if utilnet.IsIPv6(ipNet.IP) {
-		return netlink.FAMILY_V6
-	} else {
-		return netlink.FAMILY_V4
-	}
-}
-
-func filterRouteByDstAndTable(linkIndex int, subnet *net.IPNet, table int) (*netlink.Route, uint64) {
-	return &netlink.Route{
-			Dst:       subnet,
-			LinkIndex: linkIndex,
-			Table:     table,
-		},
-		netlink.RT_FILTER_DST | netlink.RT_FILTER_OIF | netlink.RT_FILTER_TABLE
-}
-
-func filterRouteByTable(linkIndex, table int) (*netlink.Route, uint64) {
-	return &netlink.Route{
-			LinkIndex: linkIndex,
-			Table:     table,
-		},
-		netlink.RT_FILTER_OIF | netlink.RT_FILTER_TABLE
 }
 
 func subscribeNetlinkRouteEvents(stopCh <-chan struct{}) (bool, chan netlink.RouteUpdate) {
@@ -363,20 +289,71 @@ func subscribeNetlinkRouteEvents(stopCh <-chan struct{}) (bool, chan netlink.Rou
 	return true, routeEventCh
 }
 
-// RoutePartiallyEqual compares a limited set of route attributes.
-// The reason for not using the Equal method associated with type netlink.Route is because a user will only specify a limited
-// subset of fields but when we introspect routes seen on the system, other fields are populated by default and therefore
-// won't be equal anymore with user defined routes. Compare a limited set of fields that we care about.
-// Also, netlink.Routes Equal method doesn't compare MTU.
-func RoutePartiallyEqual(r, x netlink.Route) bool {
-	return r.LinkIndex == x.LinkIndex &&
-		util.IsIPNetEqual(r.Dst, x.Dst) &&
-		r.Src.Equal(x.Src) &&
-		r.Gw.Equal(x.Gw) &&
-		r.Table == x.Table &&
-		r.Flags == x.Flags &&
-		r.MTU == x.MTU &&
-		r.Type == x.Type &&
-		r.Priority == x.Priority &&
-		r.Scope == x.Scope
+func equalOrLeftZero[T comparable](l, r, z T) bool {
+	return l == z || l == r
+}
+
+func equalOrLeftZeroFunc[T any](eq func(l, r T) bool, l, r, z T) bool {
+	return eq(l, z) || eq(l, r)
+}
+
+// routePartiallyEqualWantedToExisting compares non zero values of left wanted route with the
+// right existing route. The reason for not using the Equal method associated
+// with type netlink.Route is because a user will only specify a limited subset
+// of fields but when we introspect routes seen on the system, other fields are
+// populated by default and therefore won't be equal anymore with user defined
+// routes. Also, netlink.Routes Equal method doesn't compare MTU.
+func routePartiallyEqualWantedToExisting(w, e *netlink.Route) bool {
+	if (w == nil) != (e == nil) {
+		return false
+	}
+	if w == e {
+		return true
+	}
+	// this compares dst, table and priority which must be equal for us
+	if keyFromNetlink(w) != keyFromNetlink(e) {
+		return false
+	}
+	var z netlink.Route
+	return equalOrLeftZero(w.LinkIndex, e.LinkIndex, z.LinkIndex) &&
+		equalOrLeftZero(w.ILinkIndex, e.ILinkIndex, z.ILinkIndex) &&
+		equalOrLeftZero(w.Scope, e.Scope, z.Scope) &&
+		equalOrLeftZeroFunc(func(l, r net.IP) bool { return l.Equal(r) }, w.Src, e.Src, z.Src) &&
+		equalOrLeftZeroFunc(func(l, r net.IP) bool { return l.Equal(r) }, w.Gw, e.Gw, z.Gw) &&
+		equalOrLeftZeroFunc(
+			func(l, r []*netlink.NexthopInfo) bool {
+				return slices.EqualFunc(l, r,
+					func(l, r *netlink.NexthopInfo) bool { return l == r || (l != nil && r != nil && l.Equal(*r)) },
+				)
+			}, w.MultiPath, e.MultiPath, z.MultiPath) &&
+		equalOrLeftZero(w.Protocol, e.Protocol, z.Protocol) &&
+		equalOrLeftZero(w.Family, e.Family, z.Family) &&
+		equalOrLeftZero(w.Type, e.Type, z.Type) &&
+		equalOrLeftZero(w.Tos, e.Tos, z.Tos) &&
+		equalOrLeftZero(w.Flags, e.Flags, z.Flags) &&
+		equalOrLeftZeroFunc(func(l, r *int) bool { return l == r || (l != nil && r != nil && *l == *r) }, w.MPLSDst, e.MPLSDst, z.MPLSDst) &&
+		equalOrLeftZeroFunc(func(l, r netlink.Destination) bool { return l == r || (l != nil && r != nil && l.Equal(r)) }, w.NewDst, e.NewDst, z.NewDst) &&
+		equalOrLeftZeroFunc(func(l, r netlink.Encap) bool { return l == r || (l != nil && r != nil && l.Equal(r)) }, w.Encap, e.Encap, z.Encap) &&
+		equalOrLeftZeroFunc(func(l, r netlink.Destination) bool { return l == r || (l != nil && r != nil && l.Equal(r)) }, w.Via, e.Via, z.Via) &&
+		equalOrLeftZero(w.Realm, e.Realm, z.Realm) &&
+		equalOrLeftZero(w.MTU, e.MTU, z.MTU) &&
+		equalOrLeftZero(w.Window, e.Window, z.Window) &&
+		equalOrLeftZero(w.Rtt, e.Rtt, z.Rtt) &&
+		equalOrLeftZero(w.RttVar, e.RttVar, z.RttVar) &&
+		equalOrLeftZero(w.Ssthresh, e.Ssthresh, z.Ssthresh) &&
+		equalOrLeftZero(w.Cwnd, e.Cwnd, z.Cwnd) &&
+		equalOrLeftZero(w.AdvMSS, e.AdvMSS, z.AdvMSS) &&
+		equalOrLeftZero(w.Reordering, e.Reordering, z.Reordering) &&
+		equalOrLeftZero(w.Hoplimit, e.Hoplimit, z.Hoplimit) &&
+		equalOrLeftZero(w.InitCwnd, e.InitCwnd, z.InitCwnd) &&
+		equalOrLeftZero(w.Features, e.Features, z.Features) &&
+		equalOrLeftZero(w.RtoMin, e.RtoMin, z.RtoMin) &&
+		equalOrLeftZero(w.InitRwnd, e.InitRwnd, z.InitRwnd) &&
+		equalOrLeftZero(w.QuickACK, e.QuickACK, z.QuickACK) &&
+		equalOrLeftZero(w.Congctl, e.Congctl, z.Congctl) &&
+		equalOrLeftZero(w.FastOpenNoCookie, e.FastOpenNoCookie, z.FastOpenNoCookie)
+}
+
+func isRouteNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "no such process")
 }

--- a/go-controller/pkg/node/routemanager/route_manager_test.go
+++ b/go-controller/pkg/node/routemanager/route_manager_test.go
@@ -2,6 +2,7 @@ package routemanager
 
 import (
 	"net"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -14,9 +15,13 @@ import (
 	"golang.org/x/sys/unix"
 
 	utilsnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 )
+
+// mainTableID is the default routing table. IPRoute2 names the default routing table as 'main'
+const mainTableID = 254
 
 var _ = ginkgo.Describe("Route Manager", func() {
 	defer ginkgo.GinkgoRecover()
@@ -112,54 +117,54 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 
 		ginkgo.It("applies route with subnet, gateway IP, src IP, MTU", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Gw: loGWIP, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Gw: loGWIP, MTU: loMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("applies route with subnets, gateway IP, src IP", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("applies route with subnets, gateway IP", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("applies route with subnets", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("route exists, has different mtu and is updated", func() {
-			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRoute(testNS, route)).Should(gomega.Succeed())
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loAlternativeMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loAlternativeMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("route exists, has different src and is updated", func() {
-			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			route := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRoute(testNS, route)).Should(gomega.Succeed())
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, Src: loIPDiff, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
@@ -188,75 +193,75 @@ var _ = ginkgo.Describe("Route Manager", func() {
 
 	ginkgo.Context("del route", func() {
 		ginkgo.It("del route with dst", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			gomega.Expect(delRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeFalse())
 		})
 
 		ginkgo.It("del route with dst and gateway", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			gomega.Expect(delRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeFalse())
 		})
 
 		ginkgo.It("del route with dst, gateway and MTU", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, MTU: loMTU, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Gw: loGWIP, MTU: loMTU, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			gomega.Expect(delRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeFalse())
 		})
 
 		ginkgo.It("del route amongst multiple managed routes present", func() {
-			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, rAlt)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
-			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, rDefault)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRoutesInTable(testNS, []netlink.Route{rDefault, rAlt}, loLink.Attrs().Index, MainTableID)
+				return isRoutesInTable(testNS, []netlink.Route{rDefault, rAlt}, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			gomega.Expect(delRouteViaManager(rm, testNS, rAlt)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeFalse())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, rDefault, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, rDefault, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("del route and ignores unmanaged route", func() {
-			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			rAlt := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: altSubnet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRoute(testNS, rAlt)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
-			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID, Type: unix.RTN_UNICAST}
+			rDefault := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, rDefault)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRoutesInTable(testNS, []netlink.Route{rDefault, rAlt}, loLink.Attrs().Index, MainTableID)
+				return isRoutesInTable(testNS, []netlink.Route{rDefault, rAlt}, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			gomega.Expect(delRouteViaManager(rm, testNS, rDefault)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, rAlt, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
@@ -271,10 +276,10 @@ var _ = ginkgo.Describe("Route Manager", func() {
 
 	ginkgo.Context("runtime sync", func() {
 		ginkgo.It("reapplies managed route that was removed (gw IP, mtu, src IP)", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			// clear routes and wait for sync to reapply
 			routeList, err := getRouteList(testNS, loLink, netlink.FAMILY_ALL)
@@ -283,15 +288,15 @@ var _ = ginkgo.Describe("Route Manager", func() {
 			gomega.Expect(deleteRoutes(testNS, routeList...)).ShouldNot(gomega.HaveOccurred())
 			// wait for sync to activate since managed routes have been deleted
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("reapplies managed route that was removed (mtu, src IP)", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			// clear routes and wait for sync to reapply
 			routeList, err := getRouteList(testNS, loLink, netlink.FAMILY_ALL)
@@ -300,23 +305,23 @@ var _ = ginkgo.Describe("Route Manager", func() {
 			gomega.Expect(deleteRoutes(testNS, routeList...)).ShouldNot(gomega.HaveOccurred())
 			// wait for sync to activate since managed routes have been deleted
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("reapplies managed route that was removed because link is down", func() {
-			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: MainTableID, Type: unix.RTN_UNICAST}
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
 			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 			gomega.Expect(setLinkDown(testNS, loLink)).ShouldNot(gomega.HaveOccurred())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeFalse())
 			gomega.Expect(setLinkUp(testNS, loLink)).ShouldNot(gomega.HaveOccurred())
 			gomega.Eventually(func() bool {
-				return isRouteInTable(testNS, r, loLink.Attrs().Index, MainTableID)
+				return isRouteInTable(testNS, r, loLink.Attrs().Index, mainTableID)
 			}, time.Second).Should(gomega.BeTrue())
 		})
 
@@ -340,7 +345,7 @@ var _ = ginkgo.Describe("Route Manager", func() {
 				if err = netlink.LinkSetUp(link); err != nil {
 					return err
 				}
-				r := netlink.Route{LinkIndex: link.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: MainTableID, Type: unix.RTN_UNICAST}
+				r := netlink.Route{LinkIndex: link.Attrs().Index, Dst: v4DefaultRouteIPNet, Table: mainTableID, Type: unix.RTN_UNICAST}
 				if err = rm.Add(r); err != nil {
 					return err
 				}
@@ -348,6 +353,70 @@ var _ = ginkgo.Describe("Route Manager", func() {
 			})).Should(gomega.Succeed())
 			time.Sleep(400 * time.Millisecond) // sync period is 300 ms
 		})
+	})
+})
+
+var _ = ginkgo.Describe("Route Manager", func() {
+	ginkgo.It("partially compares expected routes with installed routes", func() {
+		values := map[string]any{
+			"int":           1,
+			"Scope":         uint8(1),
+			"IPNet":         ovntest.MustParseIPNet("10.0.0.0/16"),
+			"IP":            ovntest.MustParseIP("10.0.0.0"),
+			"NexthopInfo":   []*netlink.NexthopInfo{{LinkIndex: 1}},
+			"RouteProtocol": 1,
+			"*int":          ptr.To(1),
+			"Destination":   &netlink.Via{Addr: ovntest.MustParseIP("10.0.0.0")},
+			"Encap":         &netlink.IP6tnlEncap{Src: ovntest.MustParseIP("10.0.0.0")},
+			"string":        "test",
+		}
+		keys := map[string]bool{
+			"Dst":      true,
+			"Priority": true,
+			"Table":    true,
+		}
+
+		var getName func(reflect.Type, string) string
+		getName = func(t reflect.Type, prefix string) string {
+			name := prefix + t.Name()
+			_, known := values[name]
+			if known {
+				return name
+			}
+			kind := t.Kind()
+			switch kind {
+			case reflect.Pointer:
+				return getName(t.Elem(), "*")
+			case reflect.Slice:
+				return getName(t.Elem(), "[]")
+			default:
+				return t.Name()
+			}
+		}
+
+		// we iterate all the fields of a Route and test that:
+		// - correctly detects differences of non zero left values against zero right values
+		// - correctly detects differences of zero left values against non zero right values if key
+		// - correctly ignores differences of zero left values against non zero right values if not key
+		var z netlink.Route
+		zv := reflect.ValueOf(z)
+		for i := 0; i < zv.NumField(); i++ {
+			var t netlink.Route
+			tv := reflect.ValueOf(&t).Elem()
+			fv := tv.Field(i)
+			ft := fv.Type()
+			fn := tv.Type().Field(i).Name
+
+			ftn := getName(ft, "")
+
+			gomega.Expect(values).To(gomega.HaveKey(ftn), "unexpected field %q of type %s", fn, ftn)
+
+			fv.Set(reflect.ValueOf(values[ftn]).Convert(ft))
+
+			isKey := keys[fn]
+			gomega.Expect(routePartiallyEqualWantedToExisting(&t, &z)).To(gomega.BeFalse(), "differences of non zero left values against zero right values not detected for field %s", fn)
+			gomega.Expect(routePartiallyEqualWantedToExisting(&z, &t)).ToNot(gomega.Equal(isKey), "differences of zero left values against non zero right values not ignored (or detected if field is key) for field %s", fn)
+		}
 	})
 })
 
@@ -367,6 +436,14 @@ func addRoute(targetNS ns.NetNS, r netlink.Route) error {
 // isRouteInTable ensure only the expected route for a link are within a table
 func isRouteInTable(targetNs ns.NetNS, expectedRoute netlink.Route, linkIndex, table int) bool {
 	return isRoutesInTable(targetNs, []netlink.Route{expectedRoute}, linkIndex, table)
+}
+
+func filterRouteByTable(linkIndex, table int) (*netlink.Route, uint64) {
+	return &netlink.Route{
+			LinkIndex: linkIndex,
+			Table:     table,
+		},
+		netlink.RT_FILTER_OIF | netlink.RT_FILTER_TABLE
 }
 
 // isRoutesInTable ensures only the slice of expected routes for a link are present within a table
@@ -391,7 +468,7 @@ func isRoutesInTable(targetNs ns.NetNS, expectedRoutes []netlink.Route, linkInde
 	for _, expectedRoute := range expectedRoutes {
 		found = false
 		for _, existingRoute := range existingRoutes {
-			if RoutePartiallyEqual(existingRoute, expectedRoute) {
+			if routePartiallyEqualWantedToExisting(&expectedRoute, &existingRoute) {
 				found = true
 				break
 			}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	iputils "github.com/containernetworking/plugins/pkg/ip"
+	"github.com/vishvananda/netlink"
 
 	utilnet "k8s.io/utils/net"
 )
@@ -346,4 +347,34 @@ func IPNetsIPToStringSlice(ips []*net.IPNet) []string {
 // interface index
 func CalculateRouteTableID(ifIndex int) int {
 	return ifIndex + RoutingTableIDStart
+}
+
+// RouteEqual compare two routes
+func RouteEqual(l, r *netlink.Route) bool {
+	if (l == nil) != (r == nil) {
+		return false
+	}
+	if l == r {
+		return true
+	}
+	if !l.Equal(*r) {
+		return false
+	}
+	return l.Family == r.Family &&
+		l.MTU == r.MTU &&
+		l.Window == r.Window &&
+		l.Rtt == r.Rtt &&
+		l.RttVar == r.RttVar &&
+		l.Ssthresh == r.Ssthresh &&
+		l.Cwnd == r.Cwnd &&
+		l.AdvMSS == r.AdvMSS &&
+		l.Reordering == r.Reordering &&
+		l.Hoplimit == r.Hoplimit &&
+		l.InitCwnd == r.InitCwnd &&
+		l.Features == r.Features &&
+		l.RtoMin == r.RtoMin &&
+		l.InitRwnd == r.InitRwnd &&
+		l.QuickACK == r.QuickACK &&
+		l.Congctl == r.Congctl &&
+		l.FastOpenNoCookie == r.FastOpenNoCookie
 }


### PR DESCRIPTION
For a number of reasons:

1. Performance

With BGP the number of routes that can be installed on the system scales
up. Tests with > 1500 routes cause trouble. The current sync
implementation has exponential loops. On each iteration,
RouteListFiltered is called which dumps all the routes on the system and
then filters client side. netlink API is by value, and this causes high
GC crunch.

Changed sync implementation to have sequential loops and a single list
call to netlink. Changed to avoid listing routes in any other case.

sync is still a heavy operation that keeps a lock and migh require
further optimizations. This is a first take.

2. Consistency

The used RoutePartiallyEqual had a different criteria than what was used
to actually delete a route from netlink, leaving the door open for
inconsistencies. This could be thought of as a compromise due to the fact
that routes can assume different defaults when installed than those
provided. Proposal is to do a bit better and ignore those defaults when
comparing against kernel routes as a unified criteria. Should fulfill our
use cases but might need further tweaking in the future. Potential
problem is that kernel switches back an incorrect value to default
instead of throwing us an error which can cause a route to constantly
sync. Much of this is undocumented as far as I could tell but anyway has
not been observed with the specific routes that we install.

Also, the current implementation was validating and indexing by link index
which is actually not a required field of a route. Instead, key routes by
priority, prefix and table. Route manager assumes ownership of all the
routes with any of the provided keys and will delete unrecognized routes
on sync. This is inline to what our previous netlink delete was doing.

3. Other

* Reset ticker on each sync iteration to avoid backlogging.
* Cleaned up excessive logging