### PR TITLE
Prevent UDN deletion race condition by checking controller state

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -146,6 +146,7 @@ func NewClusterManager(
 			ovnClient.UserDefinedNetworkClient,
 			wf.UserDefinedNetworkInformer(), wf.ClusterUserDefinedNetworkInformer(),
 			udntemplate.RenderNetAttachDefManifest,
+			cm.networkManager.Interface(),
 			wf.PodCoreInformer(),
 			wf.NamespaceInformer(),
 			cm.recorder,

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -38,6 +38,7 @@ import (
 	userdefinednetworkinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/userdefinednetwork/v1"
 	userdefinednetworklister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/listers/userdefinednetwork/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -72,6 +73,8 @@ type Controller struct {
 	// trying to create an object with the same name.
 	createNetworkLock sync.Mutex
 
+	networkManager networkmanager.Interface
+
 	udnClient         userdefinednetworkclientset.Interface
 	udnLister         userdefinednetworklister.UserDefinedNetworkLister
 	cudnLister        userdefinednetworklister.ClusterUserDefinedNetworkLister
@@ -93,6 +96,7 @@ func New(
 	udnInformer userdefinednetworkinformer.UserDefinedNetworkInformer,
 	cudnInformer userdefinednetworkinformer.ClusterUserDefinedNetworkInformer,
 	renderNadFn RenderNetAttachDefManifest,
+	networkManager networkmanager.Interface,
 	podInformer corev1informer.PodInformer,
 	namespaceInformer corev1informer.NamespaceInformer,
 	eventRecorder record.EventRecorder,
@@ -108,6 +112,7 @@ func New(
 		renderNadFn:                 renderNadFn,
 		podInformer:                 podInformer,
 		namespaceInformer:           namespaceInformer,
+		networkManager:              networkManager,
 		networkInUseRequeueInterval: defaultNetworkInUseCheckInterval,
 		namespaceTracker:            map[string]sets.Set[string]{},
 		eventRecorder:               eventRecorder,
@@ -410,6 +415,12 @@ func (c *Controller) syncUserDefinedNetwork(udn *userdefinednetworkv1.UserDefine
 				return nil, fmt.Errorf("failed to delete NetworkAttachmentDefinition [%s/%s]: %w", udn.Namespace, udn.Name, err)
 			}
 
+			// Ensure that the network controller is stopped(GetActiveNetwork returns nil) before allowing the UDN
+			// to be removed.
+			if c.networkManager.GetActiveNetwork(util.GenerateUDNNetworkName(udn.Namespace, udn.Name)) != nil {
+				return nil, &networkInUseError{err: fmt.Errorf("cannot remove UDN, controller for network %s is still running", util.GenerateUDNNetworkName(udn.Namespace, udn.Name))}
+			}
+
 			controllerutil.RemoveFinalizer(udn, template.FinalizerUserDefinedNetwork)
 			udn, err := c.udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Update(context.Background(), udn, metav1.UpdateOptions{})
 			if err != nil {
@@ -580,6 +591,12 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 
 			if len(errs) > 0 {
 				return nil, errors.Join(errs...)
+			}
+
+			// Ensure that the network controller is stopped(GetActiveNetwork returns nil) before allowing the cUDN
+			// to be removed.
+			if c.networkManager.GetActiveNetwork(util.GenerateCUDNNetworkName(cudn.Name)) != nil {
+				return nil, &networkInUseError{err: fmt.Errorf("cannot remove cluster UDN, controller for network %s is still running", util.GenerateCUDNNetworkName(cudn.Name))}
 			}
 
 			var err error

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -15,6 +15,7 @@ import (
 	netv1lister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -87,8 +88,6 @@ type Controller struct {
 	eventRecorder               record.EventRecorder
 }
 
-const defaultNetworkInUseCheckInterval = 1 * time.Minute
-
 func New(
 	nadClient netv1clientset.Interface,
 	nadInfomer netv1infomer.NetworkAttachmentDefinitionInformer,
@@ -104,18 +103,17 @@ func New(
 	udnLister := udnInformer.Lister()
 	cudnLister := cudnInformer.Lister()
 	c := &Controller{
-		nadClient:                   nadClient,
-		nadLister:                   nadInfomer.Lister(),
-		udnClient:                   udnClient,
-		udnLister:                   udnLister,
-		cudnLister:                  cudnLister,
-		renderNadFn:                 renderNadFn,
-		podInformer:                 podInformer,
-		namespaceInformer:           namespaceInformer,
-		networkManager:              networkManager,
-		networkInUseRequeueInterval: defaultNetworkInUseCheckInterval,
-		namespaceTracker:            map[string]sets.Set[string]{},
-		eventRecorder:               eventRecorder,
+		nadClient:         nadClient,
+		nadLister:         nadInfomer.Lister(),
+		udnClient:         udnClient,
+		udnLister:         udnLister,
+		cudnLister:        cudnLister,
+		renderNadFn:       renderNadFn,
+		podInformer:       podInformer,
+		namespaceInformer: namespaceInformer,
+		networkManager:    networkManager,
+		namespaceTracker:  map[string]sets.Set[string]{},
+		eventRecorder:     eventRecorder,
 	}
 	udnCfg := &controller.ControllerConfig[userdefinednetworkv1.UserDefinedNetwork]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -389,7 +387,8 @@ func (c *Controller) reconcileUDN(key string) error {
 
 	var networkInUse *networkInUseError
 	if errors.As(syncErr, &networkInUse) {
-		c.udnController.ReconcileAfter(key, c.networkInUseRequeueInterval)
+		// Call ReconcileRateLimited directly to ensure retries without the default limits
+		c.udnController.ReconcileRateLimited(key)
 		return updateStatusErr
 	}
 
@@ -452,34 +451,34 @@ func (c *Controller) updateUserDefinedNetworkStatus(udn *userdefinednetworkv1.Us
 
 	networkCreatedCondition := newNetworkCreatedCondition(nad, syncError)
 
-	conditions, updated := updateCondition(udn.Status.Conditions, networkCreatedCondition)
-
-	if updated {
-		var err error
-		conditionsApply := make([]*metaapplyv1.ConditionApplyConfiguration, len(conditions))
-		for i := range conditions {
-			conditionsApply[i] = &metaapplyv1.ConditionApplyConfiguration{
-				Type:               &conditions[i].Type,
-				Status:             &conditions[i].Status,
-				LastTransitionTime: &conditions[i].LastTransitionTime,
-				Reason:             &conditions[i].Reason,
-				Message:            &conditions[i].Message,
-			}
-		}
-		udnApplyConf := udnapplyconfkv1.UserDefinedNetwork(udn.Name, udn.Namespace).
-			WithStatus(udnapplyconfkv1.UserDefinedNetworkStatus().
-				WithConditions(conditionsApply...))
-		opts := metav1.ApplyOptions{FieldManager: "user-defined-network-controller"}
-		udn, err = c.udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).ApplyStatus(context.Background(), udnApplyConf, opts)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return fmt.Errorf("failed to update UserDefinedNetwork status: %w", err)
-		}
-		klog.Infof("Updated status UserDefinedNetwork [%s/%s]", udn.Namespace, udn.Name)
+	updated := meta.SetStatusCondition(&udn.Status.Conditions, *networkCreatedCondition)
+	if !updated {
+		return nil
 	}
 
+	var err error
+	conditionsApply := make([]*metaapplyv1.ConditionApplyConfiguration, len(udn.Status.Conditions))
+	for i, condition := range udn.Status.Conditions {
+		conditionsApply[i] = &metaapplyv1.ConditionApplyConfiguration{
+			Type:               &condition.Type,
+			Status:             &condition.Status,
+			LastTransitionTime: &condition.LastTransitionTime,
+			Reason:             &condition.Reason,
+			Message:            &condition.Message,
+		}
+	}
+	udnApplyConf := udnapplyconfkv1.UserDefinedNetwork(udn.Name, udn.Namespace).
+		WithStatus(udnapplyconfkv1.UserDefinedNetworkStatus().
+			WithConditions(conditionsApply...))
+	opts := metav1.ApplyOptions{FieldManager: "user-defined-network-controller"}
+	udn, err = c.udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).ApplyStatus(context.Background(), udnApplyConf, opts)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to update UserDefinedNetwork status: %w", err)
+	}
+	klog.Infof("Updated status UserDefinedNetwork [%s/%s]", udn.Namespace, udn.Name)
 	return nil
 }
 
@@ -505,21 +504,6 @@ func newNetworkCreatedCondition(nad *netv1.NetworkAttachmentDefinition, syncErro
 	}
 
 	return networkCreatedCondition
-}
-
-func updateCondition(conditions []metav1.Condition, cond *metav1.Condition) ([]metav1.Condition, bool) {
-	if len(conditions) == 0 {
-		return append(conditions, *cond), true
-	}
-
-	idx := slices.IndexFunc(conditions, func(c metav1.Condition) bool {
-		return (c.Type == cond.Type) &&
-			(c.Status != cond.Status || c.Reason != cond.Reason || c.Message != cond.Message)
-	})
-	if idx != -1 {
-		return slices.Replace(conditions, idx, idx+1, *cond), true
-	}
-	return conditions, false
 }
 
 func (c *Controller) cudnNeedUpdate(_ *userdefinednetworkv1.ClusterUserDefinedNetwork, _ *userdefinednetworkv1.ClusterUserDefinedNetwork) bool {
@@ -549,7 +533,8 @@ func (c *Controller) reconcileCUDN(key string) error {
 
 	var networkInUse *networkInUseError
 	if errors.As(syncErr, &networkInUse) {
-		c.cudnController.ReconcileAfter(key, c.networkInUseRequeueInterval)
+		// Call ReconcileRateLimited directly to ensure retries without the default limits
+		c.cudnController.ReconcileRateLimited(key)
 		return updateStatusErr
 	}
 
@@ -688,18 +673,18 @@ func (c *Controller) updateClusterUDNStatus(cudn *userdefinednetworkv1.ClusterUs
 
 	networkCreatedCondition := newClusterNetworCreatedCondition(nads, syncError)
 
-	conditions, updated := updateCondition(cudn.Status.Conditions, networkCreatedCondition)
+	updated := meta.SetStatusCondition(&cudn.Status.Conditions, networkCreatedCondition)
 	if !updated {
 		return nil
 	}
-	conditionsApply := make([]*metaapplyv1.ConditionApplyConfiguration, len(conditions))
-	for i := range conditions {
+	conditionsApply := make([]*metaapplyv1.ConditionApplyConfiguration, len(cudn.Status.Conditions))
+	for i, condition := range cudn.Status.Conditions {
 		conditionsApply[i] = &metaapplyv1.ConditionApplyConfiguration{
-			Type:               &conditions[i].Type,
-			Status:             &conditions[i].Status,
-			LastTransitionTime: &conditions[i].LastTransitionTime,
-			Reason:             &conditions[i].Reason,
-			Message:            &conditions[i].Message,
+			Type:               &condition.Type,
+			Status:             &condition.Status,
+			LastTransitionTime: &condition.LastTransitionTime,
+			Reason:             &condition.Reason,
+			Message:            &condition.Message,
 		}
 	}
 	var err error
@@ -720,7 +705,7 @@ func (c *Controller) updateClusterUDNStatus(cudn *userdefinednetworkv1.ClusterUs
 	return nil
 }
 
-func newClusterNetworCreatedCondition(nads []netv1.NetworkAttachmentDefinition, syncError error) *metav1.Condition {
+func newClusterNetworCreatedCondition(nads []netv1.NetworkAttachmentDefinition, syncError error) metav1.Condition {
 	var namespaces []string
 	for _, nad := range nads {
 		namespaces = append(namespaces, nad.Namespace)
@@ -728,7 +713,7 @@ func newClusterNetworCreatedCondition(nads []netv1.NetworkAttachmentDefinition, 
 	affectedNamespaces := strings.Join(namespaces, ", ")
 
 	now := metav1.Now()
-	condition := &metav1.Condition{
+	condition := metav1.Condition{
 		Type:               conditionTypeNetworkCreated,
 		Status:             metav1.ConditionTrue,
 		Reason:             "NetworkAttachmentDefinitionCreated",

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -26,6 +26,8 @@ import (
 	udnclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
 	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
+	nmtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/networkmanager"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -59,9 +61,11 @@ var _ = Describe("User Defined Network Controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Start()).To(Succeed())
 
+		networkManager, err := networkmanager.NewForCluster(&nmtest.FakeControllerManager{}, f, cs, nil)
+		Expect(err).NotTo(HaveOccurred())
 		return New(cs.NetworkAttchDefClient, f.NADInformer(),
 			cs.UserDefinedNetworkClient, f.UserDefinedNetworkInformer(), f.ClusterUserDefinedNetworkInformer(),
-			renderNADStub, f.PodCoreInformer(), f.NamespaceInformer(), nil,
+			renderNADStub, networkManager.Interface(), f.PodCoreInformer(), f.NamespaceInformer(), nil,
 		)
 	}
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/nad.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/nad.go
@@ -3,6 +3,7 @@ package userdefinednetwork
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -31,6 +32,8 @@ func NetAttachDefNotInUse(nad *netv1.NetworkAttachmentDefinition, pods []*corev1
 		}
 	}
 	if len(connectedPods) > 0 {
+		// Sort the connected pods to ensure a consistent error
+		slices.Sort(connectedPods)
 		return fmt.Errorf("network in use by the following pods: %v", connectedPods)
 	}
 	return nil

--- a/go-controller/pkg/controller/controller.go
+++ b/go-controller/pkg/controller/controller.go
@@ -27,6 +27,7 @@ const (
 // to reconcile through its Reconcile method
 type Reconciler interface {
 	Reconcile(key string)
+	ReconcileRateLimited(key string)
 	ReconcileAfter(key string, duration time.Duration)
 	addHandler() error
 	startWorkers() error
@@ -270,6 +271,10 @@ func (c *controller[T]) processNextQueueItem() bool {
 
 func (c *controller[T]) Reconcile(key string) {
 	c.queue.Add(key)
+}
+
+func (c *controller[T]) ReconcileRateLimited(key string) {
+	c.queue.AddRateLimited(key)
 }
 
 func (c *controller[T]) ReconcileAfter(key string, duration time.Duration) {

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -39,6 +39,11 @@ type Interface interface {
 	// GetNetwork returns the network of the given name or nil if unknown
 	GetNetwork(name string) util.NetInfo
 
+	// GetActiveNetwork returns the NetInfo currently held by the controller for the given network.
+	// This may differ from the NetInfo returned by GetNetwork which reflects the API state.
+	// Returns nil if there is no running controller for the provided network.
+	GetActiveNetwork(network string) util.NetInfo
+
 	// DoWithLock takes care of locking and unlocking while iterating over all role primary user defined networks.
 	DoWithLock(f func(network util.NetInfo) error) error
 	GetActiveNetworkNamespaces(networkName string) ([]string, error)
@@ -202,6 +207,13 @@ func (nm defaultNetworkManager) DoWithLock(f func(network util.NetInfo) error) e
 
 func (nm defaultNetworkManager) GetActiveNetworkNamespaces(_ string) ([]string, error) {
 	return []string{"default"}, nil
+}
+
+func (nm defaultNetworkManager) GetActiveNetwork(network string) util.NetInfo {
+	if network != types.DefaultNetworkName {
+		return nil
+	}
+	return &util.DefaultNetInfo{}
 }
 
 var def Controller = &defaultNetworkManager{}

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -669,3 +669,13 @@ func (c *nadController) handleNetworkID(old util.NetInfo, new util.MutableNetInf
 
 	return nil
 }
+
+func (c *nadController) GetActiveNetwork(network string) util.NetInfo {
+	c.RLock()
+	defer c.RUnlock()
+	state := c.networkController.getNetworkState(network)
+	if state == nil {
+		return nil
+	}
+	return state.controller
+}

--- a/go-controller/pkg/testing/networkmanager/fake.go
+++ b/go-controller/pkg/testing/networkmanager/fake.go
@@ -78,6 +78,10 @@ func (fnm *FakeNetworkManager) GetNetwork(networkName string) util.NetInfo {
 	return &util.DefaultNetInfo{}
 }
 
+func (fnm *FakeNetworkManager) GetActiveNetwork(networkName string) util.NetInfo {
+	return fnm.GetNetwork(networkName)
+}
+
 func (fnm *FakeNetworkManager) GetActiveNetworkNamespaces(networkName string) ([]string, error) {
 	namespaces := make([]string, 0)
 	for namespaceName, primaryNAD := range fnm.PrimaryNetworks {


### PR DESCRIPTION
Adds `GetActiveNetwork` method to verify network controllers are stopped before allowing UDN/CUDN deletion, preventing race conditions in a scenario where a network is recreated before the cluster-manager controller stopped running.
Replaces custom condition update logic with standard k8s `meta.SetStatusCondition` to avoid updating condtions even if they haven't changed. Use rate limiting instead of fixed interval re-queuing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent deletion of user-defined network resources while their network controllers are active.
  * Added ability to query whether a network controller is active.
  * Use rate-limited retries during reconciliation and modernized status condition handling.

* **Bug Fixes**
  * More reliable removal of network resources by detecting active controllers.
  * Consistent, sorted pod lists in error messages.

* **Tests**
  * Tests updated to use the network-manager interface for controller scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->