### PR TITLE
Revert "Skip session affinity conformance test"

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -44,9 +44,6 @@ service.kubernetes.io/headless
 # TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/95351
 should resolve connection reset issue #74839
 
-# TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/129049
-Services should be able to switch session affinity for NodePort service
-
 # api flakes
 sig-api-machinery
 


### PR DESCRIPTION
This reverts commit 089009ce060d31f3d2ede8a9f575be0b974219b7.
The test was fixed in https://github.com/kubernetes/kubernetes/pull/129049 and now as we have done k8s 1.33 bump https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5319 it should be in.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4965

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Removed outdated comment references in the e2e-kind script (Kubernetes PR and session affinity note). This is a non-functional cleanup with no changes to test flow, logic, or results.
* Chores
  * Tidied internal test script comments to improve maintainability. No impact on features, settings, performance, or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->