### PR TITLE
Add metrics for UDN

### DIFF
--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -91,6 +91,28 @@ var metricEgressIPRebalanceCount = prometheus.NewCounter(prometheus.CounterOpts{
 
 /** EgressIP metrics recorded from cluster-manager ends**/
 
+var metricUDNCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "user_defined_networks",
+	Help:      "The total number of UserDefinedNetworks in the cluster"},
+	[]string{
+		"role",
+		"topology",
+	},
+)
+
+var metricCUDNCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "cluster_user_defined_networks",
+	Help:      "The total number of ClusterUserDefinedNetworks in the cluster"},
+	[]string{
+		"role",
+		"topology",
+	},
+)
+
 // RegisterClusterManagerBase registers ovnkube cluster manager base metrics with the Prometheus registry.
 // This function should only be called once.
 func RegisterClusterManagerBase() {
@@ -130,6 +152,8 @@ func RegisterClusterManagerFunctional() {
 		prometheus.MustRegister(metricEgressIPRebalanceCount)
 		prometheus.MustRegister(metricEgressIPCount)
 	}
+	prometheus.MustRegister(metricUDNCount)
+	prometheus.MustRegister(metricCUDNCount)
 	if err := prometheus.Register(MetricResourceRetryFailuresCount); err != nil {
 		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
 			panic(err)
@@ -164,4 +188,24 @@ func RecordEgressIPRebalance(count int) {
 // This total may include multiple Egress IPs per EgressIP CR.
 func RecordEgressIPCount(count float64) {
 	metricEgressIPCount.Set(count)
+}
+
+// IncrementUDNCount increments the number of UserDefinedNetworks of the given type
+func IncrementUDNCount(role, topology string) {
+	metricUDNCount.WithLabelValues(role, topology).Inc()
+}
+
+// DecrementUDNCount decrements the number of UserDefinedNetworks of the given type
+func DecrementUDNCount(role, topology string) {
+	metricUDNCount.WithLabelValues(role, topology).Dec()
+}
+
+// IncrementCUDNCount increments the number of ClusterUserDefinedNetworks of the given type
+func IncrementCUDNCount(role, topology string) {
+	metricCUDNCount.WithLabelValues(role, topology).Inc()
+}
+
+// DecrementCUDNCount decrements the number of ClusterUserDefinedNetworks of the given type
+func DecrementCUDNCount(role, topology string) {
+	metricCUDNCount.WithLabelValues(role, topology).Dec()
 }


### PR DESCRIPTION
Adds metrics to count UDNs and CUDNs, grouped by role (primary/secondary) and topology (L2/L3).

(for https://issues.redhat.com/browse/OCPBUGS-54806)

This assumes that the clustermanager watches all UDN/CUDN creations and deletions, which seems to be correct?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new metrics to monitor the number of UserDefinedNetworks and ClusterUserDefinedNetworks, categorized by role and topology.
  * Metrics are automatically updated when these network objects are created or deleted, providing improved visibility into network resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->