### PR TITLE
scale test fixes: memory leak + changed ofport

### DIFF
--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -275,12 +275,12 @@ func checkPorts(netConfigs []*bridgeUDNConfiguration, physIntf, ofPortPhys strin
 
 		}
 		if netConfig.ofPortPatch != curOfportPatch {
-			if netConfig.isDefaultNetwork() || curOfportPatch != "" {
+			if netConfig.isDefaultNetwork() {
 				klog.Errorf("Fatal error: patch port %s ofport changed from %s to %s",
 					netConfig.patchPort, netConfig.ofPortPatch, curOfportPatch)
 				os.Exit(1)
 			} else {
-				klog.Warningf("Patch port %s removed for existing network", netConfig.patchPort)
+				klog.Warningf("UDN patch port %s changed for existing network from %v to %v. Expecting bridge config update.", netConfig.patchPort, netConfig.ofPortPatch, curOfportPatch)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -168,6 +168,11 @@ type Controller struct {
 	useTemplates bool
 
 	netInfo util.NetInfo
+
+	// handlers stored for shutdown
+	nodeHandler     cache.ResourceEventHandlerRegistration
+	svcHandler      cache.ResourceEventHandlerRegistration
+	endpointHandler cache.ResourceEventHandlerRegistration
 }
 
 // Run will not return until stopCh is closed. workers determines how many
@@ -180,15 +185,15 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, wg *sync.WaitGroup
 		// wait until we're told to stop
 		<-stopCh
 
-		klog.Infof("Shutting down controller %s for network=%s", controllerName, c.netInfo.GetNetworkName())
-		c.queue.ShutDown()
+		c.Cleanup()
 	}()
 
 	c.useLBGroups = useLBGroups
 	c.useTemplates = useTemplates
 	klog.Infof("Starting controller %s for network=%s", controllerName, c.netInfo.GetNetworkName())
 
-	nodeHandler, err := c.nodeTracker.Start(c.nodeInformer)
+	var err error
+	c.nodeHandler, err = c.nodeTracker.Start(c.nodeInformer)
 	if err != nil {
 		return err
 	}
@@ -197,12 +202,12 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, wg *sync.WaitGroup
 	c.startupDoneLock.Lock()
 	c.startupDone = false
 	c.startupDoneLock.Unlock()
-	if !util.WaitForHandlerSyncWithTimeout(nodeControllerName, stopCh, types.HandlerSyncTimeout, nodeHandler.HasSynced) {
+	if !util.WaitForHandlerSyncWithTimeout(nodeControllerName, stopCh, types.HandlerSyncTimeout, c.nodeHandler.HasSynced) {
 		return fmt.Errorf("error syncing node tracker handler")
 	}
 
 	klog.Infof("Setting up event handlers for services for network=%s", c.netInfo.GetNetworkName())
-	svcHandler, err := c.serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
+	c.svcHandler, err = c.serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
@@ -212,7 +217,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, wg *sync.WaitGroup
 	}
 
 	klog.Infof("Setting up event handlers for endpoint slices for network=%s", c.netInfo.GetNetworkName())
-	endpointHandler, err := c.endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(
+	c.endpointHandler, err = c.endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(
 		// Filter out endpointslices that don't belong to this network (i.e. keep only kube-generated endpointslices if
 		// on default network, keep only mirrored endpointslices for this network if on UDN)
 		util.GetEndpointSlicesEventHandlerForNetwork(
@@ -227,7 +232,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, wg *sync.WaitGroup
 	}
 
 	klog.Infof("Waiting for service and endpoint handlers to sync for network=%s", c.netInfo.GetNetworkName())
-	if !util.WaitForHandlerSyncWithTimeout(controllerName, stopCh, types.HandlerSyncTimeout, svcHandler.HasSynced, endpointHandler.HasSynced) {
+	if !util.WaitForHandlerSyncWithTimeout(controllerName, stopCh, types.HandlerSyncTimeout, c.svcHandler.HasSynced, c.endpointHandler.HasSynced) {
 		return fmt.Errorf("error syncing service and endpoint handlers")
 	}
 
@@ -253,6 +258,27 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, wg *sync.WaitGroup
 	}
 
 	return nil
+}
+
+func (c *Controller) Cleanup() {
+	klog.Infof("Shutting down controller %s for network=%s", controllerName, c.netInfo.GetNetworkName())
+	c.queue.ShutDown()
+
+	if c.nodeHandler != nil {
+		if err := c.nodeInformer.Informer().RemoveEventHandler(c.nodeHandler); err != nil {
+			klog.Errorf("Failed to remove node handler for network %s: %v", c.netInfo.GetNetworkName(), err)
+		}
+	}
+	if c.svcHandler != nil {
+		if err := c.serviceInformer.Informer().RemoveEventHandler(c.svcHandler); err != nil {
+			klog.Errorf("Failed to remove service handler for network %s: %v", c.netInfo.GetNetworkName(), err)
+		}
+	}
+	if c.endpointHandler != nil {
+		if err := c.endpointSliceInformer.Informer().RemoveEventHandler(c.endpointHandler); err != nil {
+			klog.Errorf("Failed to remove endpoint handler for network %s: %v", c.netInfo.GetNetworkName(), err)
+		}
+	}
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -822,6 +822,11 @@ func (nInfo *secondaryNetInfo) canReconcile(other NetInfo) bool {
 	if nInfo == nil && other == nil {
 		return true
 	}
+	// if network ID has changed, it means the network was re-created, and all controllers
+	// should execute delete+create instead of update
+	if nInfo.GetNetworkID() != types.InvalidID && other.GetNetworkID() != types.InvalidID && nInfo.GetNetworkID() != other.GetNetworkID() {
+		return false
+	}
 	if nInfo.netName != other.GetNetworkName() {
 		return false
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of patch port changes for non-default networks, providing clearer warning messages and expecting bridge configuration updates instead of exiting.
  * Enhanced shutdown process for service controllers by explicitly removing event handlers and cleaning up resources, reducing the risk of resource leaks.

* **Improvements**
  * Updated network reconciliation logic to prevent updates when network IDs differ, ensuring more reliable network management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->