### PR TITLE
udn, pre assigned port net ids: provision the default net NAD CR

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -1016,7 +1016,7 @@ func (c *Controller) getSelectedNADs(networkSelectors apitypes.NetworkSelectors)
 		case apitypes.DefaultNetwork:
 			// if we are selecting the default networkdefault network label,
 			// make sure a NAD exists for it
-			nad, err := c.getOrCreateDefaultNetworkNAD()
+			nad, err := util.EnsureDefaultNetworkNAD(c.nadLister, c.nadClient)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get/create default network NAD: %w", err)
 			}
@@ -1045,34 +1045,6 @@ func (c *Controller) getSelectedNADs(networkSelectors apitypes.NetworkSelectors)
 	}
 
 	return selected, nil
-}
-
-// getOrCreateDefaultNetworkNAD ensure that a well-known NAD exists for the
-// default network in ovn-k namespace.
-func (c *Controller) getOrCreateDefaultNetworkNAD() (*nadtypes.NetworkAttachmentDefinition, error) {
-	nad, err := c.nadLister.NetworkAttachmentDefinitions(config.Kubernetes.OVNConfigNamespace).Get(types.DefaultNetworkName)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-	if nad != nil {
-		return nad, nil
-	}
-	return c.nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(config.Kubernetes.OVNConfigNamespace).Create(
-		context.Background(),
-		&nadtypes.NetworkAttachmentDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      types.DefaultNetworkName,
-				Namespace: config.Kubernetes.OVNConfigNamespace,
-			},
-			Spec: nadtypes.NetworkAttachmentDefinitionSpec{
-				Config: fmt.Sprintf("{\"cniVersion\": \"0.4.0\", \"name\": \"ovn-kubernetes\", \"type\": \"%s\"}", config.CNI.Plugin),
-			},
-		},
-		// note we don't set ourselves as field manager for this create as we
-		// want to process the resulting event that would otherwise be filtered
-		// out in nadNeedsUpdate
-		metav1.CreateOptions{},
-	)
 }
 
 // getEgressIPsByNodesByNetworks iterates all existing egress IPs that apply to

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -1051,7 +1051,7 @@ func TestController_reconcile(t *testing.T) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			// prime the default network NAD
 			if defaultNAD == nil {
-				defaultNAD, err = c.getOrCreateDefaultNetworkNAD()
+				defaultNAD, err = util.EnsureDefaultNetworkNAD(c.nadLister, c.nadClient)
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 				// update it with the annotation that network manager would set
 				defaultNAD.Annotations = map[string]string{types.OvnNetworkNameAnnotation: types.DefaultNetworkName}

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -150,6 +150,12 @@ func (c *Controller) Run() error {
 		return fmt.Errorf("unable to start user-defined network controller: %v", err)
 	}
 
+	if util.IsPreconfiguredUDNAddressesEnabled() {
+		if _, err := util.EnsureDefaultNetworkNAD(c.nadLister, c.nadClient); err != nil {
+			return fmt.Errorf("failed to ensure default network nad exists: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1378,6 +1378,12 @@ func IsRouteAdvertisementsEnabled() bool {
 	return config.OVNKubernetesFeature.EnableMultiNetwork && config.OVNKubernetesFeature.EnableRouteAdvertisements
 }
 
+// IsPreconfiguredUDNAddressesEnabled indicates if user defined IPs / MAC
+// addresses can be set in primary UDNs
+func IsPreconfiguredUDNAddressesEnabled() bool {
+	return IsNetworkSegmentationSupportEnabled() && config.OVNKubernetesFeature.EnablePreconfiguredUDNAddresses
+}
+
 func DoesNetworkRequireIPAM(netInfo NetInfo) bool {
 	return !((netInfo.TopologyType() == types.Layer2Topology || netInfo.TopologyType() == types.LocalnetTopology) && len(netInfo.Subnets()) == 0)
 }

--- a/go-controller/pkg/util/nad.go
+++ b/go-controller/pkg/util/nad.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	nadtypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
+	nadlisters "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+// EnsureDefaultNetworkNAD ensures that a well-known NAD exists for the
+// default network in ovn-k namespace. This will allow the users to customize
+// the primary UDN attachments with static IPs, and/or MAC address requests, by
+// using the multus-cni `default network` feature.
+func EnsureDefaultNetworkNAD(nadLister nadlisters.NetworkAttachmentDefinitionLister, nadClient nadclientset.Interface) (*nadtypes.NetworkAttachmentDefinition, error) {
+	nad, err := nadLister.NetworkAttachmentDefinitions(config.Kubernetes.OVNConfigNamespace).Get(types.DefaultNetworkName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if nad != nil {
+		return nad, nil
+	}
+	return nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(config.Kubernetes.OVNConfigNamespace).Create(
+		context.Background(),
+		&nadtypes.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      types.DefaultNetworkName,
+				Namespace: config.Kubernetes.OVNConfigNamespace,
+			},
+			Spec: nadtypes.NetworkAttachmentDefinitionSpec{
+				Config: fmt.Sprintf("{\"cniVersion\": \"0.4.0\", \"name\": \"ovn-kubernetes\", \"type\": \"%s\"}", config.CNI.Plugin),
+			},
+		},
+		// note we don't set ourselves as field manager for this create as we
+		// want to process the resulting event that would otherwise be filtered
+		// out in nadNeedsUpdate
+		metav1.CreateOptions{},
+	)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
The "pre assigned port net ids" feature requires a NAD for the `default` network to be provisioned. This PR provisions that NAD whenever the cluster manager starts.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
Depends-on: 
- #5332 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic provisioning of a default network attachment when specific features are enabled.
  * Introduced configuration checks to determine if preconfigured user-defined network addresses are supported.

* **Bug Fixes**
  * Ensured that the default network attachment is not created when related features are disabled.

* **Tests**
  * Improved test coverage for scenarios involving automatic provisioning of network attachments based on feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->