### PR TITLE
Ensure that UDN update events trigger updates for NAD annotations correctly

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -445,6 +445,63 @@ var _ = Describe("User Defined Network Controller", func() {
 				}
 			})
 
+			It("should update NAD annotations and preserve internal OVNK annotations on UDN update", func() {
+				testNamespaces := []string{"red", "blue"}
+				var objs []runtime.Object
+				for _, nsName := range testNamespaces {
+					objs = append(objs, testNamespace(nsName))
+				}
+				cudn := testClusterUDN("test", testNamespaces...)
+				cudn.Spec.Network = udnv1.NetworkSpec{Topology: udnv1.NetworkTopologyLayer2, Layer2: &udnv1.Layer2Config{
+					Subnets: udnv1.DualStackCIDRs{"10.10.10.0/24"},
+				}}
+				cudn.Annotations = map[string]string{"foo": "bar"}
+
+				objs = append(objs, cudn)
+				networkName := ovntypes.CUDNPrefix + cudn.Name
+				expectedNsNADs := map[string]*netv1.NetworkAttachmentDefinition{}
+				for _, nsName := range testNamespaces {
+					nad := testClusterUdnNAD(cudn.Name, nsName)
+					nadName := nsName + "/" + cudn.Name
+					nad.Spec.Config = `{"cniVersion":"1.0.0","name":"` + networkName + `","netAttachDefName":"` + nadName + `","role":"","subnets":"10.10.10.0/24","topology":"layer2","type":"ovn-k8s-cni-overlay"}`
+					nad.Annotations = map[string]string{
+						"foo":                             "bar",
+						ovntypes.OvnNetworkNameAnnotation: networkName,
+						ovntypes.OvnNetworkIDAnnotation:   "6",
+					}
+					expectedNsNADs[nsName] = nad.DeepCopy()
+					objs = append(objs, nad)
+				}
+
+				c = newTestController(template.RenderNetAttachDefManifest, objs...)
+				Expect(c.Run()).To(Succeed())
+
+				By("updating CUDN with a new annotation")
+				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				updatedCUDN := cudn.DeepCopy()
+				updatedCUDN.Annotations = map[string]string{"foo2": "bar2"}
+				_, err = cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Update(context.Background(), updatedCUDN, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				for testNamespace, expectedNAD := range expectedNsNADs {
+					expectedNAD.Annotations = map[string]string{
+						"foo2":                            "bar2",
+						ovntypes.OvnNetworkNameAnnotation: networkName,
+						ovntypes.OvnNetworkIDAnnotation:   "6",
+					}
+
+					Eventually(func(g Gomega) {
+						actualNAD, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().
+							NetworkAttachmentDefinitions(testNamespace).
+							Get(context.Background(), cudn.Name, metav1.GetOptions{})
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(actualNAD).To(Equal(expectedNAD), "NAD should exist, have updated "+
+							"annotations, and preserve internal annotations")
+					}).Should(Succeed())
+				}
+			})
+
 			When("CR exist, and few connected & disconnected namespaces", func() {
 				const (
 					cudnName       = "global-network"


### PR DESCRIPTION
With b05875b1d671edb696455ef517d9a4ba1e156b9a we introduced copying the UDN annotations to the NAD, except for internal annotations (k8s.ovn.org). However, this patch missed doing this on update events.

Props to @jcaamano for finding this issue!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NetworkAttachmentDefinition updates now preserve platform/internal annotations and merge them with user annotations; controller skips updates unless config, labels, or annotations actually change.

* **Tests**
  * Added reconciliation tests confirming annotation changes propagate to NADs across namespaces while preserving internal annotations and keeping network configuration stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->