### PR TITLE
Add the IP rule for a UDN only when it is advertised to the default VRF

### DIFF
--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1754,7 +1754,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway.vrfTableId = test.vrftableID
-			rules, delRules, err := udnGateway.constructUDNVRFIPRules(false)
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
 			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
@@ -1776,7 +1776,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 	}
 }
 
-func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
+func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToTheDefaultNetwork(t *testing.T) {
 	type testRule struct {
 		priority int
 		family   int
@@ -1941,7 +1941,198 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway.vrfTableId = test.vrftableID
-			rules, delRules, err := udnGateway.constructUDNVRFIPRules(true)
+			udnGateway.isNetworkAdvertised = true
+			udnGateway.isNetworkAdvertisedToDefaultVRF = true
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
+			g.Expect(err).ToNot(HaveOccurred())
+			for i, rule := range rules {
+				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
+				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))
+				g.Expect(rule.Family).To(Equal(test.expectedRules[i].family))
+				if rule.Dst != nil {
+					g.Expect(*rule.Dst).To(Equal(test.expectedRules[i].dst))
+				} else {
+					g.Expect(rule.Mark).To(Equal(test.expectedRules[i].mark))
+				}
+			}
+			for i, rule := range delRules {
+				g.Expect(rule.Priority).To(Equal(test.deleteRules[i].priority))
+				g.Expect(rule.Table).To(Equal(test.deleteRules[i].table))
+				g.Expect(rule.Family).To(Equal(test.deleteRules[i].family))
+				g.Expect(*rule.Dst).To(Equal(test.deleteRules[i].dst))
+			}
+		})
+	}
+}
+
+func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNoneDefaultNetwork(t *testing.T) {
+	type testRule struct {
+		priority int
+		family   int
+		table    int
+		mark     uint32
+		dst      net.IPNet
+	}
+	type testConfig struct {
+		desc          string
+		vrftableID    int
+		v4mode        bool
+		v6mode        bool
+		expectedRules []testRule
+		deleteRules   []testRule
+	}
+
+	tests := []testConfig{
+		{
+			desc:       "v4 rule test",
+			vrftableID: 1007,
+			expectedRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
+					mark:     0x1003,
+				},
+			},
+			deleteRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
+					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+				},
+			},
+			v4mode: true,
+		},
+		{
+			desc:       "v6 rule test",
+			vrftableID: 1009,
+			expectedRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					mark:     0x1003,
+				},
+			},
+			deleteRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+				},
+			},
+			v6mode: true,
+		},
+		{
+			desc:       "dualstack rule test",
+			vrftableID: 1010,
+			expectedRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					mark:     0x1003,
+				},
+			},
+			deleteRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+				},
+			},
+			v4mode: true,
+			v6mode: true,
+		},
+	}
+	config.Gateway.V6MasqueradeSubnet = "fd69::/112"
+	config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			g := NewWithT(t)
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+			config.IPv4Mode = test.v4mode
+			config.IPv6Mode = test.v6mode
+			cidr := ""
+			if config.IPv4Mode {
+				cidr = "100.128.0.0/16/24"
+			}
+			if config.IPv4Mode && config.IPv6Mode {
+				cidr += ",ae70::/60"
+			} else if config.IPv6Mode {
+				cidr = "ae70::/60"
+			}
+			nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+				types.Layer3Topology, cidr, types.NetworkRolePrimary)
+			ovntest.AnnotateNADWithNetworkID("3", nad)
+			netInfo, err := util.ParseNADInfo(nad)
+			g.Expect(err).ToNot(HaveOccurred())
+			mutableNetInfo := util.NewMutableNetInfo(netInfo)
+			mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{node.Name: {"bluenet"}})
+			ofm := getDummyOpenflowManager()
+			// create dummy gateway interface(Need to run this test as root)
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "breth0",
+				},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			udnGateway, err := NewUserDefinedNetworkGateway(mutableNetInfo, node, nil, nil, nil, nil, &gateway{openflowManager: ofm})
+			g.Expect(err).NotTo(HaveOccurred())
+			// delete dummy gateway interface after creating UDN gateway(Need to run this test as root)
+			err = netlink.LinkDel(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "breth0",
+				},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			udnGateway.vrfTableId = test.vrftableID
+			udnGateway.isNetworkAdvertised = true
+			udnGateway.isNetworkAdvertisedToDefaultVRF = false
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
 			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
@@ -2072,7 +2263,8 @@ func TestUserDefinedNetworkGateway_updateAdvertisedUDNIsolationRules(t *testing.
 			udng := &UserDefinedNetworkGateway{
 				NetInfo: netInfo,
 			}
-			err = udng.updateAdvertisedUDNIsolationRules(tt.isNetworkAdvertised)
+			udng.isNetworkAdvertised = tt.isNetworkAdvertised
+			err = udng.updateAdvertisedUDNIsolationRules()
 			g.Expect(err).NotTo(HaveOccurred())
 
 			v4Elems, err := nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV4)


### PR DESCRIPTION
## 📑 Description
When an UDN is advertised to a non default VRF, we shall not add the ip rule to the default VRF. Otherwise if another UDN is advertised to the default VRF with the same subnet. The ingress traffic intended for the second UDN cannot be correctly routed to its respective VRF.


## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

1. Create UDN-A. Configure VRF-lite for a UDN-A
2. Create UDN-B with the same subnet as UDN-A. Make sure the node-subets from both UDNs are the same for a node.
3. Advertise UDN-B to the default VRF.
4. Create pod-a and pod-b connect to UDN-A and UDN-B respectively. Make sure pod-a and pod-b are scheduled to the same node.
5. Try to access an external host from pod-b in UDN-B. 
