### PR TITLE
incorrect CNI result for primary UDN is returned in the unprivileged …

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -238,7 +238,7 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 			return nil, err
 		}
 		if primaryUDNPodRequest != nil {
-			err = primaryUDNCmdAddGetCNIResultFunc(response, getCNIResultFn, primaryUDNPodRequest, clientset, primaryUDNPodInfo)
+			err = primaryUDNCmdAddGetCNIResultFunc(response.Result, getCNIResultFn, primaryUDNPodRequest, clientset, primaryUDNPodInfo)
 			if err != nil {
 				return nil, err
 			}
@@ -254,24 +254,24 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 	return response, nil
 }
 
-func primaryUDNCmdAddGetCNIResultFunc(response *Response, getCNIResultFn getCNIResultFunc, primaryUDNPodRequest *PodRequest,
+func primaryUDNCmdAddGetCNIResultFunc(result *current.Result, getCNIResultFn getCNIResultFunc, primaryUDNPodRequest *PodRequest,
 	clientset PodInfoGetter, primaryUDNPodInfo *PodInterfaceInfo) error {
 	primaryUDNResult, err := getCNIResultFn(primaryUDNPodRequest, clientset, primaryUDNPodInfo)
 	if err != nil {
 		return err
 	}
 
-	response.Result.Routes = append(response.Result.Routes, primaryUDNResult.Routes...)
-	numOfInitialIPs := len(response.Result.IPs)
-	numOfInitialIfaces := len(response.Result.Interfaces)
-	response.Result.Interfaces = append(response.Result.Interfaces, primaryUDNResult.Interfaces...)
-	response.Result.IPs = append(response.Result.IPs, primaryUDNResult.IPs...)
+	result.Routes = append(result.Routes, primaryUDNResult.Routes...)
+	numOfInitialIPs := len(result.IPs)
+	numOfInitialIfaces := len(result.Interfaces)
+	result.Interfaces = append(result.Interfaces, primaryUDNResult.Interfaces...)
+	result.IPs = append(result.IPs, primaryUDNResult.IPs...)
 
 	// Offset the index of the default network IPs to correctly point to the default network interfaces
-	for i := numOfInitialIPs; i < len(response.Result.IPs); i++ {
-		ifaceIPConfig := response.Result.IPs[i].Copy()
-		if response.Result.IPs[i].Interface != nil {
-			response.Result.IPs[i].Interface = current.Int(*ifaceIPConfig.Interface + numOfInitialIfaces)
+	for i := numOfInitialIPs; i < len(result.IPs); i++ {
+		ifaceIPConfig := result.IPs[i].Copy()
+		if result.IPs[i].Interface != nil {
+			result.IPs[i].Interface = current.Int(*ifaceIPConfig.Interface + numOfInitialIfaces)
 		}
 	}
 	return nil

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -266,7 +266,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 			primaryUDNPodRequest := response.PrimaryUDNPodReq
 			primaryUDNPodRequest.ctx, primaryUDNPodRequest.cancel = context.WithCancel(pr.ctx)
 			defer primaryUDNPodRequest.cancel()
-			err = primaryUDNCmdAddGetCNIResultFunc(response, getCNIResult, primaryUDNPodRequest, clientset, response.PrimaryUDNPodInfo)
+			err = primaryUDNCmdAddGetCNIResultFunc(result, getCNIResult, primaryUDNPodRequest, clientset, response.PrimaryUDNPodInfo)
 			if err != nil {
 				klog.Error(err.Error())
 				return err

--- a/go-controller/pkg/cni/udn/resource.go
+++ b/go-controller/pkg/cni/udn/resource.go
@@ -20,12 +20,11 @@ func getPodResourceInfo(pod *corev1.Pod, resourceName string) (*types.ResourceIn
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resources allocated for pod %s from ResourceClient: %v", podDesc, err)
 	}
-	klog.V(5).Infof("ResourceMap for pod %s: %+v", pod, resourceMap)
-
 	entry, ok := resourceMap[resourceName]
 	if !ok {
 		return nil, fmt.Errorf("failed to get resources allocated for pod %s: no resources for resource %s", podDesc, resourceName)
 	}
+	klog.V(5).Infof("ResourceMap for pod %s resource %s: %+v", podDesc, resourceName, entry)
 	return entry, nil
 }
 


### PR DESCRIPTION
…mode

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how CNI results are merged during pod setup to operate directly on the computed result, reducing indirection and improving clarity. No change to user-visible behavior.

* **Logging**
  * Reduced verbosity by logging only the relevant resource entry for a pod at high log levels, decreasing noise without affecting functionality.

* **Chores**
  * Minor internal cleanups to align call sites with the new result-merging approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->