### PR TITLE
Prevent changes to default-network pod annotation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -513,7 +513,7 @@ jobs:
       TRAFFIC_FLOW_TESTS: "${{ matrix.traffic-flow-tests }}"
       ENABLE_ROUTE_ADVERTISEMENTS: "${{ matrix.routeadvertisements != '' }}"
       ADVERTISE_DEFAULT_NETWORK:  "${{ matrix.routeadvertisements == 'advertise-default' }}"
-      ENABLE_PRE_CONF_UDN_ADDR: "${{ ( ( matrix.target == 'multi-homing' && matrix.network-segmentation == 'enable-network-segmentation' ) || matrix.target == 'kv-live-migration' ) && matrix.ic == 'ic-single-node-zones' }}"
+      ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (matrix.target == 'network-segmentation' || matrix.network-segmentation == 'enable-network-segmentation') }}"
     steps:
 
     - name: Install VRF kernel module

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -1075,6 +1075,7 @@ ovn_route_advertisements_enable=${ovn_route_advertisements_enable} \
 ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
 ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
 ovn_route_advertisements_enable=${ovn_route_advertisements_enable} \
+ovn_pre_conf_udn_addr_enable=${ovn_pre_conf_udn_addr_enable} \
   jinjanate ../templates/rbac-ovnkube-master.yaml.j2 -o ${output_dir}/rbac-ovnkube-master.yaml
 
 cp ../templates/rbac-ovnkube-identity.yaml.j2 ${output_dir}/rbac-ovnkube-identity.yaml

--- a/dist/templates/rbac-ovnkube-master.yaml.j2
+++ b/dist/templates/rbac-ovnkube-master.yaml.j2
@@ -191,3 +191,42 @@ spec:
         apiVersions: ["v1"]
         operations:  ["UPDATE"]
         resources:   ["namespaces"]
+
+{% if ovn_pre_conf_udn_addr_enable == "true" -%}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: default-network-annotation
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["UPDATE"]
+        resources:   ["pods"]
+  failurePolicy: Fail
+  validations:
+    # Prevent any changes to the default-network annotation after pod creation:
+    # - If annotation exists in old pod: new pod must have same annotation with identical value
+    # - If annotation doesn't exist in old pod: new pod must also not have it
+    - expression: >
+        ('v1.multus-cni.io/default-network' in oldObject.metadata.annotations)
+        ? ('v1.multus-cni.io/default-network' in object.metadata.annotations) && oldObject.metadata.annotations['v1.multus-cni.io/default-network'] == object.metadata.annotations['v1.multus-cni.io/default-network']
+        : !('v1.multus-cni.io/default-network' in object.metadata.annotations)
+      message: "The 'v1.multus-cni.io/default-network' annotation cannot be changed after the pod was created"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: default-network-annotation-binding
+spec:
+  policyName: default-network-annotation
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["UPDATE"]
+        resources:   ["pods"]
+{%- endif %}


### PR DESCRIPTION
Based on the enhancement: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5238
Adds a ValidatingAdmissionPolicy to make the 'v1.multus-cni.io/default-network' annotation immutable after a pod is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests verifying the default-network annotation on pods cannot be added, changed, or removed after creation, ensuring admission policy enforces immutability.
* **Chores**
  * Updated CI workflow condition for enabling pre-configured user-defined network addresses to focus on network-segmentation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->