### PR TITLE
Isolate default network services from UDN pods

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -241,7 +241,6 @@ func (g *gateway) AddEgressIP(eip *egressipv1.EgressIP) error {
 		if err = g.Reconcile(); err != nil {
 			return fmt.Errorf("failed to sync gateway: %v", err)
 		}
-		g.openflowManager.requestFlowSync()
 	}
 	return nil
 }
@@ -258,7 +257,6 @@ func (g *gateway) UpdateEgressIP(oldEIP, newEIP *egressipv1.EgressIP) error {
 		if err = g.Reconcile(); err != nil {
 			return fmt.Errorf("failed to sync gateway: %v", err)
 		}
-		g.openflowManager.requestFlowSync()
 	}
 	return nil
 }
@@ -275,7 +273,6 @@ func (g *gateway) DeleteEgressIP(eip *egressipv1.EgressIP) error {
 		if err = g.Reconcile(); err != nil {
 			return fmt.Errorf("failed to sync gateway: %v", err)
 		}
-		g.openflowManager.requestFlowSync()
 	}
 	return nil
 }
@@ -290,7 +287,6 @@ func (g *gateway) SyncEgressIP(eips []interface{}) error {
 	if err := g.Reconcile(); err != nil {
 		return fmt.Errorf("failed to sync gateway: %v", err)
 	}
-	g.openflowManager.requestFlowSync()
 	return nil
 }
 
@@ -492,6 +488,8 @@ func (g *gateway) Reconcile() error {
 	if err := g.openflowManager.updateBridgeFlowCache(g.nodeIPManager.ListAddresses()); err != nil {
 		return err
 	}
+	// let's sync these flows immediately
+	g.openflowManager.requestFlowSync()
 	err := g.updateSNATRules()
 	if err != nil {
 		return err

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -411,18 +411,33 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 			}
 
 			ipPrefix := "ip"
-			masqueradeSubnet := config.Gateway.V4MasqueradeSubnet
 			if !utilnet.IsIPv4String(service.Spec.ClusterIP) {
 				ipPrefix = "ipv6"
-				masqueradeSubnet = config.Gateway.V6MasqueradeSubnet
 			}
 			// table 2, user-defined network host -> OVN towards default cluster network services
 			defaultNetConfig := npw.ofm.defaultBridge.getActiveNetworkBridgeConfig(types.DefaultNetworkName)
-
-			npw.ofm.updateFlowCacheEntry(key, []string{fmt.Sprintf("cookie=%s, priority=300, table=2, %s, %s_src=%s, %s_dst=%s, "+
+			// sample flow: cookie=0xdeff105, duration=2319.685s, table=2, n_packets=496, n_bytes=67111, priority=300,
+			//              ip,nw_dst=10.96.0.1 actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
+			// This flow is used for UDNs and advertised UDNs to be able to reach kapi and dns services alone on default network
+			flows := []string{fmt.Sprintf("cookie=%s, priority=300, table=2, %s, %s_dst=%s, "+
 				"actions=set_field:%s->eth_dst,output:%s",
-				defaultOpenFlowCookie, ipPrefix, ipPrefix, masqueradeSubnet, ipPrefix, service.Spec.ClusterIP,
-				npw.ofm.getDefaultBridgeMAC().String(), defaultNetConfig.ofPortPatch)})
+				defaultOpenFlowCookie, ipPrefix, ipPrefix, service.Spec.ClusterIP,
+				npw.ofm.getDefaultBridgeMAC().String(), defaultNetConfig.ofPortPatch)}
+			if util.IsRouteAdvertisementsEnabled() {
+				// if the network is advertised, then for the reply from kapi and dns services to go back
+				// into the UDN's VRF we need flows that statically send this to the local port
+				// sample flow: cookie=0xdeff105, duration=264.196s, table=0, n_packets=0, n_bytes=0, priority=490,ip,
+				//              in_port="patch-breth0_ov",nw_src=10.96.0.10,actions=ct(table=3,zone=64001,nat)
+				// this flow is meant to match all advertised UDNs and then the ip rules on the host will take
+				// this packet into the corresponding UDNs
+				// NOTE: We chose priority 490 to differentiate this flow from the flow at priority 500 added for the
+				// non-advertised UDNs reponse for debugging purposes:
+				// sample flow for non-advertised UDNs: cookie=0xdeff105, duration=684.087s, table=0, n_packets=0, n_bytes=0,
+				//				idle_age=684, priority=500,ip,in_port=2,nw_src=10.96.0.0/16,nw_dst=169.254.0.0/17 actions=ct(table=3,zone=64001,nat)
+				flows = append(flows, fmt.Sprintf("cookie=%s, priority=490, in_port=%s, ip, ip_src=%s,actions=ct(zone=%d,nat,table=3)",
+					defaultOpenFlowCookie, defaultNetConfig.ofPortPatch, service.Spec.ClusterIP, config.Default.HostMasqConntrackZone))
+			}
+			npw.ofm.updateFlowCacheEntry(key, flows)
 		}
 	}
 	return utilerrors.Join(errors...)
@@ -1593,6 +1608,37 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 					"actions=ct(commit,zone=%d,table=2)",
 					defaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix,
 					masqSubnet, protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone))
+			if util.IsRouteAdvertisementsEnabled() {
+				// If the UDN is advertised then instead of matching on the masqSubnet
+				// we match on the UDNPodSubnet itself and we also don't SNAT to 169.254.0.2
+				// sample flow: cookie=0xdeff105, duration=1472.742s, table=0, n_packets=9, n_bytes=666, priority=550
+				//              ip,in_port=LOCAL,nw_src=103.103.0.0/16,nw_dst=10.96.0.0/16 actions=ct(commit,table=2,zone=64001)
+				for _, netConfig := range bridge.patchedNetConfigs() {
+					if netConfig.isDefaultNetwork() {
+						continue
+					}
+					if netConfig.advertised.Load() {
+						var udnAdvertisedSubnets []*net.IPNet
+						for _, clusterEntry := range netConfig.subnets {
+							udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
+						}
+						// Filter subnets based on the clusterIP service family
+						// NOTE: We don't support more than 1 subnet CIDR of same family type; we only pick the first one
+						matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(svcCIDR), udnAdvertisedSubnets)
+						if err != nil {
+							klog.Infof("Unable to determine UDN subnet for the provided family isIPV6: %t, %v", utilnet.IsIPv6CIDR(svcCIDR), err)
+							continue
+						}
+
+						// Use the filtered subnet for the flow compute instead of the masqueradeIP
+						dftFlows = append(dftFlows,
+							fmt.Sprintf("cookie=%s, priority=550, in_port=%s, %s, %s_src=%s, %s_dst=%s, "+
+								"actions=ct(commit,zone=%d,table=2)",
+								defaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix,
+								matchingIPFamilySubnet.String(), protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone))
+					}
+				}
+			}
 		}
 
 		masqDst := masqIP
@@ -1706,10 +1752,27 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			if netConfig.isDefaultNetwork() {
 				continue
 			}
+			srcIPOrSubnet := netConfig.v4MasqIPs.ManagementPort.IP.String()
+			if util.IsRouteAdvertisementsEnabled() && netConfig.advertised.Load() {
+				var udnAdvertisedSubnets []*net.IPNet
+				for _, clusterEntry := range netConfig.subnets {
+					udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
+				}
+				// Filter subnets based on the clusterIP service family
+				// NOTE: We don't support more than 1 subnet CIDR of same family type; we only pick the first one
+				matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(false, udnAdvertisedSubnets)
+				if err != nil {
+					klog.Infof("Unable to determine IPV4 UDN subnet for the provided family isIPV6: %v", err)
+					continue
+				}
+
+				// Use the filtered subnets for the flow compute instead of the masqueradeIP
+				srcIPOrSubnet = matchingIPFamilySubnet.String()
+			}
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, ip, ip_src=%s, "+
 					"actions=set_field:%s->eth_dst,output:%s",
-					defaultOpenFlowCookie, netConfig.v4MasqIPs.ManagementPort.IP,
+					defaultOpenFlowCookie, srcIPOrSubnet,
 					bridgeMacAddress, netConfig.ofPortPatch))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, ip, pkt_mark=%s, "+
@@ -1724,11 +1787,27 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			if netConfig.isDefaultNetwork() {
 				continue
 			}
+			srcIPOrSubnet := netConfig.v6MasqIPs.ManagementPort.IP.String()
+			if util.IsRouteAdvertisementsEnabled() && netConfig.advertised.Load() {
+				var udnAdvertisedSubnets []*net.IPNet
+				for _, clusterEntry := range netConfig.subnets {
+					udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
+				}
+				// Filter subnets based on the clusterIP service family
+				// NOTE: We don't support more than 1 subnet CIDR of same family type; we only pick the first one
+				matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(true, udnAdvertisedSubnets)
+				if err != nil {
+					klog.Infof("Unable to determine IPV6 UDN subnet for the provided family isIPV6: %v", err)
+					continue
+				}
 
+				// Use the filtered subnets for the flow compute instead of the masqueradeIP
+				srcIPOrSubnet = matchingIPFamilySubnet.String()
+			}
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, ip6, ipv6_src=%s, "+
 					"actions=set_field:%s->eth_dst,output:%s",
-					defaultOpenFlowCookie, netConfig.v6MasqIPs.ManagementPort.IP,
+					defaultOpenFlowCookie, srcIPOrSubnet,
 					bridgeMacAddress, netConfig.ofPortPatch))
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, ip6, pkt_mark=%s, "+

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -932,9 +932,12 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 	// add below OpenFlows based on the gateway mode and whether the network is advertised or not:
 	// table=1, n_packets=0, n_bytes=0, priority=16,ip,nw_dst=128.192.0.2 actions=LOCAL (Both gateway modes)
 	// table=1, n_packets=0, n_bytes=0, priority=15,ip,nw_dst=128.192.0.0/14 actions=output:3 (shared gateway mode)
+	// necessary service isolation flows based on whether network is advertised or not
 	if err := udng.openflowManager.updateBridgeFlowCache(udng.nodeIPManager.ListAddresses()); err != nil {
 		return fmt.Errorf("error while updating logical flow for UDN %s: %s", udng.GetNetworkName(), err)
 	}
+	// let's sync these flows immediately
+	udng.openflowManager.requestFlowSync()
 
 	if err := udng.updateAdvertisedUDNIsolationRules(isNetworkAdvertised); err != nil {
 		return fmt.Errorf("error while updating advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	rafakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	factoryMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory/mocks"
@@ -273,6 +274,42 @@ func checkDefaultSvcIsolationOVSFlows(flows []string, defaultConfig *bridgeUDNCo
 	Expect(nTable0DefaultFlows).To(Equal(1))
 	Expect(nTable0UDNMasqFlows).To(Equal(1))
 	Expect(nTable2Flows).To(Equal(1))
+}
+
+func checkAdvertisedUDNSvcIsolationOVSFlows(flows []string, netConfig *bridgeUDNConfiguration, netName, bridgeMAC string, svcCIDR *net.IPNet, expectedNFlows int) {
+	By(fmt.Sprintf("Checking advertsised UDN %s service isolation flows for %s; expected %d flows",
+		netName, svcCIDR.String(), expectedNFlows))
+
+	var matchingIPFamilySubnet *net.IPNet
+	var protoPrefix string
+	var udnAdvertisedSubnets []*net.IPNet
+	var err error
+	for _, clusterEntry := range netConfig.subnets {
+		udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
+	}
+	if utilnet.IsIPv4CIDR(svcCIDR) {
+		matchingIPFamilySubnet, err = util.MatchFirstIPNetFamily(false, udnAdvertisedSubnets)
+		Expect(err).ToNot(HaveOccurred())
+		protoPrefix = "ip"
+	} else {
+		matchingIPFamilySubnet, err = util.MatchFirstIPNetFamily(false, udnAdvertisedSubnets)
+		Expect(err).ToNot(HaveOccurred())
+		protoPrefix = "ip6"
+	}
+
+	var nFlows int
+	for _, flow := range flows {
+		if strings.Contains(flow, fmt.Sprintf("priority=200, table=2, %s, %s_src=%s, actions=set_field:%s->eth_dst,output:%s",
+			protoPrefix, protoPrefix, matchingIPFamilySubnet, bridgeMAC, netConfig.ofPortPatch)) {
+			nFlows++
+		}
+		if strings.Contains(flow, fmt.Sprintf("priority=550, in_port=LOCAL, %s, %s_src=%s, %s_dst=%s, actions=ct(commit,zone=64001,table=2)",
+			protoPrefix, protoPrefix, matchingIPFamilySubnet, protoPrefix, svcCIDR)) {
+			nFlows++
+		}
+	}
+
+	Expect(nFlows).To(Equal(expectedNFlows))
 }
 
 func checkUDNSvcIsolationOVSFlows(flows []string, netConfig *bridgeUDNConfiguration, netName, bridgeMAC string, svcCIDR *net.IPNet, expectedNFlows int) {
@@ -1018,6 +1055,247 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 				// Expect no more flows per UDN for tables 0 and 2 for service isolation.
 				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", bridgeMAC, svcCIDR, 0)
+			}
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+	// TODO: There is opportunity to fold some of these tests into describetables to cut down code duplication and test plumbing
+	ovntest.OnSupportedPlatformsIt("should create and delete correct openflows on breth0 for an advertised L3 user defined network", func() {
+		config.IPv4Mode = true
+		config.IPv6Mode = true
+		config.Gateway.Interface = "eth0"
+		config.Gateway.NodeportEnable = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+		ifAddrs := ovntest.MustParseIPNets(v4NodeIP, v6NodeIP)
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids":       fmt.Sprintf("{\"%s\": \"%s\"}", netName, netID),
+					"k8s.ovn.org/node-subnets":      fmt.Sprintf("{\"default\":[\"%s\"],\"%s\":[\"%s\", \"%s\"]}", v4NodeSubnet, netName, v4NodeSubnet, v6NodeSubnet),
+					"k8s.ovn.org/host-cidrs":        fmt.Sprintf("[\"%s\", \"%s\"]", v4NodeIP, v6NodeIP),
+					"k8s.ovn.org/l3-gateway-config": "{\"default\": {}}",
+				},
+			},
+			Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: strings.Split(v4NodeIP, "/")[0]},
+				{Type: corev1.NodeInternalIP, Address: strings.Split(v6NodeIP, "/")[0]}},
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16/24,ae70::/60/64", types.NetworkRolePrimary)
+		ovntest.AnnotateNADWithNetworkID(netID, nad)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		mutableNetInfo := util.NewMutableNetInfo(netInfo)
+		mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{node.Name: {netName}})
+		// need this for getGatewayNextHops
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 port-to-br eth0",
+			Output: "breth0",
+		})
+
+		setManagementPortFakeCommands(fexec, nodeName)
+		setUpGatewayFakeOVSCommands(fexec)
+		_, ipNet, err := net.ParseCIDR(v4NodeSubnet)
+		Expect(err).NotTo(HaveOccurred())
+		mgtPortMAC = util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipNet).IP).String()
+		getCreationFakeCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, mutableNetInfo.MTU())
+		getRPFilterLooseModeFakeCommands(fexec)
+		setUpUDNOpenflowManagerFakeOVSCommands(fexec)
+		setUpUDNOpenflowManagerCheckPortsFakeOVSCommands(fexec)
+		getDeletionFakeOVSCommands(fexec, mgtPort)
+		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
+		kubeFakeClient := fake.NewSimpleClientset(
+			&corev1.NodeList{
+				Items: []corev1.Node{*node},
+			},
+		)
+		fakeClient := &util.OVNNodeClientset{
+			KubeClient:                kubeFakeClient,
+			NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+			UserDefinedNetworkClient:  udnfakeclient.NewSimpleClientset(),
+			RouteAdvertisementsClient: rafakeclient.NewSimpleClientset(),
+		}
+
+		stop := make(chan struct{})
+		wf, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			close(stop)
+			wf.Shutdown()
+		}()
+		err = wf.Start()
+		Expect(err).NotTo(HaveOccurred())
+
+		_, _ = util.SetFakeIPTablesHelpers()
+		_ = nodenft.SetFakeNFTablesHelper()
+
+		// Make Management port
+		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
+		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, mutableNetInfo)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodeAnnotatorMock := &kubemocks.Annotator{}
+		nodeAnnotatorMock.On("Delete", mock.Anything).Return(nil)
+		nodeAnnotatorMock.On("Set", mock.Anything, map[string]*util.L3GatewayConfig{
+			types.DefaultNetworkName: {
+				ChassisID:   "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",
+				BridgeID:    "breth0",
+				InterfaceID: "breth0_worker1",
+				MACAddress:  ovntest.MustParseMAC("00:00:00:55:66:99"),
+				IPAddresses: ifAddrs,
+				VLANID:      ptr.To(uint(0)),
+			}}).Return(nil)
+		nodeAnnotatorMock.On("Set", mock.Anything, mock.Anything).Return(nil)
+		nodeAnnotatorMock.On("Run").Return(nil)
+		kubeMock.On("SetAnnotationsOnNode", node.Name, map[string]interface{}{
+			"k8s.ovn.org/node-masquerade-subnet": "{\"ipv4\":\"169.254.0.0/17\",\"ipv6\":\"fd69::/112\"}",
+		}).Return(nil)
+		kubeMock.On("SetAnnotationsOnNode", node.Name, map[string]interface{}{
+			"k8s.ovn.org/host-cidrs":          "[\"192.168.1.10/24\",\"fc00:f853:ccd:e793::3/64\"]",
+			"k8s.ovn.org/l3-gateway-config":   "{\"default\":{\"mode\":\"\"}}",
+			"k8s.ovn.org/node-primary-ifaddr": "{\"ipv4\":\"192.168.1.10/24\",\"ipv6\":\"fc00:f853:ccd:e793::3/64\"}",
+		}).Return(nil)
+
+		wg.Add(1)
+		go func() {
+			defer GinkgoRecover()
+			defer wg.Done()
+			err := testNS.Do(func(ns.NetNS) error {
+				rm.Run(stop, 10*time.Second)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
+
+			// create dummy management interface
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: types.K8sMgmtIntfName,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = mp.Start(stop)
+			Expect(err).NotTo(HaveOccurred())
+
+			// make preparations for creating openflow manager in DNCC which can be used for SNCC
+			localGw, err := newGateway(
+				nodeName,
+				nodeSubnets,
+				gatewayNextHops,
+				gatewayIntf,
+				"",
+				ifAddrs,
+				nodeAnnotatorMock,
+				mp,
+				&kubeMock,
+				wf,
+				rm,
+				nil,
+				networkmanager.Default().Interface(),
+				config.GatewayModeLocal,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			stop := make(chan struct{})
+			wg := &sync.WaitGroup{}
+			err = localGw.initFunc()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(localGw.Init(stop, wg)).To(Succeed())
+			// we cannot start the shared gw directly because it will spawn a goroutine that may not be bound to the test netns
+			// Start does two things, starts nodeIPManager which spawns a go routine and also starts openflow manager by spawning a go routine
+			//sharedGw.Start()
+			localGw.nodeIPManager.sync()
+			// we cannot start openflow manager directly because it spawns a go routine
+			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
+			err = localGw.openflowManager.updateBridgeFlowCache(localGw.nodeIPManager.ListAddresses())
+			Expect(err).NotTo(HaveOccurred())
+			localGw.openflowManager.syncFlows()
+
+			udnGateway, err := NewUserDefinedNetworkGateway(mutableNetInfo, node, wf.NodeCoreInformer().Lister(),
+				&kubeMock, vrf, ipRulesManager, localGw)
+			Expect(err).NotTo(HaveOccurred())
+			flowMap := udnGateway.gateway.openflowManager.flowCache
+			Expect(flowMap["DEFAULT"]).To(HaveLen(46))
+
+			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
+			var udnFlows int
+			for _, flows := range flowMap {
+				for _, flow := range flows {
+					mark := fmt.Sprintf("0x%x", udnGateway.masqCTMark)
+					if strings.Contains(flow, mark) {
+						// UDN Flow
+						udnFlows++
+					}
+				}
+			}
+			Expect(udnFlows).To(Equal(0))
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(1)) // only default network
+
+			Expect(udnGateway.AddNetwork()).To(Succeed())
+			flowMap = udnGateway.gateway.openflowManager.flowCache
+			Expect(flowMap["DEFAULT"]).To(HaveLen(69))                                // 18 UDN Flows and 5 advertisedUDN flows are added by default
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(2)) // default network + UDN network
+			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["default"]
+			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["bluenet"]
+			bridgeMAC := udnGateway.openflowManager.defaultBridge.macAddress.String()
+			ofPortHost := udnGateway.openflowManager.defaultBridge.ofPortHost
+			for _, flows := range flowMap {
+				for _, flow := range flows {
+					if strings.Contains(flow, fmt.Sprintf("0x%x", udnGateway.masqCTMark)) {
+						// UDN Flow
+						udnFlows++
+					} else if strings.Contains(flow, fmt.Sprintf("in_port=%s", bridgeUdnConfig.ofPortPatch)) {
+						udnFlows++
+					}
+				}
+			}
+			Expect(udnFlows).To(Equal(14))
+			openflowManagerCheckPorts(udnGateway.openflowManager)
+
+			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+				// Check flows for default network service CIDR.
+				checkDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
+
+				// Expect exactly one flow per advertised UDN for table 2 and table 0 for service isolation.
+				checkAdvertisedUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", bridgeMAC, svcCIDR, 2)
+			}
+
+			// The second call to checkPorts() will return no ofPort for the UDN - simulating a deletion that already was
+			// processed by ovn-northd/ovn-controller.  We should not be panicking on that.
+			// See setUpUDNOpenflowManagerCheckPortsFakeOVSCommands() for the order of ofPort query results.
+			openflowManagerCheckPorts(udnGateway.openflowManager)
+
+			cnode := node.DeepCopy()
+			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
+			Expect(udnGateway.DelNetwork()).To(Succeed())
+			flowMap = udnGateway.gateway.openflowManager.flowCache
+			Expect(flowMap["DEFAULT"]).To(HaveLen(46))                                // only default network flows are present
+			Expect(udnGateway.openflowManager.defaultBridge.netConfig).To(HaveLen(1)) // default network only
+			udnFlows = 0
+			for _, flows := range flowMap {
+				for _, flow := range flows {
+					if strings.Contains(flow, fmt.Sprintf("0x%x", udnGateway.masqCTMark)) {
+						// UDN Flow
+						udnFlows++
+					}
+				}
+			}
+			Expect(udnFlows).To(Equal(0))
+
+			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+				// Check flows for default network service CIDR.
+				checkDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
+
+				// Expect no more flows per UDN for table 2 and table0 for service isolation.
+				checkAdvertisedUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", bridgeMAC, svcCIDR, 0)
 			}
 			return nil
 		})

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -837,9 +837,11 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 					err := true
 					out := curlConnectionTimeoutCode
-					if isLocalGWModeEnabled() {
-						// FIXME: L3 - pod in the UDN should NOT be able to access a default network service
-						err = false
+					if cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 {
+						// FIXME: prevent looping of traffic in L2 UDNs
+						// bad behaviour: packet is looping from management port -> breth0 -> GR -> management port -> breth0 and so on
+						// which is a never ending loop
+						// this causes curl timeout with code 7 host unreachable instead of code 28
 						out = ""
 					}
 					return podsNetA[0].Name, podsNetA[0].Namespace, net.JoinHostPort(svcNetDefault.Spec.ClusterIPs[ipFamilyIndex], "8080") + "/clientip", out, err

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -716,7 +716,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				// to targetAddress. If clientNamespace is empty the function assumes clientName is a node that will be used as the
 				// client.
 				var checkConnectivity = func(clientName, clientNamespace, targetAddress string) (string, error) {
-					curlCmd := []string{"curl", "-g", "-q", "-s", "--max-time", "5", targetAddress}
+					curlCmd := []string{"curl", "-g", "-q", "-s", "--max-time", "2", "--insecure", targetAddress}
 					var out string
 					var err error
 					if clientNamespace != "" {
@@ -845,6 +845,10 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						out = ""
 					}
 					return podsNetA[0].Name, podsNetA[0].Namespace, net.JoinHostPort(svcNetDefault.Spec.ClusterIPs[ipFamilyIndex], "8080") + "/clientip", out, err
+				}),
+			ginkgo.Entry("pod in the UDN should be able to access kapi in default network service",
+				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+					return podsNetA[0].Name, podsNetA[0].Namespace, "https://kubernetes.default/healthz", "", false
 				}),
 			ginkgo.Entry("pod in the UDN should not be able to access a service in a different UDN",
 				func(ipFamilyIndex int) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Currently the behaviour of an advertised UDN is that
UDN pods are able to talk any service in the default
network in local gateway mode.

Expected behaviour is that advertised UDN pods should
only be able to reach kapi and dns services in the
default network and rest of them should not be
reachable.

Solution adopted is to change all the relevant flows
that were using masIP subnet for services isolation
on br-ex to use the podsubnets.

Caveat is: if user advertises overlapping podSubnets
then things will fall apart and assumption is users
can't do that.

Flow details (post fix I don't want to call out the
current behaviour to avoid confusions -> current behaviour
was using the default network flows for UDN pods which was
wrong):

Onward packet

1) cookie=0xdeff105, duration=1472.742s, table=0, n_packets=9, n_bytes=666,
   priority=550,ip,in_port=LOCAL,nw_src=103.103.0.0/16,nw_dst=10.96.0.0/16 actions=ct(commit,table=2,zone=64001)
this flow is same as that for UDNs with the masSubnet as the src

2) cookie=0xdeff105, duration=1472.742s, table=2, n_packets=9, n_bytes=666,
   priority=200,ip,nw_src=103.103.0.0/16 actions=mod_dl_dst:02:42:ac:12:00:03,output:3
this flow is also same flow as that for UDNs with the masIP as the src

So in this above way ^ any traffic from any advertised UDNs towards clusterIP
range will always be taken into the patch port of that respective UDN
and this guarantees isolation towards services belonging in other UDNs
since that given UDN won't have any LBs for those services

Return packet

3) There is no need for returning any packets correctly unless its for
kapi and/or dns

for UDNs, I see this flow:
cookie=0xdeff105, duration=684.087s, table=0, n_packets=0, n_bytes=0,
idle_age=684, priority=500,ip,in_port=2,nw_src=10.96.0.0/16,nw_dst=169.254.0.0/17 actions=ct(table=3,zone=64001,nat)
 cookie=0xdeff105, duration=684.050s, table=0, n_packets=0, n_bytes=0,
idle_age=684, priority=500,ip,in_port=4,nw_src=10.96.0.0/16,nw_dst=169.254.0.0/17 actions=ct(table=3,zone=64001,nat)

but for BGP I change these two flows:
cookie=0xdeff105, duration=5216.234s, table=2, n_packets=1067, n_bytes=120337,
priority=300,ip,nw_src=169.254.0.0/17,nw_dst=10.96.0.1 actions=mod_dl_dst:96:fd:12:44:a1:83,output:"patch-breth0_ov"
cookie=0xdeff105, duration=5216.234s, table=2, n_packets=0, n_bytes=0,
priority=300,ip,nw_src=169.254.0.0/17,nw_dst=10.96.0.10 actions=mod_dl_dst:96:fd:12:44:a1:83,output:"patch-breth0_ov"

into:

 cookie=0xdeff105, duration=2319.685s, table=2, n_packets=496, n_bytes=67111,
priority=300,ip,nw_dst=10.96.0.1 actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
 cookie=0xdeff105, duration=2319.685s, table=2, n_packets=0, n_bytes=0,
priority=300,ip,nw_dst=10.96.0.10 actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"

that is generic enough for both UDN and BGP packets to match on.

There is scope for scale improvement by combining the onward packet flows
at tables 0 and 2 into one entity, but maybe that could also be done for UDNs?

There is now isolation established between UDN pods and default network
because except kapi and dns all other traffic matching clusterIP is sent
to the respective UDN patch ports where its black-holed (in l3 it goes
back and forth from breth0 to GR and back where its dropped using 105 flow).

However in L2 we do see the expected bad behaviour where packet is looping from
management port -> breth0 -> GR -> management port -> breth0 and so on
which is a never ending loop
If we decide to perhaps ban the circular looping and optimize the flow better
using a proper drop rule:

inport=LOCAL, srcIP=UDNSubnet, dstIP=serviceSubnet -> 1 per advertised UDN “DROP”
that can be considered as a future improvement here

dump:
```
tcpdump: listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot length 262144 bytes
20:13:18.881036 33dfd1008b804_3 P   ifindex 15 0a:58:67:67:00:05 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 64, id 25988, offset 0, flags [DF], proto TCP (6), length
60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x1614 (incorrect -> 0x5b5d), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale
 7], length 0
20:13:18.881626 ovn-k8s-mp1 In  ifindex 8 0a:58:64:41:00:03 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 63, id 25988, offset 0, flags [DF], proto TCP (6), length 60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x5b5d (correct), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale 7], length
0
20:13:18.881651 breth0 Out ifindex 4 02:42:ac:12:00:02 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 62, id 25988, offset 0, flags [DF], proto TCP (6), length 60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x5b5d (correct), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale 7], length
0
20:13:18.882283 ovn-k8s-mp1 In  ifindex 8 0a:58:64:41:00:03 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 61, id 25988, offset 0, flags [DF], proto TCP (6), length 60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x5b5d (correct), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale 7], length
0
20:13:18.882298 breth0 Out ifindex 4 02:42:ac:12:00:02 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 60, id 25988, offset 0, flags [DF], proto TCP (6), length 60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x5b5d (correct), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale 7], length
0
20:13:18.882402 ovn-k8s-mp1 In  ifindex 8 0a:58:64:41:00:03 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 59, id 25988, offset 0, flags [DF], proto TCP (6), length 60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x5b5d (correct), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale 7], length
0
20:13:18.882414 breth0 Out ifindex 4 02:42:ac:12:00:02 ethertype IPv4 (0x0800), length 80: (tos 0x0, ttl 58, id 25988, offset 0, flags [DF], proto TCP (6), length 60)
    103.103.0.5.36363 > 10.96.164.25.80: Flags [S], cksum 0x5b5d (correct), seq 2541324161, win 65280, options [mss 1360,sackOK,TS val 984084514 ecr 0,nop,wscale 7], length
```

$ oc rsh -n blue blue3
/ # curl --local-port 36363 10.96.164.25:80
curl: (7) Failed to connect to 10.96.164.25 port 80 after 3 ms: Host is unreachable

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
E2E and unit tests were done
