### PR TITLE
Revert "Skipped conformance tests for upgrade CI"

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -47,23 +47,6 @@ should resolve connection reset issue #74839
 # TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/129049
 Services should be able to switch session affinity for NodePort service
 
-# FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5460
-# Skipping tests for now, commit to be reverted once kube rebase to 1.33 completes
-# TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/130181
-should update the ephemeral containers in an existing pod 
-will start an ephemeral container in an existing pod
-
-# FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5460
-# Skipping test for now, commit to be reverted once kube rebase to 1.33 completes
-# TO BE FIXED BY https://github.com/kubernetes/kubernetes/commit/3698050dc799a3c81a50ef050e763bade4184c4d
-# Could not determine why the failure is happening in 1.32 but the test does pass in 1.33
-should work with a search path containing an underscore and a search path with a single dot
-
-# FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5460
-# Skipping test for now, commit to be reverted once kube rebase to 1.33 completes
-# TO BE FIXED BY backport of https://github.com/kubernetes/kubernetes/pull/128850
-should connect to the named ports exposed by restartable init containers
-
 # api flakes
 sig-api-machinery
 


### PR DESCRIPTION
This reverts commit e307c17fddf5da02f8df0aa3064dbad88b4c0f89 that was added to skip the tests that failed in 1.32
The tests failed in upgrade CI. They are expected to pass post kube rebase to 1.33.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Enabled skipped tests
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5460 

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled several previously skipped end-to-end tests related to ephemeral containers, search paths, and named ports in init containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->