### PR TITLE
Gate ovn-controller start until ovnkube controller syncs following a reboot

### DIFF
--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -329,7 +329,7 @@ func runWebhook(ctx context.Context, restCfg *rest.Config) error {
 	nodeWebhook := admission.WithCustomValidator(
 		scheme.Scheme,
 		&corev1.Node{},
-		ovnwebhook.NewNodeAdmissionWebhook(cliCfg.enableInterconnect, cliCfg.enableHybridOverlay, cliCfg.extraAllowedUsers.Value()...),
+		ovnwebhook.NewNodeAdmissionWebhook(cliCfg.enableHybridOverlay, cliCfg.extraAllowedUsers.Value()...),
 	).WithRecoverPanic(true)
 
 	nodeHandler, err := admission.StandaloneWebhook(

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -515,6 +515,15 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				return
 			}
 
+			// SB DB maybe stale if IC is enabled and ovn-controller will only be allowed to connect here.
+			if config.OVNKubernetesFeature.EnableInterconnect && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+				for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
+					if err := auth.SetDBAuth(); err != nil {
+						controllerErr = fmt.Errorf("unable to set the authentication towards OVN local dbs")
+					}
+				}
+			}
+
 			// record delay until ready
 			metrics.MetricOVNKubeControllerReadyDuration.Set(time.Since(startTime).Seconds())
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -745,60 +745,6 @@ func getOVNSBZone() (string, error) {
 	return dbZone, nil
 }
 
-/** HACK BEGIN **/
-// TODO(tssurya): Remove this HACK a few months from now.
-// checkOVNSBNodeLRSR returns true if the logical router static route for the
-// the given nodeSubnet is present in the SBDB
-func checkOVNSBNodeLRSR(nodeSubnet *net.IPNet) bool {
-	var matchv4, matchv6 string
-	v6 := true
-	v4 := true
-	if config.IPv6Mode && utilnet.IsIPv6CIDR(nodeSubnet) {
-		matchv6 = fmt.Sprintf("match=\"reg7 == 0 && ip6.dst == %s\"", nodeSubnet)
-		stdout, stderr, err := util.RunOVNSbctl("--bare", "--columns", "_uuid", "find", "logical_flow", matchv6)
-		klog.Infof("Upgrade Hack: checkOVNSBNodeLRSR for node - %s : match %s : stdout - %s : stderr - %s : err %v",
-			nodeSubnet, matchv6, stdout, stderr, err)
-		v6 = (err == nil && stderr == "" && stdout != "")
-	}
-	if config.IPv4Mode && !utilnet.IsIPv6CIDR(nodeSubnet) {
-		matchv4 = fmt.Sprintf("match=\"reg7 == 0 && ip4.dst == %s\"", nodeSubnet)
-		stdout, stderr, err := util.RunOVNSbctl("--bare", "--columns", "_uuid", "find", "logical_flow", matchv4)
-		klog.Infof("Upgrade Hack: checkOVNSBNodeLRSR for node - %s : match %s : stdout - %s : stderr - %s : err %v",
-			nodeSubnet, matchv4, stdout, stderr, err)
-		v4 = (err == nil && stderr == "" && stdout != "")
-	}
-	return v6 && v4
-}
-
-func fetchLBNames() string {
-	stdout, stderr, err := util.RunOVNSbctl("--bare", "--columns", "name", "find", "Load_Balancer")
-	if err != nil || stderr != "" {
-		klog.Errorf("Upgrade hack: fetchLBNames could not fetch services %v/%v", err, stderr)
-		return stdout // will be empty and we will retry
-	}
-	klog.Infof("Upgrade Hack: fetchLBNames: stdout - %s : stderr - %s : err %v", stdout, stderr, err)
-	return stdout
-}
-
-// lbExists returns true if the OVN load balancer for the corresponding namespace/name
-// was created
-func lbExists(lbNames, namespace, name string) bool {
-	stitchedServiceName := "Service_" + namespace + "/" + name
-	match := strings.Contains(lbNames, stitchedServiceName)
-	klog.Infof("Upgrade Hack: lbExists for service - %s/%s/%s : match - %v",
-		namespace, name, stitchedServiceName, match)
-	return match
-}
-
-func portExists(namespace, name string) bool {
-	lspName := fmt.Sprintf("logical_port=%s", util.GetLogicalPortName(namespace, name))
-	stdout, stderr, err := util.RunOVNSbctl("--bare", "--columns", "_uuid", "find", "Port_Binding", lspName)
-	klog.Infof("Upgrade Hack: portExists for pod - %s/%s : stdout - %s : stderr - %s", namespace, name, stdout, stderr)
-	return err == nil && stderr == "" && stdout != ""
-}
-
-/** HACK END **/
-
 // Init executes the first steps to start the DefaultNodeNetworkController.
 // It is split from Start() and executed before SecondaryNodeNetworkController (SNNC),
 // to allow SNNC to reference the openflow manager created in Init.
@@ -978,7 +924,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting the default node network controller")
 
 	var err error
-	var node *corev1.Node
 
 	if nc.mgmtPortController == nil {
 		return fmt.Errorf("default node network controller hasn't been pre-started")
@@ -991,11 +936,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
 	}
 
-	if node, err = nc.watchFactory.GetNode(nc.name); err != nil {
-		return fmt.Errorf("error retrieving node %s: %v", nc.name, err)
-	}
-
-	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
 	waiter := newStartupWaiter()
 
 	// Use the device from environment when the DP resource name is specified.
@@ -1042,125 +982,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 			return err
 		}
 	}
-
-	/** HACK BEGIN **/
-	// TODO(tssurya): Remove this HACK a few months from now. This has been added only to
-	// minimize disruption for upgrades when moving to interconnect=true.
-	// We want the legacy ovnkube-master to wait for remote ovnkube-node to
-	// signal it using "k8s.ovn.org/remote-zone-migrated" annotation before
-	// considering a node as remote when we upgrade from "global" (1 zone IC)
-	// zone to multi-zone. This is so that network disruption for the existing workloads
-	// is negligible and until the point where ovnkube-node flips the switch to connect
-	// to the new SBDB, it would continue talking to the legacy RAFT ovnkube-sbdb to ensure
-	// OVN/OVS flows are intact.
-	// STEP1: ovnkube-node start's up in remote zone and sets the "k8s.ovn.org/zone-name" above.
-	// STEP2: We delay the flip of connection for ovnkube-node(ovn-controller) to the new remote SBDB
-	//        until the new remote ovnkube-controller has finished programming all the K8s core objects
-	//        like routes, services and pods. Until then the ovnkube-node will talk to legacy SBDB.
-	// STEP3: Once we get the signal that the new SBDB is ready, we set the "k8s.ovn.org/remote-zone-migrated" annotation
-	// STEP4: We call setDBAuth to now point to new SBDB
-	// STEP5: Legacy ovnkube-master sees "k8s.ovn.org/remote-zone-migrated" annotation on this node and now knows that
-	//        this node has remote-zone-migrated successfully and tears down old setup and creates new IC resource
-	//        plumbing (takes 80ms based on what we saw in CI runs so we might still have that small window of disruption).
-	// NOTE: ovnkube-node in DPU host mode doesn't go through upgrades for OVN-IC and has no SBDB to connect to. Thus this part shall be skipped.
-	var syncNodes, syncServices, syncPods bool
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.OVNKubernetesFeature.EnableInterconnect && nc.sbZone != types.OvnDefaultZone && !util.HasNodeMigratedZone(node) {
-		klog.Info("Upgrade Hack: Interconnect is enabled")
-		var err1 error
-		start := time.Now()
-		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(_ context.Context) (bool, error) {
-			// we loop through all the nodes in the cluster and ensure ovnkube-controller has finished creating the LRSR required for pod2pod overlay communication
-			if !syncNodes {
-				nodes, err := nc.watchFactory.GetNodes()
-				if err != nil {
-					err1 = fmt.Errorf("upgrade hack: error retrieving node %s: %v", nc.name, err)
-					return false, nil
-				}
-				for _, node := range nodes {
-					node := *node
-					if nc.name != node.Name && util.GetNodeZone(&node) != config.Default.Zone && !util.NoHostSubnet(&node) {
-						nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(&node, types.DefaultNetworkName)
-						if err != nil {
-							if util.IsAnnotationNotSetError(err) {
-								klog.Infof("Skipping node %q. k8s.ovn.org/node-subnets annotation was not found", node.Name)
-								continue
-							}
-							err1 = fmt.Errorf("unable to fetch node-subnet annotation for node %s: err, %v", node.Name, err)
-							return false, nil
-						}
-						for _, nodeSubnet := range nodeSubnets {
-							klog.Infof("Upgrade Hack: node %s, subnet %s", node.Name, nodeSubnet)
-							if !checkOVNSBNodeLRSR(nodeSubnet) {
-								err1 = fmt.Errorf("upgrade hack: unable to find LRSR for node %s", node.Name)
-								return false, nil
-							}
-						}
-					}
-				}
-				klog.Infof("Upgrade Hack: Syncing nodes took %v", time.Since(start))
-				syncNodes = true
-			}
-			// we loop through all existing services in the cluster and ensure ovnkube-controller has finished creating LoadBalancers required for services to work
-			if !syncServices {
-				services, err := nc.watchFactory.GetServices()
-				if err != nil {
-					err1 = fmt.Errorf("upgrade hack: error retrieving the services %v", err)
-					return false, nil
-				}
-				lbNames := fetchLBNames()
-				for _, s := range services {
-					// don't process headless service
-					if !util.ServiceTypeHasClusterIP(s) || !util.IsClusterIPSet(s) {
-						continue
-					}
-					if !lbExists(lbNames, s.Namespace, s.Name) {
-						return false, nil
-					}
-				}
-				klog.Infof("Upgrade Hack: Syncing services took %v", time.Since(start))
-				syncServices = true
-			}
-			if !syncPods {
-				pods, err := nc.watchFactory.GetAllPods()
-				if err != nil {
-					err1 = fmt.Errorf("upgrade hack: error retrieving the services %v", err)
-					return false, nil
-				}
-				for _, p := range pods {
-					if !util.PodScheduled(p) || util.PodCompleted(p) || util.PodWantsHostNetwork(p) {
-						continue
-					}
-					if p.Spec.NodeName != nc.name {
-						// remote pod
-						continue
-					}
-					if !portExists(p.Namespace, p.Name) {
-						return false, nil
-					}
-				}
-				klog.Infof("Upgrade Hack: Syncing pods took %v", time.Since(start))
-				syncPods = true
-			}
-			return true, nil
-		})
-		if err != nil {
-			return fmt.Errorf("upgrade hack: failed while waiting for the remote ovnkube-controller to be ready: %v, %v", err, err1)
-		}
-		if err := util.SetNodeZoneMigrated(nodeAnnotator, nc.sbZone); err != nil {
-			return fmt.Errorf("upgrade hack: failed to set node zone annotation for node %s: %w", nc.name, err)
-		}
-		if err := nodeAnnotator.Run(); err != nil {
-			return fmt.Errorf("upgrade hack: failed to set node %s annotations: %w", nc.name, err)
-		}
-		klog.Infof("ovnkube-node %s finished annotating node with remote-zone-migrated; took: %v", nc.name, time.Since(start))
-		for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
-			if err := auth.SetDBAuth(); err != nil {
-				return fmt.Errorf("upgrade hack: Unable to set the authentication towards OVN local dbs")
-			}
-		}
-		klog.Infof("Upgrade hack: ovnkube-node %s finished setting DB Auth; took: %v", nc.name, time.Since(start))
-	}
-	/** HACK END **/
 
 	// Wait for management port and gateway resources to be created by the master
 	klog.Infof("Waiting for gateway and management port readiness...")

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -915,20 +915,6 @@ func (bnc *BaseNetworkController) GetLocalZoneNodes() ([]*corev1.Node, error) {
 
 // isLocalZoneNode returns true if the node is part of the local zone.
 func (bnc *BaseNetworkController) isLocalZoneNode(node *corev1.Node) bool {
-	/** HACK BEGIN **/
-	// TODO(tssurya): Remove this HACK a few months from now. This has been added only to
-	// minimize disruption for upgrades when moving to interconnect=true.
-	// We want the legacy ovnkube-master to wait for remote ovnkube-node to
-	// signal it using "k8s.ovn.org/remote-zone-migrated" annotation before
-	// considering a node as remote when we upgrade from "global" (1 zone IC)
-	// zone to multi-zone. This is so that network disruption for the existing workloads
-	// is negligible and until the point where ovnkube-node flips the switch to connect
-	// to the new SBDB, it would continue talking to the legacy RAFT ovnkube-sbdb to ensure
-	// OVN/OVS flows are intact.
-	if bnc.zone == types.OvnDefaultZone {
-		return !util.HasNodeMigratedZone(node)
-	}
-	/** HACK END **/
 	return util.GetNodeZone(node) == bnc.zone
 }
 

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -124,7 +124,6 @@ func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) (cache.Res
 				oldObj.Name != newObj.Name ||
 				util.NodeHostCIDRsAnnotationChanged(oldObj, newObj) ||
 				util.NodeZoneAnnotationChanged(oldObj, newObj) ||
-				util.NodeMigratedZoneAnnotationChanged(oldObj, newObj) ||
 				util.NoHostSubnet(oldObj) != util.NoHostSubnet(newObj) {
 				nt.updateNode(newObj)
 			}
@@ -152,7 +151,7 @@ func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) (cache.Res
 // updateNodeInfo updates the node info cache, and syncs all services
 // if it changed.
 func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName, chassisID string, l3gatewayAddresses,
-	hostAddresses []net.IP, podSubnets []*net.IPNet, zone string, nodePortDisabled, migrated bool) {
+	hostAddresses []net.IP, podSubnets []*net.IPNet, zone string, nodePortDisabled bool) {
 	ni := nodeInfo{
 		name:               nodeName,
 		l3gatewayAddresses: l3gatewayAddresses,
@@ -163,7 +162,6 @@ func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName, chassisI
 		chassisID:          chassisID,
 		nodePortDisabled:   nodePortDisabled,
 		zone:               zone,
-		migrated:           migrated,
 	}
 	for i := range podSubnets {
 		ni.podSubnets = append(ni.podSubnets, *podSubnets[i]) // de-pointer
@@ -266,7 +264,6 @@ func (nt *nodeTracker) updateNode(node *corev1.Node) {
 		hsn,
 		util.GetNodeZone(node),
 		!nodePortEnabled,
-		util.HasNodeMigratedZone(node),
 	)
 }
 

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1118,20 +1118,6 @@ func (e *EgressIPController) isPodScheduledinLocalZone(pod *corev1.Pod) bool {
 
 // isLocalZoneNode returns true if the node is part of the local zone.
 func (e *EgressIPController) isLocalZoneNode(node *corev1.Node) bool {
-	/** HACK BEGIN **/
-	// TODO(tssurya): Remove this HACK a few months from now. This has been added only to
-	// minimize disruption for upgrades when moving to interconnect=true.
-	// We want the legacy ovnkube-master to wait for remote ovnkube-node to
-	// signal it using "k8s.ovn.org/remote-zone-migrated" annotation before
-	// considering a node as remote when we upgrade from "global" (1 zone IC)
-	// zone to multi-zone. This is so that network disruption for the existing workloads
-	// is negligible and until the point where ovnkube-node flips the switch to connect
-	// to the new SBDB, it would continue talking to the legacy RAFT ovnkube-sbdb to ensure
-	// OVN/OVS flows are intact.
-	if e.zone == types.OvnDefaultZone {
-		return !util.HasNodeMigratedZone(node)
-	}
-	/** HACK END **/
 	return util.GetNodeZone(node) == e.zone
 }
 

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -56,18 +56,6 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OVNNodeEncapIPs: nil,
 }
 
-// interconnectNodeAnnotationChecks holds annotations allowed for ovnkube-node:<nodeName> users in IC environments
-var interconnectNodeAnnotationChecks = map[string]checkNodeAnnot{
-	util.OvnNodeMigratedZoneName: func(v annotationChange, nodeName string) error {
-		// it is allowed for the annotation to be set to <nodeName>
-		if (v.action == added || v.action == changed) && v.value == nodeName {
-			return nil
-		}
-
-		return fmt.Errorf("%s can only be set to %s, it cannot be removed", util.OvnNodeMigratedZoneName, nodeName)
-	},
-}
-
 // hybridOverlayNodeAnnotationChecks holds annotations allowed for ovnkube-node:<nodeName> users hybrid overlay environments
 var hybridOverlayNodeAnnotationChecks = map[string]checkNodeAnnot{
 	hotypes.HybridOverlayDRMAC: nil,
@@ -80,12 +68,9 @@ type NodeAdmission struct {
 	extraAllowedUsers sets.Set[string]
 }
 
-func NewNodeAdmissionWebhook(enableInterconnect, enableHybridOverlay bool, extraAllowedUsers ...string) *NodeAdmission {
+func NewNodeAdmissionWebhook(enableHybridOverlay bool, extraAllowedUsers ...string) *NodeAdmission {
 	checks := make(map[string]checkNodeAnnot)
 	maps.Copy(checks, commonNodeAnnotationChecks)
-	if enableInterconnect {
-		maps.Copy(checks, interconnectNodeAnnotationChecks)
-	}
 	if enableHybridOverlay {
 		maps.Copy(checks, hybridOverlayNodeAnnotationChecks)
 	}

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -113,22 +113,6 @@ const (
 	// ovnkube-node gets the node's zone from the OVN Southbound database.
 	OvnNodeZoneName = "k8s.ovn.org/zone-name"
 
-	/** HACK BEGIN **/
-	// TODO(tssurya): Remove this annotation a few months from now (when one or two release jump
-	// upgrades are done). This has been added only to minimize disruption for upgrades when
-	// moving to interconnect=true.
-	// We want the legacy ovnkube-master to wait for remote ovnkube-node to
-	// signal it using "k8s.ovn.org/remote-zone-migrated" annotation before
-	// considering a node as remote when we upgrade from "global" (1 zone IC)
-	// zone to multi-zone. This is so that network disruption for the existing workloads
-	// is negligible and until the point where ovnkube-node flips the switch to connect
-	// to the new SBDB, it would continue talking to the legacy RAFT ovnkube-sbdb to ensure
-	// OVN/OVS flows are intact.
-	// OvnNodeMigratedZoneName is the zone to which the node belongs to. It is set by ovnkube-node.
-	// ovnkube-node gets the node's zone from the OVN Southbound database.
-	OvnNodeMigratedZoneName = "k8s.ovn.org/remote-zone-migrated"
-	/** HACK END **/
-
 	// OvnTransitSwitchPortAddr is the annotation to store the node Transit switch port ips.
 	// It is set by cluster manager.
 	OvnTransitSwitchPortAddr = "k8s.ovn.org/node-transit-switch-port-ifaddr"
@@ -1325,26 +1309,6 @@ func NodeIDAnnotationChanged(oldNode, newNode *corev1.Node) bool {
 func SetNodeZone(nodeAnnotator kube.Annotator, zoneName string) error {
 	return nodeAnnotator.Set(OvnNodeZoneName, zoneName)
 }
-
-/** HACK BEGIN **/
-// TODO(tssurya): Remove this a few months from now
-// SetNodeZoneMigrated sets the node's zone in the 'ovnNodeMigratedZoneName' node annotation.
-func SetNodeZoneMigrated(nodeAnnotator kube.Annotator, zoneName string) error {
-	return nodeAnnotator.Set(OvnNodeMigratedZoneName, zoneName)
-}
-
-// HasNodeMigratedZone returns true if node has its ovnNodeMigratedZoneName set already
-func HasNodeMigratedZone(node *corev1.Node) bool {
-	_, ok := node.Annotations[OvnNodeMigratedZoneName]
-	return ok
-}
-
-// NodeMigratedZoneAnnotationChanged returns true if the ovnNodeMigratedZoneName annotation changed for the node
-func NodeMigratedZoneAnnotationChanged(oldNode, newNode *corev1.Node) bool {
-	return oldNode.Annotations[OvnNodeMigratedZoneName] != newNode.Annotations[OvnNodeMigratedZoneName]
-}
-
-/** HACK END **/
 
 // GetNodeZone returns the zone of the node set in the 'ovnNodeZoneName' node annotation.
 // If the annotation is not set, it returns the 'default' zone name.


### PR DESCRIPTION
For IC mode, after a Node reboot, SB DB may contain stale control plane data because ovnkube-controller has not config'd OVN and changes propagated to SB DB. The issue we see downstream is that when an egress Node which hosts an EgressIP IP, and when it reboots, ovn-controller will connect to SB DB which will contain stale SNAT to support EgressIP. ovn-controller will GARP for the EgressIP IP even though the EgressIP IP may have already been assigned to another Node. 

The issue may also be present for a simple pod restart if the EIP moves while ovnkube-controller is restarting. This PR wont fix that scenario.

For restart scenario, gate ovn-controller until ovnkube controller has syncd and the changes have reached SB DB for IC mode only. Its up to an external entity to clear the ovn-remote value before ovnkube controller starts for the reboot scenario because the ovn-remote is not cleared when ovnkube exists because we dont want to disrupt traffic for simple ovnkube pod restart case.

Other options were considered including wiping the OVN DBs on startup before ovnkube-node pod starts but we may wipe out dynamic info like learned MACs. Adding non-reboot persistant storage was also considered but was overly complex.

Also, we do not want to gate starting ovn-controller for a simple ovnkube pod restart because it would affect the data plane whereas post reboot, there will not be any active workloads.

Downstream bug: https://issues.redhat.com/browse/OCPBUGS-42303
