### PR TITLE
[UDN,BGP] Fix the host drop rules to match on new state

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -3040,8 +3040,8 @@ func getIPv(ipnet *net.IPNet) string {
 //	chain udn-bgp-drop {
 //	  comment "Drop traffic generated locally towards advertised UDN subnets"
 //	   type filter hook output priority filter; policy accept;
-//	   ip daddr @advertised-udn-subnets-v4 counter packets 0 bytes 0 drop
-//	   ip6 daddr @advertised-udn-subnets-v6 counter packets 0 bytes 0 drop
+//	   ct state new ip daddr @advertised-udn-subnets-v4 counter packets 0 bytes 0 drop
+//	   ct state new ip6 daddr @advertised-udn-subnets-v6 counter packets 0 bytes 0 drop
 //	 }
 func configureAdvertisedUDNIsolationNFTables() error {
 	counterIfDebug := ""
@@ -3083,11 +3083,11 @@ func configureAdvertisedUDNIsolationNFTables() error {
 
 	tx.Add(&knftables.Rule{
 		Chain: nftablesUDNBGPOutputChain,
-		Rule:  knftables.Concat(fmt.Sprintf("ip daddr @%s", nftablesAdvertisedUDNsSetV4), counterIfDebug, "drop"),
+		Rule:  knftables.Concat("ct state new", fmt.Sprintf("ip daddr @%s", nftablesAdvertisedUDNsSetV4), counterIfDebug, "drop"),
 	})
 	tx.Add(&knftables.Rule{
 		Chain: nftablesUDNBGPOutputChain,
-		Rule:  knftables.Concat(fmt.Sprintf("ip6 daddr @%s", nftablesAdvertisedUDNsSetV6), counterIfDebug, "drop"),
+		Rule:  knftables.Concat("ct state new", fmt.Sprintf("ip6 daddr @%s", nftablesAdvertisedUDNsSetV6), counterIfDebug, "drop"),
 	})
 	return nft.Run(context.TODO(), tx)
 }


### PR DESCRIPTION
When we did the NFT rules to block traffic
going from host to advertised UDN pod
subnets, we did not mean to also block
replies from host to advertised UDN pod
subnets for traffic initiated by UDN pods.

Given the rules lie in OUTPUT table this would
match on replies as well, so traffic like
pod to kube-apiserver host-networked pod backend
is broken because of this.

Let's change the rule to only match on NEW state
which is what we wanted to do in the original
change.

The current rules unintentionally block traffic
in reverse direction.

First step towards getting https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5140

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers

Note that the L2 Advertised UDNs behave differently and this traffic (UDN advertised pod to other node) doesn't work because of assymmetry reasons. However the future PRs to SNAT this traffic to nodeIP will fix this.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
I included e2e tests
