### PR TITLE
Allow docker build on release-1.1 branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: ovn-docker-images
 
 on:
   push:
-    branches: [ master,release-1.0 ]
+    branches: [ master,release-1.0,release-1.1 ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Same as https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4441

This ensures that when PRs are merged into the release-1.1 branch, the CI will run to build and push Docker images for 1.1 tag

/cc @kyrtapz or @ricky-rav this is the last PR we want

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated build and release workflow to run on the release-1.1 branch in addition to master and release-1.0. This ensures builds and artifacts are produced for the new release line. No changes to app functionality; end users will not see interface or feature differences from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->