### PR TITLE
POC Disable hash rethinking

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -657,6 +657,14 @@ func (*defaultPodRequestInterfaceOps) ConfigureInterface(pr *PodRequest, getter 
 		}
 	}
 
+	err = netns.Do(func(_ ns.NetNS) error {
+		err := setSysctl("/proc/sys/net/core/txrehash", 0)
+		return err
+	})
+	if err != nil {
+		klog.Warningf("Failed to disable", err)
+	}
+
 	return []*current.Interface{hostIface, contIface}, nil
 }
 


### PR DESCRIPTION
TCP connections between pods hosted on different nodes are encapsulated with Geneve. The source port of the Geneve traffic stays the same for the duration of the TCP connection, which allows, when running on top of a cloud provider, acceleration of datapath and efficient connection tracking.

When TCP retransmissions occur, Linux "rethinks" the hash associated to the TCP socket, and this leads to a change of the source port of the Geneve traffic

https://docs.kernel.org/admin-guide/sysctl/net.html#txrehash

In practice this leads to an explosion of flows when running on top of cloud providers such as Azure. Each retransmission causes the UDP source port to change, leading to a multiplication of flows, reaching the limit of the infrastructure. Each new flow is expected to go through a slow software path before being hardware accelerated, so established TCP traffic suffers even more.

To fix it we disable hash rethinking on the pod interface.

The effect can be seen in kind, creating a client and server between 2 pods on 2 nodes:

```bash
k run -n default --grace-period=1 --command=True --rm -ti --image=localhost/ovn-daemonset-fedora:dev --image-pull-policy=Never --overrides '{"spec":{"nodeSelector":{"kubernetes.io/hostname":"ovn-worker"}}}' --port=12345 --expose server -- bash
socat TCP-LISTEN:12345 -

k run -n default --grace-period=1 --command=True --rm -ti --image=localhost/ovn-daemonset-fedora:dev --image-pull-policy=Never --overrides '{"spec":{"nodeSelector":{"kubernetes.io/hostname":"ovn-worker2"}}}'  client -- bash
socat - TCP:server.default.svc:12345
```

then reproducing TCP retransmissions, for example with an iptables rule to cut the traffic:
```bash
podman inspect ovn-worker | grep netns
nsenter --net=/run/netns/netns-... iptables -I INPUT -p udp -j DROP
```

a tcpdump on the traffic will show the source port changing for each retransmission.

On OpenShift an other way to test the fix is to set a kubeletconfig allowing the unsafe sysctl:

```yaml
  kubeletConfig:
    allowedUnsafeSysctls:
    - net.core.txrehash
```

then running pods with

```bash
--overrides '{"spec":{"securityContext":{"sysctls":[{"name":"net.core.txrehash", "value":"0"}]}, "nodeSelector":{"kubernetes.io/hostname":"..."}}}'
```

This change should generally benefit any deployment of ovn-kubernetes on a IaaS that implements stateful connection tracking. On baremetal deployments it should not matter and maybe preferrably should not be activated.

This was reported as well in RHEL-90228

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
This is is a proof of concept I would like to share with the maintainers of ovn-kubernetes to gather their feedback.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
