### PR TITLE
Configure isolation and routes during network addition

### DIFF
--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -363,17 +363,16 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
 
 	// create the iprules for this network
-	err = udng.updateUDNVRFIPRule()
-	if err != nil {
+	if err = udng.updateUDNVRFIPRules(isNetworkAdvertised); err != nil {
 		return fmt.Errorf("failed to update IP rules for network %s: %w", udng.GetNetworkName(), err)
 	}
 
 	if err = udng.updateAdvertisedUDNIsolationRules(isNetworkAdvertised); err != nil {
-		return fmt.Errorf("failed to configure isolation rules for network %s: %w", udng.GetNetworkName(), err)
+		return fmt.Errorf("failed to update isolation rules for network %s: %w", udng.GetNetworkName(), err)
 	}
 
 	if err := udng.updateUDNVRFIPRoute(isNetworkAdvertised); err != nil {
-		return fmt.Errorf("failed to configure ip routes for network %s: %w", udng.GetNetworkName(), err)
+		return fmt.Errorf("failed to update ip routes for network %s: %w", udng.GetNetworkName(), err)
 	}
 
 	// add loose mode for rp filter on management port
@@ -789,12 +788,11 @@ func (udng *UserDefinedNetworkGateway) getV6MasqueradeIP() (*net.IPNet, error) {
 // 2000:	from all to 10.132.0.0/14 lookup 1007
 // 2000:	from all fwmark 0x1001 lookup 1009
 // 2000:	from all to 10.134.0.0/14 lookup 1009
-func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules() ([]netlink.Rule, []netlink.Rule, error) {
+func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(isNetworkAdvertised bool) ([]netlink.Rule, []netlink.Rule, error) {
 	var addIPRules []netlink.Rule
 	var delIPRules []netlink.Rule
 	var masqIPRules []netlink.Rule
 	var subnetIPRules []netlink.Rule
-	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
 	masqIPv4, err := udng.getV4MasqueradeIP()
 	if err != nil {
 		return nil, nil, err
@@ -923,7 +921,7 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
 	udng.openflowManager.defaultBridge.netConfig[udng.GetNetworkName()].advertised.Store(isNetworkAdvertised)
 
-	if err := udng.updateUDNVRFIPRule(); err != nil {
+	if err := udng.updateUDNVRFIPRules(isNetworkAdvertised); err != nil {
 		return fmt.Errorf("error while updating ip rule for UDN %s: %s", udng.GetNetworkName(), err)
 	}
 
@@ -944,10 +942,10 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 	return nil
 }
 
-// updateUDNVRFIPRule updates IP rules for a network depending on whether the
+// updateUDNVRFIPRules updates IP rules for a network depending on whether the
 // network is advertised or not
-func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRule() error {
-	addIPRules, deleteIPRules, err := udng.constructUDNVRFIPRules()
+func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRules(isNetworkAdvertised bool) error {
+	addIPRules, deleteIPRules, err := udng.constructUDNVRFIPRules(isNetworkAdvertised)
 	if err != nil {
 		return fmt.Errorf("unable to get iprules for network %s, err: %v", udng.GetNetworkName(), err)
 	}

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1447,7 +1447,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway.vrfTableId = test.vrftableID
-			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules(false)
 			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
@@ -1634,7 +1634,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway.vrfTableId = test.vrftableID
-			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules(true)
 			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))


### PR DESCRIPTION
This change fixes a case where we add a network that is already advertised. We should configure the missing bits on startup too, not only during reconciliation.

I was wondering about extracting and reusing the code already present in `doReconcile` but it is going to require some refactor around `udng.gateway.Reconcile` that also calls `openflowManager.updateBridgeFlowCache` so I want to defer that for the future. 

cc: @tssurya @arghosh93 @jcaamano 