### PR TITLE
ovnkube in dpu host mode: advanced gateway detection

### DIFF
--- a/docs/features/hardware-offload/derive-from-mgmt-port.md
+++ b/docs/features/hardware-offload/derive-from-mgmt-port.md
@@ -1,0 +1,163 @@
+# From PCI Address Gateway Interface Feature
+
+## Overview
+
+The "derive-from-mgmt-port" gateway interface feature is a new capability in OVN-Kubernetes that enables automatic gateway interface resolution in DPU (Data Processing Unit) host mode deployments. This feature automatically discovers and configures the appropriate Physical Function (PF) interface as the gateway interface based on the Virtual Function (VF) used for the management port.
+
+## Problem Statement
+
+In DPU deployments, the host typically has access to Virtual Functions (VFs) for management purposes, while the Physical Functions (PFs) are used for external connectivity. Previously, administrators had to manually specify the gateway interface, which required:
+
+1. Knowledge of the hardware topology
+2. Manual mapping of VF to PF relationships
+3. Configuration updates when hardware changes
+4. Potential for misconfiguration
+
+## Solution
+
+The "derive-from-mgmt-port" feature automates the gateway interface discovery process by:
+
+1. **Automatic Discovery**: Automatically finds the PF interface associated with the management port VF
+2. **Hardware Abstraction**: Eliminates the need for manual hardware topology knowledge
+3. **Dynamic Configuration**: Adapts to hardware changes automatically
+4. **Reduced Configuration**: Simplifies deployment configuration
+
+## Benefits
+
+### For Administrators
+
+- **Simplified Configuration**: No need to manually specify gateway interfaces
+- **Reduced Errors**: Eliminates manual mapping errors
+- **Hardware Agnostic**: Works with any SR-IOV capable hardware
+- **Dynamic Adaptation**: Automatically adapts to hardware changes
+
+### For Operations
+
+- **Faster Deployment**: Reduced configuration time
+- **Consistent Setup**: Standardized gateway interface selection
+- **Reduced Maintenance**: Less manual intervention required
+- **Better Reliability**: Fewer configuration-related issues
+
+### For Development
+
+- **Cleaner Code**: Centralized gateway interface logic
+- **Better Testing**: Comprehensive unit test coverage
+- **Extensible Design**: Foundation for future enhancements
+
+## Technical Implementation
+
+### Code Changes
+
+1. **New Constant**: Added `DeriveFromMgmtPort = "derive-from-mgmt-port"` constant in `go-controller/pkg/types/const.go`
+2. **Enhanced Logic**: Extended gateway initialization in `go-controller/pkg/node/default_node_network_controller.go`
+3. **Comprehensive Testing**: Added unit tests covering success and failure scenarios
+
+### Key Functions
+
+- `getManagementPortNetDev()`: Resolves management port device name
+- `GetPciFromNetDevice()`: Retrieves PCI address from network device
+- `GetPfPciFromVfPci()`: Resolves PF PCI address from VF PCI address
+- `GetNetDevicesFromPci()`: Discovers network devices associated with PCI address
+
+### Error Handling
+
+The implementation includes robust error handling for:
+- Missing network devices
+- PCI address resolution failures
+- SR-IOV operation failures
+- Hardware compatibility issues
+
+## Configuration Examples
+
+### Basic Configuration
+
+```bash
+--ovnkube-node-mode=dpu-host
+--ovnkube-node-mgmt-port-netdev=pf0vf0
+--gateway-interface=derive-from-mgmt-port
+```
+
+### Helm Configuration
+
+```yaml
+ovnkube-node:
+  mode: dpu-host
+  mgmtPortNetdev: pf0vf0
+  
+gateway:
+  interface: derive-from-mgmt-port
+```
+
+### Configuration File
+
+```ini
+[OvnKubeNode]
+mode=dpu-host
+mgmt-port-netdev=pf0vf0
+
+[Gateway]
+interface=derive-from-mgmt-port
+```
+
+## Migration Guide
+
+### From Manual Configuration
+
+**Before:**
+```bash
+--gateway-interface=eth0
+```
+
+**After:**
+```bash
+--gateway-interface=derive-from-mgmt-port
+```
+
+### Verification Steps
+
+1. Verify SR-IOV configuration is correct
+2. Ensure management port device is properly configured
+3. Check that PF interfaces are available
+4. Monitor logs for successful gateway interface resolution
+
+## Testing
+
+### Unit Tests
+
+Comprehensive unit tests cover:
+- Successful gateway interface resolution
+- Error handling for missing devices
+- PCI address resolution failures
+- Network device discovery failures
+
+### Integration Tests
+
+The feature integrates with existing:
+- Gateway initialization
+- DPU host mode functionality
+- SR-IOV operations
+- Network configuration
+
+## Future Enhancements
+
+Potential improvements include:
+- Support for multiple gateway interfaces
+- Enhanced device selection criteria
+- Integration with device plugins
+- Support for non-SR-IOV hardware
+- Advanced error reporting and diagnostics
+
+## Related Documentation
+
+- [DPU Gateway Interface Configuration](dpu-gateway-interface.md)
+- [DPU Support](dpu-support.md)
+- [Gateway Accelerated Interface Configuration](../design/gateway-accelerated-interface-configuration.md)
+- [Configuration Guide](../../getting-started/configuration.md)
+
+## Support
+
+For issues related to this feature:
+1. Check the troubleshooting section in the DPU Gateway Interface Configuration guide
+2. Verify SR-IOV hardware and driver support
+3. Review error messages and logs
+4. Consult the OVN-Kubernetes community for additional support 

--- a/docs/features/hardware-offload/dpu-gateway-interface.md
+++ b/docs/features/hardware-offload/dpu-gateway-interface.md
@@ -1,0 +1,208 @@
+# DPU Gateway Interface Configuration
+
+## Overview
+
+In DPU (Data Processing Unit) host mode deployments, OVN-Kubernetes supports automatic gateway interface resolution from PCI address. This feature is particularly useful when the management port is a Virtual Function (VF) and you want to automatically select the corresponding Physical Function (PF) interface as the gateway.
+
+## Background
+
+In DPU deployments, the host typically has access to Virtual Functions (VFs) for management purposes, while the Physical Functions (PFs) are used for external connectivity. The "derive-from-mgmt-port" feature allows OVN-Kubernetes to automatically discover and configure the appropriate PF interface as the gateway interface based on the VF used for the management port.
+
+## How It Works
+
+When configured with `--gateway-interface=derive-from-mgmt-port`, OVN-Kubernetes performs the following steps:
+
+1. **Management Port Resolution**: Gets the management port network device name (specified by `--ovnkube-node-mgmt-port-netdev`)
+2. **VF PCI Address Retrieval**: Retrieves the PCI address of the management port device (VF)
+3. **PF PCI Address Resolution**: Gets the Physical Function (PF) PCI address from the Virtual Function (VF) PCI address
+4. **Network Device Discovery**: Retrieves all network devices associated with the PF PCI address
+5. **Interface Selection**: Selects the first available network device as the gateway interface
+
+## Configuration
+
+### Command Line Options
+
+```bash
+--ovnkube-node-mode=dpu-host
+--ovnkube-node-mgmt-port-netdev=pf0vf0
+--gateway-interface=derive-from-mgmt-port
+```
+
+### Configuration File
+
+```ini
+[OvnKubeNode]
+mode=dpu-host
+mgmt-port-netdev=pf0vf0
+
+[Gateway]
+interface=derive-from-mgmt-port
+```
+
+### Helm Configuration
+
+```yaml
+ovnkube-node:
+  mode: dpu-host
+  mgmtPortNetdev: pf0vf0
+  
+gateway:
+  interface: derive-from-mgmt-port
+```
+
+## Example Scenario
+
+Consider a DPU setup with the following configuration:
+
+- **Management port device**: `pf0vf0` (Virtual Function)
+- **VF PCI address**: `0000:01:02.3`
+- **PF PCI address**: `0000:01:00.0`
+- **Available PF interfaces**: `eth0`, `eth1`
+
+With `--gateway-interface=derive-from-mgmt-port`, OVN-Kubernetes will:
+
+1. Start with the management port device `pf0vf0`
+2. Get its PCI address `0000:01:02.3`
+3. Resolve the PF PCI address to `0000:01:00.0`
+4. Find all network devices associated with PF `0000:01:00.0`: `eth0`, `eth1`
+5. Select `eth0` (first device) as the gateway interface
+
+## Requirements
+
+### Hardware Requirements
+
+- SR-IOV capable network interface card
+- Virtual Function (VF) and Physical Function (PF) setup
+- Management port configured as a VF
+
+### Software Requirements
+
+- SR-IOV utilities available on the system
+- OVN-Kubernetes running in DPU host mode
+- Proper VF/PF driver support
+
+### Configuration Requirements
+
+- Must be used in DPU host mode (`--ovnkube-node-mode=dpu-host`)
+- Management port netdev must be specified (`--ovnkube-node-mgmt-port-netdev`)
+- Gateway interface must be set to `derive-from-mgmt-port`
+
+## Error Handling
+
+The system will return an error in the following scenarios:
+
+### No Network Devices Found
+
+```
+no netdevs found for pci address 0000:01:00.0
+```
+
+**Cause**: The PF PCI address doesn't have any associated network devices.
+
+**Resolution**: Verify that the PF has network interfaces configured and are visible to the system.
+
+### PCI Address Resolution Failure
+
+```
+failed to get PCI address
+```
+
+**Cause**: Unable to retrieve the PCI address from the management port device.
+
+**Resolution**: Ensure the management port device exists and is properly configured.
+
+### PF PCI Address Resolution Failure
+
+```
+failed to get PF PCI address
+```
+
+**Cause**: Unable to resolve the PF PCI address from the VF PCI address.
+
+**Resolution**: Verify SR-IOV configuration and driver support.
+
+### Network Device Discovery Failure
+
+```
+failed to get network devices
+```
+
+**Cause**: Unable to retrieve network devices associated with the PF PCI address.
+
+**Resolution**: Check SR-IOV utilities and system configuration.
+
+## Troubleshooting
+
+### Verify SR-IOV Configuration
+
+```bash
+# Check if SR-IOV is enabled
+lspci | grep -i ethernet
+
+# Check VF configuration
+ip link show
+
+# Check PF/VF relationship
+ls /sys/bus/pci/devices/*/virtfn*
+```
+
+### Verify Management Port Device
+
+```bash
+# Check if management port device exists
+ip link show pf0vf0
+
+# Check PCI address
+ethtool -i pf0vf0 | grep bus-info
+```
+
+### Debug PCI Address Resolution
+
+```bash
+# Get VF PCI address
+cat /sys/class/net/pf0vf0/device/address
+
+# Get PF PCI address (if available)
+cat /sys/class/net/pf0vf0/device/physfn/address
+```
+
+## Integration with Existing Features
+
+### Gateway Accelerated Interface
+
+The "derive-from-mgmt-port" feature is used in conjunction with management interface to select the appropriate gateway accelerated interface.
+
+The management port can be specified through one of the following options:
+```
+  --ovnkube-node-mgmt-port-netdev)
+    OVNKUBE_NODE_MGMT_PORT_NETDEV=$VALUE
+```
+
+```
+  --ovnkube-node-mgmt-port-dp-resource-name)
+    OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME=$VALUE
+```
+
+OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME has priority over OVNKUBE_NODE_MGMT_PORT_NETDEV and it is easier to use since it points to a SRIOV Device Plugin pool name.
+
+### Multiple Network Support
+
+This feature works with multiple network support and can be used in environments where pods have multiple interfaces connected to different networks.
+
+## Limitations
+
+- Only available in DPU host mode
+- Requires SR-IOV capable hardware
+- Limited to the first available network device from the PF
+- Depends on proper VF/PF driver support
+- May not work with all SR-IOV implementations
+
+## Future Enhancements
+
+Potential improvements to this feature could include:
+
+- Support for selecting specific network devices based on criteria
+- Integration with device plugin resources
+- Support for multiple gateway interfaces
+- Enhanced error reporting and diagnostics
+- Support for non-SR-IOV hardware configurations 

--- a/docs/features/hardware-offload/dpu-support.md
+++ b/docs/features/hardware-offload/dpu-support.md
@@ -43,6 +43,8 @@ These aforementioned parts are expected to be deployed also on two different Kub
 #### OVN Kubernetes component on a DPU-Enabled Host
 - ovn-node
 
+For detailed configuration of gateway interfaces in DPU host mode, see [DPU Gateway Interface Configuration](dpu-gateway-interface.md).
+
 ### DPU Cluster
 ---
 

--- a/docs/installation/ovn_k8s.conf.5
+++ b/docs/installation/ovn_k8s.conf.5
@@ -124,6 +124,16 @@ or set to "shared" (share a network interface) or "local" (use a NAT-ed virtual 
 This interface will be used as the gateway interface in "shared" mode. If not
 specified the interface with the default route will be used.
 .TP
+\fBinterface\fR=derive-from-mgmt-port
+In DPU host mode, automatically resolve the gateway interface from PCI address.
+This performs the following steps:
+1. Get the management port network device name
+2. Retrieve the PCI address of the management port device
+3. Get the Physical Function (PF) PCI address from the Virtual Function (VF) PCI address
+4. Retrieve all network devices associated with the PF PCI address
+5. Select the first available network device as the gateway interface
+This option requires SR-IOV capable hardware and must be used with DPU host mode.
+.TP
 \fBnext-hop\fR=1.2.3.4
 This is the gateway IP address of \fBinterface\fR to which traffic exiting the
 OVN logical network should be sent in "shared" mode. If not specified

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -187,6 +187,9 @@ const (
 	NodeModeDPU     = "dpu"
 	NodeModeDPUHost = "dpu-host"
 
+	// Gateway interface configuration
+	DeriveFromMgmtPort = "derive-from-mgmt-port"
+
 	// Geneve header length for IPv4 (https://github.com/openshift/cluster-network-operator/pull/720#issuecomment-664020823)
 	GeneveHeaderLengthIPv4 = 58
 	// Geneve header length for IPv6 (https://github.com/openshift/cluster-network-operator/pull/720#issuecomment-664020823)


### PR DESCRIPTION
This patch introduces a new way to detect the gateway interface in the case ovnkube is running in DPU-HOST mode.

Introduce the argument `derive-from-mgmt-port`, if this is specified as the gateway interface, we will identify the physical function of the device used as an management port accelerated interface.

Signed-off-by: Alin Gabriel Serdean <aserdean@nvidia.com>
Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5239
