### PR TITLE
contrib: Enable working with local-registry when using podman

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -822,6 +822,11 @@ set_ovn_image() {
 }
 
 build_ovn_image() {
+  local push_args
+  if [ "$OCI_BIN" == "podman" ]; then
+    push_args="--tls-verify=false"
+  fi
+
   if [ "$OVN_IMAGE" == local ]; then
     set_ovn_image
 
@@ -834,14 +839,14 @@ build_ovn_image() {
     # store in local registry
     if [ "$KIND_LOCAL_REGISTRY" == true ];then
       echo "Pushing built image to local $OCI_BIN registry"
-      $OCI_BIN push "${OVN_IMAGE}"
+      $OCI_BIN push "${push_args}" "${OVN_IMAGE}"
     fi
   # We should push to local registry if image is not remote
   elif [ "${OVN_IMAGE}" != "" -a "${KIND_LOCAL_REGISTRY}" == true ] && (echo "$OVN_IMAGE" | grep / -vq); then
     local local_registry_ovn_image="localhost:5000/${OVN_IMAGE}"
     $OCI_BIN tag "$OVN_IMAGE" $local_registry_ovn_image
     OVN_IMAGE=$local_registry_ovn_image
-    $OCI_BIN push $OVN_IMAGE
+    $OCI_BIN push "${push_args}" "$OVN_IMAGE"
   fi
 }
 

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -504,6 +504,11 @@ check_dependencies() {
   	  echo "Dependency not met: Neither docker nor podman found"
   	  exit 1
   fi
+
+  if ! command_exists skopeo; then
+      echo "Dependency not met: skopeo not installed. Run the following command to install it: 'sudo dnf install skopeo'"
+      exit 1
+  fi
 }
 
 OPENSSL=""
@@ -853,8 +858,9 @@ build_ovn_image() {
 create_ovn_kube_manifests() {
     local ovnkube_image=${OVN_IMAGE}
     if [ "$KIND_LOCAL_REGISTRY" == true ];then
-      # When updating with local registry we have to reference the sha
-      ovnkube_image=$($OCI_BIN inspect --format='{{index .RepoDigests 0}}' $OVN_IMAGE)
+      # When updating with local registry we have to reference the image digest (SHA)
+      # Check the image digest in the local registry because it might be different then the digest in the local container runtime
+      ovnkube_image=$(skopeo inspect --format "{{.Name}}@{{.Digest}}" --tls-verify=false  "docker://$OVN_IMAGE")
     fi
     pushd ${DIR}/../dist/images
     if [ "$OVN_ENABLE_INTERCONNECT" == true ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
When podman is installed, it impossible to work with a local registry because the automation fail to push images to the local registry.

On podman push, it defaults to secure connection.
In our case the local registry uses an insecure connection result in podman push failures making it impossible to work with the local registry when podman is installed.

Set podman to skip secure connection check when pushing OVN-K images to the local registry.

The automation inspect the built ovnkube-image digest (SHA) 
and pass it to the daemonset manifest, in order to ensure the latest built image is deployed.

Some container runtime (e.g. podman) may not retain the same digest, result in having
one image digest in the local runtime image and different one on the local registry.
Which makes OVN-K to not become ready.

In order to overcome this, get the actual image digest that exist in the local registry.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
This change introduce new dependency for the project - [skopeo](https://github.com/containers/skopeo)


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
