### PR TITLE
Fix mgmt port allocation with VFs provided as resource for DPU

### DIFF
--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -35,6 +35,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeGatewayMtuSupport:          nil,
 	util.OvnNodeManagementPort:             nil,
 	util.OvnNodeDontSNATSubnets:            nil,
+	util.OVNNodePrimaryDPUHostAddr:         nil,
 	util.OvnNodeChassisID: func(v annotationChange, _ string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)


### PR DESCRIPTION
## 📑 Description
This PR fixes several issues when allocating the management port with a SR-IOV resource instead of hard coding the SR-IOV netdev name.
    
Such issues come from the fact that the gateway and management port interfaces need to be present during Init. Otherwise other parts of the code will not have the proper interface.

Also Fix Node Admission Webhook for OVNNodePrimaryDPUHostAddr annotation.

## How to verify it
Run ovn-kubernetes with the NVIDIA BF3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically derives the gateway interface from the management port when running in DPU host mode (when configured).
  * Allows the OVN node primary DPU host address annotation to be set.
* **Refactor**
  * Resolves management port device and gateway interface during initialization for earlier, consistent setup.
  * Adds clearer logs for explicit overrides and resource-derived configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->