### PR TITLE
Allow ICMP and ICMPv6 regardless of network policy

### DIFF
--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -83,6 +83,7 @@ set_default_params() {
   export KIND_IPV4_SUPPORT=true
 
   export OVN_ENABLE_DNSNAMERESOLVER=${OVN_ENABLE_DNSNAMERESOLVER:-false}
+  export OVN_ENABLE_ICMP_NETPOL=${OVN_ENABLE_ICMP_NETPOL:-false}
 }
 
 usage() {
@@ -126,6 +127,7 @@ usage() {
     echo "-wk  | --num-workers                 Number of worker nodes. DEFAULT: 2 workers"
     echo "-cn  | --cluster-name                Configure the kind cluster's name"
     echo "-dns | --enable-dnsnameresolver      Enable DNSNameResolver for resolving the DNS names used in the DNS rules of EgressFirewall."
+    echo "--allow-icmp-netpol                   Allows ICMP and ICMPv6 traffic globally, regardless of network policy rules"
     echo "-ic  | --enable-interconnect         Enable interconnect with each node as a zone (only valid if OVN_HA is false)"
     echo "-npz | --nodes-per-zone              Specify number of nodes per zone (Default 0, which means global zone; >0 means interconnect zone, where 1 for single-node zone, >1 for multi-node zone). If this value > 1, then (total k8s nodes (workers + 1) / num of nodes per zone) should be zero."
     echo ""
@@ -188,6 +190,8 @@ parse_args() {
                                                   ;;
             -dns | --enable-dnsnameresolver )     OVN_ENABLE_DNSNAMERESOLVER=true
                                                   ;;
+            --allow-icmp-netpol )                 OVN_ENABLE_ICMP_NETPOL=true
+                                                  ;;
             -ic | --enable-interconnect )         OVN_ENABLE_INTERCONNECT=true
                                                   ;;
             -npz | --nodes-per-zone )             shift
@@ -228,6 +232,7 @@ print_params() {
      echo "KIND_NUM_MASTER = $KIND_NUM_MASTER"
      echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
      echo "OVN_ENABLE_DNSNAMERESOLVER= $OVN_ENABLE_DNSNAMERESOLVER"
+     echo "OVN_ENABLE_ICMP_NETPOL= $OVN_ENABLE_ICMP_NETPOL"
      echo "OVN_ENABLE_INTERCONNECT = $OVN_ENABLE_INTERCONNECT"
      if [[ $OVN_ENABLE_INTERCONNECT == true ]]; then
        echo "KIND_NUM_NODES_PER_ZONE = $KIND_NUM_NODES_PER_ZONE"
@@ -421,6 +426,7 @@ helm install ovn-kubernetes . -f "${value_file}" \
           --set global.emptyLbEvents=$(if [ "${OVN_EMPTY_LB_EVENTS}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableDNSNameResolver=$(if [ "${OVN_ENABLE_DNSNAMERESOLVER}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableNetworkQos=$(if [ "${OVN_NETWORK_QOS_ENABLE}" == "true" ]; then echo "true"; else echo "false"; fi) \
+          --set global.allowICMPNetpol=$(if [ "${OVN_ENABLE_ICMP_NETPOL}" == "true" ]; then echo "true"; else echo "false"; fi) \
           ${ovnkube_db_options}
 EOF
        )

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -154,6 +154,7 @@ usage() {
     echo "-obs | --observability                Enable OVN Observability feature."
     echo "-rae | --enable-route-advertisements  Enable route advertisements"
     echo "-adv | --advertise-default-network    Applies a RouteAdvertisements configuration to advertise the default network on all nodes"
+    echo "--allow-icmp-netpol                   Allows ICMP and ICMPv6 traffic globally, regardless of network policy rules"
     echo ""
 }
 
@@ -360,6 +361,8 @@ parse_args() {
                                                 ;;
             -dns | --enable-dnsnameresolver )   OVN_ENABLE_DNSNAMERESOLVER=true
                                                 ;;
+            --allow-icmp-netpol )               OVN_ENABLE_ICMP_NETPOL=true
+                                                ;;
             -h | --help )                       usage
                                                 exit
                                                 ;;
@@ -447,6 +450,7 @@ print_params() {
      echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
      echo "OVN_MTU= $OVN_MTU"
      echo "OVN_ENABLE_DNSNAMERESOLVER= $OVN_ENABLE_DNSNAMERESOLVER"
+     echo "OVN_ENABLE_ICMP_NETPOL= $OVN_ENABLE_ICMP_NETPOL"
      echo ""
 }
 
@@ -609,6 +613,7 @@ set_default_params() {
   OVN_ENABLE_INTERCONNECT=${OVN_ENABLE_INTERCONNECT:-false}
   OVN_ENABLE_OVNKUBE_IDENTITY=${OVN_ENABLE_OVNKUBE_IDENTITY:-true}
   OVN_NETWORK_QOS_ENABLE=${OVN_NETWORK_QOS_ENABLE:-false}
+  OVN_ENABLE_ICMP_NETPOL=${OVN_ENABLE_ICMP_NETPOL:-false}
 
 
   if [ "$OVN_COMPACT_MODE" == true ] && [ "$OVN_ENABLE_INTERCONNECT" != false ]; then
@@ -911,7 +916,8 @@ create_ovn_kube_manifests() {
     --mtu="${OVN_MTU}" \
     --enable-dnsnameresolver="${OVN_ENABLE_DNSNAMERESOLVER}" \
     --mtu="${OVN_MTU}" \
-    --enable-observ="${OVN_OBSERV_ENABLE}"
+    --enable-observ="${OVN_OBSERV_ENABLE}" \
+    --allow-icmp-netpol="${OVN_ENABLE_ICMP_NETPOL}"
   popd
 }
 

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -99,6 +99,8 @@ OVN_NETWORK_QOS_ENABLE=
 OVN_ENABLE_DNSNAMERESOLVER="false"
 OVN_NOHOSTSUBNET_LABEL=""
 OVN_DISABLE_REQUESTEDCHASSIS="false"
+OVN_ENABLE_ICMP_NETPOL="false"
+
 # IN_UPGRADE is true only if called by upgrade-ovn.sh during the upgrade test,
 # it will render only the parts in ovn-setup.yaml related to RBAC permissions.
 IN_UPGRADE=
@@ -369,6 +371,9 @@ while [ "$1" != "" ]; do
   --enable-dnsnameresolver)
     OVN_ENABLE_DNSNAMERESOLVER=$VALUE
     ;;
+  --allow-icmp-netpol)
+    OVN_ENABLE_ICMP_NETPOL=$VALUE
+    ;;
   --enable-observ)
     OVN_OBSERV_ENABLE=$VALUE
     ;;
@@ -574,6 +579,9 @@ echo "ovn_network_qos_enable: ${ovn_network_qos_enable}"
 
 ovn_enable_dnsnameresolver=${OVN_ENABLE_DNSNAMERESOLVER}
 echo "ovn_enable_dnsnameresolver: ${ovn_enable_dnsnameresolver}"
+
+ovn_allow_icmp_netpol=${OVN_ENABLE_ICMP_NETPOL}
+echo "ovn_allow_icmp_netpol: ${ovn_allow_icmp_netpol}"
 
 ovn_observ_enable=${OVN_OBSERV_ENABLE}
 echo "ovn_observ_enable: ${ovn_observ_enable}"
@@ -782,6 +790,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
   ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+  ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   ovn_observ_enable=${ovn_observ_enable} \
   ovn_nohostsubnet_label=${ovn_nohostsubnet_label} \
   ovn_disable_requestedchassis=${ovn_disable_requestedchassis} \
@@ -828,6 +837,7 @@ ovn_image=${ovnkube_image} \
   ovn_v6_transit_switch_subnet=${ovn_v6_transit_switch_subnet} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+  ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   ovn_observ_enable=${ovn_observ_enable} \
   jinjanate ../templates/ovnkube-control-plane.yaml.j2 -o ${output_dir}/ovnkube-control-plane.yaml
 
@@ -926,6 +936,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
   ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+  ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   ovn_observ_enable=${ovn_observ_enable} \
   jinjanate ../templates/ovnkube-single-node-zone.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone.yaml
 
@@ -992,6 +1003,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
   ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+  ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   ovn_observ_enable=${ovn_observ_enable} \
   jinjanate ../templates/ovnkube-zone-controller.yaml.j2 -o ${output_dir}/ovnkube-zone-controller.yaml
 
@@ -1054,15 +1066,18 @@ net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
 ovn_enable_interconnect=${ovn_enable_interconnect} \
 ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
 ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   jinjanate ../templates/rbac-ovnkube-node.yaml.j2 -o ${output_dir}/rbac-ovnkube-node.yaml
 
 ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
 ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
 ovn_route_advertisements_enable=${ovn_route_advertisements_enable} \
   jinjanate ../templates/rbac-ovnkube-cluster-manager.yaml.j2 -o ${output_dir}/rbac-ovnkube-cluster-manager.yaml
 
 ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
 ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
+ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
 ovn_route_advertisements_enable=${ovn_route_advertisements_enable} \
   jinjanate ../templates/rbac-ovnkube-master.yaml.j2 -o ${output_dir}/rbac-ovnkube-master.yaml
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -96,6 +96,7 @@ fi
 # OVN_NORTHD_BACKOFF_INTERVAL - ovn northd backoff interval in ms (default 300)
 # OVN_ENABLE_SVC_TEMPLATE_SUPPORT - enable svc template support
 # OVN_ENABLE_DNSNAMERESOLVER - enable dns name resolver support
+# OVN_ENABLE_ICMP_NETPOL - allow ICMP and ICMPv6 regardless of network policy
 # OVN_OBSERV_ENABLE - enable observability for ovnkube
 
 # The argument to the command is the operation to be performed
@@ -316,6 +317,8 @@ ovn_enable_svc_template_support=${OVN_ENABLE_SVC_TEMPLATE_SUPPORT:-true}
 ovn_network_qos_enable=${OVN_NETWORK_QOS_ENABLE:-false}
 # OVN_ENABLE_DNSNAMERESOLVER - enable dns name resolver support
 ovn_enable_dnsnameresolver=${OVN_ENABLE_DNSNAMERESOLVER:-false}
+# OVN_ENABLE_ICMP_NETPOL - allow ICMP/ICMPv6 with network policy
+ovn_allow_icmp_netpol=${OVN_ENABLE_ICMP_NETPOL:-false}
 # OVN_OBSERV_ENABLE - enable observability for ovnkube
 ovn_observ_enable=${OVN_OBSERV_ENABLE:-false}
 # OVN_NOHOSTSUBNET_LABEL - node label indicating nodes managing their own network
@@ -1322,6 +1325,12 @@ ovn-master() {
   fi
   echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
 
+  ovn_allow_icmp_netpol_flag=
+  if [[ ${ovn_allow_icmp_netpol} == "true" ]]; then
+	  ovn_allow_icmp_netpol_flag="--allow-icmp-netpol"
+  fi
+  echo "ovn_allow_icmp_netpol_flag=${ovn_allow_icmp_netpol_flag}"
+
   /usr/bin/ovnkube --init-master ${K8S_NODE} \
     ${anp_enabled_flag} \
     ${disable_forwarding_flag} \
@@ -1355,6 +1364,7 @@ ovn-master() {
     ${persistent_ips_enabled_flag} \
     ${network_qos_enabled_flag} \
     ${ovn_enable_dnsnameresolver_flag} \
+    ${ovn_allow_icmp_netpol_flag} \
     ${nohostsubnet_label_option} \
     ${ovn_disable_requestedchassis_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
@@ -1620,6 +1630,12 @@ ovnkube-controller() {
   fi
   echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
 
+  ovn_allow_icmp_netpol_flag=
+  if [[ ${ovn_allow_icmp_netpol} == "true" ]]; then
+	  ovn_allow_icmp_netpol_flag="--allow-icmp-netpol"
+  fi
+  echo "ovn_allow_icmp_netpol_flag=${ovn_allow_icmp_netpol_flag}"
+
   ovn_observ_enable_flag=
   if [[ ${ovn_observ_enable} == "true" ]]; then
     ovn_observ_enable_flag="--enable-observability"
@@ -1660,6 +1676,7 @@ ovnkube-controller() {
     ${ovn_v6_masquerade_subnet_opt} \
     ${network_qos_enabled_flag} \
     ${ovn_enable_dnsnameresolver_flag} \
+    ${ovn_allow_icmp_netpol_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --gateway-mode=${ovn_gateway_mode} \
     --host-network-namespace ${ovn_host_network_namespace} \
@@ -2048,6 +2065,12 @@ ovnkube-controller-with-node() {
   fi
   echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
 
+  ovn_allow_icmp_netpol_flag=
+  if [[ ${ovn_allow_icmp_netpol} == "true" ]]; then
+	  ovn_allow_icmp_netpol_flag="--allow-icmp-netpol"
+  fi
+  echo "ovn_allow_icmp_netpol_flag=${ovn_allow_icmp_netpol_flag}"
+
   ovn_observ_enable_flag=
   if [[ ${ovn_observ_enable} == "true" ]]; then
     ovn_observ_enable_flag="--enable-observability"
@@ -2106,6 +2129,7 @@ ovnkube-controller-with-node() {
     ${ssl_opts} \
     ${network_qos_enabled_flag} \
     ${ovn_enable_dnsnameresolver_flag} \
+    ${ovn_allow_icmp_netpol_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --export-ovs-metrics \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
@@ -2300,6 +2324,12 @@ ovn-cluster-manager() {
   fi
   echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
 
+  ovn_allow_icmp_netpol_flag=
+  if [[ ${ovn_allow_icmp_netpol} == "true" ]]; then
+	  ovn_allow_icmp_netpol_flag="--allow-icmp-netpol"
+  fi
+  echo "ovn_allow_icmp_netpol_flag=${ovn_allow_icmp_netpol_flag}"
+
   echo "=============== ovn-cluster-manager ========== MASTER ONLY"
   /usr/bin/ovnkube --init-cluster-manager ${K8S_NODE} \
     ${anp_enabled_flag} \
@@ -2327,6 +2357,7 @@ ovn-cluster-manager() {
     ${ovn_v6_transit_switch_subnet_opt} \
     ${network_qos_enabled_flag} \
     ${ovn_enable_dnsnameresolver_flag} \
+    ${ovn_allow_icmp_netpol_flag} \
     --gateway-mode=${ovn_gateway_mode} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --host-network-namespace ${ovn_host_network_namespace} \

--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -178,6 +178,8 @@ spec:
           value: "{{ ovn_network_qos_enable }}"
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: "{{ ovn_enable_dnsnameresolver }}"
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: "{{ ovn_allow_icmp_netpol }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -312,6 +312,8 @@ spec:
           value: "{{ ovn_network_qos_enable }}"
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: "{{ ovn_enable_dnsnameresolver }}"
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: "{{ ovn_allow_icmp_netpol }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -464,6 +464,8 @@ spec:
           value: "{{ ovn_network_qos_enable }}"
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: "{{ ovn_enable_dnsnameresolver }}"
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: "{{ ovn_allow_icmp_netpol }}"
 
         readinessProbe:
           exec:

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -390,6 +390,8 @@ spec:
           value: "local"
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: "{{ ovn_enable_dnsnameresolver }}"
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: "{{ ovn_allow_icmp_netpol }}"
         - name: OVN_OBSERV_ENABLE
           value: "{{ ovn_observ_enable }}"
       # end of container

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -426,6 +426,7 @@ type OVNKubernetesFeatureConfig struct {
 	DisableUDNHostIsolation      bool `gcfg:"disable-udn-host-isolation"`
 	EnableMultiNetworkPolicy     bool `gcfg:"enable-multi-networkpolicy"`
 	EnableStatelessNetPol        bool `gcfg:"enable-stateless-netpol"`
+	AllowICMPNetPol              bool `gcfg:"allow-icmp-netpol"`
 	EnableInterconnect           bool `gcfg:"enable-interconnect"`
 	EnableMultiExternalGateway   bool `gcfg:"enable-multi-external-gateway"`
 	EnablePersistentIPs          bool `gcfg:"enable-persistent-ips"`
@@ -1099,6 +1100,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use stateless network policy feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableStatelessNetPol,
 		Value:       OVNKubernetesFeature.EnableStatelessNetPol,
+	},
+	&cli.BoolFlag{
+		Name:        "allow-icmp-netpol",
+		Usage:       "Configure to use enable ICMP and ICMPv6 traffic to not be denied by network policy.",
+		Destination: &cliConfig.OVNKubernetesFeature.AllowICMPNetPol,
+		Value:       OVNKubernetesFeature.AllowICMPNetPol,
 	},
 	&cli.BoolFlag{
 		Name:        "enable-interconnect",

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -34,7 +34,10 @@ const (
 	// netpolDefaultDenyACLType is used to distinguish default deny and arp allow acls create for the same port group
 	defaultDenyACL netpolDefaultDenyACLType = "defaultDeny"
 	arpAllowACL    netpolDefaultDenyACLType = "arpAllow"
+	icmpAllowACL   netpolDefaultDenyACLType = "icmpAllow"
 
+	// icmpAllowPolicyMatch is the match used when creating default allow ICMP and ICMPv6 ACLs for a namespace
+	icmpAllowPolicyMatch = "(icmp || icmp6)"
 	// arpAllowPolicyMatch is the match used when creating default allow ARP ACLs for a namespace
 	arpAllowPolicyMatch   = "(arp || nd)"
 	allowHairpinningACLID = "allow-hairpinning"
@@ -377,16 +380,22 @@ func (bnc *BaseNetworkController) defaultDenyPortGroupName(namespace string, acl
 }
 
 func (bnc *BaseNetworkController) buildDenyACLs(namespace, pgName string, aclLogging *libovsdbutil.ACLLoggingLevels,
-	aclDir libovsdbutil.ACLDirection) (denyACL, allowACL *nbdb.ACL) {
+	aclDir libovsdbutil.ACLDirection) []*nbdb.ACL {
 	denyMatch := libovsdbutil.GetACLMatch(pgName, "", aclDir)
-	allowMatch := libovsdbutil.GetACLMatch(pgName, arpAllowPolicyMatch, aclDir)
+	allowARPMatch := libovsdbutil.GetACLMatch(pgName, arpAllowPolicyMatch, aclDir)
+	allowICMPMatch := libovsdbutil.GetACLMatch(pgName, icmpAllowPolicyMatch, aclDir)
 	aclPipeline := libovsdbutil.ACLDirectionToACLPipeline(aclDir)
 
-	denyACL = libovsdbutil.BuildACL(bnc.getDefaultDenyPolicyACLIDs(namespace, aclDir, defaultDenyACL),
-		types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, aclPipeline)
-	allowACL = libovsdbutil.BuildACL(bnc.getDefaultDenyPolicyACLIDs(namespace, aclDir, arpAllowACL),
-		types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, nil, aclPipeline)
-	return
+	acls := make([]*nbdb.ACL, 0, 3)
+	acls = append(acls, libovsdbutil.BuildACL(bnc.getDefaultDenyPolicyACLIDs(namespace, aclDir, defaultDenyACL),
+		types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, aclPipeline))
+	acls = append(acls, libovsdbutil.BuildACL(bnc.getDefaultDenyPolicyACLIDs(namespace, aclDir, arpAllowACL),
+		types.DefaultAllowPriority, allowARPMatch, nbdb.ACLActionAllow, nil, aclPipeline))
+	if config.OVNKubernetesFeature.AllowICMPNetPol {
+		acls = append(acls, libovsdbutil.BuildACL(bnc.getDefaultDenyPolicyACLIDs(namespace, aclDir, icmpAllowACL),
+			types.DefaultAllowPriority, allowICMPMatch, nbdb.ACLActionAllow, nil, aclPipeline))
+	}
+	return acls
 }
 
 func (bnc *BaseNetworkController) addPolicyToDefaultPortGroups(np *networkPolicy, aclLogging *libovsdbutil.ACLLoggingLevels) error {
@@ -433,17 +442,18 @@ func (bnc *BaseNetworkController) delPolicyFromDefaultPortGroups(np *networkPoli
 func (bnc *BaseNetworkController) createDefaultDenyPGAndACLs(namespace, policy string, aclLogging *libovsdbutil.ACLLoggingLevels) error {
 	ingressPGIDs := bnc.getDefaultDenyPolicyPortGroupIDs(namespace, libovsdbutil.ACLIngress)
 	ingressPGName := libovsdbutil.GetPortGroupName(ingressPGIDs)
-	ingressDenyACL, ingressAllowACL := bnc.buildDenyACLs(namespace, ingressPGName, aclLogging, libovsdbutil.ACLIngress)
+	ingressACLs := bnc.buildDenyACLs(namespace, ingressPGName, aclLogging, libovsdbutil.ACLIngress)
 	egressPGIDs := bnc.getDefaultDenyPolicyPortGroupIDs(namespace, libovsdbutil.ACLEgress)
 	egressPGName := libovsdbutil.GetPortGroupName(egressPGIDs)
-	egressDenyACL, egressAllowACL := bnc.buildDenyACLs(namespace, egressPGName, aclLogging, libovsdbutil.ACLEgress)
-	ops, err := libovsdbops.CreateOrUpdateACLsOps(bnc.nbClient, nil, bnc.GetSamplingConfig(), ingressDenyACL, ingressAllowACL, egressDenyACL, egressAllowACL)
+	egressACLs := bnc.buildDenyACLs(namespace, egressPGName, aclLogging, libovsdbutil.ACLEgress)
+	allACLs := append(ingressACLs, egressACLs...)
+	ops, err := libovsdbops.CreateOrUpdateACLsOps(bnc.nbClient, nil, bnc.GetSamplingConfig(), allACLs...)
 	if err != nil {
 		return err
 	}
 
-	ingressPG := libovsdbutil.BuildPortGroup(ingressPGIDs, nil, []*nbdb.ACL{ingressDenyACL, ingressAllowACL})
-	egressPG := libovsdbutil.BuildPortGroup(egressPGIDs, nil, []*nbdb.ACL{egressDenyACL, egressAllowACL})
+	ingressPG := libovsdbutil.BuildPortGroup(ingressPGIDs, nil, ingressACLs)
+	egressPG := libovsdbutil.BuildPortGroup(egressPGIDs, nil, egressACLs)
 	ops, err = libovsdbops.CreateOrUpdatePortGroupsOps(bnc.nbClient, ops, ingressPG, egressPG)
 	if err != nil {
 		return err

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -538,6 +538,93 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("correctly creates and deletes network policy and multi network policy with the same policy - allow ICMP", func() {
+			app.Action = func(*cli.Context) error {
+				var err error
+
+				config.OVNKubernetesFeature.AllowICMPNetPol = true
+				topology := ovntypes.Layer2Topology
+				subnets := "10.1.0.0/24"
+				setSecondaryNetworkTestData(topology, subnets)
+
+				namespace1 := *newNamespace(namespaceName1)
+				nPodTest := getTestPod(namespace1.Name, nodeName)
+				nPodTest.addNetwork(secondaryNetworkName, nadNamespacedName, "", "", "", "10.1.1.1", "0a:58:0a:01:01:01", "secondary", 1, nil)
+				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
+
+				watchNodes := false
+				node := *newNode(nodeName, "192.168.126.202/24")
+
+				startOvn(initialDB, watchNodes, []corev1.Node{node}, []corev1.Namespace{namespace1}, nil, nil,
+					[]nettypes.NetworkAttachmentDefinition{*nad}, []testPod{nPodTest}, map[string]string{labelName: labelVal})
+
+				ginkgo.By("Creating networkPolicy applied to the pod")
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Create(context.TODO(), networkPolicy, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithAddresses(namespaceName1, []string{nPodTest.podIP})
+
+				dataParams := newNetpolDataParams(networkPolicy).
+					withLocalPortUUIDs(nPodTest.portUUID).
+					withTCPPeerPorts(portNum)
+				gressPolicyExpectedData1 := getPolicyData(dataParams)
+				defaultDenyExpectedData1 := getDefaultDenyData(dataParams)
+				initData := getUpdatedInitialDB([]testPod{nPodTest})
+				expectedData1 := append(initData, gressPolicyExpectedData1...)
+				expectedData1 = append(expectedData1, defaultDenyExpectedData1...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData1...))
+
+				ginkgo.By("Creating multi-networkPolicy applied to the pod")
+				mpolicy := convertNetPolicyToMultiNetPolicy(networkPolicy)
+				mpolicy.Annotations = map[string]string{PolicyForAnnotation: nadNamespacedName}
+
+				_, err = fakeOvn.fakeClient.MultiNetworkPolicyClient.K8sCniCncfIoV1beta1().MultiNetworkPolicies(mpolicy.Namespace).
+					Create(context.TODO(), mpolicy, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeOvn.fakeClient.MultiNetworkPolicyClient.K8sCniCncfIoV1beta1().MultiNetworkPolicies(mpolicy.Namespace).
+					Get(context.TODO(), mpolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ocInfo := fakeOvn.secondaryControllers[secondaryNetworkName]
+				portInfo := nPodTest.getNetworkPortInfo(secondaryNetworkName, nadNamespacedName)
+				gomega.Expect(portInfo).NotTo(gomega.BeNil())
+				ocInfo.asf.ExpectAddressSetWithAddresses(namespaceName1, []string{portInfo.podIP})
+
+				dataParams2 := newNetpolDataParams(networkPolicy).
+					withLocalPortUUIDs(portInfo.portUUID).
+					withTCPPeerPorts(portNum).
+					withNetInfo(netInfo)
+				gressPolicyExpectedData2 := getPolicyData(dataParams2)
+				defaultDenyExpectedData2 := getDefaultDenyData(dataParams2)
+				expectedData2 := append(expectedData1, gressPolicyExpectedData2...)
+				expectedData2 = append(expectedData2, defaultDenyExpectedData2...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData2...))
+
+				// Delete the multi network policy
+				ginkgo.By("Deleting the multi network policy")
+				err = fakeOvn.fakeClient.MultiNetworkPolicyClient.K8sCniCncfIoV1beta1().MultiNetworkPolicies(mpolicy.Namespace).
+					Delete(context.TODO(), mpolicy.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData1))
+
+				ginkgo.By("Deleting the network policy")
+				err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Delete(context.TODO(), networkPolicy.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(initData))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.DescribeTable("correctly adds and deletes pod IPs from secondary network namespace address set",
 			func(topology string, remote bool) {
 				app.Action = func(*cli.Context) error {

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -40,6 +41,9 @@ func getStaleDefaultDenyACL(netpolName, namespace, match string, deny, egress bo
 	name := namespace + "_" + netpolName
 	if !deny {
 		aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, direction, arpAllowACL)
+		if strings.Contains(match, "icmp") {
+			aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, direction, icmpAllowACL)
+		}
 		priority = types.DefaultAllowPriority
 		action = nbdb.ACLActionAllow
 		name = getStaleARPAllowACLName(namespace)
@@ -73,34 +77,44 @@ func getStaleDefaultDenyData(networkPolicy *knet.NetworkPolicy) []libovsdbtest.T
 
 	egressPGName := fakeController.defaultDenyPortGroupName(namespace, libovsdbutil.ACLEgress)
 	egressDenyACL := getStaleDefaultDenyACL(netpolName, namespace, "inport == @"+egressPGName, true, true)
-	egressAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "inport == @"+egressPGName+" && "+arpAllowPolicyMatch, false, true)
+	egressARPAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "inport == @"+egressPGName+" && "+arpAllowPolicyMatch, false, true)
+
+	testData := []libovsdbtest.TestData{egressDenyACL, egressARPAllowACL}
+	egressACLs := []*nbdb.ACL{egressDenyACL, egressARPAllowACL}
+
+	if config.OVNKubernetesFeature.AllowICMPNetPol {
+		egressICMPAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "inport == @"+egressPGName+" && "+icmpAllowPolicyMatch, false, true)
+		testData = append(testData, egressICMPAllowACL)
+		egressACLs = append(egressACLs, egressICMPAllowACL)
+	}
 
 	ingressPGName := fakeController.defaultDenyPortGroupName(namespace, libovsdbutil.ACLIngress)
 	ingressDenyACL := getStaleDefaultDenyACL(netpolName, namespace, "outport == @"+ingressPGName, true, false)
-	ingressAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "outport == @"+ingressPGName+" && "+arpAllowPolicyMatch, false, false)
+	ingressARPAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "outport == @"+ingressPGName+" && "+arpAllowPolicyMatch, false, false)
+
+	ingressACLs := []*nbdb.ACL{ingressDenyACL, ingressARPAllowACL}
+	testData = append(testData, ingressDenyACL, ingressARPAllowACL)
+	if config.OVNKubernetesFeature.AllowICMPNetPol {
+		ingressICMPAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "outport == @"+ingressPGName+" && "+icmpAllowPolicyMatch, false, false)
+		testData = append(testData, ingressICMPAllowACL)
+		ingressACLs = append(ingressACLs, ingressICMPAllowACL)
+	}
 
 	egressDenyPG := libovsdbutil.BuildPortGroup(
 		fakeController.getDefaultDenyPolicyPortGroupIDs(namespace, libovsdbutil.ACLEgress),
 		nil,
-		[]*nbdb.ACL{egressDenyACL, egressAllowACL},
+		egressACLs,
 	)
 	egressDenyPG.UUID = egressDenyPG.Name + "-UUID"
 
 	ingressDenyPG := libovsdbutil.BuildPortGroup(
 		fakeController.getDefaultDenyPolicyPortGroupIDs(namespace, libovsdbutil.ACLIngress),
 		nil,
-		[]*nbdb.ACL{ingressDenyACL, ingressAllowACL},
+		ingressACLs,
 	)
 	ingressDenyPG.UUID = ingressDenyPG.Name + "-UUID"
 
-	return []libovsdbtest.TestData{
-		egressDenyACL,
-		egressAllowACL,
-		ingressDenyACL,
-		ingressAllowACL,
-		egressDenyPG,
-		ingressDenyPG,
-	}
+	return append(testData, egressDenyPG, ingressDenyPG)
 }
 
 // getStalePolicyACLs builds stale ACLs for given peers
@@ -251,6 +265,34 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 	ginkgo.Context("on startup", func() {
 
 		ginkgo.It("reconciles an existing networkPolicy updating stale ACLs", func() {
+			namespace1 := *newNamespace(namespaceName1)
+			namespace2 := *newNamespace(namespaceName2)
+			networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+				namespace2.Name, "", true, true)
+			// start with stale ACLs
+			gressPolicyInitialData := getStalePolicyData(networkPolicy, []string{namespace2.Name})
+			defaultDenyInitialData := getStaleDefaultDenyData(networkPolicy)
+			initialData := initialDB.NBData
+			initialData = append(initialData, gressPolicyInitialData...)
+			initialData = append(initialData, defaultDenyInitialData...)
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
+				[]knet.NetworkPolicy{*networkPolicy})
+
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+			_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+				Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// make sure stale ACLs were updated
+			expectedData := getNamespaceWithSinglePolicyExpectedData(
+				newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+				initialDB.NBData)
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+		})
+
+		ginkgo.It("reconciles an existing networkPolicy updating stale ACLs - Allow ICMP", func() {
+			config.OVNKubernetesFeature.AllowICMPNetPol = true
 			namespace1 := *newNamespace(namespaceName1)
 			namespace2 := *newNamespace(namespaceName2)
 			networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -107,7 +107,7 @@ func getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress bool, params *
 	egressDenyACL.UUID = aclIDs.String() + "-UUID"
 
 	aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, libovsdbutil.ACLEgress, arpAllowACL)
-	egressAllowACL := libovsdbops.BuildACL(
+	egressARPAllowACL := libovsdbops.BuildACL(
 		libovsdbutil.GetACLName(aclIDs),
 		nbdb.ACLDirectionFromLport,
 		types.DefaultAllowPriority,
@@ -122,7 +122,36 @@ func getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress bool, params *
 		},
 		types.DefaultACLTier,
 	)
-	egressAllowACL.UUID = aclIDs.String() + "-UUID"
+	egressARPAllowACL.UUID = aclIDs.String() + "-UUID"
+
+	testData := []libovsdbtest.TestData{
+		egressDenyACL,
+		egressARPAllowACL,
+	}
+	egressACLs := []*nbdb.ACL{egressDenyACL, egressARPAllowACL}
+
+	if config.OVNKubernetesFeature.AllowICMPNetPol {
+		aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, libovsdbutil.ACLEgress, icmpAllowACL)
+		egressICMPAllowACL := libovsdbops.BuildACL(
+			libovsdbutil.GetACLName(aclIDs),
+			nbdb.ACLDirectionFromLport,
+			types.DefaultAllowPriority,
+			"inport == @"+egressPGName+" && "+icmpAllowPolicyMatch,
+			nbdb.ACLActionAllow,
+			types.OvnACLLoggingMeter,
+			"",
+			false,
+			aclIDs.GetExternalIDs(),
+			map[string]string{
+				"apply-after-lb": "true",
+			},
+			types.DefaultACLTier,
+		)
+		egressICMPAllowACL.UUID = aclIDs.String() + "-UUID"
+		testData = append(testData, egressICMPAllowACL)
+		egressACLs = append(egressACLs, egressICMPAllowACL)
+
+	}
 
 	ingressPGName := fakeController.defaultDenyPortGroupName(namespace, libovsdbutil.ACLIngress)
 	aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, libovsdbutil.ACLIngress, defaultDenyACL)
@@ -142,7 +171,7 @@ func getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress bool, params *
 	ingressDenyACL.UUID = aclIDs.String() + "-UUID"
 
 	aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, libovsdbutil.ACLIngress, arpAllowACL)
-	ingressAllowACL := libovsdbops.BuildACL(
+	ingressARPAllowACL := libovsdbops.BuildACL(
 		libovsdbutil.GetACLName(aclIDs),
 		nbdb.ACLDirectionToLport,
 		types.DefaultAllowPriority,
@@ -155,7 +184,31 @@ func getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress bool, params *
 		nil,
 		types.DefaultACLTier,
 	)
-	ingressAllowACL.UUID = aclIDs.String() + "-UUID"
+	ingressARPAllowACL.UUID = aclIDs.String() + "-UUID"
+
+	ingressACLs := []*nbdb.ACL{ingressDenyACL, ingressARPAllowACL}
+	if config.OVNKubernetesFeature.AllowICMPNetPol {
+		aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, libovsdbutil.ACLIngress, icmpAllowACL)
+		ingressICMPAllowACL := libovsdbops.BuildACL(
+			libovsdbutil.GetACLName(aclIDs),
+			nbdb.ACLDirectionToLport,
+			types.DefaultAllowPriority,
+			"outport == @"+ingressPGName+" && "+icmpAllowPolicyMatch,
+			nbdb.ACLActionAllow,
+			types.OvnACLLoggingMeter,
+			"",
+			false,
+			aclIDs.GetExternalIDs(),
+			nil,
+			types.DefaultACLTier,
+		)
+		ingressICMPAllowACL.UUID = aclIDs.String() + "-UUID"
+		ingressACLs = append(ingressACLs, ingressICMPAllowACL)
+	}
+
+	for _, acl := range ingressACLs {
+		testData = append(testData, acl)
+	}
 
 	lsps := []*nbdb.LogicalSwitchPort{}
 	for _, uuid := range params.localPortUUIDs {
@@ -166,10 +219,11 @@ func getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress bool, params *
 	if policyTypeEgress {
 		egressDenyPorts = lsps
 	}
+
 	egressDenyPG := libovsdbutil.BuildPortGroup(
 		fakeController.getDefaultDenyPolicyPortGroupIDs(namespace, libovsdbutil.ACLEgress),
 		egressDenyPorts,
-		[]*nbdb.ACL{egressDenyACL, egressAllowACL},
+		egressACLs,
 	)
 	egressDenyPG.UUID = egressDenyPG.Name + "-UUID"
 
@@ -180,18 +234,11 @@ func getDefaultDenyDataHelper(policyTypeIngress, policyTypeEgress bool, params *
 	ingressDenyPG := libovsdbutil.BuildPortGroup(
 		fakeController.getDefaultDenyPolicyPortGroupIDs(namespace, libovsdbutil.ACLIngress),
 		ingressDenyPorts,
-		[]*nbdb.ACL{ingressDenyACL, ingressAllowACL},
+		ingressACLs,
 	)
 	ingressDenyPG.UUID = ingressDenyPG.Name + "-UUID"
 
-	return []libovsdbtest.TestData{
-		egressDenyACL,
-		egressAllowACL,
-		ingressDenyACL,
-		ingressAllowACL,
-		egressDenyPG,
-		ingressDenyPG,
-	}
+	return append(testData, egressDenyPG, ingressDenyPG)
 }
 
 func getDefaultDenyData(params *netpolDataParams) []libovsdbtest.TestData {
@@ -772,6 +819,35 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 		ginkgo.It("reconciles an existing networkPolicy with empty db", func() {
 			app.Action = func(*cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+				// add namespaces to initial Database
+				initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4, namespace2AddressSetv4)
+
+				networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+					namespace2.Name, "", true, true)
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*networkPolicy},
+					nil, nil)
+
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				expectedData := getNamespaceWithSinglePolicyExpectedData(
+					newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+					initialDB.NBData)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("reconciles an existing networkPolicy with empty db - Allow ICMP", func() {
+			app.Action = func(*cli.Context) error {
+				config.OVNKubernetesFeature.AllowICMPNetPol = true
 				namespace1 := *newNamespace(namespaceName1)
 				namespace2 := *newNamespace(namespaceName2)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -163,6 +163,8 @@ spec:
           value: {{ hasKey .Values.global "enablePersistentIPs" | ternary .Values.global.enablePersistentIPs false | quote }}
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: {{ hasKey .Values.global "allowICMPNetpol" | ternary .Values.global.allowICMPNetpol false | quote }}
       # end of container
       volumes:
       # TODO: Need to check why we need this?

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -285,6 +285,8 @@ spec:
           value: {{ hasKey .Values.global "enablePersistentIPs" | ternary .Values.global.enablePersistentIPs false | quote }}
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: {{ hasKey .Values.global "allowICMPNetpol" | ternary .Values.global.allowICMPNetpol false | quote }}
         - name: OVN_DISABLE_REQUESTEDCHASSIS
           value: {{ default "false" .Values.global.disableRequestedchassis | quote }}
       # end of container

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -439,6 +439,8 @@ spec:
           value: {{ hasKey .Values.global "enableSvcTemplate" | ternary .Values.global.enableSvcTemplate true | quote }}
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: {{ hasKey .Values.global "allowICMPNetpol" | ternary .Values.global.allowICMPNetpol false | quote }}
         - name: OVN_OBSERV_ENABLE
           value: {{ hasKey .Values.global "enableObservability" | ternary .Values.global.enableObservability false | quote }}
         - name: OVN_NETWORK_QOS_ENABLE

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -356,6 +356,8 @@ spec:
           value: "local"
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
+        - name: OVN_ENABLE_ICMP_NETPOL
+          value: {{ hasKey .Values.global "allowICMPNetpol" | ternary .Values.global.allowICMPNetpol false | quote }}
         - name: OVN_OBSERV_ENABLE
           value: {{ hasKey .Values.global "enableObservability" | ternary .Values.global.enableObservability false | quote }}
       # end of container

--- a/helm/ovn-kubernetes/values-multi-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-multi-node-zone.yaml
@@ -104,6 +104,8 @@ global:
   lFlowCacheLimitKb: ""
   # -- Configure to use DNSNameResolver feature with ovn-kubernetes
   enableDNSNameResolver: false
+  # -- Configure to allow ICMP and ICMPv6 traffic to bypass network policy deny rules
+  allowICMPNetpol: false
   # -- Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
   disableSnatMultipleGws: ""
   # -- Controls if forwarding is allowed on OVNK controlled interfaces

--- a/helm/ovn-kubernetes/values-no-ic.yaml
+++ b/helm/ovn-kubernetes/values-no-ic.yaml
@@ -93,6 +93,8 @@ global:
   enableLFlowCache: true
   # -- Configure to use DNSNameResolver feature with ovn-kubernetes
   enableDNSNameResolver: false
+  # -- Configure to allow ICMP and ICMPv6 traffic to bypass network policy deny rules
+  allowICMPNetpol: false
   # -- Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled
   # @default -- unlimited
   lFlowCacheLimit: ""

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -105,6 +105,8 @@ global:
   enablePersistentIPs: true
   # -- Configure to use DNSNameResolver feature with ovn-kubernetes
   enableDNSNameResolver: false
+  # -- Configure to allow ICMP and ICMPv6 traffic to bypass network policy deny rules
+  allowICMPNetpol: false
   # -- Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
   disableSnatMultipleGws: ""
   # -- Controls if forwarding is allowed on OVNK controlled interfaces


### PR DESCRIPTION
Adds a global config knob "--allow-icmp-netpol" which adds permissive ACL rules for icmp || icmp6 when network policy default deny rules are generated.