### PR TITLE
SNAT traffic from advertised UDNs towards UDN enabled default services

### DIFF
--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -89,6 +89,10 @@ type UserDefinedNetworkGateway struct {
 
 	// gwInterfaceIndex holds the link index of gateway interface
 	gwInterfaceIndex int
+
+	// save BGP state at the start of reconciliation loop run to handle it consistently throughout the run
+	isNetworkAdvertisedToDefaultVRF bool
+	isNetworkAdvertised             bool
 }
 
 func NewUserDefinedNetworkGateway(netInfo util.NetInfo, node *corev1.Node, nodeLister listers.NodeLister,
@@ -225,18 +229,18 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 		return fmt.Errorf("could not add VRF %s routes for network %s, err: %v", vrfDeviceName, udng.GetNetworkName(), err)
 	}
 
-	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
+	udng.updateAdvertisementStatus()
 
 	// create the iprules for this network
-	if err = udng.updateUDNVRFIPRules(isNetworkAdvertised); err != nil {
+	if err = udng.updateUDNVRFIPRules(); err != nil {
 		return fmt.Errorf("failed to update IP rules for network %s: %w", udng.GetNetworkName(), err)
 	}
 
-	if err = udng.updateAdvertisedUDNIsolationRules(isNetworkAdvertised); err != nil {
+	if err = udng.updateAdvertisedUDNIsolationRules(); err != nil {
 		return fmt.Errorf("failed to update isolation rules for network %s: %w", udng.GetNetworkName(), err)
 	}
 
-	if err := udng.updateUDNVRFIPRoute(isNetworkAdvertised); err != nil {
+	if err := udng.updateUDNVRFIPRoute(); err != nil {
 		return fmt.Errorf("failed to update ip routes for network %s: %w", udng.GetNetworkName(), err)
 	}
 
@@ -314,18 +318,16 @@ func (udng *UserDefinedNetworkGateway) DelNetwork() error {
 		}
 	}
 
-	if util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name) {
-		err := udng.updateAdvertisedUDNIsolationRules(false)
-		if err != nil {
-			return fmt.Errorf("failed to remove advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)
-		}
+	err := udng.deleteAdvertisedUDNIsolationRules()
+	if err != nil {
+		return fmt.Errorf("failed to remove advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)
 	}
 
 	if err := udng.delMarkChain(); err != nil {
 		return err
 	}
 	// delete the management port interface for this network
-	err := udng.deleteUDNManagementPort()
+	err = udng.deleteUDNManagementPort()
 	if err != nil {
 		return err
 	}
@@ -483,8 +485,7 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 
 	// Route2: Add default route: default via 172.18.0.1 dev breth0 mtu 1400
 	// necessary for UDN CNI and host-networked pods default traffic to go to node's gatewayIP
-	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
-	defaultRoute, err := udng.getDefaultRoute(isNetworkAdvertised)
+	defaultRoute, err := udng.getDefaultRouteExceptIfVRFLite()
 	if err != nil {
 		return nil, fmt.Errorf("unable to add default route for network %s, err: %v", udng.GetNetworkName(), err)
 	}
@@ -585,15 +586,7 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 	return retVal, nil
 }
 
-func (udng *UserDefinedNetworkGateway) getDefaultRoute(isNetworkAdvertised bool) ([]netlink.Route, error) {
-	vrfs := udng.GetPodNetworkAdvertisedOnNodeVRFs(udng.node.Name)
-	// If the network is advertised on a non default VRF then we should only consider routes received from external BGP
-	// device and not send any traffic based on default route similar to one present in default VRF. This is more important
-	// for VRF-Lite usecase where we need traffic to leave from vlan device instead of default gateway interface.
-	if isNetworkAdvertised && !slices.Contains(vrfs, types.DefaultNetworkName) {
-		return nil, nil
-	}
-
+func (udng *UserDefinedNetworkGateway) getDefaultRoute() ([]netlink.Route, error) {
 	networkMTU := udng.NetInfo.MTU()
 	if networkMTU == 0 {
 		networkMTU = config.Default.MTU
@@ -616,6 +609,16 @@ func (udng *UserDefinedNetworkGateway) getDefaultRoute(isNetworkAdvertised bool)
 		})
 	}
 	return retVal, nil
+}
+
+func (udng *UserDefinedNetworkGateway) getDefaultRouteExceptIfVRFLite() ([]netlink.Route, error) {
+	// If the network is advertised on a non default VRF then we should only consider routes received from external BGP
+	// device and not send any traffic based on default route similar to one present in default VRF. This is more important
+	// for VRF-Lite usecase where we need traffic to leave from vlan device instead of default gateway interface.
+	if udng.isNetworkAdvertised && !udng.isNetworkAdvertisedToDefaultVRF {
+		return nil, nil
+	}
+	return udng.getDefaultRoute()
 }
 
 // getV4MasqueradeIP returns the V4 management port masqueradeIP for this network
@@ -644,21 +647,18 @@ func (udng *UserDefinedNetworkGateway) getV6MasqueradeIP() (*net.IPNet, error) {
 
 // constructUDNVRFIPRules constructs rules that redirect matching packets
 // into the corresponding UDN VRF routing table.
-// If the network is not advertised, an example of the rules we set for two
-// networks is:
+//
+// When a network is not advertised on the default VRF, an example of the rules
+// we set for it is:
 // 2000:	from all fwmark 0x1001 lookup 1007
 // 2000:	from all to 169.254.0.12 lookup 1007
-// 2000:	from all fwmark 0x1002 lookup 1009
-// 2000:	from all to 169.254.0.14 lookup 1009
-// If the network is advertised, an example of the rules we set for two
-// networks is:
+//
+// When a network is advertised on the default VRF, an example of the rules
+// we set for it is:
 // 2000:	from all fwmark 0x1001 lookup 1007
 // 2000:	from all to 10.132.0.0/14 lookup 1007
 // 2000:	from all to 169.254.0.12 lookup 1007
-// 2000:	from all fwmark 0x1001 lookup 1009
-// 2000:	from all to 10.134.0.0/14 lookup 1009
-// 2000:	from all to 169.254.0.14 lookup 1009
-func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(isNetworkAdvertised bool) ([]netlink.Rule, []netlink.Rule, error) {
+func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules() ([]netlink.Rule, []netlink.Rule, error) {
 	var addIPRules []netlink.Rule
 	var delIPRules []netlink.Rule
 	var masqIPRules []netlink.Rule
@@ -691,12 +691,14 @@ func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules(isNetworkAdvertise
 		}
 	}
 	switch {
-	case !isNetworkAdvertised:
+	case udng.isNetworkAdvertisedToDefaultVRF:
+		// the network is advertised to the default VRF
+		addIPRules = append(addIPRules, masqIPRules...)
+		addIPRules = append(addIPRules, subnetIPRules...)
+	default:
+		// network is not advertised on the default VRF
 		addIPRules = append(addIPRules, masqIPRules...)
 		delIPRules = append(delIPRules, subnetIPRules...)
-	default:
-		addIPRules = append(addIPRules, subnetIPRules...)
-		addIPRules = append(addIPRules, masqIPRules...)
 	}
 	return addIPRules, delIPRules, nil
 }
@@ -794,19 +796,20 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 		return fmt.Errorf("openflow manager with default bridge configuration has not been provided for network %s", udng.GetNetworkName())
 	}
 
+	udng.updateAdvertisementStatus()
+
 	// update bridge configuration
-	isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
 	netConfig := udng.openflowManager.defaultBridge.GetNetworkConfig(udng.GetNetworkName())
 	if netConfig == nil {
 		return fmt.Errorf("missing bridge configuration for network %s", udng.GetNetworkName())
 	}
-	netConfig.Advertised.Store(isNetworkAdvertised)
+	netConfig.Advertised.Store(udng.isNetworkAdvertised)
 
-	if err := udng.updateUDNVRFIPRules(isNetworkAdvertised); err != nil {
+	if err := udng.updateUDNVRFIPRules(); err != nil {
 		return fmt.Errorf("error while updating ip rule for UDN %s: %s", udng.GetNetworkName(), err)
 	}
 
-	if err := udng.updateUDNVRFIPRoute(isNetworkAdvertised); err != nil {
+	if err := udng.updateUDNVRFIPRoute(); err != nil {
 		return fmt.Errorf("error while updating ip route for UDN %s: %s", udng.GetNetworkName(), err)
 	}
 
@@ -820,16 +823,16 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 	// let's sync these flows immediately
 	udng.openflowManager.requestFlowSync()
 
-	if err := udng.updateAdvertisedUDNIsolationRules(isNetworkAdvertised); err != nil {
+	if err := udng.updateAdvertisedUDNIsolationRules(); err != nil {
 		return fmt.Errorf("error while updating advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)
 	}
 	return nil
 }
 
 // updateUDNVRFIPRules updates IP rules for a network depending on whether the
-// network is advertised or not
-func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRules(isNetworkAdvertised bool) error {
-	addIPRules, deleteIPRules, err := udng.constructUDNVRFIPRules(isNetworkAdvertised)
+// network is advertised to the default VRF or not
+func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRules() error {
+	addIPRules, deleteIPRules, err := udng.constructUDNVRFIPRules()
 	if err != nil {
 		return fmt.Errorf("unable to get iprules for network %s, err: %v", udng.GetNetworkName(), err)
 	}
@@ -848,30 +851,40 @@ func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRules(isNetworkAdvertised b
 }
 
 // Add or remove default route from a vrf device based on the network is
-// advertised on its own network or default network
-func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRoute(isNetworkAdvertised bool) error {
-	vrfs := udng.GetPodNetworkAdvertisedOnNodeVRFs(udng.node.Name)
-	if isNetworkAdvertised && !slices.Contains(vrfs, types.DefaultNetworkName) {
+// advertised on its own network or the default network
+func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRoute() error {
+	vrfName := util.GetNetworkVRFName(udng.NetInfo)
+
+	switch {
+	case udng.isNetworkAdvertised && !udng.isNetworkAdvertisedToDefaultVRF:
+		// Remove default route for networks advertised to non-default VRF
 		if err := udng.removeDefaultRouteFromVRF(); err != nil {
-			return fmt.Errorf("error while removing default route from VRF %s corresponding to network %s: %s",
-				util.GetNetworkVRFName(udng.NetInfo), udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to remove default route from VRF %s for network %s: %v",
+				vrfName, udng.GetNetworkName(), err)
 		}
-	} else if !isNetworkAdvertised || slices.Contains(vrfs, types.DefaultNetworkName) {
-		defaultRoute, err := udng.getDefaultRoute(isNetworkAdvertised)
+
+	default:
+		// Add default route for networks that are either:
+		// - not advertised
+		// - advertised to default VRF
+		defaultRoute, err := udng.getDefaultRouteExceptIfVRFLite()
 		if err != nil {
-			return fmt.Errorf("unable to get default route for network %s, err: %v", udng.GetNetworkName(), err)
+			return fmt.Errorf("failed to get default route for network %s: %v",
+				udng.GetNetworkName(), err)
 		}
-		if err = udng.vrfManager.AddVRFRoutes(util.GetNetworkVRFName(udng.NetInfo), defaultRoute); err != nil {
-			return fmt.Errorf("error while adding default route to VRF %s corresponding to network %s, err: %v",
-				util.GetNetworkVRFName(udng.NetInfo), udng.GetNetworkName(), err)
+
+		if err = udng.vrfManager.AddVRFRoutes(vrfName, defaultRoute); err != nil {
+			return fmt.Errorf("failed to add default route to VRF %s for network %s: %v",
+				vrfName, udng.GetNetworkName(), err)
 		}
 	}
+
 	return nil
 }
 
 func (udng *UserDefinedNetworkGateway) removeDefaultRouteFromVRF() error {
 	vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
-	defaultRoute, err := udng.getDefaultRoute(false)
+	defaultRoute, err := udng.getDefaultRoute()
 	if err != nil {
 		return fmt.Errorf("unable to get default route for network %s, err: %v", udng.GetNetworkName(), err)
 	}
@@ -900,38 +913,21 @@ func (udng *UserDefinedNetworkGateway) removeDefaultRouteFromVRF() error {
 //	   comment "advertised UDNs V4 subnets"
 //	   elements = { 10.10.0.0/16 comment "cluster_udn_l3network" }
 //	}
-func (udng *UserDefinedNetworkGateway) updateAdvertisedUDNIsolationRules(isNetworkAdvertised bool) error {
+func (udng *UserDefinedNetworkGateway) updateAdvertisedUDNIsolationRules() error {
+	switch {
+	case udng.isNetworkAdvertised:
+		return udng.addAdvertisedUDNIsolationRules()
+	default:
+		return udng.deleteAdvertisedUDNIsolationRules()
+	}
+}
+
+func (udng *UserDefinedNetworkGateway) addAdvertisedUDNIsolationRules() error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("failed to get nftables helper: %v", err)
 	}
 	tx := nft.NewTransaction()
-
-	if !isNetworkAdvertised {
-		existingV4, err := nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV4)
-		if err != nil {
-			if !knftables.IsNotFound(err) {
-				return fmt.Errorf("could not list existing items in %s set: %w", nftablesAdvertisedUDNsSetV4, err)
-			}
-		}
-		existingV6, err := nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV6)
-		if err != nil {
-			if !knftables.IsNotFound(err) {
-				return fmt.Errorf("could not list existing items in %s set: %w", nftablesAdvertisedUDNsSetV6, err)
-			}
-		}
-
-		for _, elem := range append(existingV4, existingV6...) {
-			if elem.Comment != nil && *elem.Comment == udng.GetNetworkName() {
-				tx.Delete(elem)
-			}
-		}
-
-		if tx.NumOperations() == 0 {
-			return nil
-		}
-		return nft.Run(context.TODO(), tx)
-	}
 
 	for _, udnNet := range udng.Subnets() {
 		set := nftablesAdvertisedUDNsSetV4
@@ -950,4 +946,42 @@ func (udng *UserDefinedNetworkGateway) updateAdvertisedUDNIsolationRules(isNetwo
 		return nil
 	}
 	return nft.Run(context.TODO(), tx)
+}
+
+func (udng *UserDefinedNetworkGateway) deleteAdvertisedUDNIsolationRules() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get nftables helper: %v", err)
+	}
+	tx := nft.NewTransaction()
+
+	existingV4, err := nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV4)
+	if err != nil {
+		if !knftables.IsNotFound(err) {
+			return fmt.Errorf("could not list existing items in %s set: %w", nftablesAdvertisedUDNsSetV4, err)
+		}
+	}
+	existingV6, err := nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV6)
+	if err != nil {
+		if !knftables.IsNotFound(err) {
+			return fmt.Errorf("could not list existing items in %s set: %w", nftablesAdvertisedUDNsSetV6, err)
+		}
+	}
+
+	for _, elem := range append(existingV4, existingV6...) {
+		if elem.Comment != nil && *elem.Comment == udng.GetNetworkName() {
+			tx.Delete(elem)
+		}
+	}
+
+	if tx.NumOperations() == 0 {
+		return nil
+	}
+	return nft.Run(context.TODO(), tx)
+}
+
+func (udng *UserDefinedNetworkGateway) updateAdvertisementStatus() {
+	vrfs := udng.GetPodNetworkAdvertisedOnNodeVRFs(udng.node.Name)
+	udng.isNetworkAdvertised = len(vrfs) > 0
+	udng.isNetworkAdvertisedToDefaultVRF = slices.Contains(vrfs, types.DefaultNetworkName)
 }

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1656,7 +1656,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway.vrfTableId = test.vrftableID
-			rules, delRules, err := udnGateway.constructUDNVRFIPRules(false)
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
 			g.Expect(err).ToNot(HaveOccurred())
 			for i, rule := range rules {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
@@ -1678,7 +1678,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 	}
 }
 
-func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
+func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 	type testRule struct {
 		priority int
 		family   int
@@ -1710,13 +1710,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
 				},
 			},
 			v4mode: true,
@@ -1735,13 +1735,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      *ovntest.MustParseIPNet("ae70::/60"),
 				},
 			},
 			v6mode: true,
@@ -1766,18 +1766,6 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V6,
-					table:    1010,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
-				},
-				{
-					priority: UDNMasqueradeIPRulePriority,
-					family:   netlink.FAMILY_V4,
-					table:    1010,
 					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
 				},
 				{
@@ -1785,6 +1773,18 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 					family:   netlink.FAMILY_V6,
 					table:    1010,
 					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					dst:      *ovntest.MustParseIPNet("ae70::/60"),
 				},
 			},
 			v4mode: true,
@@ -1837,7 +1837,198 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertised(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway.vrfTableId = test.vrftableID
-			rules, delRules, err := udnGateway.constructUDNVRFIPRules(true)
+			udnGateway.isNetworkAdvertised = true
+			udnGateway.isNetworkAdvertisedToDefaultVRF = true
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
+			g.Expect(err).ToNot(HaveOccurred())
+			for i, rule := range rules {
+				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
+				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))
+				g.Expect(rule.Family).To(Equal(test.expectedRules[i].family))
+				if rule.Dst != nil {
+					g.Expect(*rule.Dst).To(Equal(test.expectedRules[i].dst))
+				} else {
+					g.Expect(rule.Mark).To(Equal(test.expectedRules[i].mark))
+				}
+			}
+			for i, rule := range delRules {
+				g.Expect(rule.Priority).To(Equal(test.deleteRules[i].priority))
+				g.Expect(rule.Table).To(Equal(test.deleteRules[i].table))
+				g.Expect(rule.Family).To(Equal(test.deleteRules[i].family))
+				g.Expect(*rule.Dst).To(Equal(test.deleteRules[i].dst))
+			}
+		})
+	}
+}
+
+func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T) {
+	type testRule struct {
+		priority int
+		family   int
+		table    int
+		mark     uint32
+		dst      net.IPNet
+	}
+	type testConfig struct {
+		desc          string
+		vrftableID    int
+		v4mode        bool
+		v6mode        bool
+		expectedRules []testRule
+		deleteRules   []testRule
+	}
+
+	tests := []testConfig{
+		{
+			desc:       "v4 rule test",
+			vrftableID: 1007,
+			expectedRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
+					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+				},
+			},
+			deleteRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1007,
+					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+				},
+			},
+			v4mode: true,
+		},
+		{
+			desc:       "v6 rule test",
+			vrftableID: 1009,
+			expectedRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+				},
+			},
+			deleteRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1009,
+					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+				},
+			},
+			v6mode: true,
+		},
+		{
+			desc:       "dualstack rule test",
+			vrftableID: 1010,
+			expectedRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					mark:     0x1003,
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+				},
+			},
+			deleteRules: []testRule{
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V4,
+					table:    1010,
+					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+				},
+				{
+					priority: UDNMasqueradeIPRulePriority,
+					family:   netlink.FAMILY_V6,
+					table:    1010,
+					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+				},
+			},
+			v4mode: true,
+			v6mode: true,
+		},
+	}
+	config.Gateway.V6MasqueradeSubnet = "fd69::/112"
+	config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			g := NewWithT(t)
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+			config.IPv4Mode = test.v4mode
+			config.IPv6Mode = test.v6mode
+			cidr := ""
+			if config.IPv4Mode {
+				cidr = "100.128.0.0/16/24"
+			}
+			if config.IPv4Mode && config.IPv6Mode {
+				cidr += ",ae70::/60"
+			} else if config.IPv6Mode {
+				cidr = "ae70::/60"
+			}
+			nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+				types.Layer3Topology, cidr, types.NetworkRolePrimary)
+			ovntest.AnnotateNADWithNetworkID("3", nad)
+			netInfo, err := util.ParseNADInfo(nad)
+			g.Expect(err).ToNot(HaveOccurred())
+			mutableNetInfo := util.NewMutableNetInfo(netInfo)
+			mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{node.Name: {"bluenet"}})
+			ofm := getDummyOpenflowManager()
+			// create dummy gateway interface(Need to run this test as root)
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "breth0",
+				},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			udnGateway, err := NewUserDefinedNetworkGateway(mutableNetInfo, node, nil, nil, nil, nil, &gateway{openflowManager: ofm})
+			g.Expect(err).NotTo(HaveOccurred())
+			// delete dummy gateway interface after creating UDN gateway(Need to run this test as root)
+			err = netlink.LinkDel(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "breth0",
+				},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			udnGateway.vrfTableId = test.vrftableID
+			udnGateway.isNetworkAdvertised = true
+			udnGateway.isNetworkAdvertisedToDefaultVRF = false
+			rules, delRules, err := udnGateway.constructUDNVRFIPRules()
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(rules).To(HaveLen(len(test.expectedRules)))
 			g.Expect(delRules).To(HaveLen(len(test.deleteRules)))
@@ -1970,7 +2161,8 @@ func TestUserDefinedNetworkGateway_updateAdvertisedUDNIsolationRules(t *testing.
 			udng := &UserDefinedNetworkGateway{
 				NetInfo: netInfo,
 			}
-			err = udng.updateAdvertisedUDNIsolationRules(tt.isNetworkAdvertised)
+			udng.isNetworkAdvertised = tt.isNetworkAdvertised
+			err = udng.updateAdvertisedUDNIsolationRules()
 			g.Expect(err).NotTo(HaveOccurred())
 
 			v4Elems, err := nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV4)

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -28,6 +28,8 @@ import (
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -822,12 +824,41 @@ func (bsnc *BaseSecondaryNetworkController) buildUDNEgressSNAT(localPodSubnets [
 	networkID := bsnc.GetNetworkID()
 	// calculate MAC
 	dstMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(localPodSubnets[0]).IP)
+	dstMacMatch := getMasqueradeManagementIPSNATMatch(dstMac.String())
 
 	extIDs := map[string]string{
 		types.NetworkExternalID:  bsnc.GetNetworkName(),
 		types.TopologyExternalID: bsnc.TopologyType(),
 	}
+
+	var nodeIPsAS, svcIPsAS addressset.AddressSet
+	if isUDNAdvertised {
+		// For advertised networks, we need to SNAT any traffic leaving the
+		// pods from these networks towards the node IPs in the cluster. In
+		// order to do such a conditional SNAT, we need an address set that
+		// contains the node IPs in the cluster. Given that egressIP feature
+		// already has an address set containing these nodeIPs owned by the
+		// default network controller, let's re-use it.
+		nodeIPsASIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, DefaultNetworkControllerName)
+		nodeIPsAS, err = bsnc.addressSetFactory.GetAddressSet(nodeIPsASIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get address set with IDs %v: %w", nodeIPsASIDs, err)
+		}
+
+		// We also need to SNAT any traffic leaving the pods from these
+		// networks towards the default network service cluster IPs
+		// accessible from UDNs: we want the reply traffic to hit the
+		// masquerade IP rule rather than the UDN subnet ip rule to allow
+		// for overlaps in VRF-Lite configurations
+		svcIPsASIDs := udnenabledsvc.GetAddressSetDBIDs()
+		svcIPsAS, err = bsnc.addressSetFactory.GetAddressSet(svcIPsASIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get address set with IDs %v: %w", svcIPsASIDs, err)
+		}
+	}
+
 	for _, localPodSubnet := range localPodSubnets {
+		snatMatch := dstMacMatch
 		ipFamily := utilnet.IPv4
 		masqIP, err = udn.AllocateV4MasqueradeIPs(networkID)
 		if utilnet.IsIPv6CIDR(localPodSubnet) {
@@ -840,25 +871,24 @@ func (bsnc *BaseSecondaryNetworkController) buildUDNEgressSNAT(localPodSubnets [
 		if masqIP == nil {
 			return nil, fmt.Errorf("masquerade IP cannot be empty network %s (%d): %v", bsnc.GetNetworkName(), networkID, err)
 		}
-		if !isUDNAdvertised {
-			snats = append(snats, libovsdbops.BuildSNATWithMatch(&masqIP.ManagementPort.IP, localPodSubnet, outputPort,
-				extIDs, getMasqueradeManagementIPSNATMatch(dstMac.String())))
-		} else {
-			// For advertised networks, we need to SNAT any traffic leaving the pods from these networks towards the node IPs
-			// in the cluster. In order to do such a conditional SNAT, we need an address set that contains the node IPs in the cluster.
-			// Given that egressIP feature already has an address set containing these nodeIPs owned by the default network controller, let's re-use it.
-			dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, DefaultNetworkControllerName)
-			addrSet, err := bsnc.addressSetFactory.GetAddressSet(dbIDs)
-			if err != nil {
-				return nil, fmt.Errorf("cannot ensure that addressSet %s exists: %w", NodeIPAddrSetName, err)
-			}
-			ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := addrSet.GetASHashNames()
 
-			snats = append(snats, libovsdbops.BuildSNATWithMatch(&masqIP.ManagementPort.IP, localPodSubnet, outputPort,
-				extIDs, fmt.Sprintf("%s && (%s)", getMasqueradeManagementIPSNATMatch(dstMac.String()),
-					getClusterNodesDestinationBasedSNATMatch(ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS, ipFamily))))
+		if isUDNAdvertised {
+			additionalSNATMatch := getClusterNodesDestinationBasedSNATMatch(ipFamily, nodeIPsAS, svcIPsAS)
+			if additionalSNATMatch != "" {
+				snatMatch = fmt.Sprintf("%s && %s", snatMatch, additionalSNATMatch)
+			}
 		}
+
+		snat := libovsdbops.BuildSNATWithMatch(
+			&masqIP.ManagementPort.IP,
+			localPodSubnet,
+			outputPort,
+			extIDs,
+			snatMatch,
+		)
+		snats = append(snats, snat)
 	}
+
 	return snats, nil
 }
 
@@ -866,15 +896,28 @@ func getMasqueradeManagementIPSNATMatch(dstMac string) string {
 	return fmt.Sprintf("eth.dst == %s", dstMac)
 }
 
-// getClusterNodesDestinationBasedSNATMatch creates destination-based SNAT match for the specified IP family
-func getClusterNodesDestinationBasedSNATMatch(ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS string, ipFamily utilnet.IPFamily) string {
-	var match string
-	if ipFamily == utilnet.IPv4 {
-		match = fmt.Sprintf("ip4.dst == $%s", ipv4ClusterNodeIPAS)
-	} else {
-		match = fmt.Sprintf("ip6.dst == $%s", ipv6ClusterNodeIPAS)
+// getClusterNodesDestinationBasedSNATMatch creates destination-based SNAT match
+// for the specified IP family. Returns an empty string if there is no address
+// set for the provided IP family.
+func getClusterNodesDestinationBasedSNATMatch(ipFamily utilnet.IPFamily, addressSets ...addressset.AddressSet) string {
+	asMatches := make([]string, 0, len(addressSets))
+	for _, as := range addressSets {
+		asIPv4, asIPv6 := as.GetASHashNames()
+		switch {
+		case ipFamily == utilnet.IPv4 && asIPv4 != "":
+			asMatches = append(asMatches, fmt.Sprintf("ip4.dst == $%s", asIPv4))
+		case ipFamily == utilnet.IPv6 && asIPv6 != "":
+			asMatches = append(asMatches, fmt.Sprintf("ip6.dst == $%s", asIPv6))
+		}
 	}
-	return match
+	switch len(asMatches) {
+	case 0:
+		return ""
+	case 1:
+		return asMatches[0]
+	default:
+		return fmt.Sprintf("(%s)", strings.Join(asMatches, " || "))
+	}
 }
 
 func (bsnc *BaseSecondaryNetworkController) ensureDHCP(pod *corev1.Pod, podAnnotation *util.PodAnnotation, lsp *nbdb.LogicalSwitchPort) error {


### PR DESCRIPTION
Just as we currently do with traffic towards nodes.

Specifically this allows for networks advertised with a VRF-Lite configuration with a subnet overlap to reach these services. Otherwise the return path could hit an ip rule corresponding to a different advertised network forwarding it to an inappropriate destination.

This undoes the revert of from https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5284. This PR was removing the ip rule for a VRF-Lite configured subnet, precisely to allow overlaps as well. However doing that without the SNAT implemented in this PR broke VRF-Lite configured network to kapi/dns traffic. For the original commit,  some minor conflicts are resolved here related to the fact that networks advertised on the default VRF only had the network subnet ip rule at the time, but since then that changed to having both the network subnet and the masquerade ip rule. So when this commit was implemented we had
```
// When a network is not advertised, an example of the rules
// we set for it is:
// 2000:	from all fwmark 0x1001 lookup 1007
// 2000:	from all to 169.254.0.12 lookup 1007
//
// When a network is advertised, an example of the rules
// we set for it is:
// 2000:	from all fwmark 0x1001 lookup 1007
// 2000:	from all to 10.132.0.0/14 lookup 1007
```
but then it changed to
```
// When a network is not advertised, an example of the rules
// we set for it is:
// 2000:	from all fwmark 0x1001 lookup 1007
// 2000:	from all to 169.254.0.12 lookup 1007
//
// When a network is advertised, an example of the rules
// we set for it is:
// 2000:	from all fwmark 0x1001 lookup 1007
// 2000:	from all to 169.254.0.12 lookup 1007
// 2000:	from all to 10.132.0.0/14 lookup 1007
```
making this commit for VRF-Lite a special case of the first scenario, making things a bit more nuanced:
```
// When a network is not advertised on the default VRF, an example of the rules
// we set for it is:
// 2000:	from all fwmark 0x1001 lookup 1007
// 2000:	from all to 169.254.0.12 lookup 1007
//
// When a network is advertised on the default VRF, an example of the rules
// we set for it is:
// 2000:	from all fwmark 0x1001 lookup 1007
// 2000:	from all to 10.132.0.0/14 lookup 1007
// 2000:	from all to 169.254.0.12 lookup 1007
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UDN egress SNAT now uses address-set–based destination matching for more accurate outbound NAT.

* **Refactor**
  * Centralized, cached network-advertisement state for consistent reconciliation and VRF‑aware decisions.
  * VRF‑Lite aware default-route handling to avoid incorrect routes when advertised to non‑default VRFs.
  * Isolation rule management split into explicit add/delete flows for clearer rule lifecycle.

* **Tests**
  * Expanded dual‑stack coverage, added default vs non‑default VRF tests, and updated CIDR/mask expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->