### PR TITLE
Restore "Fixes FDB learning" commit after bridge refactoring

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -525,7 +525,7 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 			actions += "output:" + netConfig.OfPortPatch + ","
 		}
 
-		actions += strip_vlan + "output:" + ofPortHost
+		actions += strip_vlan + "NORMAL"
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=10, table=0, %s dl_dst=%s, actions=%s",
 				nodetypes.DefaultOpenFlowCookie, match_vlan, bridgeMacAddress, actions))


### PR DESCRIPTION
Let's restore commit 813e2800dd840c8d678c5bb79f116c5ebda2ec0d, which didn't make it to the bridgeconfig refactoring (https://github.com/ovn-kubernetes/ovn-kubernetes/commit/28f9c1eccc0e72fadfee4c19db00f0bb02748223)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated packet forwarding behavior to use a standard forwarding action, improving how packets destined to the bridge MAC address are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->