### PR TITLE
Update makefile go version

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -11,7 +11,7 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
-GO_VERSION ?= 1.23
+GO_VERSION ?= 1.24
 GO_DOCKER_IMG = quay.io/lib/golang:${GO_VERSION}
 # CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
 # podman/docker is installed on the system.


### PR DESCRIPTION
```
$ make test
podman run -it --rm --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN --privileged -v /home/surya/go/src/github.com/ovn-org/ovn-kubernetes:/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS= -e GINKGO_FOCUS="" quay.io/lib/golang:1.23 sh -c "RACE=1 DOCKER_TEST=1 COVERALLS= PKGS="" hack/test-go.sh focus \"\" "
go: go.mod requires go >= 1.24.0 (running go 1.23.6; GOTOOLCHAIN=local)
```

@pperiyasamy @asood-rh we missed a spot during kube rebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded Go toolchain used for builds and tests from 1.23 to 1.24.
  - Aligns containerized build environment with the latest Go release for improved performance, security updates, and compatibility with current dependencies.
  - No functional changes to runtime behavior or public APIs.
  - No action required for users; the release remains backward-compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->