### PR TITLE
add ipsec e2e metric case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -489,7 +489,7 @@ jobs:
           - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
     needs: [ build-pr ]
     env:
-            JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}-${{ matrix.ipsec }}"
+      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}-${{ matrix.ipsec }}"
       OVN_HYBRID_OVERLAY_ENABLE: ${{ (matrix.target == 'control-plane' || matrix.target == 'control-plane-helm') && (matrix.ipfamily == 'ipv4' || matrix.ipfamily == 'dualstack' ) }}
       OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || matrix.target == 'network-segmentation' || matrix.target == 'bgp' || matrix.target == 'bgp-loose-isolation' }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || matrix.target == 'bgp' || matrix.target == 'bgp-loose-isolation' }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -456,6 +456,7 @@ jobs:
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "traffic-flow-tests": "1,2,3"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones","ipsec":"enable-ipsec"}
           - {"target": "control-plane-helm","ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane-helm","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
@@ -488,7 +489,7 @@ jobs:
           - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
     needs: [ build-pr ]
     env:
-      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
+            JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}-${{ matrix.ipsec }}"
       OVN_HYBRID_OVERLAY_ENABLE: ${{ (matrix.target == 'control-plane' || matrix.target == 'control-plane-helm') && (matrix.ipfamily == 'ipv4' || matrix.ipfamily == 'dualstack' ) }}
       OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || matrix.target == 'network-segmentation' || matrix.target == 'bgp' || matrix.target == 'bgp-loose-isolation' }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || matrix.target == 'bgp' || matrix.target == 'bgp-loose-isolation' }}"
@@ -517,6 +518,7 @@ jobs:
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (matrix.target == 'network-segmentation' || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
       OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"
+      ENABLE_IPSEC: "${{ matrix.ipsec == 'enable-ipsec' }}"
     steps:
 
     - name: Install VRF kernel module
@@ -635,6 +637,12 @@ jobs:
       run: |
         export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test install-kind
+
+    - name: Install prom2json binary
+      run: |
+        set -x
+        go install github.com/prometheus/prom2json/cmd/prom2json@latest
+        PATH=$PATH:$(go env GOPATH)/bin
 
     - name: traffic-flow-tests setup
       timeout-minutes: 5

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1086,7 +1086,7 @@ install_ipsec() {
   success=false
   for i in {1..60}; do
     # ... try to get all CSRs and sign them
-    csrs=$(oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}')
+    csrs=$(kubectl get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}')
     for csr in ${csrs}; do
       kubectl get csr "${csr}" -o jsonpath='{.spec.request}' | base64 --decode | \
           sed -n '/BEGIN CERTIFICATE REQUEST/,$p' > "${csr}"

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -107,6 +107,7 @@ IN_UPGRADE=
 # northd-backoff-interval, in ms
 OVN_NORTHD_BACKOFF_INTERVAL=
 OVN_OBSERV_ENABLE="false"
+ENABLE_IPSEC="false"
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -942,6 +943,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovn_network_qos_enable=${ovn_network_qos_enable} \
+  enable_ipsec=${enable_ipsec} \
   ovn_northd_backoff_interval=${ovn_northd_backoff_interval} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
@@ -1010,6 +1012,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovn_network_qos_enable=${ovn_network_qos_enable} \
+  enable_ipsec=${enable_ipsec} \
   ovn_northd_backoff_interval=${ovn_enable_backoff_interval} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -1052,6 +1052,7 @@ ovn_image=${ovnkube_image} \
 
 if ${enable_ipsec}; then
   ovn_image=${image} \
+    ovn_unprivileged_mode=${ovn_unprivileged_mode} \
     jinjanate ../templates/ovn-ipsec.yaml.j2 -o ${output_dir}/ovn-ipsec.yaml
 fi
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -97,6 +97,7 @@ fi
 # OVN_ENABLE_SVC_TEMPLATE_SUPPORT - enable svc template support
 # OVN_ENABLE_DNSNAMERESOLVER - enable dns name resolver support
 # OVN_OBSERV_ENABLE - enable observability for ovnkube
+# ENABLE_IPSEC - enable ipsec for ovn networked pod traffic
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -327,6 +328,8 @@ ovn_nohostsubnet_label=${OVN_NOHOSTSUBNET_LABEL:-""}
 # OVN_DISABLE_REQUESTEDCHASSIS - disable requested-chassis option during pod creation
 # should be set to true when dpu nodes are in the cluster
 ovn_disable_requestedchassis=${OVN_DISABLE_REQUESTEDCHASSIS:-false}
+# ENABLE_IPSEC - enable ipsec for ovnk networked pod traffic
+enable_ipsec=${ENABLE_IPSEC:-false}
 
 # external_ids:host-k8s-nodename is set on an Open_vSwitch enabled system if the ovnkube stack
 # should function on behalf of a different host than external_ids:hostname. This includes
@@ -1006,6 +1009,11 @@ local-nb-ovsdb() {
 
   ovn-nbctl set NB_Global . name=${K8S_NODE}
   ovn-nbctl set NB_Global . options:name=${K8S_NODE}
+
+ [[ "true" == "${ENABLE_IPSEC}" ]] && {
+    ovn-nbctl set nb_global . ipsec=true
+    echo "=============== nb-ovsdb ========== reconfigured for ipsec"
+  }
 
   tail --follow=name ${OVN_LOGDIR}/ovsdb-server-nb.log &
   ovn_tail_pid=$!

--- a/dist/templates/ovn-ipsec.yaml.j2
+++ b/dist/templates/ovn-ipsec.yaml.j2
@@ -101,7 +101,6 @@ spec:
             # Generate an SSL private key and use the key to create a certitificate signing request
             umask 077 && openssl genrsa -out /etc/openvswitch/keys/ipsec-privkey.pem 2048
             openssl req -new -text \
-                        -extensions v3_req \
                         -addext "subjectAltName = DNS:${cn}" \
                         -subj "/C=US/O=ovnkubernetes/OU=kind/CN=${cn}" \
                         -key /etc/openvswitch/keys/ipsec-privkey.pem \

--- a/dist/templates/ovn-ipsec.yaml.j2
+++ b/dist/templates/ovn-ipsec.yaml.j2
@@ -66,6 +66,7 @@ spec:
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default
+      {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
       priorityClassName: "system-node-critical"
       initContainers:
       - name: ovn-keys
@@ -263,6 +264,8 @@ spec:
           name: host-var-log-ovs
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        - mountPath: /var/run/pluto
+          name: host-var-run-pluto
         resources:
           requests:
             cpu: 10m
@@ -289,6 +292,10 @@ spec:
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch
+          type: DirectoryOrCreate
+      - name: host-var-run-pluto
+        hostPath:
+          path: /var/run/pluto
           type: DirectoryOrCreate
       - name: signer-ca
         configMap:

--- a/dist/templates/ovn-ipsec.yaml.j2
+++ b/dist/templates/ovn-ipsec.yaml.j2
@@ -230,6 +230,16 @@ spec:
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 
+          # Whenever ovn-ipsec pod is restarted, previous pluto process pid file
+          # is not removed timely. so not able to get new pluto daemon running
+          # again and throws "/run/pluto/pluto.pid" already exists error.
+          # So remove stale pluto.pid if no pluto process is running and then start new
+          # pluto process.
+          if [ -f /var/run/pluto/pluto.pid ] && ! pgrep -F /var/run/pluto/pluto.pid > /dev/null 2>&1; then
+            echo "Removing stale pluto.pid"
+            rm -f /var/run/pluto/pluto.pid
+          fi
+
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules
           /usr/libexec/ipsec/_stackmanager start

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -83,6 +83,8 @@ spec:
           value: "{{ ovn_gateway_mode }}"
         - name: OVN_ROUTE_ADVERTISEMENTS_ENABLE
           value: "{{ ovn_route_advertisements_enable }}"
+        - name: ENABLE_IPSEC
+          value: "{{ enable_ipsec }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -308,6 +308,10 @@ spec:
         - mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
           name: host-devinfo-dp
           readOnly: true
+        {% if enable_ipsec=="true" -%}
+        - mountPath: /var/run/pluto
+          name: run-pluto
+        {% endif %}
 
         resources:
           requests:
@@ -646,9 +650,18 @@ spec:
       - name: run-systemd
         hostPath:
           path: /run/systemd
+<<<<<<< HEAD
       - name: host-devinfo-dp
         hostPath:
           path: /var/run/k8s.cni.cncf.io/devinfo/dp
+=======
+      {% if enable_ipsec=="true" -%}
+      - name: run-pluto
+        hostPath:
+          path: /var/run/pluto
+          type: DirectoryOrCreate
+      {% endif %}
+>>>>>>> 59d185436 (Add IPsec tunnel state metric)
 
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -97,6 +97,8 @@ spec:
           value: "{{ ovn_loglevel_nb }}"
         - name: OVN_NORTHD_BACKOFF_INTERVAL
           value: "{{ ovn_northd_backoff_interval }}"
+        - name: ENABLE_IPSEC
+          value: "{{ enable_ipsec }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -282,6 +282,10 @@ spec:
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
+        {% if enable_ipsec=="true" -%}
+        - mountPath: /var/run/pluto
+          name: run-pluto
+        {% endif %}
 
         resources:
           requests:
@@ -442,6 +446,12 @@ spec:
       - name: host-etc-ovs
         hostPath:
           path: /etc/openvswitch
+      {% if enable_ipsec=="true" -%}
+      - name: run-pluto
+        hostPath:
+          path: /var/run/pluto
+          type: DirectoryOrCreate
+      {% endif %}
 
       tolerations:
       - operator: "Exists"

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/vishvananda/netlink v1.3.1-0.20250206174618-62fb240731fa
+	github.com/vishvananda/netns v0.0.4
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.38.0
 	golang.org/x/sync v0.12.0
@@ -125,7 +126,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -74,6 +74,7 @@ function testrun {
 # These packages requires root for network namespace manipulation in unit tests
 root_pkgs=(
     "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/controllermanager"
+    "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
     "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node"
     "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip"
     "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -304,6 +304,8 @@ func (cm *ControllerManager) configureMetrics(stopChan <-chan struct{}) {
 	metrics.RegisterOVNKubeControllerFunctional(stopChan)
 	metrics.RunTimestamp(stopChan, cm.sbClient, cm.nbClient)
 	metrics.MonitorIPSec(cm.nbClient)
+	metrics.MonitorIPsecTunnelsState(stopChan, cm.wg,
+		util.RunOVSVsctl, util.RunIPsec)
 }
 
 func (cm *ControllerManager) createACLLoggingMeter() error {

--- a/go-controller/pkg/metrics/ipsec.go
+++ b/go-controller/pkg/metrics/ipsec.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type ipsecClient func(args ...string) (string, string, error)
+
+func listEstablishedIPsecTunnels(ipsec ipsecClient) (sets.Set[string], error) {
+	ipsecTunnels := sets.Set[string]{}
+	stdout, stderr, err := ipsec("showstates")
+	if err != nil {
+		return ipsecTunnels, fmt.Errorf("failed to retrieve ipsec states, stderr: %v, err: %v",
+			stderr, err)
+	}
+	if stdout == "" {
+		return ipsecTunnels, nil
+	}
+	// sample output:
+	// 000 #7: "ovn-60abc6-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 25883s; REPLACE in 26153s; IKE SA #5; idle;
+	// 000 #7: "ovn-60abc6-0-in-1" esp.9d4cfa02@172.18.0.4 esp.950d136b@172.18.0.2 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B
+	// 000 #10: "ovn-60abc6-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 25527s; REPLACE in 26153s; newest; eroute owner; IKE SA #5; idle;
+	// 000 #10: "ovn-60abc6-0-in-1" esp.fac8b437@172.18.0.4 esp.f4d763b9@172.18.0.2 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B
+	// 000 #5: "ovn-60abc6-0-out-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 25883s; REPLACE in 26153s; newest; idle;
+	// 000 #6: "ovn-60abc6-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 25883s; REPLACE in 26153s; newest; eroute owner; IKE SA #5; idle;
+	// 000 #6: "ovn-60abc6-0-out-1" esp.92964e3b@172.18.0.4 esp.4aa37686@172.18.0.2 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B
+	lines := strings.Split(string(stdout), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "ESTABLISHED_CHILD_SA") {
+			// Extract IPsec tunnel name which is enclosed with double quotes.
+			matches := regexp.MustCompile(`"([^"]*)"`).FindAllStringSubmatch(line, -1)
+			for _, match := range matches {
+				// match always contains two elements.
+				// match[0]: The full text that matched the regex, for example "\"ovn-60abc6-0-in-1\"".
+				// match[1]: The captured group inside the match, i.e. the part inside the parentheses, for example "ovn-60abc6-0-in-1".
+				ipsecTunnels.Insert(strings.Fields(match[1])...)
+			}
+		}
+	}
+	return ipsecTunnels, nil
+}

--- a/go-controller/pkg/metrics/ipsec_test.go
+++ b/go-controller/pkg/metrics/ipsec_test.go
@@ -1,0 +1,223 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics/mocks"
+)
+
+type fakeIPsecClient struct {
+	output clientOutput
+	mutex  *sync.Mutex
+}
+
+func NewFakeIPsecClient(data clientOutput) fakeIPsecClient {
+	return fakeIPsecClient{output: data, mutex: &sync.Mutex{}}
+}
+
+func (c *fakeIPsecClient) FakeCall(...string) (string, string, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.output.stdout, c.output.stderr, c.output.err
+}
+
+func (c *fakeIPsecClient) ChangeOutput(newOutput clientOutput) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.output = newOutput
+}
+
+var _ = ginkgo.Describe("IPsec metrics", func() {
+	var (
+		localIP                    = "10.89.0.2"
+		geneveTunnelName1          = "ovn-8ebfff-0"
+		remoteIP1                  = "10.89.0.3"
+		geneveTunnelName2          = "ovn-e9845d-0"
+		remoteIP2                  = "10.89.0.4"
+		stopChan                   chan struct{}
+		wg                         *sync.WaitGroup
+		mockIPsecTunnelStateMetric *mocks.GaugeMock
+	)
+
+	ginkgo.BeforeEach(func() {
+		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
+		mockIPsecTunnelStateMetric = mocks.NewGaugeMock()
+		metricIPsecTunnelState = mockIPsecTunnelStateMetric
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("clean up resources for the test")
+		close(stopChan)
+		wg.Wait()
+		err := netlink.XfrmStateDel(getBaseState())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.Context("Tunnel state", func() {
+		ginkgo.It("when geneve tunnels are present with IKE Child SAs established", func() {
+			ovsVsCtlCmdOutput := clientOutput{
+				stdout: fmt.Sprintf(`{"data":[["%[1]s","up","up",["map",[["csum","true"],["key","flow"],
+				["local_ip","%[2]s"],["remote_ip","%[3]s"],["remote_name","8ebfffbe-3cac-4a67-8f42-c74b708f8cc6"]]]],
+				["%[4]s","up","up",["map",[["csum","true"],["key","flow"],["local_ip","%[2]s"],["remote_ip","%[5]s"],
+				["remote_name","e9845dc0-283f-4ea0-a9fa-4418bb6708c4"]]]]], "headings":["name","admin_state",
+				"link_state","options"]}`, geneveTunnelName1, localIP, remoteIP1, geneveTunnelName2, remoteIP2),
+				stderr: "",
+				err:    nil,
+			}
+			ovsVsctl := NewFakeOVSClientWithSameOutput(ovsVsCtlCmdOutput)
+			ipsecCmdOutput := clientOutput{
+				stdout: `000 #13: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23543s; REPLACE in 24315s; newest; eroute owner; IKE SA #16; idle;
+                             000 #16: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23975s; REPLACE in 24736s; newest; idle;
+                             000 #11: "ovn-8ebfff-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23942s; REPLACE in 24212s; newest; eroute owner; IKE SA #16; idle;
+                             000 #14: "ovn-e9845d-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23575s; REPLACE in 24525s; newest; idle;
+                             000 #15: "ovn-e9845d-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23873s; REPLACE in 24623s; newest; eroute owner; IKE SA #14; idle;
+                             000 #12: "ovn-e9845d-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 24034s; REPLACE in 24304s; newest; eroute owner; IKE SA #14; idle;`,
+				stderr: "",
+				err:    nil,
+			}
+			ipsec := NewFakeIPsecClient(ipsecCmdOutput)
+			MonitorIPsecTunnelsState(stopChan, wg, ovsVsctl.FakeCall, ipsec.FakeCall)
+			time.Sleep(2 * time.Second) // Allow some time for the goroutine to start
+			err := netlink.XfrmStateAdd(getBaseState())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int {
+				return int(mockIPsecTunnelStateMetric.GetValue())
+			}).WithTimeout(20 * time.Second).Should(gomega.Equal(1))
+		})
+		ginkgo.It("when geneve tunnels are present with IKE Child SAs not established for a tunnel", func() {
+			ovsVsCtlCmdOutput := clientOutput{
+				stdout: fmt.Sprintf(`{"data":[["%[1]s","up","up",["map",[["csum","true"],["key","flow"],
+				["local_ip","%[2]s"],["remote_ip","%[3]s"],["remote_name","8ebfffbe-3cac-4a67-8f42-c74b708f8cc6"]]]],
+				["%[4]s","up","up",["map",[["csum","true"],["key","flow"],["local_ip","%[2]s"],["remote_ip","%[5]s"],
+				["remote_name","e9845dc0-283f-4ea0-a9fa-4418bb6708c4"]]]]], "headings":["name","admin_state",
+				"link_state","options"]}`, geneveTunnelName1, localIP, remoteIP1, geneveTunnelName2, remoteIP2),
+				stderr: "",
+				err:    nil,
+			}
+			ovsVsctl := NewFakeOVSClientWithSameOutput(ovsVsCtlCmdOutput)
+			ipsecCmdOutput := clientOutput{
+				stdout: `000 #13: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23543s; REPLACE in 24315s; newest; eroute owner; IKE SA #16; idle;
+                             000 #16: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23975s; REPLACE in 24736s; newest; idle;
+                             000 #14: "ovn-e9845d-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23575s; REPLACE in 24525s; newest; idle;
+                             000 #15: "ovn-e9845d-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23873s; REPLACE in 24623s; newest; eroute owner; IKE SA #14; idle;
+                             000 #12: "ovn-e9845d-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 24034s; REPLACE in 24304s; newest; eroute owner; IKE SA #14; idle;`,
+				stderr: "",
+				err:    nil,
+			}
+			ipsec := NewFakeIPsecClient(ipsecCmdOutput)
+			MonitorIPsecTunnelsState(stopChan, wg, ovsVsctl.FakeCall, ipsec.FakeCall)
+			time.Sleep(2 * time.Second) // Allow some time for the goroutine to start
+			err := netlink.XfrmStateAdd(getBaseState())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int {
+				return int(mockIPsecTunnelStateMetric.GetValue())
+			}).WithTimeout(20 * time.Second).Should(gomega.Equal(0))
+		})
+
+		ginkgo.It("check IKE Child SA establishment when geneve tunnel interface flapping scenario", func() {
+			// Test no IPsec tunnel metrics when both Geneve tunnels are down.
+			ovsVsCtlCmdOutput := clientOutput{
+				stdout: fmt.Sprintf(`{"data":[["%[1]s","up","down",["map",[["csum","true"],["key","flow"],
+				["local_ip","%[2]s"],["remote_ip","%[3]s"],["remote_name","8ebfffbe-3cac-4a67-8f42-c74b708f8cc6"]]]],
+				["%[4]s","up","down",["map",[["csum","true"],["key","flow"],["local_ip","%[2]s"],["remote_ip","%[5]s"],
+				["remote_name","e9845dc0-283f-4ea0-a9fa-4418bb6708c4"]]]]], "headings":["name","admin_state",
+				"link_state","options"]}`, geneveTunnelName1, localIP, remoteIP1, geneveTunnelName2, remoteIP2),
+				stderr: "",
+				err:    nil,
+			}
+			ovsVsctl := NewFakeOVSClientWithSameOutput(ovsVsCtlCmdOutput)
+			ipsecCmdOutput := clientOutput{stdout: "", stderr: "", err: nil}
+			ipsec := NewFakeIPsecClient(ipsecCmdOutput)
+			MonitorIPsecTunnelsState(stopChan, wg, ovsVsctl.FakeCall, ipsec.FakeCall)
+			time.Sleep(2 * time.Second) // Allow some time for the goroutine to start
+			state := getBaseState()
+			err := netlink.XfrmStateAdd(state)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Consistently(func() int {
+				return int(mockIPsecTunnelStateMetric.GetValue())
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal(0))
+			// Test correspoding IPsec tunnel metrics when one of the Geneve tunnels is down.
+			ovsVsCtlCmdOutput = clientOutput{
+				stdout: fmt.Sprintf(`{"data":[["%[1]s","up","up",["map",[["csum","true"],["key","flow"],
+				["local_ip","%[2]s"],["remote_ip","%[3]s"],["remote_name","8ebfffbe-3cac-4a67-8f42-c74b708f8cc6"]]]],
+				["%[4]s","up","down",["map",[["csum","true"],["key","flow"],["local_ip","%[2]s"],["remote_ip","%[5]s"],
+				["remote_name","e9845dc0-283f-4ea0-a9fa-4418bb6708c4"]]]]], "headings":["name","admin_state",
+				"link_state","options"]}`, geneveTunnelName1, localIP, remoteIP1, geneveTunnelName2, remoteIP2),
+				stderr: "",
+				err:    nil,
+			}
+			ovsVsctl.ChangeOutput(ovsVsCtlCmdOutput)
+			ipsecCmdOutput = clientOutput{
+				stdout: `000 #13: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23543s; REPLACE in 24315s; newest; eroute owner; IKE SA #16; idle;
+                             000 #16: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23975s; REPLACE in 24736s; newest; idle;
+                             000 #11: "ovn-8ebfff-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23942s; REPLACE in 24212s; newest; eroute owner; IKE SA #16; idle;`,
+				stderr: "",
+				err:    nil,
+			}
+			ipsec.ChangeOutput(ipsecCmdOutput)
+			err = netlink.XfrmStateDel(state)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Consistently(func() int {
+				return int(mockIPsecTunnelStateMetric.GetValue())
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal(0))
+			// Test correspoding IPsec tunnel metrics when Geneve tunnels are up.
+			ovsVsCtlCmdOutput = clientOutput{
+				stdout: fmt.Sprintf(`{"data":[["%[1]s","up","up",["map",[["csum","true"],["key","flow"],
+				["local_ip","%[2]s"],["remote_ip","%[3]s"],["remote_name","8ebfffbe-3cac-4a67-8f42-c74b708f8cc6"]]]],
+				["%[4]s","up","up",["map",[["csum","true"],["key","flow"],["local_ip","%[2]s"],["remote_ip","%[5]s"],
+				["remote_name","e9845dc0-283f-4ea0-a9fa-4418bb6708c4"]]]]], "headings":["name","admin_state",
+				"link_state","options"]}`, geneveTunnelName1, localIP, remoteIP1, geneveTunnelName2, remoteIP2),
+				stderr: "",
+				err:    nil,
+			}
+			ovsVsctl.ChangeOutput(ovsVsCtlCmdOutput)
+			ipsecCmdOutput = clientOutput{
+				stdout: `000 #13: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23543s; REPLACE in 24315s; newest; eroute owner; IKE SA #16; idle;
+                             000 #16: "ovn-8ebfff-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23975s; REPLACE in 24736s; newest; idle;
+                             000 #11: "ovn-8ebfff-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23942s; REPLACE in 24212s; newest; eroute owner; IKE SA #16; idle;
+                             000 #14: "ovn-e9845d-0-in-1":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in 23575s; REPLACE in 24525s; newest; idle;
+                             000 #15: "ovn-e9845d-0-in-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 23873s; REPLACE in 24623s; newest; eroute owner; IKE SA #14; idle;
+                             000 #12: "ovn-e9845d-0-out-1":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in 24034s; REPLACE in 24304s; newest; eroute owner; IKE SA #14; idle;`,
+				stderr: "",
+				err:    nil,
+			}
+			ipsec.ChangeOutput(ipsecCmdOutput)
+			err = netlink.XfrmStateAdd(state)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int {
+				return int(mockIPsecTunnelStateMetric.GetValue())
+			}).WithTimeout(20 * time.Second).Should(gomega.Equal(1))
+		})
+	})
+})
+
+func getBaseState() *netlink.XfrmState {
+	return &netlink.XfrmState{
+		// Force 4 byte notation for the IPv4 addresses
+		Src:   net.ParseIP("127.0.0.1").To4(),
+		Dst:   net.ParseIP("127.0.0.2").To4(),
+		Proto: netlink.XFRM_PROTO_ESP,
+		Mode:  netlink.XFRM_MODE_TUNNEL,
+		Spi:   1,
+		Auth: &netlink.XfrmStateAlgo{
+			Name: "hmac(sha256)",
+			Key:  []byte("abcdefghijklmnopqrstuvwzyzABCDEF"),
+		},
+		Crypt: &netlink.XfrmStateAlgo{
+			Name: "cbc(aes)",
+			Key:  []byte("abcdefghijklmnopqrstuvwzyzABCDEF"),
+		},
+		Mark: &netlink.XfrmMark{
+			Value: 0x12340000,
+			Mask:  0xffff0000,
+		},
+	}
+}

--- a/go-controller/pkg/metrics/mocks/gauge.go
+++ b/go-controller/pkg/metrics/mocks/gauge.go
@@ -1,6 +1,9 @@
 package mocks
 
 import (
+	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,10 +12,11 @@ import (
 
 type GaugeMock struct {
 	value float64
+	mutex *sync.Mutex
 }
 
 func NewGaugeMock() *GaugeMock {
-	return &GaugeMock{}
+	return &GaugeMock{mutex: &sync.Mutex{}}
 }
 
 func (GaugeMock) Desc() *prometheus.Desc {
@@ -24,7 +28,6 @@ func (GaugeMock) Write(*io_prometheus_client.Metric) error {
 }
 
 func (GaugeMock) Describe(chan<- *prometheus.Desc) {
-	panic("unimplemented")
 }
 
 func (GaugeMock) Collect(chan<- prometheus.Metric) {
@@ -32,33 +35,120 @@ func (GaugeMock) Collect(chan<- prometheus.Metric) {
 }
 
 func (h *GaugeMock) Observe(value float64) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
 	h.value = value
 }
 
 func (gm *GaugeMock) Set(value float64) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value = value
 }
 
 func (gm *GaugeMock) Inc() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value++
 }
 
 func (gm *GaugeMock) Dec() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value--
 }
 
 func (gm *GaugeMock) Add(value float64) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value += value
 }
 
 func (gm *GaugeMock) Sub(value float64) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value -= value
 }
 
 func (gm *GaugeMock) SetToCurrentTime() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value = float64(time.Now().UnixMilli())
 }
 
 func (gm *GaugeMock) GetValue() float64 {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	return gm.value
+}
+
+type GaugeVecMock struct {
+	gaugesByLabels map[string]*GaugeMock
+	mutex          *sync.Mutex
+}
+
+func NewGaugeVecMock() *GaugeVecMock {
+	return &GaugeVecMock{gaugesByLabels: make(map[string]*GaugeMock),
+		mutex: &sync.Mutex{}}
+}
+
+func (GaugeVecMock) GetMetricWithLabelValues(_ ...string) (prometheus.Gauge, error) {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) GetMetricWith(_ prometheus.Labels) (prometheus.Gauge, error) {
+	panic("unimplemented")
+}
+
+func (v *GaugeVecMock) WithLabelValues(lvs ...string) prometheus.Gauge {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	key := strings.Join(lvs, "-")
+	if g, exists := v.gaugesByLabels[key]; exists {
+		return g
+	}
+	newGauge := NewGaugeMock()
+	v.gaugesByLabels[key] = newGauge
+	return newGauge
+}
+
+func (GaugeVecMock) With(_ prometheus.Labels) prometheus.Gauge {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) MustCurryWith(_ prometheus.Labels) *prometheus.GaugeVec {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) DeleteLabelValues(_ ...string) bool {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) Delete(_ prometheus.Labels) bool {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) DeletePartialMatch(_ prometheus.Labels) int {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) Describe(chan<- *prometheus.Desc) {
+}
+
+func (GaugeVecMock) Collect(chan<- prometheus.Metric) {
+	panic("unimplemented")
+}
+
+func (GaugeVecMock) Reset() {
+	panic("unimplemented")
+}
+
+func (v *GaugeVecMock) GetValue(lvs ...string) (float64, error) {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	key := strings.Join(lvs, "-")
+	if g, exists := v.gaugesByLabels[key]; exists {
+		return g.GetValue(), nil
+	}
+	return 0, fmt.Errorf("no gauge metric found for label value selector %v", lvs)
 }

--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -4,6 +4,7 @@
 package metrics
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -20,6 +21,7 @@ import (
 	ovsops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
 var (
@@ -919,4 +921,81 @@ func registerOvsMetrics(ovsDBClient libovsdbclient.Client, metricsScrapeInterval
 		// OVS coverage/show metrics updater.
 		go coverageShowMetricsUpdater(ovsVswitchd, stopChan)
 	})
+}
+
+type TunnelInfo struct {
+	Name       string
+	AdminState vswitchd.InterfaceAdminState
+	OperState  vswitchd.InterfaceLinkState
+	LocalIP    string
+	RemoteIP   string
+	RemoteName string
+}
+
+func listGeneveTunnels(ovsVsctl ovsClient) ([]TunnelInfo, error) {
+	var geneveTunnels []TunnelInfo
+	stdout, stderr, err := ovsVsctl("--format=json", "--columns=name,admin_state,link_state,options",
+		"find", "Interface", "type=geneve")
+	if err != nil {
+		return geneveTunnels, fmt.Errorf("failed to retrieve Geneve tunnels stderr %v: %v", stderr, err)
+	}
+	if stdout == "" {
+		return geneveTunnels, nil
+	}
+	type OvsdbData struct {
+		Data [][]interface{} `json:"data"`
+	}
+	var ovsResult OvsdbData
+	err = json.Unmarshal([]byte(stdout), &ovsResult)
+	if err != nil {
+		return geneveTunnels, fmt.Errorf("failed to parse json output %s for Geneve tunnels, err: %v",
+			stdout, err)
+	}
+	// sample output for data:
+	// {"data":[["ovn-b4fd07-0","up","up",["map",[["csum","true"],["key","flow"],["local_ip","172.18.0.2"],["remote_ip","172.18.0.3"],["remote_name","b4fd07bf-ba35-40a6-af0c-116226d806a6"]]]],
+	// ["ovn-60abc6-0","up","up",["map",[["csum","true"],["key","flow"],["local_ip","172.18.0.2"],["remote_ip","172.18.0.4"],["remote_name","60abc6e1-fb4b-4816-9370-9e0fb1a2c9d7"]]]]]}
+	for _, entry := range ovsResult.Data {
+		if len(entry) != 4 {
+			klog.Errorf("Can not to parse retrieved Geneve tunnel entry %v", entry)
+			continue
+		}
+		name, ok := entry[0].(string)
+		if !ok {
+			continue
+		}
+		adminState, ok := entry[1].(string)
+		if !ok {
+			continue
+		}
+		operState, ok := entry[2].(string)
+		if !ok {
+			continue
+		}
+		optionMap, ok := entry[3].([]interface{})
+		if !ok || len(optionMap) != 2 || optionMap[0] != "map" {
+			continue
+		}
+		mapEntry, ok := optionMap[1].([]interface{})
+		if !ok {
+			continue
+		}
+		options := make(map[string]string)
+		for _, pair := range mapEntry {
+			kv, ok := pair.([]interface{})
+			if !ok || len(kv) != 2 {
+				continue
+			}
+			key, value := kv[0].(string), kv[1].(string)
+			options[key] = value
+		}
+		geneveTunnels = append(geneveTunnels, TunnelInfo{
+			Name:       name,
+			AdminState: adminState,
+			OperState:  operState,
+			LocalIP:    options["local_ip"],
+			RemoteIP:   options["remote_ip"],
+			RemoteName: options["remote_name"],
+		})
+	}
+	return geneveTunnels, nil
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -35,6 +35,7 @@ const (
 	ovsdbClientCommand = "ovsdb-client"
 	ovsdbToolCommand   = "ovsdb-tool"
 	ipCommand          = "ip"
+	ipsecCommand       = "ipsec"
 	powershellCommand  = "powershell"
 	netshCommand       = "netsh"
 	routeCommand       = "route"
@@ -124,6 +125,7 @@ type execHelper struct {
 	ovsdbToolPath   string
 	ovnRunDir       string
 	ipPath          string
+	ipsecPath       string
 	powershellPath  string
 	netshPath       string
 	routePath       string
@@ -247,6 +249,10 @@ func SetExecWithoutOVS(exec kexec.Interface) error {
 		}
 	} else {
 		runner.ipPath, err = exec.LookPath(ipCommand)
+		if err != nil {
+			return err
+		}
+		runner.ipsecPath, err = exec.LookPath(ipsecCommand)
 		if err != nil {
 			return err
 		}
@@ -642,6 +648,12 @@ func RunNetsh(args ...string) (string, string, error) {
 // RunRoute runs a command via the Windows route utility
 func RunRoute(args ...string) (string, string, error) {
 	stdout, stderr, err := run(runner.routePath, args...)
+	return strings.TrimSpace(stdout.String()), stderr.String(), err
+}
+
+// RunIPsec runs a command via the Libreswan "ipsec" utility
+func RunIPsec(args ...string) (string, string, error) {
+	stdout, stderr, err := run(runner.ipsecPath, args...)
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -574,13 +574,13 @@ func TestSetExec(t *testing.T) {
 		{
 			desc:         "positive, test when 'runner' is nil",
 			expectedErr:  nil,
-			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil}, CallTimes: 10},
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil}, CallTimes: 11},
 			setRunnerNil: true,
 		},
 		{
 			desc:         "positive, test when 'runner' is not nil",
 			expectedErr:  nil,
-			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil}, CallTimes: 10},
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil}, CallTimes: 11},
 			setRunnerNil: false,
 		},
 	}
@@ -609,17 +609,27 @@ func TestSetExecWithoutOVS(t *testing.T) {
 		{
 			desc:        "positive, ip path found",
 			expectedErr: nil,
-			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil}, CallTimes: 2},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil}, CallTimes: 3},
+		},
+		{
+			desc:        "positive, ipsec path found",
+			expectedErr: nil,
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ipsec", nil}, CallTimes: 3},
 		},
 		{
 			desc:        "positive, sysctl path found",
 			expectedErr: nil,
-			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"sysctl", nil}, CallTimes: 2},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"sysctl", nil}, CallTimes: 3},
 		},
 		{
 			desc:        "negative, ip path not found",
 			expectedErr: fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`),
 			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`)}},
+		},
+		{
+			desc:        "negative, ipsec path not found",
+			expectedErr: fmt.Errorf(`exec: \"ipsec:\" executable file not found in $PATH`),
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ipsec:\" executable file not found in $PATH`)}},
 		},
 		{
 			desc:        "negative, sysctl path not found",

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -74,7 +74,6 @@ spec:
             # Generate an SSL private key and use the key to create a certitificate signing request
             umask 077 && openssl genrsa -out /etc/openvswitch/keys/ipsec-privkey.pem 2048
             openssl req -new -text \
-                        -extensions v3_req \
                         -addext "subjectAltName = DNS:${cn}" \
                         -subj "/C=US/O=ovnkubernetes/OU=kind/CN=${cn}" \
                         -key /etc/openvswitch/keys/ipsec-privkey.pem \

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -202,6 +202,16 @@ spec:
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 
+          # Whenever ovn-ipsec pod is restarted, previous pluto process pid file
+          # is not removed timely. so not able to get new pluto daemon running
+          # again and throws "/run/pluto/pluto.pid" already exists error.
+          # So remove stale pluto.pid if no pluto process is running and then start new
+          # pluto process.
+          if [ -f /var/run/pluto/pluto.pid ] && ! pgrep -F /var/run/pluto/pluto.pid > /dev/null 2>&1; then
+            echo "Removing stale pluto.pid"
+            rm -f /var/run/pluto/pluto.pid
+          fi
+
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules
           /usr/libexec/ipsec/_stackmanager start

--- a/test/e2e/ipsec.go
+++ b/test/e2e/ipsec.go
@@ -1,0 +1,179 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/deploymentconfig"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+var _ = ginkgo.Describe("IPsec", func() {
+
+	f := wrappedTestFramework("ipsec")
+	var nodes *v1.NodeList
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		if !isIPsecEnabled() {
+			ginkgo.Skip("Test requires IPsec enabled cluster. but IPsec is not enabled in this cluster.")
+		}
+		nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			e2eskipper.Skipf(
+				"Test requires >= 2 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+	})
+	ginkgo.Context("Test IPsec metrics ", func() {
+		// Validate IPsec metrics can be retrieved in IPsec enabled cluster
+		// Verify two kinds of metrics were collected
+		// "ovnkube_controller_ipsec_enabled 1" is the IPsec legacy metric
+		// "ovnkube_controller_ipsec_tunnel_state 1" is the new one added, 1 reflect tunnel up, 0 reflecting tunnel down.
+		// Kill the pluto process to bring down the IPsec tunnel
+		// Verify all the IPsec tunnels down, metrics set to 0
+		// Wait pluto process back
+		// Verify metrics reflected that, set back to 1
+		ginkgo.It("Get IPsec metrics which reflect the down and up state of the IPsec tunnel", func() {
+			ipsecMetricName := "ovnkube_controller_ipsec_enabled"
+			ipsecTunnelMetricName := "ovnkube_controller_ipsec_tunnel_state"
+			node1 := nodes.Items[0]
+
+			ovnKubernetesNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+			ovnPods, err := f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "name=ovnkube-node",
+			})
+			if err != nil {
+				framework.Failf("failed to list OVN pods: %v", err)
+			}
+
+			for _, ovnPod := range ovnPods.Items {
+				ginkgo.By(fmt.Sprintf("Verify IPsec enabled metric from ovn pod %s", ovnPod.Name))
+				ipsecMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecMetricName)
+				gomega.Expect(ipsecMetricValue).Should(gomega.Equal("1"))
+
+				ginkgo.By(fmt.Sprintf("Verify IPsec tunnel metrics reflecting up from ovn pod %s", ovnPod.Name))
+				ipsecTunnelMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecTunnelMetricName)
+				gomega.Expect(ipsecTunnelMetricValue).Should(gomega.Equal("1"))
+			}
+
+			ipsecContainer := "ovn-ipsec"
+			ginkgo.By(fmt.Sprintf("Kill pluto process in IPsec pod which was deployed on node %s", node1.Name))
+			ipsecPod, err := f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app=ovn-ipsec",
+				FieldSelector: "spec.nodeName=" + node1.Name,
+			})
+			if err != nil && apierrors.IsNotFound(err) {
+				framework.Failf("could not get ipsec pods: %v", err)
+			}
+			if len(ipsecPod.Items) == 0 {
+				framework.Failf("no ovn-ipsec pods found on node %s", node1.Name)
+			}
+
+			_, err = e2ekubectl.RunKubectl(ovnKubernetesNamespace, "exec", ipsecPod.Items[0].Name, "--container", ipsecContainer, "--",
+				"bash", "-c", "sudo pkill pluto")
+			framework.ExpectNoError(err, "killing pluto process failed")
+
+			ginkgo.By("Verify IPsec tunnel metrics reflecting down from ovn pods.")
+			gomega.Eventually(func() bool {
+				for _, ovnPod := range ovnPods.Items {
+					ipsecTunnelMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecTunnelMetricName)
+					if ipsecTunnelMetricValue != "0" {
+						return false
+					}
+				}
+				return true
+			}, 10*time.Second, 5*time.Second).Should(gomega.BeTrue())
+
+			// Recreate the ipsec pod to bring back pluto
+			err = f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).Delete(context.TODO(), ipsecPod.Items[0].Name, metav1.DeleteOptions{})
+			if err != nil {
+				framework.Failf("failed to delete pod %s: %v", ipsecPod.Items[0].Name, err)
+			}
+
+			ginkgo.By(fmt.Sprintf("Wait the recreated ipsec pod to be ready on node %s", node1.Name))
+			gomega.Eventually(func() bool {
+				ginkgo.By(fmt.Sprintf("Get the new ipsec pod on node %s", node1.Name))
+				ipsecPod, err := f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: "app=ovn-ipsec",
+					FieldSelector: "spec.nodeName=" + node1.Name,
+				})
+				if err != nil && apierrors.IsNotFound(err) {
+					return false
+				}
+				if len(ipsecPod.Items) == 0 {
+					return false
+				}
+
+				framework.Logf("Wait pluto process back in ipsec pod %s", ipsecPod.Items[0].Name)
+				output, _ := e2ekubectl.RunKubectl(ovnKubernetesNamespace, "exec", ipsecPod.Items[0].Name, "--container", ipsecContainer, "--",
+					"bash", "-c", "sudo ps -ef | grep pluto | grep -v ovs-monitor-ipsec")
+				return strings.Contains(output, " /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf")
+			}, 20*time.Second, 5*time.Second).Should(gomega.BeTrue())
+
+			ginkgo.By("Verify IPsec metrics reflecting the up tunnel from all ovn pods")
+			//Wait a few seconds for tunnels setting up.
+			gomega.Eventually(func() bool {
+				for _, ovnPod := range ovnPods.Items {
+					ipsecTunnelMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecTunnelMetricName)
+					if ipsecTunnelMetricValue != "1" {
+						return false
+					}
+				}
+				return true
+			}, 20*time.Second, 5*time.Second).Should(gomega.BeTrue())
+		})
+
+	})
+
+})
+
+// Get metric value by prom2json tool which is for name:value pair,not for labels matching.
+func getMetricValue(f *framework.Framework, podName, podNamespace, metricName string) string {
+	ginkgo.GinkgoHelper()
+
+	pod, err := f.ClientSet.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		framework.Failf("failed to get pod %s in namespace %s: %v", podName, podNamespace, err)
+	}
+
+	podIP := pod.Status.PodIP
+	if podIP == "" {
+		framework.Failf("no pod IP available for pod %s", podName)
+	}
+
+	metricURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(podIP, "9410"))
+	// Run prom2json directly from the host where tests are running
+	metricURLCmd := fmt.Sprintf("prom2json %s | jq '.[] | select(.name == \"%s\") | .metrics[].value' ", metricURL, metricName)
+	cmd := exec.Command("bash", "-c", metricURLCmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		framework.Failf("prom2json failed: %v", err)
+	}
+
+	// Use prom2json and jq to extract the specific metric value from the output
+	values := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(values) == 0 || values[0] == "" {
+		framework.Failf("no metric value found for %s", metricName)
+	}
+
+	metric := strings.Trim(values[0], `"`)
+	framework.Logf("The value of %s is %s", metricName, metric)
+
+	return metric
+}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1196,6 +1196,11 @@ func isPreConfiguredUdnAddressesEnabled() bool {
 	return val == "true"
 }
 
+func isIPsecEnabled() bool {
+	val, present := os.LookupEnv("ENABLE_IPSEC")
+	return present && val == "true"
+}
+
 func singleNodePerZone() bool {
 	if singleNodePerZoneResult == nil {
 		args := []string{"get", "pods", "--selector=app=ovnkube-node", "-o", "jsonpath={.items[0].spec.containers[*].name}"}


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->
This is an end to end case for IPSec metrics which is being developed with PR https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5201


 How to verify it
```
[ReportAfterSuite] Kubernetes e2e JUnit report
/root/code/ovn-kubernetes/test/e2e/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go:615
[ReportAfterSuite] PASSED [0.005 seconds]
------------------------------

Ran 1 of 501 Specs in 12.202 seconds
SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 498 Skipped
--- PASS: TestE2E (12.23s)
PASS
ok  	github.com/ovn-org/ovn-kubernetes/test/e2e	12.397s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added IPsec end-to-end test for metrics and tunnel failure/recovery, new unit tests for IPsec logic, and an isIPsecEnabled helper.
* **Chores**
  * Extended CI e2e matrix for IPsec, exposed ENABLE_IPSEC, added prom2json install step, and adjusted kind CSR command.
* **New Features**
  * Added IPsec tunnel health Prometheus metric, Geneve tunnel discovery, ipsec command support, and stale Pluto PID cleanup.
* **Refactor**
  * Made metric test mocks and fake clients concurrency-safe with mutex protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->