### PR TITLE
cluster-manager clbs if udn requests PersistentIPs but it is not enabled

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -166,6 +166,9 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter) (map[s
 			netConfSpec.VLANID = int(cfg.VLAN.Access.ID)
 		}
 	}
+	if netConfSpec.AllowPersistentIPs && !config.OVNKubernetesFeature.EnablePersistentIPs {
+		return nil, fmt.Errorf("allowPersistentIPs is set but persistentIPs is Disabled")
+	}
 
 	if err := util.ValidateNetConf(nadName, netConfSpec); err != nil {
 		return nil, err

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
@@ -301,6 +301,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 			// must be defined so the primary user defined network can match the ip families of the underlying cluster
 			config.IPv4Mode = true
 			config.IPv6Mode = true
+			config.OVNKubernetesFeature.EnablePersistentIPs = true
 			nad, err := RenderNetAttachDefManifest(testUdn, testNs)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nad.TypeMeta).To(Equal(expectedNAD.TypeMeta))
@@ -436,6 +437,7 @@ var _ = Describe("NetAttachDefTemplate", func() {
 			// must be defined so the primary user defined network can match the ip families of the underlying cluster
 			config.IPv4Mode = true
 			config.IPv6Mode = true
+			config.OVNKubernetesFeature.EnablePersistentIPs = true
 			nad, err := RenderNetAttachDefManifest(cudn, testNs)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nad.TypeMeta).To(Equal(expectedNAD.TypeMeta))


### PR DESCRIPTION
The log shows 'failed to run ovnkube: failed to start cluster manager: initial sync failed: failed to sync network cluster_udn_test-net: [clustermanager-nad-controller network controller]: failed to ensure network cluster_udn_test-net: failed to start network cluster) cluster_udn_test-net: failed to initialize pod ip allocator: network "cluster_udn_test-net" allows persistent IPs but missing the claims reconciler'

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation to ensure persistent IPs can only be enabled if the corresponding global feature flag is active.

* **Tests**
  * Updated tests to enable the persistent IPs feature flag during relevant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->