### PR TITLE
gateway: Refactor gateway initialization and DPU host handling

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1028,7 +1028,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	// Complete gateway initialization
 	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
-		err = nc.initGatewayDPUHost(nc.nodeAddress)
+		err = nc.initGatewayDPUHost(nc.nodeAddress, nodeAnnotator)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -563,26 +563,29 @@ func (b *bridgeConfiguration) getGatewayIface() string {
 func (b *bridgeConfiguration) updateInterfaceIPAddresses(node *corev1.Node) ([]*net.IPNet, error) {
 	b.Lock()
 	defer b.Unlock()
-	ifAddrs, err := getNetworkInterfaceIPAddresses(b.getGatewayIface())
-	if err != nil {
-		return nil, err
-	}
 
-	// For DPU, here we need to use the DPU host's IP address which is the tenant cluster's
-	// host internal IP address instead of the DPU's external bridge IP address.
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
-		nodeAddrStr, err := util.GetNodePrimaryIP(node)
+	var err error
+	var ifAddrs []*net.IPNet
+	if config.OvnKubeNode.Mode == types.NodeModeFull {
+		ifAddrs, err = getNetworkInterfaceIPAddresses(b.getGatewayIface())
+	} else {
+		// For DPU, here we need to use the DPU host's IP address which is the tenant cluster's
+		// host internal IP address instead of the DPU's external bridge IP address.
+		nodeAddrStr, err := util.GetNodeIfAddrAnnotation(node)
 		if err != nil {
 			return nil, err
 		}
-		nodeAddr := net.ParseIP(nodeAddrStr)
-		if nodeAddr == nil {
+		nodeAddr, _, err := net.ParseCIDR(nodeAddrStr.IPv4)
+		if err != nil {
 			return nil, fmt.Errorf("failed to parse node IP address. %v", nodeAddrStr)
 		}
 		ifAddrs, err = getDPUHostPrimaryIPAddresses(nodeAddr, ifAddrs)
 		if err != nil {
 			return nil, err
 		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	b.ips = ifAddrs

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/vishvananda/netlink"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
@@ -324,7 +326,7 @@ func (nc *DefaultNodeNetworkController) initGatewayPreStart(
 	subnets []*net.IPNet,
 	nodeAnnotator kube.Annotator,
 	mgmtPort managementport.Interface,
-	kubeNodeIP net.IP,
+	_ net.IP,
 ) (*gateway, error) {
 
 	klog.Info("Initializing Gateway Functionality for Gateway PreStart")
@@ -351,7 +353,19 @@ func (nc *DefaultNodeNetworkController) initGatewayPreStart(
 	// For DPU need to use the host IP addr which currently is assumed to be K8s Node cluster
 	// internal IP address.
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {
-		ifAddrs, err = getDPUHostPrimaryIPAddresses(kubeNodeIP, ifAddrs)
+		var node *corev1.Node
+		if node, err = nc.watchFactory.GetNode(nc.name); err != nil {
+			return nil, fmt.Errorf("error retrieving node %s: %v", nc.name, err)
+		}
+		nodeAddrStr, err := util.GetNodeIfAddrAnnotation(node)
+		if err != nil {
+			return nil, err
+		}
+		nodeAddr, _, err := net.ParseCIDR(nodeAddrStr.IPv4)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse node IP address. %v", nodeAddrStr)
+		}
+		ifAddrs, err = getDPUHostPrimaryIPAddresses(nodeAddr, ifAddrs)
 		if err != nil {
 			return nil, err
 		}
@@ -488,22 +502,22 @@ func interfaceForEXGW(intfName string) string {
 	return intfName
 }
 
-func (nc *DefaultNodeNetworkController) initGatewayDPUHost(kubeNodeIP net.IP) error {
+func (nc *DefaultNodeNetworkController) initGatewayDPUHost(kubeNodeIP net.IP, nodeAnnotator kube.Annotator) error {
 	// A DPU host gateway is complementary to the shared gateway running
 	// on the DPU embedded CPU. it performs some initializations and
 	// watch on services for iptable rule updates and run a loadBalancerHealth checker
 	// Note: all K8s Node related annotations are handled from DPU.
 	klog.Info("Initializing Shared Gateway Functionality on DPU host")
 	var err error
+	var gwIntf, gatewayIntf string
+	gatewayIntfTemp := config.Gateway.Interface
 
-	// Force gateway interface to be the interface associated with kubeNodeIP
-	gwIntf, err := getInterfaceByIP(kubeNodeIP)
+	gwIntf, err = getInterfaceByIP(kubeNodeIP)
 	if err != nil {
 		return err
 	}
 	config.Gateway.Interface = gwIntf
-
-	_, gatewayIntf, err := getGatewayNextHops()
+	_, gatewayIntf, err = getGatewayNextHops()
 	if err != nil {
 		return err
 	}
@@ -511,6 +525,37 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost(kubeNodeIP net.IP) er
 	ifAddrs, err := getNetworkInterfaceIPAddresses(gatewayIntf)
 	if err != nil {
 		return err
+	}
+
+	nodeIPNetv4, _ := util.MatchFirstIPNetFamily(false, ifAddrs)
+	nodeAddrSet := sets.New[string](nodeIPNetv4.String())
+
+	if gatewayIntfTemp != "" && gatewayIntfTemp != gatewayIntf {
+		config.Gateway.Interface = gatewayIntfTemp
+		gatewayIntf = config.Gateway.Interface
+		gwIntf = gatewayIntf
+
+		ifAddrs, err = getNetworkInterfaceIPAddresses(gatewayIntf)
+		if err != nil {
+			return err
+		}
+
+		nodeIPNetv4, _ = util.MatchFirstIPNetFamily(false, ifAddrs)
+		nodeAddrSet.Insert(nodeIPNetv4.String())
+	}
+
+	if err := util.SetNodePrimaryIfAddrs(nodeAnnotator, ifAddrs); err != nil {
+		klog.Errorf("Unable to set primary IP net label on node, err: %v", err)
+		return err
+	}
+
+	if err := util.SetNodeHostCIDRs(nodeAnnotator, nodeAddrSet); err != nil {
+		klog.Errorf("Unable to set host-cidrs on node, err: %v", err)
+		return err
+	}
+
+	if err := nodeAnnotator.Run(); err != nil {
+		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
 	}
 
 	// Delete stale masquerade resources if there are any. This is to make sure that there

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -720,6 +720,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 
 		nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
 
+		err = util.SetNodePrimaryIfAddrs(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
+		config.Gateway.RouterSubnet = nodeSubnet
+		Expect(err).NotTo(HaveOccurred())
 		err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
 		Expect(err).NotTo(HaveOccurred())
 		err = nodeAnnotator.Run()
@@ -887,8 +890,11 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
+			k := &kube.Kube{KClient: kubeFakeClient}
 
-			err := nc.initGatewayDPUHost(net.ParseIP(hostIP))
+			nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)
+
+			err := nc.initGatewayDPUHost(net.ParseIP(hostIP), nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
 
 			link, err := netlink.LinkByName(uplinkName)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2445,6 +2445,9 @@ func newGateway(
 			gwBridge.eipMarkIPs = gw.bridgeEIPAddrManager.GetCache()
 		}
 		gw.nodeIPManager = newAddressManager(nodeName, kube, mgmtPort, watchFactory, gwBridge)
+		if gw.nodeIPManager == nil {
+			return fmt.Errorf("failed to allocate newAddressManager")
+		}
 
 		if config.OvnKubeNode.Mode == types.NodeModeFull {
 			// Delete stale masquerade resources if there are any. This is to make sure that there

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -317,12 +317,8 @@ func (c *addressManager) updateNodeAddressAnnotations() error {
 
 func (c *addressManager) updateHostCIDRs(ifAddrs []*net.IPNet) error {
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {
-		// For DPU mode, here we need to use the DPU host's IP address which is the tenant cluster's
-		// host internal IP address instead.
-		// Currently we are only intentionally supporting IPv4 for DPU here.
-		nodeIPNetv4, _ := util.MatchFirstIPNetFamily(false, ifAddrs)
-		nodeAddrSet := sets.New[string](nodeIPNetv4.String())
-		return util.SetNodeHostCIDRs(c.nodeAnnotator, nodeAddrSet)
+		// The host CIDR should be updated only by the full and host mode
+		return nil
 	}
 
 	return util.SetNodeHostCIDRs(c.nodeAnnotator, c.cidrs)

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -77,6 +77,7 @@ func makeNodeSwitchTargetIPs(node string, c *lbConfig) (targetIPsV4, targetIPsV6
 func makeNodeRouterTargetIPs(node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
 	targetIPsV4 = c.clusterEndpoints.V4IPs
 	targetIPsV6 = c.clusterEndpoints.V6IPs
+	var v4Updated, v6Updated bool
 
 	if c.externalTrafficLocal {
 		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
@@ -92,9 +93,15 @@ func makeNodeRouterTargetIPs(node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, ho
 	}
 
 	// Any targets local to the node need to have a special
-	// harpin IP added, but only for the router LB
-	targetIPsV4, v4Updated := util.UpdateIPsSlice(targetIPsV4, node.l3gatewayAddressesStr(), []string{hostMasqueradeIPV4})
-	targetIPsV6, v6Updated := util.UpdateIPsSlice(targetIPsV6, node.l3gatewayAddressesStr(), []string{hostMasqueradeIPV6})
+	// hairpin IP added, but only for the router LB
+	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		// hairpin traffic of the hostaddress in case of the DPU
+		targetIPsV4, v4Updated = util.UpdateIPsSlice(targetIPsV4, node.hostAddressesStr(), []string{hostMasqueradeIPV4})
+		targetIPsV6, v6Updated = util.UpdateIPsSlice(targetIPsV6, node.hostAddressesStr(), []string{hostMasqueradeIPV6})
+	} else {
+		targetIPsV4, v4Updated = util.UpdateIPsSlice(targetIPsV4, node.l3gatewayAddressesStr(), []string{hostMasqueradeIPV4})
+		targetIPsV6, v6Updated = util.UpdateIPsSlice(targetIPsV6, node.l3gatewayAddressesStr(), []string{hostMasqueradeIPV6})
+	}
 
 	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
 	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs) || v4Updated


### PR DESCRIPTION
- Improve DPU host gateway configuration with better IP handling
- Fix node interface address handling for DPU mode
- Clean up gateway interface selection logic for DPU and DPU-HOST
- Update node annotations for DPU host mode
- Remove redundant code and improve error handling
- Fix typos and improve code readability

This change simplifies the gateway initialization flow and improves the handling of DPU (Data Processing Unit) host configurations.

The main idea is that the DPU in host mode is the one that dictates how the network looks and the DPU side just follows.
