### PR TITLE
ovnkube.sh: get_node_zone: default to node name as zone 

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -803,8 +803,12 @@ function memory_trim_on_compaction_supported {
 function get_node_zone() {
   zone=$(kubectl --subresource=status --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
      get node ${K8S_NODE} -o=jsonpath={'.metadata.labels.k8s\.ovn\.org/zone-name'})
-  if [ "$zone" == "" ]; then
-    zone="global"
+  if [ -z "$zone" ]; then
+    if [[ ${ovn_enable_interconnect} == "true" ]]; then
+      zone="${K8S_NODE}"
+    else
+      zone="global"
+    fi
   fi
   echo "$zone"
 }


### PR DESCRIPTION
If the `k8s.ovn.org/zone-name` label is not set on the node, the fallback logic now uses the node name as the zone when `ovn_enable_interconnect` is true. Otherwise, the zone defaults to "global" as before.

Also updated the empty string check to use `-z`, which is more idiomatic in Bash.
