### PR TITLE
udn: Fix NAD template for join subnets field

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -192,7 +192,7 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter) (map[s
 		cniNetConf["mtu"] = mtu
 	}
 	if len(netConfSpec.JoinSubnet) > 0 {
-		cniNetConf["joinSubnets"] = netConfSpec.JoinSubnet
+		cniNetConf["joinSubnet"] = netConfSpec.JoinSubnet
 	}
 	if len(netConfSpec.Subnets) > 0 {
 		cniNetConf["subnets"] = netConfSpec.Subnets

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
@@ -326,7 +326,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 				"netAttachDefName": "mynamespace/test-net",
 				"role": "primary",
 				"topology": "layer3",
-				"joinSubnets": "100.65.0.0/16,fd99::/64",
+				"joinSubnet": "100.65.0.0/16,fd99::/64",
 				"subnets": "192.168.100.0/16,2001:dbb::/60",
 				"mtu": 1500
 			}`,
@@ -350,7 +350,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 			  "netAttachDefName": "mynamespace/test-net",
 			  "role": "primary",
 			  "topology": "layer2",
-			  "joinSubnets": "100.65.0.0/16,fd99::/64",
+			  "joinSubnet": "100.65.0.0/16,fd99::/64",
 			  "subnets": "192.168.100.0/24,2001:dbb::/64",
 			  "mtu": 1500,
 			  "allowPersistentIPs": true
@@ -376,7 +376,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 			  "netAttachDefName": "mynamespace/test-net",
 			  "role": "primary",
 			  "topology": "layer2",
-			  "joinSubnets": "100.62.0.0/24,fd92::/64",
+			  "joinSubnet": "100.62.0.0/24,fd92::/64",
 			  "subnets": "192.168.100.0/24,2001:dbb::/64",
 			  "mtu": 1500,
 			  "allowPersistentIPs": true
@@ -461,7 +461,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 				"netAttachDefName": "mynamespace/test-net",
 				"role": "primary",
 				"topology": "layer3",
-				"joinSubnets": "100.65.0.0/16,fd99::/64",
+				"joinSubnet": "100.65.0.0/16,fd99::/64",
 				"subnets": "192.168.100.0/16,2001:dbb::/60",
 				"mtu": 1500
 			}`,
@@ -485,7 +485,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 			  "netAttachDefName": "mynamespace/test-net",
 			  "role": "primary",
 			  "topology": "layer2",
-			  "joinSubnets": "100.65.0.0/16,fd99::/64",
+			  "joinSubnet": "100.65.0.0/16,fd99::/64",
 			  "subnets": "192.168.100.0/24,2001:dbb::/64",
 			  "mtu": 1500,
 			  "allowPersistentIPs": true
@@ -511,7 +511,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 			  "netAttachDefName": "mynamespace/test-net",
 			  "role": "primary",
 			  "topology": "layer2",
-			  "joinSubnets": "100.62.0.0/24,fd92::/64",
+			  "joinSubnet": "100.62.0.0/24,fd92::/64",
 			  "subnets": "192.168.100.0/24,2001:dbb::/64",
 			  "mtu": 1500,
 			  "allowPersistentIPs": true


### PR DESCRIPTION
## 📑 Description
When a CUDN/UDN is create with joinSubnets field configured it should generate the net-attach-def with `joinSubnet` field, the code was using `joinSubnets` wich is not undertood by ovn-kubernetes.
Fixes #https://issues.redhat.com/browse/OCPBUGS-56418

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
Run UDN with joinSubnets configured it should have that subnet at the ovn topology.
