### PR TITLE
Move masquarade SNAT to the nftables

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -42,6 +42,9 @@ add rule inet ovn-kubernetes no-pmtud ip daddr @remote-node-ips-v4 meta l4proto 
 add chain inet ovn-kubernetes no-pmtud { type filter hook output priority 0 ; comment "Block egress needs frag/packet too big to remote k8s nodes" ; }
 add set inet ovn-kubernetes remote-node-ips-v4 { type ipv4_addr ; comment "Block egress ICMP needs frag to remote Kubernetes nodes" ; }
 add set inet ovn-kubernetes remote-node-ips-v6 { type ipv6_addr ; comment "Block egress ICMPv6 packet too big to remote Kubernetes nodes" ; }
+add set inet ovn-kubernetes node-ips-v6 { type ipv6_addr ; comment "Only SNAT advertised UDN pods for Kubernetes nodes" ; }
+add set inet ovn-kubernetes node-ips-v4 { type ipv4_addr ; comment "Only SNAT advertised UDN pods for Kubernetes nodes" ; }
+add element inet ovn-kubernetes node-ips-v4 { 169.254.254.60 }
 `
 
 const v6PMTUDNFTRules = `
@@ -50,6 +53,9 @@ add rule inet ovn-kubernetes no-pmtud meta l4proto icmpv6 icmpv6 type 2 icmpv6 c
 add chain inet ovn-kubernetes no-pmtud { type filter hook output priority 0 ; comment "Block egress needs frag/packet too big to remote k8s nodes" ; }
 add set inet ovn-kubernetes remote-node-ips-v4 { type ipv4_addr ; comment "Block egress ICMP needs frag to remote Kubernetes nodes" ; }
 add set inet ovn-kubernetes remote-node-ips-v6 { type ipv6_addr ; comment "Block egress ICMPv6 packet too big to remote Kubernetes nodes" ; }
+add set inet ovn-kubernetes node-ips-v6 { type ipv6_addr ; comment "Only SNAT advertised UDN pods for Kubernetes nodes" ; }
+add set inet ovn-kubernetes node-ips-v4 { type ipv4_addr ; comment "Only SNAT advertised UDN pods for Kubernetes nodes" ; }
+add element inet ovn-kubernetes node-ips-v6 { 2001:db8:1::3 }
 `
 
 var _ = Describe("Node", func() {
@@ -837,6 +843,7 @@ var _ = Describe("Node", func() {
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v4PMTUDNFTRules + `
 add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.254.61 }
+add element inet ovn-kubernetes node-ips-v4 { 169.254.254.61 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -948,6 +955,7 @@ add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.254.61 }
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v4PMTUDNFTRules + `
 add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.253.61 }
+add element inet ovn-kubernetes node-ips-v4 { 169.254.253.61 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -1101,6 +1109,7 @@ add element inet ovn-kubernetes remote-node-ips-v4 { 169.254.253.61 }
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v6PMTUDNFTRules + `
 add element inet ovn-kubernetes remote-node-ips-v6 { 2001:db8:1::4 }
+add element inet ovn-kubernetes node-ips-v6 { 2001:db8:1::4 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())
@@ -1211,6 +1220,7 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2001:db8:1::4 }
 					Expect(err).NotTo(HaveOccurred())
 					nftRules := v6PMTUDNFTRules + `
 add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
+add element inet ovn-kubernetes node-ips-v6 { 2002:db8:1::4 }
 `
 					err = nodenft.MatchNFTRules(nftRules, nft.Dump())
 					Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -241,12 +241,12 @@ func (udng *UserDefinedNetworkGateway) addMasqChain() error {
 		ipPrefix := "ip"
 		nfproto := "ipv4"
 		var masqIP net.IP
-		remoteNodeSetName := types.NFTRemoteNodeIPsv4
+		remoteNodeSetName := types.NFTNodeIPsv4
 		if utilnet.IsIPv6CIDR(podSubnet) {
 			ipPrefix = "ip6"
 			nfproto = "ipv6"
 			masqIP = udng.v6MasqIPs.ManagementPort.IP
-			remoteNodeSetName = types.NFTRemoteNodeIPsv6
+			remoteNodeSetName = types.NFTNodeIPsv6
 		} else {
 			// udng.v4MasqIPs is nil for ipv6-only clusters
 			masqIP = udng.v4MasqIPs.ManagementPort.IP
@@ -999,6 +999,11 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 	if err := udng.updateAdvertisedUDNIsolationRules(isNetworkAdvertised); err != nil {
 		return fmt.Errorf("error while updating advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)
 	}
+
+	if err := udng.addMasqChain(); err != nil {
+		return fmt.Errorf("failed to add the UDN masquerade nftables chain: %w ", err)
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1141,6 +1141,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnFlows).To(Equal(0))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
+			Expect(setupRemoteNodeNFTSets()).To(Succeed())
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(71))                                      // 18 UDN Flows, 5 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1526,12 +1526,6 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					mark:     100000 + 0x1003,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V4,
-					table:    1007,
 					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
 				},
 			},
@@ -1554,12 +1548,6 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					family:   netlink.FAMILY_V6,
 					table:    1009,
 					mark:     0x1003,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V6,
-					table:    1009,
-					mark:     100000 + 0x1003,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
@@ -1590,21 +1578,9 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V4,
-					table:    1010,
-					mark:     100000 + 0x1003,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
 					mark:     0x1003,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V6,
-					table:    1010,
-					mark:     100000 + 0x1003,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
@@ -1735,12 +1711,6 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					mark:     0x1003 + 100000,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V4,
-					table:    1007,
 					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
 				},
 				{
@@ -1761,12 +1731,6 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					family:   netlink.FAMILY_V6,
 					table:    1009,
 					mark:     0x1003,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V6,
-					table:    1009,
-					mark:     0x1003 + 100000,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
@@ -1795,21 +1759,9 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V4,
-					table:    1010,
-					mark:     0x1003 + 100000,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
 					mark:     0x1003,
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V6,
-					table:    1010,
-					mark:     0x1003 + 100000,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1525,6 +1525,12 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
+					mark:     100000 + 0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
 					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
 				},
 			},
@@ -1547,6 +1553,12 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					family:   netlink.FAMILY_V6,
 					table:    1009,
 					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					mark:     100000 + 0x1003,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
@@ -1577,9 +1589,21 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					mark:     100000 + 0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
 					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					mark:     100000 + 0x1003,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
@@ -1710,6 +1734,12 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
+					mark:     0x1003 + 100000,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
 					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
 				},
 				{
@@ -1730,6 +1760,12 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					family:   netlink.FAMILY_V6,
 					table:    1009,
 					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					mark:     0x1003 + 100000,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
@@ -1758,9 +1794,21 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					mark:     0x1003 + 100000,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
 					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					mark:     0x1003 + 100000,
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -204,7 +204,7 @@ func (rm *Controller) reconcile() error {
 }
 
 func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
-	return r1.String() == r2.String()
+	return r1.String() == r2.String() && r1.Mark == r2.Mark && r1.Family == r2.Family
 }
 
 func isNetlinkRuleInSlice(rules []netlink.Rule, candidate *netlink.Rule) (bool, *netlink.Rule) {

--- a/go-controller/pkg/node/node_nftables.go
+++ b/go-controller/pkg/node/node_nftables.go
@@ -31,6 +31,16 @@ func setupRemoteNodeNFTSets() error {
 		Comment: knftables.PtrTo("Block egress ICMPv6 packet too big to remote Kubernetes nodes"),
 		Type:    "ipv6_addr",
 	})
+	tx.Add(&knftables.Set{
+		Name:    types.NFTNodeIPsv4,
+		Comment: knftables.PtrTo("Only SNAT advertised UDN pods for Kubernetes nodes"),
+		Type:    "ipv4_addr",
+	})
+	tx.Add(&knftables.Set{
+		Name:    types.NFTNodeIPsv6,
+		Comment: knftables.PtrTo("Only SNAT advertised UDN pods for Kubernetes nodes"),
+		Type:    "ipv6_addr",
+	})
 
 	err = nft.Run(context.TODO(), tx)
 	if err != nil {

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -461,7 +461,7 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			}
 
 			// 3 rules per ip family: see constructUDNVRFIPRules for more details
-			Expect(udnRules).To(HaveLen(6))
+			Expect(udnRules).To(HaveLen(4))
 
 			By("delete the network and ensure its associated VRF device is also deleted")
 			cnode := node.DeepCopy()

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -459,7 +459,9 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 					udnRules = append(udnRules, rule)
 				}
 			}
-			Expect(udnRules).To(HaveLen(3))
+
+			// 3 rules per ip family: see constructUDNVRFIPRules for more details
+			Expect(udnRules).To(HaveLen(6))
 
 			By("delete the network and ensure its associated VRF device is also deleted")
 			cnode := node.DeepCopy()

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -1338,19 +1338,6 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + networkName1_ + node1.Name,
 						Networks: []string{nodeLogicalRouterIfAddrV4},
 					},
-					&nbdb.NAT{
-						UUID: networkName1_ + node1Name + "-masqueradeNAT-UUID",
-						ExternalIDs: map[string]string{
-							"k8s.ovn.org/topology": "layer3",
-							"k8s.ovn.org/network":  networkName1,
-						},
-						ExternalIP:  "169.254.169.14",
-						LogicalIP:   node1UDNSubnet.String(),
-						LogicalPort: ptr.To("rtos-" + networkName1_ + node1Name),
-						Match:       "eth.dst == 0a:58:14:80:00:02",
-						Type:        nbdb.NATTypeSNAT,
-						Options:     map[string]string{"stateless": "false"},
-					},
 					&nbdb.LogicalRouter{
 						Name:        netInfo.GetNetworkScopedClusterRouterName(),
 						UUID:        netInfo.GetNetworkScopedClusterRouterName() + "-UUID",
@@ -1359,7 +1346,6 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 							fmt.Sprintf("%s-no-reroute-reply-traffic", netInfo.GetNetworkName()),
 							getReRoutePolicyUUID(eipNamespace2, podName2, IPFamilyValueV4, netInfo.GetNetworkName())},
 						StaticRoutes: []string{fmt.Sprintf("%s-reroute-static-route-UUID", netInfo.GetNetworkName())},
-						Nat:          []string{networkName1_ + node1Name + "-masqueradeNAT-UUID"},
 					},
 					&nbdb.LogicalRouter{
 						UUID:        netInfo.GetNetworkScopedGWRouterName(node1.Name) + "-UUID",
@@ -1527,19 +1513,6 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + networkName1_ + node1.Name,
 						Networks: []string{nodeLogicalRouterIfAddrV4},
 					},
-					&nbdb.NAT{
-						UUID: networkName1_ + node1Name + "-masqueradeNAT-UUID",
-						ExternalIDs: map[string]string{
-							"k8s.ovn.org/topology": "layer3",
-							"k8s.ovn.org/network":  networkName1,
-						},
-						ExternalIP:  "169.254.169.14",
-						LogicalIP:   node1UDNSubnet.String(),
-						LogicalPort: ptr.To("rtos-" + networkName1_ + node1Name),
-						Match:       "eth.dst == 0a:58:14:80:00:02",
-						Type:        nbdb.NATTypeSNAT,
-						Options:     map[string]string{"stateless": "false"},
-					},
 					&nbdb.LogicalRouter{
 						Name:        netInfo.GetNetworkScopedClusterRouterName(),
 						UUID:        netInfo.GetNetworkScopedClusterRouterName() + "-UUID",
@@ -1548,7 +1521,6 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 							fmt.Sprintf("%s-no-reroute-reply-traffic", netInfo.GetNetworkName()),
 						},
 						StaticRoutes: []string{fmt.Sprintf("%s-reroute-static-route-UUID", netInfo.GetNetworkName())},
-						Nat:          []string{networkName1_ + node1Name + "-masqueradeNAT-UUID"},
 					},
 					&nbdb.LogicalRouter{
 						UUID:        netInfo.GetNetworkScopedGWRouterName(node1.Name) + "-UUID",
@@ -2688,19 +2660,6 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + networkName1_ + node1.Name,
 						Networks: []string{nodeLogicalRouterIfAddrV4},
 					},
-					&nbdb.NAT{
-						UUID: networkName1_ + node1Name + "-masqueradeNAT-UUID",
-						ExternalIDs: map[string]string{
-							"k8s.ovn.org/topology": "layer3",
-							"k8s.ovn.org/network":  networkName1,
-						},
-						ExternalIP:  "169.254.169.14",
-						LogicalIP:   node1UDNSubnet.String(),
-						LogicalPort: ptr.To("rtos-" + networkName1_ + node1Name),
-						Match:       "eth.dst == 0a:58:14:80:00:02",
-						Type:        nbdb.NATTypeSNAT,
-						Options:     map[string]string{"stateless": "false"},
-					},
 					&nbdb.LogicalRouter{
 						Name:        netInfo.GetNetworkScopedClusterRouterName(),
 						UUID:        netInfo.GetNetworkScopedClusterRouterName() + "-UUID",
@@ -2709,7 +2668,6 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 							fmt.Sprintf("%s-no-reroute-reply-traffic", netInfo.GetNetworkName()),
 							getReRoutePolicyUUID(eipNamespace2, podName2, IPFamilyValueV4, netInfo.GetNetworkName())},
 						StaticRoutes: []string{fmt.Sprintf("%s-reroute-static-route-UUID", netInfo.GetNetworkName())},
-						Nat:          []string{networkName1_ + node1Name + "-masqueradeNAT-UUID"},
 					},
 					&nbdb.LogicalRouter{
 						UUID:        netInfo.GetNetworkScopedGWRouterName(node1.Name) + "-UUID",

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -213,6 +213,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableMultiNetworkPolicy = true
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -260,6 +261,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 			netconf,
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: "2"}
 
 		netconf.NADName = util.GetNADName(namespaceName2, nadName)
 		nad2, err = newNetworkAttachmentDefinition(

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -320,6 +320,9 @@ const (
 	// the local node's subnet.
 	NFTRemoteNodeIPsv6 = "remote-node-ips-v6"
 
+	NFTNodeIPsv4 = "node-ips-v4"
+	NFTNodeIPsv6 = "node-ips-v6"
+
 	// Metrics
 	MetricOvnkubeNamespace               = "ovnkube"
 	MetricOvnkubeSubsystemController     = "controller"

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1054,18 +1054,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					nodePort := svcNetB.Spec.Ports[0].NodePort
 					out := curlConnectionTimeoutCode
 					errBool := true
-					if ipFamilyIndex == ipFamilyV6 && cudnATemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer2 {
-						// For Layer2 networks, we have these flows we add on breth0:
-						// cookie=0xdeff105, duration=173.245s, table=1, n_packets=0, n_bytes=0, idle_age=173, priority=14,icmp6,icmp_type=134 actions=FLOOD
-						// cookie=0xdeff105, duration=173.245s, table=1, n_packets=8, n_bytes=640, idle_age=4, priority=14,icmp6,icmp_type=136 actions=FLOOD
-						// which floods the Router Advertisement (RA, type 134) and Neighbor Advertisement (NA, type 136)
-						// Given on Layer2 the GR has the SNATs for both masqueradeIPs this works perfectly well and
-						// the networks are able to NDP for the masqueradeIPs for the other networks.
-						// This doesn't work on Layer3 networks since masqueradeIP SNATs are present on the ovn-cluster-router in that case.
-						// See the tcpdump on the issue: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5410 for more details.
-						out = ""
-						errBool = false
-					}
 
 					// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
 					return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", out, errBool


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Based on https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5140

Move SNAT for management port from ovn routers to the nftables.
We are on a mission to eventually move all SNATs to nftables, this is a first step.
This change is required for the future layer2 topology change to avoid disruption.
Upgrade logic ensures that we only keep the conditional snat if the network
already existed and pods are already wired. During an upgrade, the node
will be drained and pods will be moved. When OVNK comes up at that point
we no longer have pods on the node, and now we can remove this SNAT in
OVN, and use the one in the host nftables.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tracking of all node IPs (IPv4 and IPv6) in nftables sets for enhanced network rule management.
  * Introduced explicit masquerade nftables chains and packet marks for user-defined networks.
  * Added node pod presence checks and conditional egress SNAT management in secondary network controllers.
  * Added helper functions to detect pods on secondary networks and manage egress SNAT rules per node.

* **Bug Fixes**
  * Strengthened equality checks for network rules by including mark and family fields to ensure precise rule reconciliation.

* **Tests**
  * Enhanced test coverage for nftables sets, masquerade IP rules, and stale SNAT entry cleanup in Layer2 and Layer3 secondary network controllers.
  * Updated test setups to reflect new masquerade subnet configurations and network ID annotations.
  * Removed obsolete NAT entries from test databases to align with updated logic.
  * Added new tests for cleanup of stale egress SNAT entries in secondary network controllers.

* **Chores**
  * Removed special-case IPv6 test logic for Layer2 networks in route advertisement tests.
  * Refined comments and test expectations for clarity in masquerade and SNAT-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->