### PR TITLE
Increase InformerSyncTimeout and InformerSyncTimeout to 60s

### DIFF
--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -255,11 +255,11 @@ const (
 	// InformerSyncTimeout is used when waiting for the initial informer cache sync
 	// (i.e. all existing objects should be listed by the informer).
 	// It allows ~4 list() retries with the default reflector exponential backoff config
-	InformerSyncTimeout = 20 * time.Second
+	InformerSyncTimeout = 60 * time.Second
 
 	// HandlerSyncTimeout is used when waiting for initial object handler sync.
 	// (i.e. all the ADD events should be processed for the existing objects by the event handler)
-	HandlerSyncTimeout = 20 * time.Second
+	HandlerSyncTimeout = 60 * time.Second
 
 	// GRMACBindingAgeThreshold is the lifetime in seconds of each MAC binding
 	// entry for the gateway routers. After this time, the entry is removed and


### PR DESCRIPTION
## 📑 Description
The cache synce time could take longer time when pulling a large number of objects for apiserver.

## Additional Information for reviewers

## ✅ Checks


## How to verify it
Create more than 4000 egressfirewalls, make sure that the kube-node pods can start without timeout error.
