### PR TITLE
ovs client shouldn't be initialized on DPU Hosts

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -538,11 +538,15 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			// register ovnkube node specific prometheus metrics exported by the node
 			metrics.RegisterNodeMetrics(ctx.Done())
 
-			ovsClient, err = libovsdb.NewOVSClient(ctx.Done())
-			if err != nil {
-				nodeErr = fmt.Errorf("failed to initialize libovsdb vswitchd client: %w", err)
-				return
+			// OVS is not running on dpu-host nodes
+			if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+				ovsClient, err = libovsdb.NewOVSClient(ctx.Done())
+				if err != nil {
+					nodeErr = fmt.Errorf("failed to initialize libovsdb vswitchd client: %w", err)
+					return
+				}
 			}
+
 			nodeControllerManager, err := controllermanager.NewNodeControllerManager(
 				ovnClientset,
 				watchFactory,

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -182,8 +182,12 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 		if pr.CNIConf.PhysicalNetworkName != "" {
 			netName = pr.CNIConf.PhysicalNetworkName
 		}
-		if err := checkBridgeMapping(ovsClient, pr.CNIConf.Topology, netName); err != nil {
-			return nil, fmt.Errorf("failed bridge mapping validation: %w", err)
+
+		// Skip checking bridge mapping on DPU hosts as OVS is not present
+		if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+			if err := checkBridgeMapping(ovsClient, pr.CNIConf.Topology, netName); err != nil {
+				return nil, fmt.Errorf("failed bridge mapping validation: %w", err)
+			}
 		}
 
 		response.Result, err = getCNIResultFn(pr, clientset, podInterfaceInfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR fixes the issue of ovs client being incorrectly initialized for dpuhosts introduced by https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5145

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
