### PR TITLE
shut down nqosNodeQueue when nqos controller stops

### DIFF
--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
@@ -302,6 +302,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 	c.nqosQueue.ShutDown()
 	c.nqosNamespaceQueue.ShutDown()
 	c.nqosPodQueue.ShutDown()
+	c.nqosNodeQueue.ShutDown()
 	c.teardownMetricsCollector()
 	wg.Wait()
 }


### PR DESCRIPTION
shut down `nqosNodeQueue` when network qos controller stops, otherwise nad controller may leave stale data in northbound db.