### PR TITLE
Fix node update check for network cluster controller

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -576,7 +576,7 @@ func (h *networkClusterControllerEventHandler) UpdateResource(oldObj, newObj int
 		// 1. we missed an add event (bug in kapi informer code)
 		// 2. a user removed the annotation on the node
 		// Either way to play it safe for now do a partial json unmarshal check
-		if !nodeFailed && util.NoHostSubnet(oldNode) != util.NoHostSubnet(newNode) && !h.ncc.nodeAllocator.NeedsNodeAllocation(newNode) {
+		if !nodeFailed && util.NoHostSubnet(oldNode) == util.NoHostSubnet(newNode) && !h.ncc.nodeAllocator.NeedsNodeAllocation(newNode) {
 			// no other node updates would require us to reconcile again
 			return nil
 		}

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -195,27 +195,24 @@ func (na *NodeAllocator) NeedsNodeAllocation(node *corev1.Node) bool {
 	}
 
 	// ovn node check
-	// allocation is all or nothing, so if one field was allocated from:
-	// nodeSubnets, joinSubnet, layer 2 tunnel id, then all of them were
 	if na.hasNodeSubnetAllocation() {
-		if util.HasNodeHostSubnetAnnotation(node, na.netInfo.GetNetworkName()) {
-			return false
+		if !util.HasNodeHostSubnetAnnotation(node, na.netInfo.GetNetworkName()) {
+			return true
 		}
 	}
-
 	if na.hasJoinSubnetAllocation() {
-		if util.HasNodeGatewayRouterJoinNetwork(node, na.netInfo.GetNetworkName()) {
-			return false
+		if !util.HasNodeGatewayRouterJoinNetwork(node, na.netInfo.GetNetworkName()) {
+			return true
 		}
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() && na.netInfo.IsPrimaryNetwork() && util.DoesNetworkRequireTunnelIDs(na.netInfo) {
-		if util.HasUDNLayer2NodeGRLRPTunnelID(node, na.netInfo.GetNetworkName()) {
-			return false
+		if !util.HasUDNLayer2NodeGRLRPTunnelID(node, na.netInfo.GetNetworkName()) {
+			return true
 		}
 	}
 
-	return true
+	return false
 
 }
 


### PR DESCRIPTION
Introduced in 836ec3680aa33300d631b3e7f3bd3069bbfed2b9

This would just cause node updates to fire HandleAddUpdateNodeEvent everytime as the code prior to the aforementioned commit would have.

