### PR TITLE
OVN Kubernetes v1.1.0 Release

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -2,7 +2,7 @@
 #set -euo pipefail
 
 verify-ovsdb-raft() {
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
 
   if [[ ${ovn_db_host} == "" ]]; then
     echo "failed to retrieve the IP address of the host $(hostname). Exiting..."

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -10,7 +10,7 @@ fi
 . /root/ovndb-raft-functions.sh
 
 # This script is the entrypoint to the image.
-# Supports version 1.0.0 daemonsets
+# Supports version 1.1.0 daemonsets
 #    Keep the daemonset versioning aligned with the ovnkube release versions
 # Commands ($1 values)
 #    ovs-server     Runs the ovs daemons - ovsdb-server and ovs-switchd (v3)
@@ -28,7 +28,7 @@ fi
 #    ovn_debug      Displays ovn/ovs configuration and flows
 
 # NOTE: The script/image must be compatible with the daemonset.
-# This script supports version 1.0.0 daemonsets
+# This script supports version 1.1.0 daemonsets
 #      When called, it starts all needed daemons.
 # Currently the version here is used to match with the image version
 # It must be updated during every release
@@ -41,7 +41,7 @@ fi
 # OVN_KUBERNETES_NAMESPACE - k8s namespace - v3
 # K8S_NODE - hostname of the node - v3
 #
-# OVN_DAEMONSET_VERSION - version match daemonset and image - v1.0.0
+# OVN_DAEMONSET_VERSION - version match daemonset and image - v1.1.0
 # K8S_TOKEN - the apiserver token. Automatically detected when running in a pod - v3
 # K8S_CACERT - the apiserver CA. Automatically detected when running in a pod - v3
 # OVN_CONTROLLER_OPTS - the options for ovn-ctl
@@ -121,11 +121,11 @@ ovnkube_logfile_maxage=${OVNKUBE_LOGFILE_MAXAGE:-"5"}
 ovnkube_libovsdb_client_logfile=${OVNKUBE_LIBOVSDB_CLIENT_LOGFILE:-}
 
 # ovnkube.sh version (Update during each release)
-ovnkube_version="1.0.0"
+ovnkube_version="1.1.0"
 
 # The daemonset version must be compatible with this script.
 # The default when OVN_DAEMONSET_VERSION is not set is version 3
-ovn_daemonset_version=${OVN_DAEMONSET_VERSION:-"1.0.0"}
+ovn_daemonset_version=${OVN_DAEMONSET_VERSION:-"1.1.0"}
 
 # hostname is the host's hostname when using host networking,
 # This is useful on the master
@@ -834,10 +834,10 @@ function get_ovnkube_zone_db_ep() {
   fi
 }
 
-# v1.0.0 - run nb_ovsdb in a separate container
+# v1.1.0 - run nb_ovsdb in a separate container
 nb-ovsdb() {
   trap 'ovsdb_cleanup nb' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnnb_db.pid
 
   if [[ ${ovn_db_host} == "" ]]; then
@@ -887,10 +887,10 @@ nb-ovsdb() {
   echo "=============== run nb_ovsdb ========== terminated"
 }
 
-# v1.0.0 - run sb_ovsdb in a separate container
+# v1.1.0 - run sb_ovsdb in a separate container
 sb-ovsdb() {
   trap 'ovsdb_cleanup sb' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnsb_db.pid
 
   if [[ ${ovn_db_host} == "" ]]; then
@@ -928,10 +928,10 @@ sb-ovsdb() {
   echo "=============== run sb_ovsdb ========== terminated"
 }
 
-# v1.0.0 - Runs ovn-dbchecker on ovnkube-db pod.
+# v1.1.0 - Runs ovn-dbchecker on ovnkube-db pod.
 ovn-dbchecker() {
   trap 'kill $(jobs -p); exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovn-dbchecker.pid
 
   # wait for ready_to_start_node
@@ -982,7 +982,7 @@ ovn-dbchecker() {
 # unix sockets
 local-nb-ovsdb() {
   trap 'ovsdb_cleanup nb' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnnb_db.pid
 
   echo "=============== run nb-ovsdb (unix sockets only) =========="
@@ -1016,7 +1016,7 @@ local-nb-ovsdb() {
 # unix sockets
 local-sb-ovsdb() {
   trap 'ovsdb_cleanup sb' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnsb_db.pid
 
   echo "=============== run sb-ovsdb (unix sockets only) ========== "
@@ -1034,10 +1034,10 @@ local-sb-ovsdb() {
   echo "=============== run sb-ovsdb (unix sockets only) ========== terminated"
 }
 
-# v1.0.0 - Runs northd on master. Does not run nb_ovsdb, and sb_ovsdb
+# v1.1.0 - Runs northd on master. Does not run nb_ovsdb, and sb_ovsdb
 run-ovn-northd() {
   trap 'ovn-appctl -t ovn-northd exit >/dev/null 2>&1; exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovn-northd.pid
   rm -f ${OVN_RUNDIR}/ovn-northd.*.ctl
 
@@ -1086,10 +1086,10 @@ run-ovn-northd() {
   exit 8
 }
 
-# v1.0.0 -  run ovnkube-identity
+# v1.1.0 -  run ovnkube-identity
 ovnkube-identity() {
     trap 'kill $(jobs -p); exit 0' TERM
-    check_ovn_daemonset_version "1.0.0"
+    check_ovn_daemonset_version "1.1.0"
     rm -f ${OVN_RUNDIR}/ovnkube-identity.pid
 
     ovnkube_enable_interconnect_flag=
@@ -1116,10 +1116,10 @@ ovnkube-identity() {
     exit 9
 }
 
-# v1.0.0 - run ovnkube --master (both cluster-manager and ovnkube-controller)
+# v1.1.0 - run ovnkube --master (both cluster-manager and ovnkube-controller)
 ovn-master() {
   trap 'kill $(jobs -p); exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnkube-master.pid
 
   echo "=============== ovn-master (wait for ready_to_start_node) ========== MASTER ONLY"
@@ -1402,10 +1402,10 @@ ovn-master() {
   exit 9
 }
 
-# v1.0.0 - run ovnkube --ovnkube-controller
+# v1.1.0 - run ovnkube --ovnkube-controller
 ovnkube-controller() {
   trap 'kill $(jobs -p); exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnkube-controller.pid
 
   echo "=============== ovnkube-controller (wait for ready_to_start_node) =========="
@@ -1718,7 +1718,7 @@ ovnkube-controller() {
 
 ovnkube-controller-with-node() {
   trap 'kill $(jobs -p) ; rm -f /etc/cni/net.d/10-ovn-kubernetes.conf ; exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnkube-controller-with-node.pid
 
   if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
@@ -2194,7 +2194,7 @@ ovnkube-controller-with-node() {
 # run ovnkube --cluster-manager.
 ovn-cluster-manager() {
   trap 'kill $(jobs -p); exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
 
   ovn_encap_port_flag=
     if [[ -n "${ovn_encap_port}" ]]; then
@@ -2409,7 +2409,7 @@ ovn-cluster-manager() {
 
 # ovn-controller - all nodes
 ovn-controller() {
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovn-controller.pid
 
   echo "=============== ovn-controller - (wait for ovs)"
@@ -2452,7 +2452,7 @@ ovn-controller() {
 # ovn-node - all nodes
 ovn-node() {
   trap 'kill $(jobs -p) ; rm -f /etc/cni/net.d/10-ovn-kubernetes.conf ; exit 0' TERM
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
   rm -f ${OVN_RUNDIR}/ovnkube.pid
 
   if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
@@ -2843,7 +2843,7 @@ ovn-node() {
 
 # cleanup-ovn-node - all nodes
 cleanup-ovn-node() {
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
 
   rm -f /etc/cni/net.d/10-ovn-kubernetes.conf
 
@@ -2867,9 +2867,9 @@ cleanup-ovn-node() {
 
 }
 
-# v1.0.0 - Runs ovn-kube-util in daemon mode to export prometheus metrics related to OVS.
+# v1.1.0 - Runs ovn-kube-util in daemon mode to export prometheus metrics related to OVS.
 ovs-metrics() {
-  check_ovn_daemonset_version "1.0.0"
+  check_ovn_daemonset_version "1.1.0"
 
   echo "=============== ovs-metrics - (wait for ovs_ready)"
   wait_for_event ovs_ready

--- a/dist/images/run-ovn-dpu.sh
+++ b/dist/images/run-ovn-dpu.sh
@@ -1,7 +1,7 @@
 docker run --pid host --network host --user=0 --name ovn -dit --cap-add=SYS_NICE -v /var/run/dbus:/var/run/dbus:ro -v \
  /var/log/openvswitch:/var/log/openvswitch -v /var/log/openvswitch:/var/log/ovn -v  \
  /var/run/openvswitch:/var/run/openvswitch -v /var/run/openvswitch:/var/run/ovn -v $K8S_CACERT:$K8S_CACERT -v \
- /etc/ovn:/ovn-cert:ro -e OVN_DAEMONSET_VERSION=1.0.0 -e OVN_LOGLEVEL_CONTROLLER="-vconsole:info" \
+ /etc/ovn:/ovn-cert:ro -e OVN_DAEMONSET_VERSION=1.1.0 -e OVN_LOGLEVEL_CONTROLLER="-vconsole:info" \
  -e K8S_APISERVER=$K8S_APISERVER -e OVN_KUBERNETES_NAMESPACE=ovn-kubernetes -e OVN_SSL_ENABLE=no \
  -e K8S_NODE=$K8S_NODE -e K8S_TOKEN=$K8S_TOKEN -e K8S_CACERT=$K8S_CACERT --entrypoint=/root/ovnkube.sh \
  ovn-daemonset:latest "ovn-controller"

--- a/dist/images/run-ovnkube-node-dpu.sh
+++ b/dist/images/run-ovnkube-node-dpu.sh
@@ -3,7 +3,7 @@ docker run --pid host --network host --user=0 --name ovn-node -dit --cap-add=NET
   -v /var/log/ovn-kubernetes:/var/log/ovn-kubernetes  -v /var/run/openvswitch:/var/run/openvswitch/ \
   -v /var/run/openvswitch:/var/run/ovn/ -v /var/run/ovn-kubernetes:/var/run/ovn-kubernetes \
   -v /etc/ovn:/ovn-cert:ro -v /var/lib/openvswitch:/etc/openvswitch:ro -v /var/lib/openvswitch:/etc/ovn:ro \
-  -e OVN_DAEMONSET_VERSION=1.0.0 -e OVN_LOGLEVEL_CONTROLLER="-vconsole:info" \
+  -e OVN_DAEMONSET_VERSION=1.1.0 -e OVN_LOGLEVEL_CONTROLLER="-vconsole:info" \
   -e OVN_NET_CIDR=$OVN_NET_CIDR -e OVN_SVC_CIDR=$OVN_SVC_CIDR -e K8S_NODE=$K8S_NODE  \
   -e OVN_GATEWAY_MODE="shared" -e OVN_GATEWAY_ROUTER_SUBNET=$OVN_GATEWAY_ROUTER_SUBNET \
   -e OVN_REMOTE_PROBE_INTERVAL=100000 -e K8S_APISERVER=$K8S_APISERVER \

--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -85,7 +85,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_master_loglevel }}"
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -139,7 +139,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
@@ -218,7 +218,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
@@ -285,7 +285,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovn_dbchecker_loglevel }}"
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -104,7 +104,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
@@ -175,7 +175,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER

--- a/dist/templates/ovnkube-identity.yaml.j2
+++ b/dist/templates/ovnkube-identity.yaml.j2
@@ -53,7 +53,7 @@ spec:
             name: webhook-cert
         env:
           - name: OVN_DAEMONSET_VERSION
-            value: "1.0.0"
+            value: "1.1.0"
           - name: K8S_APISERVER
             valueFrom:
               configMapKeyRef:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -102,7 +102,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: "{{ ovn_loglevel_northd }}"
         - name: K8S_APISERVER
@@ -199,7 +199,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_master_loglevel }}"
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -118,7 +118,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_node_loglevel }}"
         - name: OVNKUBE_LOGFILE_MAXSIZE
@@ -324,7 +324,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_CONTROLLER
           value: "{{ ovn_loglevel_controller }}"
         - name: K8S_APISERVER
@@ -383,7 +383,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -74,7 +74,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: OVN_NORTHD_BACKOFF_INTERVAL
@@ -148,7 +148,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
@@ -215,7 +215,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: "{{ ovn_loglevel_northd }}"
         - name: K8S_APISERVER
@@ -312,7 +312,7 @@ spec:
         - name: OVN_EGRESSSERVICE_ENABLE
           value: "{{ ovn_egress_service_enable }}"
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_node_loglevel }}"
         - name: OVNKUBE_LOGFILE_MAXSIZE
@@ -512,7 +512,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_CONTROLLER
           value: "{{ ovn_loglevel_controller }}"
         - name: K8S_APISERVER
@@ -568,7 +568,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -92,7 +92,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: OVN_NORTHD_BACKOFF_INTERVAL
@@ -162,7 +162,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
@@ -229,7 +229,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: "{{ ovn_loglevel_northd }}"
         - name: K8S_APISERVER
@@ -287,7 +287,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_local_loglevel }}"
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/dist/templates/ovs-node.yaml.j2
+++ b/dist/templates/ovs-node.yaml.j2
@@ -90,7 +90,7 @@ spec:
             memory: 500Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         lifecycle:
           preStop:
             exec:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -53,7 +53,7 @@ var (
 	// ovn-kubernetes build date
 	BuildDate = ""
 	// ovn-kubernetes version, to be changed with every release
-	Version = "1.0.0"
+	Version = "1.1.0"
 	// version of the go runtime used to compile ovn-kubernetes
 	GoVersion = runtime.Version()
 	// os and architecture used to build ovn-kubernetes

--- a/helm/ovn-kubernetes/Chart.yaml
+++ b/helm/ovn-kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ovn-kubernetes
 description: Helm chart to deploy ovn-kubernetes cni
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"
 home: https://ovn-kubernetes.io/
 icon: https://www.ovn.org/images/ovn-logo.png
 annotations:
@@ -13,50 +13,50 @@ sources:
   - https://github.com/ovn-org/ovn
 dependencies:
   - name: ovn-ipsec
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovn-ipsec
   - name: ovnkube-control-plane
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-control-plane
   - name: ovnkube-db
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-db
   - name: ovnkube-db-raft
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-db-raft
   - name: ovnkube-identity
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-identity
   - name: ovnkube-master
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-master
   - name: ovnkube-node
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-node
   - name: ovnkube-node-dpu
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-node-dpu
   - name: ovnkube-node-dpu-host
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-node-dpu-host
   - name: ovnkube-single-node-zone
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-single-node-zone
   - name: ovnkube-zone-controller
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovnkube-zone-controller
   - name: ovs-node
-    version: 1.0.0
+    version: 1.1.0
     tags:
       - ovs-node

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -2,7 +2,7 @@
 
 -----------------------
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 **Homepage:** <https://ovn-kubernetes.io/>
 

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovn-ipsec
 description: Helm chart to deploy ovn ipsec
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-control-plane
 description: Helm chart to deploy ovnkube-cluster-manager (only if interconnect is enabled)
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -72,7 +72,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.logLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-db-raft
 description: Helm chart to build raft based ovnkube db
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/statefulset.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel }}
         - name: K8S_APISERVER
@@ -171,7 +171,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel }}
         - name: K8S_APISERVER
@@ -237,7 +237,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.dbCheckerLogLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/helm/ovn-kubernetes/charts/ovnkube-db/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-db
 description: Helm chart for standalone ovnkube-db
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel }}
         - name: K8S_APISERVER
@@ -146,7 +146,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel }}
         - name: K8S_APISERVER

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-identity
 description: Helm chart to deploy ovnkube identity
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -58,7 +58,7 @@ spec:
             name: webhook-cert
         env:
           - name: OVN_DAEMONSET_VERSION
-            value: "1.0.0"
+            value: "1.1.0"
           - name: K8S_APISERVER
             valueFrom:
               configMapKeyRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-master/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-master
 description: Helm chart to deploy ovnkube-master
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -80,7 +80,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
         - name: K8S_APISERVER
@@ -176,7 +176,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.logLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-node-dpu-host
 description: Helm chart to deploy ovnkube-node-dpu-host
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -103,7 +103,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.logLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-node-dpu
 description: Helm chart to deploy ovnkube-node-dpu
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -114,7 +114,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.logLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE
@@ -284,7 +284,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_CONTROLLER
           value: {{ default "-vconsole:info" .Values.ovnControllerLogLevel | quote }}
         - name: K8S_APISERVER
@@ -333,7 +333,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-node/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: ovnkube-node
 description: Subchart for ovnkube-node
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -114,7 +114,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.logLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE
@@ -286,7 +286,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_CONTROLLER
           value: {{ default "-vconsole:info" .Values.ovnControllerLogLevel | quote }}
         - name: K8S_APISERVER
@@ -335,7 +335,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-single-node-zone
 description: Helm chart to deploy single node zone stack
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -74,7 +74,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel | quote }}
         - name: K8S_APISERVER
@@ -136,7 +136,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel | quote }}
         - name: K8S_APISERVER
@@ -197,7 +197,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
         - name: K8S_APISERVER
@@ -289,7 +289,7 @@ spec:
         - name: OVN_EGRESSSERVICE_ENABLE
           value: {{ default "" .Values.global.enableEgressService | quote }}
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.ovnkubeNodeLogLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE
@@ -481,7 +481,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_CONTROLLER
           value: {{ default "-vconsole:info" .Values.ovnControllerLogLevel | quote }}
         - name: K8S_APISERVER
@@ -530,7 +530,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovnkube-zone-controller
 description: Helm chart to deploy zone controller
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -79,7 +79,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NB
           value:  {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel | quote }}
         - name: K8S_APISERVER
@@ -141,7 +141,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_SB
           value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel | quote }}
         - name: K8S_APISERVER
@@ -202,7 +202,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
         - name: K8S_APISERVER
@@ -255,7 +255,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         - name: OVNKUBE_LOGLEVEL
           value: {{ default 4 .Values.ovnkubeLocalLogLevel | quote }}
         - name: OVNKUBE_LOGFILE_MAXSIZE

--- a/helm/ovn-kubernetes/charts/ovs-node/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ovs-node
 description: Helm chart to deploy ovs
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"

--- a/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
@@ -89,7 +89,7 @@ spec:
             memory: 500Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0"
+          value: "1.1.0"
         lifecycle:
           preStop:
             exec:

--- a/helm/sdn-dashboard/Chart.yaml
+++ b/helm/sdn-dashboard/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: "v2"
 description: "A Helm chart for sdn-dashboard"
 name: "sdn-dashboard"
-version: "1.0.0"
+version: "1.1.0"
 home: https://www.ovn.org/
 sources:
   - https://github.com/ovn-org/ovn-kubernetes
-appVersion: "1.0.0"
+appVersion: "1.1.0"


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->

This PR updates the necessary plumbing for OVN-Kubernetes release cut to 1.1 branch.

```
Version: 1.1.0
Git commit: 856f027c42a1431e886cd05dd237324dc8ee7bd6
Git branch: release-1.1
Go version: go1.24.5
Build date: 2025-08-08
OS/Arch: linux amd64
```

## Additional Information for reviewers

Once the branch is cut, we'd need a 1.1 branch specific PR to update the workflow for CI to run on 1.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated all chart and application version numbers from 1.0.0 to 1.1.0 across the platform, including documentation and metadata.
  * Updated environment variables in deployment and container specifications to reflect the new version (1.1.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->