### PR TITLE
Default kind and kind-helm scripts to be interconnect

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -845,3 +845,9 @@ EOF
     done
   fi
 }
+
+interconnect_arg_check() {
+  if [ "${IC_ARG_PROVIDED:-}" = "true" ]; then
+    echo "INFO: Interconnect mode is now the default mode, you do not need to use pass -ic or --enable-interconnect anymore"
+  fi
+}

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -55,6 +55,37 @@ run_kubectl() {
   done
 }
 
+setup_kubectl_bin() {
+    ###########################################################################
+    # Description:                                                            #
+    # setup kubectl for querying the cluster                                  #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   $1 - error message if not provided, it will just exit                 #
+    ###########################################################################
+    if [ ! -d "./bin" ]
+    then
+        mkdir -p ./bin
+        if_error_exit "Failed to create bin dir!"
+    fi
+
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        OS_TYPE="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        OS_TYPE="darwin"
+    fi
+
+    pushd ./bin
+       if [ ! -f ./kubectl ]; then
+           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS_TYPE}/${ARCH}/kubectl"
+           if_error_exit "Failed to download kubectl failed!"
+       fi
+    popd
+
+    chmod +x ./bin/kubectl
+    export PATH=${PATH}:$(pwd)/bin
+}
+
 command_exists() {
   cmd="$1"
   command -v ${cmd} >/dev/null 2>&1

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -255,15 +255,23 @@ print_params() {
 }
 
 check_dependencies() {
-    for cmd in $OCI_BIN kubectl kind helm go ; do \
-         if ! command_exists $cmd ; then
-           2&>1 echo "Dependency not met: $cmd"
+    if ! command_exists kubectl ; then
+      echo "'kubectl' not found, installing"
+      setup_kubectl_bin
+    fi
+
+    for cmd in "$OCI_BIN" kind helm go ; do \
+         if ! command_exists "$cmd" ; then
+           echo "Dependency not met: $cmd"
            exit 1
         fi
     done
 
     # check for currently unsupported features
-    [ "${PLATFORM_IPV6_SUPPORT}" == "true" ] && { &>1 echo "Fatal: PLATFORM_IPV6_SUPPORT support not implemented yet"; exit 1; } ||:
+    if [ "${PLATFORM_IPV6_SUPPORT:-}" = "true" ]; then
+        echo "Fatal: PLATFORM_IPV6_SUPPORT support not implemented yet"
+        exit 1
+    fi
 }
 
 helm_prereqs() {
@@ -414,7 +422,7 @@ create_ovn_kubernetes() {
       label_ovn_single_node_zones
       value_file="values-single-node-zone.yaml"
       ovnkube_db_options=""
-    elif [[ $KIND_NUM_NODES_PER_ZONE > 1 ]]; then
+    elif [[ $KIND_NUM_NODES_PER_ZONE -gt 1 ]]; then
       label_ovn_multiple_nodes_zones
       value_file="values-multi-node-zone.yaml"
       ovnkube_db_options=""

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -6,37 +6,6 @@ DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Source the kind-common file from the same directory where this script is located
 source "${DIR}/kind-common"
 
-function setup_kubectl_bin() {
-    ###########################################################################
-    # Description:                                                            #
-    # setup kubectl for querying the cluster                                  #
-    #                                                                         #
-    # Arguments:                                                              #
-    #   $1 - error message if not provided, it will just exit                 #
-    ###########################################################################
-    if [ ! -d "./bin" ]
-    then
-        mkdir -p ./bin
-        if_error_exit "Failed to create bin dir!"
-    fi
-
-    if [[ "$OSTYPE" == "linux-gnu" ]]; then
-        OS_TYPE="linux"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        OS_TYPE="darwin"
-    fi
-
-    pushd ./bin
-       if [ ! -f ./kubectl ]; then
-           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS_TYPE}/${ARCH}/kubectl"
-           if_error_exit "Failed to download kubectl failed!"
-       fi
-    popd
-
-    chmod +x ./bin/kubectl
-    export PATH=${PATH}:$(pwd)/bin
-}
-
 # Some environments (Fedora32,31 on desktop), have problems when the cluster
 # is deleted directly with kind `kind delete cluster --name ovn`, it restarts the host.
 # The root cause is unknown, this also can not be reproduced in Ubuntu 20.04 or


### PR DESCRIPTION
- Users can still deploy legacy by passing new arguments "-ce" or "--enable-central"
- Users will get a new message at the end of script execution to inform them that they no longer need to pass "-ic" or "--enable-interconnect" if they pass these deprecated args
- Fixes bugs/incorrect bash in kind-helm script
- CI should be OK as it relies on the value of the environment variable OVN_ENABLE_INTERCONNECT for jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interconnect mode is now enabled by default for deployments.
  * Added a new command-line option to explicitly select central (legacy) deployment mode.
  * Informational message provided when interconnect argument is used, indicating it is now the default.

* **Improvements**
  * Enhanced command-line argument handling for deployment mode selection with mutual exclusion enforcement.
  * Automatic installation of kubectl if missing (in one deployment script).
  * Improved error messages and help output for better clarity.

* **Bug Fixes**
  * Corrected numeric comparison for node count configuration.

* **Chores**
  * Removed redundant local kubectl setup in one deployment script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->