### PR TITLE
docs: Add Member role to governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,13 +6,16 @@ This governance explains how the project is run.
 
 - [Values](#values)
 - [Maintainers](#maintainers)
-- [Becoming a Maintainer](#becoming-a-maintainer)
+  - [Becoming a Maintainer](#becoming-a-maintainer)
+  - [Removing a Maintainer](#removing-a-maintainer)
+- [Members](#members)
+  - [Becoming a Member](#becoming-a-member)
+  - [Removing a Member](#removing-a-member)
 - [Meetings](#meetings)
-- [CNCF Resources](#cncf-resources)
-- [Code of Conduct Enforcement](#code-of-conduct)
+- [Code of Conduct](#code-of-conduct)
 - [Security Response Team](#security-response-team)
 - [Voting](#voting)
-- [Modifications](#modifying-this-charter)
+- [Modifying this Charter](#modifying-this-charter)
 
 ## Values
 
@@ -93,6 +96,42 @@ A Maintainer may be removed at any time by a 2/3 vote of the remaining maintaine
 Depending on the reason for removal, a Maintainer may be converted to Emeritus
 status.  Emeritus Maintainers will still be consulted on some project matters,
 and can be rapidly returned to Maintainer status if their availability changes.
+
+## Members
+
+Members are active contributors who have shown a commitment to the project. They
+have privileges to review pull requests and are part of the
+`ovn-kubernetes/ovn-kubernetes-members` GitHub team, which makes them eligible
+for automatic PR review assignments. Members are not Maintainers, but they are
+expected to contribute to the project and collaborate with the team.
+
+### Becoming a Member
+
+To become a Member, you need to demonstrate the following:
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews
+      for 3 months or more,
+    * perform reviews for 5 non-trivial pull requests,
+    * contribute 10 non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team (e.g., participate in project meetings,
+    join discussion in the CNCF slack channel, etc.),
+  * understanding of how the team works (policies, processes for testing and
+    code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+
+A new Member must be proposed by an existing maintainer by sending a message to
+the developer mailing list. The application is approved with two affirmative
+votes from current maintainers.
+
+### Removing a Member
+
+Members may resign at any time.
+
+Members may also be removed after being inactive for a period of 6 months or
+more, for failure to fulfill their responsibilities, or for violating the Code
+of Conduct. A Member may be removed at any time by a simple majority vote of the
+maintainers.
 
 ## Meetings
 


### PR DESCRIPTION
This change introduces a new 'Member' role to the project's governance.

This new role is for individuals who have shown a sustained commitment to the project but are not yet Maintainers.

The update to GOVERNANCE.md includes:
- A definition of the Member role and its responsibilities.
- Clear criteria for becoming a Member.
- The process for removing a Member.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
