### PR TITLE
upgrade-ovn.sh: ovnkube-identity is now a DaemonSet

### DIFF
--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -403,7 +403,6 @@ helm install ovn-kubernetes . -f "${value_file}" \
           --set k8sAPIServer=${API_URL} \
           --set podNetwork="${NET_CIDR_IPV4}/24" \
           --set serviceNetwork=${SVC_CIDR_IPV4} \
-          --set ovnkube-identity.replicas=${MASTER_REPLICAS} \
           --set ovnkube-master.replicas=${MASTER_REPLICAS} \
           --set global.image.repository=$(get_image) \
           --set global.image.tag=$(get_tag) \

--- a/docs/features/infrastructure-security-controls/node-identity.md
+++ b/docs/features/infrastructure-security-controls/node-identity.md
@@ -65,7 +65,7 @@ Some of the allowed annotations have additional checks; for instance, the IP add
 must match the node's [k8s.ovn.org/node-subnets](https://github.com/ovn-org/ovn-kubernetes/blob/5d56a53df520a085e629cdc71be092afed9c3f0f/go-controller/pkg/util/subnet_annotations.go#L15-L39) networks.
 
 
-## Deployment
+## DaemonSet
 
 In Kind,
 the feature is enabled by default and can be disabled with `--disable-ovnkube-identity` when creating the cluster.\

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -71,10 +71,10 @@ networking:
 
 This chart does not use a `values.yaml` by default. You must specify a values file during installation.
 
-- Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
+- Run `helm install` with propery `k8sAPIServer` image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values-no-ic.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values-no-ic.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Alternative Configurations
@@ -605,15 +605,6 @@ false
 </pre>
 </td>
 			<td>MTU of network interface in a Kubernetes pod</td>
-		</tr>
-		<tr>
-			<td>ovnkube-identity.replicas</td>
-			<td>int</td>
-			<td><pre lang="json">
-1
-</pre>
-</td>
-			<td>number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes</td>
 		</tr>
 		<tr>
 			<td>podNetwork</td>

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -92,10 +92,10 @@ networking:
 # kind load docker-image ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
-- Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
+- Run `helm install` with propery `k8sAPIServer` image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set global.image.repository=ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:

--- a/helm/ovn-kubernetes/values-multi-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-multi-node-zone.yaml
@@ -154,10 +154,6 @@ global:
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
-ovnkube-identity:
-    # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes
-    replicas: 1
-
 # -- prometheus monitoring related fields
 monitoring:
   # -- specify the labels for serviceMonitors to be selected for target discovery.

--- a/helm/ovn-kubernetes/values-no-ic.yaml
+++ b/helm/ovn-kubernetes/values-no-ic.yaml
@@ -167,10 +167,6 @@ global:
     auth: blah_blah_blah
     create: false
 
-ovnkube-identity:
-    # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes
-    replicas: 1
-
 ovnkube-master:
     # -- number of ovnkube-master pods
     replicas: 1

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -155,10 +155,6 @@ global:
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
-ovnkube-identity:
-    # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes
-    replicas: 1
-
 # -- prometheus monitoring related fields
 monitoring:
   # -- specify the labels for serviceMonitors to be selected for target discovery.

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -45,7 +45,7 @@ kubectl_wait_daemonset(){
     READY_REPLICAS=$(run_kubectl get daemonsets.apps $1 -n ovn-kubernetes -o=jsonpath='{.status.numberReady}')
     echo "CURRENT READY REPLICAS: $READY_REPLICAS, CURRENT DESIRED REPLICAS: $DESIRED_REPLICAS for the DaemonSet $1"
     if [[ $READY_REPLICAS -eq $DESIRED_REPLICAS ]]; then
-      UP_TO_DATE_REPLICAS=$(run_kubectl get daemonsets.apps ovnkube-node -n ovn-kubernetes  -o=jsonpath='{.status.updatedNumberScheduled}')
+      UP_TO_DATE_REPLICAS=$(run_kubectl get daemonsets.apps $1 -n ovn-kubernetes  -o=jsonpath='{.status.updatedNumberScheduled}')
       echo "CURRENT UP TO DATE REPLICAS: $UP_TO_DATE_REPLICAS for the Deployment $1"
       if [[ $READY_REPLICAS -eq $UP_TO_DATE_REPLICAS ]]; then
         break
@@ -288,7 +288,7 @@ run_kubectl apply -f rbac-ovnkube-db.yaml
 
 if [ "${OVN_ENABLE_OVNKUBE_IDENTITY}" == true ]; then
   run_kubectl apply -f ovnkube-identity.yaml
-  kubectl_wait_deployment ovnkube-identity
+  kubectl_wait_daemonset ovnkube-identity
 fi
 
 


### PR DESCRIPTION
Starting from:
https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5146 ovnkube-identity pods are now created via a DaemonSet.

The test in upgrade-ovn.sh needed to be updated accordingly.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5183
