### PR TITLE
WIP 

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -632,12 +632,11 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 
 		if ofPortPhys != "" {
-			// table 0, packets coming from external or other localnet ports. Send it through conntrack and
+			// table 0, packets coming from external. Send it through conntrack and
 			// resubmit to table 1 to know the state and mark of the connection.
-			// Note, there are higher priority rules that take care of traffic coming from LOCAL and OVN ports.
 			dftFlows = append(dftFlows,
-				fmt.Sprintf("cookie=%s, priority=50, ip, actions=ct(zone=%d, nat, table=1)",
-					nodetypes.DefaultOpenFlowCookie, config.Default.ConntrackZone))
+				fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ip, "+
+					"actions=ct(zone=%d, nat, table=1)", nodetypes.DefaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
 		}
 	}
 

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -398,7 +398,7 @@ var _ = Describe("Multi Homing", feature.MultiHoming, func() {
 					topology: "localnet",
 				},
 				podConfiguration{ // client on default network
-					name:         clientPodName + "-same-node",
+					name:         clientPodName,
 					isPrivileged: true,
 				},
 				podConfiguration{ // server attached to localnet secondary network
@@ -431,7 +431,7 @@ var _ = Describe("Multi Homing", feature.MultiHoming, func() {
 					containerCmd: httpServerContainerCmd(port),
 					hostNetwork:  true,
 				},
-				false, // not collocated on same node
+				false, // not collocated on the same node
 				Label("STORY", "SDN-5345"),
 			),
 			ginkgo.Entry(
@@ -453,7 +453,51 @@ var _ = Describe("Multi Homing", feature.MultiHoming, func() {
 					containerCmd: httpServerContainerCmd(port),
 					hostNetwork:  true,
 				},
-				true, // collocated on same node
+				true, // collocated on the same node
+				Label("STORY", "SDN-5345"),
+			),
+			ginkgo.Entry(
+				"can be reached by a host-networked pod on a different node",
+				networkAttachmentConfigParams{
+					name:     secondaryNetworkName,
+					topology: "localnet",
+				},
+				podConfiguration{ // client on default network, pod is host-networked
+					name:         clientPodName,
+					hostNetwork:  true,
+					isPrivileged: true,
+				},
+				podConfiguration{ // server on localnet
+					attachments: []nadapi.NetworkSelectionElement{{
+						Name: secondaryNetworkName,
+					}},
+					containerCmd:                 httpServerContainerCmd(port),
+					name:                         podName,
+					needsIPRequestFromHostSubnet: true,
+				},
+				false, // collocated on different nodes
+				Label("STORY", "SDN-5345"),
+			),
+			ginkgo.Entry(
+				"can be reached by a host-networked pod on the same node",
+				networkAttachmentConfigParams{
+					name:     secondaryNetworkName,
+					topology: "localnet",
+				},
+				podConfiguration{ // client on default network, pod is host-networked
+					name:         clientPodName,
+					hostNetwork:  true,
+					isPrivileged: true,
+				},
+				podConfiguration{ // server on localnet
+					attachments: []nadapi.NetworkSelectionElement{{
+						Name: secondaryNetworkName,
+					}},
+					containerCmd:                 httpServerContainerCmd(port),
+					name:                         podName,
+					needsIPRequestFromHostSubnet: true,
+				},
+				true, // collocated on the same node
 				Label("STORY", "SDN-5345"),
 			),
 		)


### PR DESCRIPTION
Revert "Drop in_port from ip dispatch OF rule"

The commit was introduced here:
https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5313/commits/1448d5ab14337b647f3e3034ea4ffc077431979a?diff=unified&w=0

The use cases with localnet-> host (same node, same subnet) and default network -> localnet (same node, same subnet) are not affected by this change (see e2e's below)

Removing the `in_port` entirely breaks a setup in which localnet uses IPs that are not within the host subnet and an external router to connect the two networks:

<img width="1920" height="1080" alt="Screenshot from 2025-08-06 20-14-05" src="https://github.com/user-attachments/assets/d61a6094-e315-4387-923b-16f91307e4f8" />
<img width="1920" height="1080" alt="Screenshot from 2025-08-06 20-14-07" src="https://github.com/user-attachments/assets/ca813407-a3a1-41c1-9d1a-59e91fe351e4" />
<img width="1920" height="1080" alt="Screenshot from 2025-08-06 20-14-09" src="https://github.com/user-attachments/assets/c970db05-d1be-419d-98bd-2a9f58a4340f" />

