### PR TITLE
[DNM] Avoid importing BGP routes for UDNs

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -684,21 +684,29 @@ func (c *Controller) generateFRRConfiguration(
 					Prefixes: advertisePrefixes,
 				},
 			}
-			neighbor.ToReceive = frrtypes.Receive{
-				Allowed: frrtypes.AllowedInPrefixes{
-					Mode: frrtypes.AllowRestricted,
-				},
-			}
-			if advertisements.Has(ratypes.PodNetwork) {
-				for _, prefix := range receivePrefixes {
-					neighbor.ToReceive.Allowed.Prefixes = append(neighbor.ToReceive.Allowed.Prefixes,
-						frrtypes.PrefixSelector{
-							Prefix: prefix,
-							LE:     selectedNetworks.prefixLength[prefix],
-							GE:     selectedNetworks.prefixLength[prefix],
-						},
-					)
+			if len(ra.Spec.NetworkSelectors) > 0 &&
+				ra.Spec.NetworkSelectors[0].NetworkSelectionType == apitypes.DefaultNetwork {
+				klog.Infof("Allow receiving prefixes from neighbor %s for default pod network RA %s",
+					neighbor.Address, ra.Name)
+				neighbor.ToReceive = frrtypes.Receive{
+					Allowed: frrtypes.AllowedInPrefixes{
+						Mode: frrtypes.AllowRestricted,
+					},
 				}
+				if advertisements.Has(ratypes.PodNetwork) {
+					for _, prefix := range receivePrefixes {
+						neighbor.ToReceive.Allowed.Prefixes = append(neighbor.ToReceive.Allowed.Prefixes,
+							frrtypes.PrefixSelector{
+								Prefix: prefix,
+								LE:     selectedNetworks.prefixLength[prefix],
+								GE:     selectedNetworks.prefixLength[prefix],
+							},
+						)
+					}
+				}
+			} else {
+				klog.Infof("Skip receiving prefixes from neighbor %s for non default pod network RA %s",
+					neighbor.Address, ra.Name)
 			}
 			targetRouter.Neighbors = append(targetRouter.Neighbors, neighbor)
 		}

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -499,7 +499,7 @@ func TestController_reconcile(t *testing.T) {
 					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
 					Routers: []*testRouter{
 						{ASN: 1, Prefixes: []string{"1.2.0.0/24", "1.3.0.0/24", "1.4.0.0/16", "1.5.0.0/16"}, Imports: []string{"black", "blue", "green", "red"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.0.0/24", "1.3.0.0/24", "1.4.0.0/16", "1.5.0.0/16"}, Receive: []string{"1.2.0.0/16/24", "1.3.0.0/16/24", "1.4.0.0/16", "1.5.0.0/16"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.0.0/24", "1.3.0.0/24", "1.4.0.0/16", "1.5.0.0/16"}},
 						}},
 						{ASN: 1, VRF: "black", Imports: []string{"default"}},
 						{ASN: 1, VRF: "blue", Imports: []string{"default"}},
@@ -740,13 +740,13 @@ func TestController_reconcile(t *testing.T) {
 					NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
 					Routers: []*testRouter{
 						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.1.1.0/24"}, Receive: []string{"1.1.0.0/16/24"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.1.1.0/24"}},
 						}},
 						{ASN: 1, VRF: "red", Prefixes: []string{"1.2.1.0/24"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.1.0/24"}, Receive: []string{"1.2.0.0/16/24"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.1.0/24"}},
 						}},
 						{ASN: 1, VRF: "green", Prefixes: []string{"1.4.0.0/16"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.4.0.0/16"}, Receive: []string{"1.4.0.0/16"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.4.0.0/16"}},
 						}},
 					},
 				},
@@ -756,7 +756,7 @@ func TestController_reconcile(t *testing.T) {
 					NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
 					Routers: []*testRouter{
 						{ASN: 1, Prefixes: []string{"1.1.2.0/24"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.1.2.0/24"}, Receive: []string{"1.1.0.0/16/24"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.1.2.0/24"}},
 						}},
 					},
 				},
@@ -766,10 +766,10 @@ func TestController_reconcile(t *testing.T) {
 					NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
 					Routers: []*testRouter{
 						{ASN: 1, VRF: "red", Prefixes: []string{"1.2.2.0/24"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.2.0/24"}, Receive: []string{"1.2.0.0/16/24"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.2.0/24"}},
 						}},
 						{ASN: 1, VRF: "green", Prefixes: []string{"1.4.0.0/16"}, Neighbors: []*testNeighbor{
-							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.4.0.0/16"}, Receive: []string{"1.4.0.0/16"}},
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.4.0.0/16"}},
 						}},
 					},
 				},


### PR DESCRIPTION
This PR would skip importing BGP routes into the node for RA belonging to a UDN network, so it gets uniform route handling for both local and remote UDN network host subnet routes. The route handling for default pod network RAs is not changed and it would still import routes to keep traffic working for the default network.