### PR TITLE
Expose error when IP conflict occurs on pod creation

### DIFF
--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -308,6 +308,7 @@ func allocatePodAnnotationWithRollback(
 	}()
 
 	podAnnotation, _ = util.UnmarshalPodAnnotation(pod.Annotations, nadName)
+	isNetworkAllocated := podAnnotation != nil
 	if podAnnotation == nil {
 		podAnnotation = &util.PodAnnotation{}
 	}
@@ -391,7 +392,7 @@ func allocatePodAnnotationWithRollback(
 
 	if hasIPAM {
 		if len(tentative.IPs) > 0 {
-			if err = ipAllocator.AllocateIPs(tentative.IPs); err != nil && !ip.IsErrAllocated(err) {
+			if err = ipAllocator.AllocateIPs(tentative.IPs); err != nil && !shouldSkipAllocateIPsError(err, isNetworkAllocated, ipamClaim) {
 				err = fmt.Errorf("failed to ensure requested or annotated IPs %v for %s: %w",
 					util.StringSlice(tentative.IPs), podDesc, err)
 				if !reallocateOnNonStaticIPRequest {
@@ -402,7 +403,7 @@ func allocatePodAnnotationWithRollback(
 				tentative.IPs = nil
 			}
 
-			if err == nil && !hasIPAMClaim { // if we have persistentIPs, we should *not* release them on rollback
+			if err == nil && (!hasIPAMClaim || !isNetworkAllocated) {
 				// copy the IPs that would need to be released
 				releaseIPs = util.CopyIPNets(tentative.IPs)
 			}
@@ -642,4 +643,31 @@ func AddRoutesGatewayIP(
 	}
 
 	return nil
+}
+
+// shouldSkipAllocateIPsError determines whether to skip/ignore IP allocation errors
+// in scenarios where IPs may already be legitimately allocated.
+// Returns false if the error is not ErrAllocated or if none of the skip conditions are met. True otherwise.
+func shouldSkipAllocateIPsError(err error, networkAllocated bool, ipamClaim *ipamclaimsapi.IPAMClaim) bool {
+	// Only skip if it's an "already allocated" error
+	if !ip.IsErrAllocated(err) {
+		return false
+	}
+
+	// If PreconfiguredUDNAddressesEnabled is disabled, always skip ErrAllocated
+	if !util.IsPreconfiguredUDNAddressesEnabled() {
+		return true
+	}
+
+	// Always skip ErrAllocated if network annotation already persisted on pod
+	if networkAllocated {
+		return true
+	}
+
+	// For persistent IP VM/Pods, if IPAMClaim already has IPs allocated, then ip already allocated, skip ErrAllocated
+	if ipamClaim != nil && len(ipamClaim.Status.IPs) > 0 {
+		return true
+	}
+
+	return false
 }

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -364,7 +364,8 @@ func (a *PodAllocator) allocatePodOnNAD(pod *corev1.Pod, nad string, network *ne
 	)
 
 	if err != nil {
-		if errors.Is(err, ipallocator.ErrFull) {
+		if errors.Is(err, ipallocator.ErrFull) ||
+			errors.Is(err, ipallocator.ErrAllocated) {
 			a.recordPodErrorEvent(pod, err)
 		}
 		return err

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -2359,4 +2359,121 @@ chpasswd: { expire: False }
 		)
 	})
 
+	Context("duplicate IP validation", func() {
+		var (
+			cudn          *udnv1.ClusterUserDefinedNetwork
+			duplicateIPv4 = "10.128.0.200" // Static IP that will be used by both VMs
+			duplicateIPv6 = "2010:100:200::200"
+			cidrIPv4      = "10.128.0.0/24"
+			cidrIPv6      = "2010:100:200::0/60"
+		)
+
+		BeforeEach(func() {
+			if !isPreConfiguredUdnAddressesEnabled() {
+				Skip("ENABLE_PRE_CONF_UDN_ADDR not configured")
+			}
+
+			l := map[string]string{
+				"e2e-framework":           fr.BaseName,
+				RequiredUDNNamespaceLabel: "",
+			}
+			ns, err := fr.CreateNamespace(context.TODO(), fr.BaseName, l)
+			Expect(err).NotTo(HaveOccurred())
+			fr.Namespace = ns
+			namespace = fr.Namespace.Name
+
+			dualCIDRs := filterDualStackCIDRs(fr.ClientSet, []udnv1.CIDR{udnv1.CIDR(cidrIPv4), udnv1.CIDR(cidrIPv6)})
+			cudn, _ = kubevirt.GenerateCUDN(namespace, "net1", udnv1.NetworkTopologyLayer2, udnv1.NetworkRolePrimary, dualCIDRs)
+			createCUDN(cudn)
+		})
+
+		createVMWithStaticIP := func(vmName string, staticIPs []string) *kubevirtv1.VirtualMachine {
+			annotations, err := kubevirt.GenerateAddressesAnnotations("net1", staticIPs)
+			Expect(err).NotTo(HaveOccurred())
+
+			vm := fedoraWithTestToolingVM(
+				nil,         // labels
+				annotations, // annotations with static IP
+				nil,         // nodeSelector
+				kubevirtv1.NetworkSource{
+					Pod: &kubevirtv1.PodNetwork{},
+				},
+				`#cloud-config
+password: fedora
+chpasswd: { expire: False }
+`,
+				`version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+    dhcp6: true
+    ipv6-address-generation: eui64`,
+			)
+			vm.Name = vmName
+			vm.Namespace = namespace
+			vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].Bridge = nil
+			vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].Binding = &kubevirtv1.PluginBinding{Name: "l2bridge"}
+			return vm
+		}
+
+		waitForVMReadinessAndVerifyIPs := func(vmName string, expectedIPs []string) {
+			vmi := &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      vmName,
+				},
+			}
+			waitVirtualMachineInstanceReadiness(vmi)
+			Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
+
+			expectedNumberOfAddresses := len(filterDualStackCIDRs(fr.ClientSet, []udnv1.CIDR{udnv1.CIDR(cidrIPv4), udnv1.CIDR(cidrIPv6)}))
+			actualAddresses := virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
+			Expect(actualAddresses).To(ConsistOf(expectedIPs), fmt.Sprintf("VM %s should get the requested static IPs", vmName))
+		}
+
+		waitForVMIPodDuplicateIPFailure := func(vmName string) {
+			Eventually(func() []corev1.Event {
+				podList, err := fr.ClientSet.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", kubevirtv1.VirtualMachineNameLabel, vmName),
+				})
+				if err != nil || len(podList.Items) == 0 {
+					return nil
+				}
+
+				events, err := fr.ClientSet.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s", podList.Items[0].Name),
+				})
+				if err != nil {
+					return nil
+				}
+
+				return events.Items
+			}).
+				WithTimeout(60*time.Second).
+				WithPolling(2*time.Second).
+				Should(ContainElement(SatisfyAll(
+					HaveField("Type", Equal("Warning")),
+					HaveField("Message", ContainSubstring("provided IP is already allocated")),
+				)), fmt.Sprintf("VM %s should fail with IP allocation error", vmName))
+		}
+
+		It("should fail when creating second VM with duplicate static IP", func() {
+			staticIPs := filterIPs(fr.ClientSet, duplicateIPv4, duplicateIPv6)
+
+			By("Creating first VM with static IP")
+			vm1 := createVMWithStaticIP("test-vm-1", staticIPs)
+			createVirtualMachine(vm1)
+			waitForVMReadinessAndVerifyIPs(vm1.Name, staticIPs)
+
+			By("Creating second VM with duplicate static IP - should fail")
+			vm2 := createVMWithStaticIP("test-vm-2", staticIPs)
+			createVirtualMachine(vm2)
+
+			By("Verifying pod fails with duplicate IP allocation error")
+			waitForVMIPodDuplicateIPFailure(vm2.Name)
+
+			By("Verifying first VM is still running normally")
+			waitForVMReadinessAndVerifyIPs(vm1.Name, staticIPs)
+		})
+	})
 })

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -2403,6 +2403,12 @@ func withLabels(labels map[string]string) podOption {
 	}
 }
 
+func withAnnotations(annotations map[string]string) podOption {
+	return func(pod *podConfiguration) {
+		pod.annotations = annotations
+	}
+}
+
 func withNetworkAttachment(networks []nadapi.NetworkSelectionElement) podOption {
 	return func(pod *podConfiguration) {
 		pod.attachments = networks


### PR DESCRIPTION
## 📑 Description
Currently when a pod is reconciled and IPs are requested, the
ipAllocator's "already allocated" errors are ignored.

In order to block IP conflicts with other pods, only ignore duplicate IP
errors in cases when PreconfiguredUDNAddressesEnabled FG is enabled and:
- the NAD's network annotation has already persiste/allocated,
indicating that the pod was already reconciled and assigned with IPs.
- the ipamClaim already has been updated with status.IPs, indicating
that OVNK already allocated the IPs for this object requesting
persistent IPs (pod/VM).

Under these new terms, when ErrAllocated is discovered and not ignored -
publish this as a pod event.

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#CORENET-6208](https://issues.redhat.com/browse/CORENET-6208)

## Additional Information for reviewers

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
1. create cluster with the `--preconfigured-udn-addresses-enable` flag
2. create UDN ns with primary L2 UDN
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Namespace
metadata:
  name: default-network-annotation
  labels:
    k8s.ovn.org/primary-user-defined-network: ""
    e2e-framework: default-network-annotation
EOF

cat <<EOF | kubectl apply -f -
apiVersion: k8s.ovn.org/v1
kind: UserDefinedNetwork
metadata:
  name: l2network
  namespace: default-network-annotation
spec:
  topology: Layer2
  layer2:
    role: Primary
    subnets:
      - 103.0.0.0/16
      - 2014:100:200::0/60
    ipam:
      mode: Enabled
      lifecycle: Persistent
EOF
```

3. create pod with multus-default-network annotation, requesting specific IP address
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: static-ip-mac-pod
  namespace: default-network-annotation
  annotations:
    v1.multus-cni.io/default-network: '[{"name":"default","namespace":"ovn-kubernetes","mac":"02:A1:B2:C3:D4:E5","ips":["103.0.0.3/16","2014:100:200::3/60"]}]'
spec:
  containers:
    - name: netshoot
      image: nicolaka/netshoot
      command: ["sleep", "infinity"]
      imagePullPolicy: IfNotPresent
  restartPolicy: Never
EOF
```

5. create another pod with multus-default-network annotation, requesting the same IP address 
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: static-ip-mac-pod-same-ipv4
  namespace: default-network-annotation
  annotations:
    v1.multus-cni.io/default-network: '[{"name":"default","namespace":"ovn-kubernetes","mac":"02:A1:B2:C3:D4:E6","ips":["103.0.0.3/16","2014:100:200::4/60"]}]'
spec:
  containers:
    - name: netshoot
      image: nicolaka/netshoot
      command: ["sleep", "infinity"]
      imagePullPolicy: IfNotPresent
  restartPolicy: Never
EOF
```

6. create VM, run migration & restart expect it to not fail on duplicate IP:
```
# Step 1: create VM
kubectl apply -f - <<EOF
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: worker1
  namespace: default-network-annotation
spec:
  running: true
  template:
    metadata:
      annotations:
        network.kubevirt.io/addresses: "{\"overlay\": [\"103.0.0.7\", \"2014:100:200::7\"]}"
    spec:
      architecture: amd64
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: containerdisk
          - disk:
              bus:
              bus: virtio
            name: cloudinitdisk
          interfaces:
          - name: overlay
            binding:
              name: l2bridge
          rng: {}
        machine:
          type: q35
        resources:
          requests:
            memory: 512Mi
      networks:
      - name: overlay
        pod: {}
      terminationGracePeriodSeconds: 5
      volumes:
      - containerDisk:
          image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241009_c8d5e5cc45
        name: containerdisk
      - cloudInitNoCloud:
          userData: |
            #cloud-config
            hostname: worker1
            manage_etc_hosts: true
            users:
              - name: core
                plain_text_passwd: core
                lock_passwd: false
                sudo: ALL=(ALL) NOPASSWD:ALL
        name: cloudinitdisk
EOF

# Step 2: Wait for the vm to be ready
kubectl wait --for=condition=Ready vm/worker1 -n default-network-annotation --timeout=15m

# Step 3: Restart VM
virtctl restart worker1 -n default-network-annotation
kubectl wait --for=condition=Ready vm/worker1 -n default-network-annotation --timeout=15m

# Step 4: start migration
kubectl apply -f - <<EOF
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstanceMigration
metadata:
  name: migration-job
  namespace: default-network-annotation
  generateName: worker1
spec:
  vmiName: worker1
EOF
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP allocation handling to skip certain "already allocated" errors when annotations or IPAM claims indicate persistence; adjusted rollback to avoid releasing persistent/tentative IPs.
  * Pod error events now recorded for both full-pool and already-allocated failures.

* **Tests**
  * Expanded unit tests for persisted annotations, feature-flag permutations, VM restart/migration, and empty IPAM claims.
  * Added e2e duplicate-IP validation for pods/VMs on user-defined networks (dual-stack); one test block duplicated.
  * Test helpers updated to accumulate per-pod annotations and added a withAnnotations helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->