### PR TITLE
Don't addup failedAttempts in pod-add-retry when it's namespace is already terminating

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -747,6 +747,12 @@ func (h *defaultNetworkControllerEventHandler) IsResourceScheduled(obj interface
 	return h.baseHandler.isResourceScheduled(h.objType, obj)
 }
 
+// IsResourceScheduledOnTerminatedNamespace returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *defaultNetworkControllerEventHandler) IsResourceScheduledOnTerminatedNamespace(obj interface{}) (bool, error) {
+	return h.baseHandler.isResourceScheduledOnTerminatedNamespace(h.objType, obj, h.watchFactory)
+}
+
 // AddResource adds the specified object to the cluster according to its type and returns the error,
 // if any, yielded during object creation.
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -99,6 +99,12 @@ func (h *secondaryLayer2NetworkControllerEventHandler) IsResourceScheduled(obj i
 	return h.baseHandler.isResourceScheduled(h.objType, obj)
 }
 
+// IsResourceScheduledOnTerminatedNamespace returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *secondaryLayer2NetworkControllerEventHandler) IsResourceScheduledOnTerminatedNamespace(obj interface{}) (bool, error) {
+	return h.baseHandler.isResourceScheduledOnTerminatedNamespace(h.objType, obj, h.watchFactory)
+}
+
 // AddResource adds the specified object to the cluster according to its type and returns the error,
 // if any, yielded during object creation.
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -97,6 +97,12 @@ func (h *secondaryLayer3NetworkControllerEventHandler) IsResourceScheduled(obj i
 	return h.baseHandler.isResourceScheduled(h.objType, obj)
 }
 
+// IsResourceScheduledOnTerminatedNamespace returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *secondaryLayer3NetworkControllerEventHandler) IsResourceScheduledOnTerminatedNamespace(obj interface{}) (bool, error) {
+	return h.baseHandler.isResourceScheduledOnTerminatedNamespace(h.objType, obj, h.watchFactory)
+}
+
 // AddResource adds the specified object to the cluster according to its type and returns the error,
 // if any, yielded during object creation.
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -94,6 +94,12 @@ func (h *secondaryLocalnetNetworkControllerEventHandler) IsResourceScheduled(obj
 	return h.baseHandler.isResourceScheduled(h.objType, obj)
 }
 
+// IsResourceScheduledOnTerminatedNamespace returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *secondaryLocalnetNetworkControllerEventHandler) IsResourceScheduledOnTerminatedNamespace(obj interface{}) (bool, error) {
+	return h.baseHandler.isResourceScheduledOnTerminatedNamespace(h.objType, obj, h.watchFactory)
+}
+
 // AddResource adds the specified object to the cluster according to its type and returns the error,
 // if any, yielded during object creation.
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -723,6 +723,11 @@ func PodTerminating(pod *corev1.Pod) bool {
 	return pod.DeletionTimestamp != nil
 }
 
+// PodTerminating checks if the pod has been deleted via API but still in the process of terminating
+func NamespaceTerminating(namespace *corev1.Namespace) bool {
+	return namespace.Status.Phase == corev1.NamespaceTerminating || namespace.DeletionTimestamp != nil
+}
+
 // EventRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
 func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {


### PR DESCRIPTION
Prior to this change, we were:

```
if entry.failedAttempts >= MaxFailedAttempts {
			klog.Warningf("Dropping retry entry for %s %s: exceeded number of failed attempts",
				r.ResourceHandler.ObjType, objKey)
			r.DeleteRetryObj(key)
			metrics.MetricResourceRetryFailuresCount.Inc()
			if entry.newObj != nil {
				r.ResourceHandler.RecordErrorEvent(entry.newObj, "RetryFailed",
					fmt.Errorf("failed to reconcile and retried %d times for object: %v", MaxFailedAttempts, entry.newObj))
			}
			return
		}
```
incrementing the resourceRetry metric whenever a pod add was done
on a terminating namespace.

```
This leads to:
W0425 05:11:51.799928    3490 obj_retry.go:265] Dropping retry entry for *v1.Pod e2e-test-resolve-local-names-jnkkz/resolve-t42vd: exceeded number of failed attempts
W0425 05:11:51.799923    3490 obj_retry.go:265] Dropping retry entry for *v1.Pod e2e-test-resolve-local-names-jnkkz/resolve-template-xgc8c: exceeded number of failed attempts
W0425 05:11:51.799936    3490 obj_retry.go:265] Dropping retry entry for *v1.Pod e2e-test-resolve-local-names-jnkkz/resolve-template-nx8rc: exceeded number of failed attempts
```

and alerts since the pod will never get scheduled anyways

```
2025-04-25T05:02:45.312400267Z E0425 05:02:45.311904       1 framework.go:1316] "Plugin Failed" err="pods \"resolve-template-nx8rc\" is forbidden: unable to create new content in namespace e2e-test-resolve-local-names-jnkkz because it is being terminated" plugin="DefaultBinder" pod="e2e-test-resolve-local-names-jnkkz/resolve-template-nx8rc" node="ip-10-0-5-38.us-west-1.compute.internal"
2025-04-25T05:02:45.312400267Z I0425 05:02:45.311931       1 schedule_one.go:1005] "Failed to bind pod" pod="e2e-test-resolve-local-names-jnkkz/resolve-template-nx8rc"
```

following the crumb of one such pod event:
```
I0425 05:09:51.535888    3898 obj_retry.go:302] Retry object setup: *v1.Pod e2e-test-resolve-local-names-jnkkz/resolve-t42vd
I0425 05:09:51.535894    3898 obj_retry.go:364] Adding new object: *v1.Pod e2e-test-resolve-local-names-jnkkz/resolve-t42vd
=====
W0425 05:12:05.086518    3898 base_network_controller_namespace.go:457] Unable to remove remote zone pod's e2e-test-resolve-local-names-jnkkz/resolve-template-nx8rc IP address from the namespace address-set, err: pod e2e-test-resolve-local-names-jnkkz/resolve-template-nx8rc: no pod IPs found
```

and we would hit the alert for resourceretry max more than 15times that causes issues in CI.

This change ignores stacking up number of retry attempts when namespace is being deleted.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

Need to add a UT for this. I wish obj_retry.go had modularized unit test already
