### PR TITLE
Change networks to relatively rare CIDR ranges

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1548,9 +1548,9 @@ fi
 			cudn       *udnv1.ClusterUserDefinedNetwork
 			vm         *kubevirtv1.VirtualMachine
 			vmi        *kubevirtv1.VirtualMachineInstance
-			cidrIPv4   = "10.128.0.0/24"
+			cidrIPv4   = "172.31.0.0/24" // subnet in private range 172.16.0.0/12 (rfc1918)
 			cidrIPv6   = "2010:100:200::0/60"
-			staticIPv4 = "10.128.0.101"
+			staticIPv4 = "172.31.0.101"
 			staticIPv6 = "2010:100:200::101"
 			staticMAC  = "02:00:00:00:00:01"
 			restart    = testCommand{
@@ -2094,7 +2094,7 @@ ip route add %[3]s via %[4]s
 	Context("with kubevirt VM using layer2 UDPN", Ordered, func() {
 		var (
 			podName                 = "virt-launcher-vm1"
-			cidrIPv4                = "10.128.0.0/24"
+			cidrIPv4                = "172.31.0.0/24"
 			cidrIPv6                = "2010:100:200::/60"
 			primaryUDNNetworkStatus nadapi.NetworkStatus
 			virtLauncherCommand     = func(command string) (string, error) {
@@ -2232,9 +2232,9 @@ ip route add %[3]s via %[4]s
 			Expect(removeImagesInNodes(kubevirt.FedoraContainerDiskImage)).To(Succeed())
 		})
 		var (
-			ipv4CIDR             = "10.128.0.0/24"
+			ipv4CIDR             = "172.31.0.0/24"
 			ipv6CIDR             = "2010:100:200::0/60"
-			vmiIPv4              = "10.128.0.100/24"
+			vmiIPv4              = "172.31.0.100/24"
 			vmiIPv6              = "2010:100:200::100/60"
 			vmiMAC               = "0A:58:0A:80:00:64"
 			staticIPsNetworkData = func(ips []string) (string, error) {

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -43,10 +43,10 @@ const (
 var _ = Describe("Multi Homing", feature.MultiHoming, func() {
 	const (
 		podName                      = "tinypod"
-		secondaryNetworkCIDR         = "10.128.0.0/16"
+		secondaryNetworkCIDR         = "172.31.0.0/16" // last subnet in private range 172.16.0.0/12 (rfc1918)
 		secondaryNetworkName         = "tenant-blue"
-		secondaryFlatL2IgnoreCIDR    = "10.128.0.0/29"
-		secondaryFlatL2NetworkCIDR   = "10.128.0.0/24"
+		secondaryFlatL2IgnoreCIDR    = "172.31.0.0/29"
+		secondaryFlatL2NetworkCIDR   = "172.31.0.0/24"
 		secondaryLocalnetIgnoreCIDR  = "60.128.0.0/29"
 		secondaryLocalnetNetworkCIDR = "60.128.0.0/24"
 		netPrefixLengthPerNode       = 24

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -60,13 +60,13 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 		nodeHostnameKey                     = "kubernetes.io/hostname"
 		podClusterNetPort            uint16 = 9000
 		podClusterNetDefaultPort     uint16 = 8080
-		userDefinedNetworkIPv4Subnet        = "10.128.0.0/16"
+		userDefinedNetworkIPv4Subnet        = "172.31.0.0/16" // last subnet in private range 172.16.0.0/12 (rfc1918)
 		userDefinedNetworkIPv6Subnet        = "2014:100:200::0/60"
-		customL2IPv4Gateway                 = "10.128.0.3"
+		customL2IPv4Gateway                 = "172.31.0.3"
 		customL2IPv6Gateway                 = "2014:100:200::3"
-		customL2IPv4ReservedCIDR            = "10.128.1.0/24"
+		customL2IPv4ReservedCIDR            = "172.31.1.0/24"
 		customL2IPv6ReservedCIDR            = "2014:100:200::100/120"
-		customL2IPv4InfraCIDR               = "10.128.0.0/30"
+		customL2IPv4InfraCIDR               = "172.31.0.0/30"
 		customL2IPv6InfraCIDR               = "2014:100:200::/122"
 		userDefinedNetworkName              = "hogwarts"
 		nadName                             = "gryffindor"
@@ -719,7 +719,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						"with L2 primary UDN",
 						"layer2",
 						4,
-						"10.128.0.0/29",
+						"172.31.0.0/29",
 						"2014:100:200::0/125",
 					),
 					// limit the number of pods to 10

--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -28,7 +28,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 	f.SkipNamespaceCreation = true
 	Context("a user defined primary network", func() {
 		const (
-			userDefinedNetworkIPv4Subnet = "10.128.0.0/16"
+			userDefinedNetworkIPv4Subnet = "172.31.0.0/16" // last subnet in private range 172.16.0.0/12 (rfc1918)
 			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
 			nadName                      = "gryffindor"
 		)

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -26,14 +26,14 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 	ginkgo.Context("on a user defined primary network", func() {
 		const (
 			nadName                      = "tenant-red"
-			userDefinedNetworkIPv4Subnet = "10.128.0.0/16"
+			userDefinedNetworkIPv4Subnet = "172.31.0.0/16" // last subnet in private range 172.16.0.0/12 (rfc1918)
 			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
-			customL2IPv4Gateway                 = "10.128.0.3"
-			customL2IPv6Gateway                 = "2014:100:200::3"
-			customL2IPv4ReservedCIDR            = "10.128.1.0/24"
-			customL2IPv6ReservedCIDR            = "2014:100:200::100/120"
-			customL2IPv4InfraCIDR               = "10.128.0.0/30"
-			customL2IPv6InfraCIDR               = "2014:100:200::/122"
+			customL2IPv4Gateway          = "172.31.0.3"
+			customL2IPv6Gateway          = "2014:100:200::3"
+			customL2IPv4ReservedCIDR     = "172.31.1.0/24"
+			customL2IPv6ReservedCIDR     = "2014:100:200::100/120"
+			customL2IPv4InfraCIDR        = "172.31.0.0/30"
+			customL2IPv6InfraCIDR        = "2014:100:200::/122"
 			nodeHostnameKey              = "kubernetes.io/hostname"
 			workerOneNodeName            = "ovn-worker"
 			workerTwoNodeName            = "ovn-worker2"

--- a/test/e2e/network_segmentation_preconfigured_layer2.go
+++ b/test/e2e/network_segmentation_preconfigured_layer2.go
@@ -102,32 +102,32 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 			netConfig: &networkAttachmentConfigParams{
 				name:     "custom-l2-net",
 				topology: "layer2",
-				cidr:     joinStrings("10.128.0.0/16", "2014:100:200::0/60"),
+				cidr:     joinStrings("172.31.0.0/16", "2014:100:200::0/60"),
 				role:     "primary",
 			},
-			expectedGatewayIPs: []string{"10.128.0.1", "2014:100:200::1"},
+			expectedGatewayIPs: []string{"172.31.0.1", "2014:100:200::1"},
 		}),
 		Entry("Layer2 with custom subnets", testConfig{
 			netConfig: &networkAttachmentConfigParams{
 				name:                "custom-l2-net",
 				topology:            "layer2",
-				cidr:                joinStrings("10.128.0.0/16", "2014:100:200::0/60"),
+				cidr:                joinStrings("172.31.0.0/16", "2014:100:200::0/60"),
 				role:                "primary",
-				defaultGatewayIPs:   joinStrings("10.128.0.10", "2014:100:200::100"),
-				reservedCIDRs:       joinStrings("10.128.1.0/24", "2014:100:200::/122"),
-				infrastructureCIDRs: joinStrings("10.128.0.10/30", "2014:100:200::100/122"),
+				defaultGatewayIPs:   joinStrings("172.31.0.10", "2014:100:200::100"),
+				reservedCIDRs:       joinStrings("172.31.1.0/24", "2014:100:200::/122"),
+				infrastructureCIDRs: joinStrings("172.31.0.10/30", "2014:100:200::100/122"),
 			},
-			expectedGatewayIPs: []string{"10.128.0.10", "2014:100:200::100"},
+			expectedGatewayIPs: []string{"172.31.0.10", "2014:100:200::100"},
 		}),
 		Entry("Layer2 with inverted gateway/management IPs", testConfig{
 			netConfig: &networkAttachmentConfigParams{
 				name:              "inv-gateway-net",
 				topology:          "layer2",
-				cidr:              joinStrings("10.128.0.0/16", "2014:100:200::0/60"),
+				cidr:              joinStrings("172.31.0.0/16", "2014:100:200::0/60"),
 				role:              "primary",
-				defaultGatewayIPs: joinStrings("10.128.0.2", "2014:100:200::2"),
+				defaultGatewayIPs: joinStrings("172.31.0.2", "2014:100:200::2"),
 			},
-			expectedGatewayIPs: []string{"10.128.0.2", "2014:100:200::2"},
+			expectedGatewayIPs: []string{"172.31.0.2", "2014:100:200::2"},
 		}),
 	)
 })

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -41,13 +41,13 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 			nadName                      = "tenant-red"
 			servicePort                  = 88
 			serviceTargetPort            = 80
-			userDefinedNetworkIPv4Subnet = "10.128.0.0/16"
+			userDefinedNetworkIPv4Subnet = "172.31.0.0/16" // last subnet in private range 172.16.0.0/12 (rfc1918)
 			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
-			customL2IPv4Gateway          = "10.128.0.3"
+			customL2IPv4Gateway          = "172.31.0.3"
 			customL2IPv6Gateway          = "2014:100:200::3"
-			customL2IPv4ReservedCIDR     = "10.128.1.0/24"
+			customL2IPv4ReservedCIDR     = "172.31.1.0/24"
 			customL2IPv6ReservedCIDR     = "2014:100:200::100/120"
-			customL2IPv4InfraCIDR        = "10.128.0.0/30"
+			customL2IPv4InfraCIDR        = "172.31.0.0/30"
 			customL2IPv6InfraCIDR        = "2014:100:200::/122"
 		)
 


### PR DESCRIPTION
10.128.x.x is used intensively as providers network or CDN CIDR.

Real fix is we provide tools for the tests to get
CIDRs for UDNs that dont conflict with CDN,
provider network at test run time instead of this static config..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated IPv4 CIDR ranges in end-to-end tests from 10.128.x.x to 172.31.x.x (e.g., /16, /24, /29) across KubeVirt, multihoming, and network-segmentation suites; inline note added that 172.16.0.0/12 is RFC1918.
  * Adjusted corresponding static IPs, gateways and CIDR-derived test data; IPv6 ranges, test logic and control flow remain unchanged.
  * No changes to public APIs or exported declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->