### PR TITLE
Fix naming of "Secondary" to be "User-Defined"

### DIFF
--- a/docs/features/user-defined-networks/user-defined-networks.md
+++ b/docs/features/user-defined-networks/user-defined-networks.md
@@ -58,11 +58,11 @@ This feature is enabled by default on all OVN-Kubernetes clusters.
 You don't need to do anything extra to start using this feature.
 There is a Feature Config option `--enable-network-segmentation` under
 `OVNKubernetesFeatureConfig` config that can be used to disable this
-feature. However note that disabling the feature will not remove
+feature. However, note that disabling the feature will not remove
 existing CRs in the cluster. This feature has to be enabled along with
 the flag for multiple-networks `--enable-multi-network` since UDNs
 use Network Attachment Definitions as underlying implementation detail
-construct and reuse the secondary network controllers.
+construct and reuse the user-defined network controllers.
 
 ## Workflow Description
 
@@ -339,7 +339,7 @@ default `eth0` interface of the pods:
 _uuid               : 1278b0f4-0a14-4637-9d05-83ba9df6ec03
 action              : allow
 direction           : from-lport
-external_ids        : {direction=Egress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:AllowHostARPSecondary:Egress", "k8s.ovn.org/name"=AllowHostARPSecondary, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
+external_ids        : {direction=Egress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:AllowHostARPPrimaryUDN:Egress", "k8s.ovn.org/name"=AllowHostARPPrimaryUDN, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
 label               : 0
 log                 : false
 match               : "inport == @a8747502060113802905 && (( arp && arp.tpa == 10.244.2.2 ) || ( nd && nd.target == fd00:10:244:3::2 ))"
@@ -355,7 +355,7 @@ tier                : 0
 _uuid               : 489ae95b-ae9d-47d0-bf1d-b2477a9ed6a2
 action              : allow
 direction           : to-lport
-external_ids        : {direction=Ingress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:AllowHostARPSecondary:Ingress", "k8s.ovn.org/name"=AllowHostARPSecondary, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
+external_ids        : {direction=Ingress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:AllowHostARPPrimaryUDN:Ingress", "k8s.ovn.org/name"=AllowHostARPPrimaryUDN, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
 label               : 0
 log                 : false
 match               : "outport == @a8747502060113802905 && (( arp && arp.spa == 10.244.2.2 ) || ( nd && nd.target == fd00:10:244:3::2 ))"
@@ -372,7 +372,7 @@ tier                : 0
 _uuid               : 980be3e4-75af-45f7-bce3-3bb08ecd8b3a
 action              : drop
 direction           : to-lport
-external_ids        : {direction=Ingress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:DenySecondary:Ingress", "k8s.ovn.org/name"=DenySecondary, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
+external_ids        : {direction=Ingress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:DenyPrimaryUDN:Ingress", "k8s.ovn.org/name"=DenyPrimaryUDN, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
 label               : 0
 log                 : false
 match               : "outport == @a8747502060113802905"
@@ -388,7 +388,7 @@ tier                : 0
 _uuid               : cca19dca-1fde-4a14-841d-7e2cce804de4
 action              : drop
 direction           : from-lport
-external_ids        : {direction=Egress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:DenySecondary:Egress", "k8s.ovn.org/name"=DenySecondary, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
+external_ids        : {direction=Egress, "k8s.ovn.org/id"="default-network-controller:UDNIsolation:DenyPrimaryUDN:Egress", "k8s.ovn.org/name"=DenyPrimaryUDN, "k8s.ovn.org/owner-controller"=default-network-controller, "k8s.ovn.org/owner-type"=UDNIsolation}
 label               : 0
 log                 : false
 match               : "inport == @a8747502060113802905"

--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -272,7 +272,7 @@ func allocatePodAnnotationWithRollback(
 	err error) {
 
 	nadName := types.DefaultNetworkName
-	if netInfo.IsSecondary() {
+	if netInfo.IsUserDefinedNetwork() {
 		nadName = util.GetNADName(network.Namespace, network.Name)
 	}
 	podDesc := fmt.Sprintf("%s/%s/%s", nadName, pod.Namespace, pod.Name)
@@ -510,7 +510,7 @@ func AddRoutesGatewayIP(
 	// generate the nodeSubnets from the allocated IPs
 	nodeSubnets := util.IPsToNetworkIPs(podAnnotation.IPs...)
 
-	if netinfo.IsSecondary() {
+	if netinfo.IsUserDefinedNetwork() {
 		// for secondary network, see if its network-attachment's annotation has default-route key.
 		// If present, then we need to add default route for it
 		podAnnotation.Gateways = append(podAnnotation.Gateways, network.GatewayRequest...)

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -154,7 +154,7 @@ func (ncc *networkClusterController) hasNodeAllocation() bool {
 		return config.OVNKubernetesFeature.EnableInterconnect
 	default:
 		// we need to allocate network IDs and subnets
-		return !ncc.IsSecondary()
+		return !ncc.IsUserDefinedNetwork()
 	}
 }
 
@@ -452,10 +452,10 @@ func (ncc *networkClusterController) newRetryFramework(objectType reflect.Type, 
 	return objretry.NewRetryFramework(ncc.stopChan, ncc.wg, ncc.watchFactory, resourceHandler)
 }
 
-// Cleanup the subnet annotations from the node for the secondary networks
+// Cleanup the subnet annotations from the node for the User Defined Networks
 func (ncc *networkClusterController) Cleanup() error {
-	if !ncc.IsSecondary() {
-		return fmt.Errorf("default network can't be cleaned up")
+	if !ncc.IsUserDefinedNetwork() {
+		return fmt.Errorf("default network cannot be cleaned up")
 	}
 
 	if ncc.hasNodeAllocation() {

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -124,11 +124,11 @@ func (na *NodeAllocator) CleanupStaleAnnotation() {
 
 func (na *NodeAllocator) hasHybridOverlayAllocation() bool {
 	// When config.HybridOverlay.ClusterSubnets is empty, assume the subnet allocation will be managed by an external component.
-	return config.HybridOverlay.Enabled && !na.netInfo.IsSecondary() && len(config.HybridOverlay.ClusterSubnets) > 0
+	return config.HybridOverlay.Enabled && !na.netInfo.IsUserDefinedNetwork() && len(config.HybridOverlay.ClusterSubnets) > 0
 }
 
 func (na *NodeAllocator) hasHybridOverlayAllocationUnmanaged() bool {
-	return config.HybridOverlay.Enabled && !na.netInfo.IsSecondary() && len(config.HybridOverlay.ClusterSubnets) == 0
+	return config.HybridOverlay.Enabled && !na.netInfo.IsUserDefinedNetwork() && len(config.HybridOverlay.ClusterSubnets) == 0
 }
 
 func (na *NodeAllocator) recordSubnetCount() {
@@ -595,7 +595,7 @@ func (na *NodeAllocator) allocateNodeSubnets(allocator SubnetAllocator, nodeName
 
 func (na *NodeAllocator) hasNodeSubnetAllocation() bool {
 	// we only allocate subnets for L3 secondary network or default network
-	return na.netInfo.TopologyType() == types.Layer3Topology || !na.netInfo.IsSecondary()
+	return na.netInfo.TopologyType() == types.Layer3Topology || !na.netInfo.IsUserDefinedNetwork()
 }
 
 func (na *NodeAllocator) markAllocatedNetworksForUnmanagedHONode(node *corev1.Node) error {

--- a/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
@@ -57,8 +57,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 		wg.Wait()
 	})
 
-	ginkgo.Context("Secondary networks", func() {
-		ginkgo.It("Attach secondary layer3 network", func() {
+	ginkgo.Context("User-Defined Networks", func() {
+		ginkgo.It("Attach layer3 UDN", func() {
 			app.Action = func(ctx *cli.Context) error {
 				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{Items: nodes()})
 				fakeClient := &util.OVNClusterManagerClientset{
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				err = f.Start()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: "blue"}, Topology: ovntypes.Layer3Topology, Subnets: "192.168.0.0/16/24"})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("The secondary network controller starts successfully", func() {
+			ginkgo.It("The UDN controller starts successfully", func() {
 				app.Action = func(ctx *cli.Context) error {
 					gomega.Expect(
 						initConfig(ctx, config.OVNKubernetesFeatureConfig{
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					err = f.Start()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-					sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					config.OVNKubernetesFeature.EnableInterconnect = false
@@ -181,7 +181,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(f.Start()).NotTo(gomega.HaveOccurred())
 
-					sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					nc := newNetworkClusterController(
@@ -226,7 +226,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 			})
 
 			ginkgo.DescribeTable(
-				"the secondary network controller",
+				"the UDN controller",
 				func(netConf *ovncnitypes.NetConf, featureConfig config.OVNKubernetesFeatureConfig, expectedError error) {
 					var err error
 					netInfo, err = util.NewNetInfo(netConf)
@@ -240,7 +240,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						err = f.Start()
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-						sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						_, err = sncm.NewNetworkController(netInfo)
@@ -378,7 +378,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 				gomega.Eventually(checkNodeAnnotations).ShouldNot(gomega.HaveOccurred())
 
-				sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Create a fake nad controller for blue network so that the red network gets cleared
@@ -476,7 +476,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						gomega.Expect(f.Start()).To(gomega.Succeed())
 
-						sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -529,7 +529,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						gomega.Expect(f.Start()).To(gomega.Succeed())
 
-						sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -578,7 +578,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						gomega.Expect(f.Start()).To(gomega.Succeed())
 
-						sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -647,7 +647,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						gomega.Expect(f.Start()).To(gomega.Succeed())
 
-						sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -719,7 +719,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						gomega.Expect(f.Start()).To(gomega.Succeed())
 
-						sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -785,7 +785,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(f.Start()).NotTo(gomega.HaveOccurred())
 
-					sncm, err := newSecondaryNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
+					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					nc := newNetworkClusterController(

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -433,7 +433,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 
 	ifaceID := util.GetIfaceId(namespace, podName)
 	if ifInfo.NetName != types.DefaultNetworkName {
-		ifaceID = util.GetSecondaryNetworkIfaceId(namespace, podName, ifInfo.NADName)
+		ifaceID = util.GetUDNIfaceId(namespace, podName, ifInfo.NADName)
 	}
 	initialPodUID := ifInfo.PodUID
 	ipStrs := make([]string, len(ifInfo.IPs))

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -164,7 +164,7 @@ type PodRequest struct {
 	// network name, for default network, this will be types.DefaultNetworkName
 	netName string
 
-	// for ovs interfaces plumbed for secondary networks, their iface-id's prefix is derived from the specific nadName;
+	// for ovs interfaces plumbed for UDNs, their iface-id's prefix is derived from the specific nadName;
 	// also, need to find the pod annotation, dpu pod connection/status annotations of the given NAD ("default"
 	// for default network).
 	nadName string

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -139,7 +139,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *ut
 	podInterfaceInfo := &PodInterfaceInfo{
 		PodAnnotation:        *podNADAnnotation,
 		MTU:                  mtu,
-		RoutableMTU:          config.Default.RoutableMTU, // TBD, configurable for secondary network?
+		RoutableMTU:          config.Default.RoutableMTU, // TBD, configurable for UDNs?
 		Ingress:              ingress,
 		Egress:               egress,
 		IsDPUHostMode:        config.OvnKubeNode.Mode == types.NodeModeDPUHost,

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -70,7 +70,7 @@ type ControllerManager struct {
 
 func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkmanager.NetworkController, error) {
 	// Pass a shallow clone of the watch factory, this allows multiplexing
-	// informers for secondary networks.
+	// informers for user-defined networks.
 	cnci, err := cm.newCommonNetworkControllerInfo(cm.watchFactory.ShallowClone())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network controller info %w", err)
@@ -78,11 +78,11 @@ func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkma
 	topoType := nInfo.TopologyType()
 	switch topoType {
 	case ovntypes.Layer3Topology:
-		return ovn.NewSecondaryLayer3NetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.eIPController, cm.portCache)
+		return ovn.NewLayer3UserDefinedNetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.eIPController, cm.portCache)
 	case ovntypes.Layer2Topology:
-		return ovn.NewSecondaryLayer2NetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.portCache, cm.eIPController)
+		return ovn.NewLayer2UserDefinedNetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.portCache, cm.eIPController)
 	case ovntypes.LocalnetTopology:
-		return ovn.NewSecondaryLocalnetNetworkController(cnci, nInfo, cm.networkManager.Interface()), nil
+		return ovn.NewLocalnetUserDefinedNetworkController(cnci, nInfo, cm.networkManager.Interface()), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }
@@ -90,7 +90,7 @@ func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkma
 // newDummyNetworkController creates a dummy network controller used to clean up specific network
 func (cm *ControllerManager) newDummyNetworkController(topoType, netName string) (networkmanager.NetworkController, error) {
 	// Pass a shallow clone of the watch factory, this allows multiplexing
-	// informers for secondary networks.
+	// informers for user-defined Networks.
 	cnci, err := cm.newCommonNetworkControllerInfo(cm.watchFactory.ShallowClone())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network controller info %w", err)
@@ -98,11 +98,11 @@ func (cm *ControllerManager) newDummyNetworkController(topoType, netName string)
 	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: topoType})
 	switch topoType {
 	case ovntypes.Layer3Topology:
-		return ovn.NewSecondaryLayer3NetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.eIPController, cm.portCache)
+		return ovn.NewLayer3UserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.eIPController, cm.portCache)
 	case ovntypes.Layer2Topology:
-		return ovn.NewSecondaryLayer2NetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.portCache, cm.eIPController)
+		return ovn.NewLayer2UserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager, cm.portCache, cm.eIPController)
 	case ovntypes.LocalnetTopology:
-		return ovn.NewSecondaryLocalnetNetworkController(cnci, netInfo, cm.networkManager.Interface()), nil
+		return ovn.NewLocalnetUserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface()), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }

--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -40,7 +40,7 @@ type NodeControllerManager struct {
 
 	defaultNodeNetworkController *node.DefaultNodeNetworkController
 
-	// networkManager creates and deletes secondary network controllers
+	// networkManager creates and deletes user-defined network controllers
 	networkManager networkmanager.Controller
 	// vrf manager that creates and manages vrfs for all UDNs
 	vrfManager *vrfmanager.Controller
@@ -52,14 +52,14 @@ type NodeControllerManager struct {
 	ovsClient client.Client
 }
 
-// NewNetworkController create secondary node network controllers for the given NetInfo
+// NewNetworkController create node user-defined network controllers for the given NetInfo
 func (ncm *NodeControllerManager) NewNetworkController(nInfo util.NetInfo) (networkmanager.NetworkController, error) {
 	topoType := nInfo.TopologyType()
 	switch topoType {
 	case ovntypes.Layer3Topology, ovntypes.Layer2Topology, ovntypes.LocalnetTopology:
 		// Pass a shallow clone of the watch factory, this allows multiplexing
-		// informers for secondary networks.
-		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(ncm.watchFactory.(*factory.WatchFactory).ShallowClone()),
+		// informers for UDNs.
+		return node.NewUserDefinedNodeNetworkController(ncm.newCommonNetworkControllerInfo(ncm.watchFactory.(*factory.WatchFactory).ShallowClone()),
 			nInfo, ncm.networkManager.Interface(), ncm.vrfManager, ncm.ruleManager, ncm.defaultNodeNetworkController.Gateway)
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
@@ -69,7 +69,7 @@ func (ncm *NodeControllerManager) GetDefaultNetworkController() networkmanager.R
 	return ncm.defaultNodeNetworkController
 }
 
-// CleanupStaleNetworks cleans up all stale entities giving list of all existing secondary network controllers
+// CleanupStaleNetworks cleans up all stale entities giving list of all existing node UDN controllers
 func (ncm *NodeControllerManager) CleanupStaleNetworks(validNetworks ...util.NetInfo) error {
 	if !util.IsNetworkSegmentationSupportEnabled() {
 		return nil
@@ -91,8 +91,8 @@ func (ncm *NodeControllerManager) newCommonNetworkControllerInfo(wf factory.Node
 
 // isNetworkManagerRequiredForNode checks if network manager should be started
 // on the node side, which requires any of the following conditions:
-// (1) dpu mode is enabled when secondary networks feature is enabled
-// (2) primary user defined networks is enabled (all modes)
+// (1) dpu mode is enabled when multiple networks feature is enabled
+// (2) primary user-defined networks is enabled (all modes)
 func isNetworkManagerRequiredForNode() bool {
 	return (config.OVNKubernetesFeature.EnableMultiNetwork && config.OvnKubeNode.Mode == ovntypes.NodeModeDPU) ||
 		util.IsNetworkSegmentationSupportEnabled() ||
@@ -114,7 +114,7 @@ func NewNodeControllerManager(ovnClient *util.OVNClientset, wf factory.NodeWatch
 		ovsClient:     ovsClient,
 	}
 
-	// need to configure OVS interfaces for Pods on secondary networks in the DPU mode
+	// need to configure OVS interfaces for Pods on UDNs in the DPU mode
 	// need to start NAD controller on node side for programming gateway pieces for UDNs
 	// need to start NAD controller on node side for VRF awareness with BGP
 	var err error

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -512,8 +512,8 @@ func RunTimestamp(stopChan <-chan struct{}, sbClient, nbClient libovsdbclient.Cl
 // RecordPodCreated extracts the scheduled timestamp and records how long it took
 // us to notice this and set up the pod's scheduling.
 func RecordPodCreated(pod *corev1.Pod, netInfo util.NetInfo) {
-	if netInfo.IsSecondary() {
-		// TBD: no op for secondary network for now, TBD
+	if netInfo.IsUserDefinedNetwork() {
+		// TBD: noop for UDN for now
 		return
 	}
 	t := time.Now()
@@ -761,8 +761,8 @@ func (pr *PodRecorder) CleanPod(podUID kapimtypes.UID) {
 }
 
 func (pr *PodRecorder) AddLSP(podUID kapimtypes.UID, netInfo util.NetInfo) {
-	if netInfo.IsSecondary() {
-		// TBD: no op for secondary network for now, TBD
+	if netInfo.IsUserDefinedNetwork() {
+		// TBD: noop for UDN for now
 		return
 	}
 	if pr.queue != nil && !pr.queueFull() {

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -115,7 +115,7 @@ func (bnnc *BaseNodeNetworkController) watchPodsDPU() (*factory.Handler, error) 
 			// add all the Pod's NADs into Pod's nadToDPUCDMap
 			// For default network, NAD name is DefaultNetworkName.
 			nadToDPUCDMap := map[string]*util.DPUConnectionDetails{}
-			if bnnc.IsSecondary() {
+			if bnnc.IsUserDefinedNetwork() {
 				if bnnc.IsPrimaryNetwork() {
 					activeNetwork, err = bnnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
 					if err != nil {

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -566,7 +566,7 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, sets.Set[strin
 			if err != nil {
 				return nil, selectedNamespaces, selectedPods, selectedNamespacesPodIPs, fmt.Errorf("failed to get active network for namespace %s: %v", namespace.Name, err)
 			}
-			if netInfo.IsSecondary() {
+			if netInfo.IsUserDefinedNetwork() {
 				// EIP for secondary host interfaces is not supported for secondary networks
 				continue
 			}
@@ -1035,7 +1035,7 @@ func (c *Controller) repairNode() error {
 					if err != nil {
 						return fmt.Errorf("failed to get active network for namespace %s: %v", namespace.Name, err)
 					}
-					if netInfo.IsSecondary() {
+					if netInfo.IsUserDefinedNetwork() {
 						// EIP for secondary host interfaces is not supported for secondary networks
 						continue
 					}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -854,8 +854,8 @@ func portExists(namespace, name string) bool {
 /** HACK END **/
 
 // Init executes the first steps to start the DefaultNodeNetworkController.
-// It is split from Start() and executed before SecondaryNodeNetworkController (SNNC),
-// to allow SNNC to reference the openflow manager created in Init.
+// It is split from Start() and executed before UserDefinedNodeNetworkController (UDNNC)
+// to allow UDNNC to reference the openflow manager created in Init.
 func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	klog.Infof("Initializing the default node network controller")
 

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("SecondaryNodeNetworkController", func() {
+var _ = Describe("UserDefinedNodeNetworkController", func() {
 	var (
 		networkID = "3"
 		nad       = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
@@ -85,7 +85,7 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		factoryMock.On("GetNodes").Return(nodeList, nil)
 		NetInfo, err := util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
-		controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{})
+		controller, err := NewUserDefinedNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{})
 		Expect(err).NotTo(HaveOccurred())
 		err = controller.Start(context.Background())
 		Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		Expect(err).NotTo(HaveOccurred())
 		getCreationFakeCommands(fexec, "ovn-k8s-mp3", mgtPortMAC, NetInfo.GetNetworkName(), "worker1", NetInfo.MTU())
 		ofm := getDummyOpenflowManager()
-		controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{openflowManager: ofm})
+		controller, err := NewUserDefinedNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{openflowManager: ofm})
 		Expect(err).NotTo(HaveOccurred())
 		err = controller.Start(context.Background())
 		Expect(err).To(HaveOccurred()) // we don't have the gateway pieces setup so its expected to fail here
@@ -144,7 +144,7 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRoleSecondary)
 		NetInfo, err := util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
-		controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{})
+		controller, err := NewUserDefinedNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{})
 		Expect(err).NotTo(HaveOccurred())
 		err = controller.Start(context.Background())
 		Expect(err).NotTo(HaveOccurred())
@@ -152,7 +152,7 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 	})
 })
 
-var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality", func() {
+var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality", func() {
 	var (
 		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
@@ -418,15 +418,15 @@ var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gate
 			Expect(err).NotTo(HaveOccurred())
 			localGw.openflowManager.syncFlows()
 
-			By("creating secondary network controller for user defined primary network")
+			By("creating a UDN controller for user-defined primary network")
 			cnnci := CommonNodeNetworkControllerInfo{name: nodeName, watchFactory: &factoryMock}
-			controller, err := NewSecondaryNodeNetworkController(&cnnci, NetInfo, nil, vrf, ipRulesManager, localGw)
+			controller, err := NewUserDefinedNodeNetworkController(&cnnci, NetInfo, nil, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(controller.gateway).To(Not(BeNil()))
 			Expect(controller.gateway.ruleManager).To(Not(BeNil()))
 			controller.gateway.kubeInterface = &kubeMock
 
-			By("starting secondary network controller for user defined primary network")
+			By("starting UDN controller for user-defined primary network")
 			err = controller.Start(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -283,9 +283,9 @@ func (oc *BaseNetworkController) doReconcile(reconcileRoutes, reconcilePendingPo
 	}
 }
 
-// BaseSecondaryNetworkController structure holds per-network fields and network specific
-// configuration for secondary network controller
-type BaseSecondaryNetworkController struct {
+// BaseUserDefinedNetworkController structure holds per-network fields and network specific
+// configuration for UDN controller
+type BaseUserDefinedNetworkController struct {
 	BaseNetworkController
 
 	// network policy events factory handler
@@ -294,7 +294,7 @@ type BaseSecondaryNetworkController struct {
 	multiNetPolicyHandler *factory.Handler
 }
 
-func (oc *BaseSecondaryNetworkController) FilterOutResource(objType reflect.Type, obj interface{}) bool {
+func (oc *BaseUserDefinedNetworkController) FilterOutResource(objType reflect.Type, obj interface{}) bool {
 	switch objType {
 	case factory.NamespaceType:
 		ns, ok := obj.(*corev1.Namespace)
@@ -343,19 +343,19 @@ func NewCommonNetworkControllerInfo(client clientset.Interface, kube *kube.KubeO
 }
 
 func (bnc *BaseNetworkController) GetLogicalPortName(pod *corev1.Pod, nadName string) string {
-	if !bnc.IsSecondary() {
+	if !bnc.IsUserDefinedNetwork() {
 		return util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		return util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		return util.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
 	}
 }
 
 func (bnc *BaseNetworkController) AddConfigDurationRecord(kind, namespace, name string) (
 	[]ovsdb.Operation, func(), time.Time, error) {
-	if !bnc.IsSecondary() {
+	if !bnc.IsUserDefinedNetwork() {
 		return recorders.GetConfigDurationRecorder().AddOVN(bnc.nbClient, kind, namespace, name)
 	}
-	// TBD: no op for secondary network for now
+	// TBD: no-op for UDN for now
 	return []ovsdb.Operation{}, func() {}, time.Time{}, nil
 }
 
@@ -799,7 +799,7 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *corev1.Node, swit
 				IPPrefix: hostSubnet.String(),
 				Nexthop:  mgmtIfAddr.IP.String(),
 			}
-			if bnc.IsSecondary() {
+			if bnc.IsUserDefinedNetwork() {
 				lrsr.ExternalIDs = map[string]string{
 					types.NetworkExternalID:  bnc.GetNetworkName(),
 					types.TopologyExternalID: bnc.TopologyType(),
@@ -878,8 +878,8 @@ func (bnc *BaseNetworkController) WatchNodes() error {
 }
 
 func (bnc *BaseNetworkController) recordNodeErrorEvent(node *corev1.Node, nodeErr error) {
-	if bnc.IsSecondary() {
-		// TBD, no op for secondary network for now
+	if bnc.IsUserDefinedNetwork() {
+		// TBD, noop for UDN for now
 		return
 	}
 	nodeRef, err := ref.GetReference(scheme.Scheme, node)
@@ -908,7 +908,7 @@ func (bnc *BaseNetworkController) doesNetworkRequireIPAM() bool {
 }
 
 func (bnc *BaseNetworkController) getPodNADNames(pod *corev1.Pod) []string {
-	if !bnc.IsSecondary() {
+	if !bnc.IsUserDefinedNetwork() {
 		return []string{types.DefaultNetworkName}
 	}
 	podNadNames, _ := util.PodNadNames(pod, bnc.GetNetInfo())
@@ -1000,8 +1000,8 @@ func (bnc *BaseNetworkController) nodeZoneClusterChanged(oldNode, newNode *corev
 }
 
 func (bnc *BaseNetworkController) findMigratablePodIPsForSubnets(subnets []*net.IPNet) ([]*net.IPNet, error) {
-	// live migration is not supported in combination with secondary networks
-	if bnc.IsSecondary() {
+	// live migration is not supported in combination with UDNs
+	if bnc.IsUserDefinedNetwork() {
 		return nil, nil
 	}
 

--- a/go-controller/pkg/ovn/base_network_controller_multicast.go
+++ b/go-controller/pkg/ovn/base_network_controller_multicast.go
@@ -199,7 +199,7 @@ func (bnc *BaseNetworkController) createDefaultDenyMulticastPolicy() error {
 		return err
 	}
 
-	if !bnc.IsSecondary() {
+	if !bnc.IsUserDefinedNetwork() {
 		// Remove old multicastDefaultDeny port group now that all ports
 		// have been added to the clusterPortGroup by WatchPods()
 		ops, err = libovsdbops.DeletePortGroupsOps(bnc.nbClient, ops, legacyMulticastDefaultDenyPortGroup)

--- a/go-controller/pkg/ovn/base_network_controller_multipolicy.go
+++ b/go-controller/pkg/ovn/base_network_controller_multipolicy.go
@@ -14,7 +14,7 @@ import (
 
 const PolicyForAnnotation = "k8s.v1.cni.cncf.io/policy-for"
 
-func (bsnc *BaseSecondaryNetworkController) syncMultiNetworkPolicies(multiPolicies []interface{}) error {
+func (bsnc *BaseUserDefinedNetworkController) syncMultiNetworkPolicies(multiPolicies []interface{}) error {
 	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range multiPolicies {
 		policy, ok := npInterface.(*mnpapi.MultiNetworkPolicy)
@@ -38,7 +38,7 @@ func (bsnc *BaseSecondaryNetworkController) syncMultiNetworkPolicies(multiPolici
 	return bsnc.syncNetworkPoliciesCommon(expectedPolicies)
 }
 
-func (bsnc *BaseSecondaryNetworkController) shouldApplyMultiPolicy(mpolicy *mnpapi.MultiNetworkPolicy) bool {
+func (bsnc *BaseUserDefinedNetworkController) shouldApplyMultiPolicy(mpolicy *mnpapi.MultiNetworkPolicy) bool {
 	policyForAnnot, ok := mpolicy.Annotations[PolicyForAnnotation]
 	if !ok {
 		klog.V(5).Infof("%s annotation not defined in multi-policy %s/%s", PolicyForAnnotation,

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -75,7 +75,7 @@ func (bnc *BaseNetworkController) shouldWatchNamespaces() bool {
 	// - The network is secondary, and multi NetworkPolicies are enabled.
 	return bnc.IsDefault() ||
 		bnc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() ||
-		bnc.IsSecondary() && util.IsMultiNetworkPoliciesSupportEnabled()
+		bnc.IsUserDefinedNetwork() && util.IsMultiNetworkPoliciesSupportEnabled()
 }
 
 // WatchNamespaces starts the watching of namespace resource and calls
@@ -466,7 +466,7 @@ func (bsnc *BaseNetworkController) removeRemoteZonePodFromNamespaceAddressSet(po
 	// tracked within the zone, nodeName will be empty which will force
 	// canReleasePodIPs to lookup all nodes.
 	nodeName := pod.Spec.NodeName
-	if !bsnc.IsSecondary() && kubevirt.IsPodLiveMigratable(pod) {
+	if !bsnc.IsUserDefinedNetwork() && kubevirt.IsPodLiveMigratable(pod) {
 		nodeName, _ = bsnc.lsManager.GetSubnetName(podIfAddrs)
 	}
 

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -786,7 +786,7 @@ func (bnc *BaseNetworkController) denyPGDeletePorts(np *networkPolicy, portNames
 
 // handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy, should be retriable.
 func (bnc *BaseNetworkController) handleLocalPodSelectorAddFunc(np *networkPolicy, objs ...interface{}) error {
-	if !bnc.IsSecondary() && config.Metrics.EnableScaleMetrics {
+	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
@@ -832,7 +832,7 @@ func (bnc *BaseNetworkController) handleLocalPodSelectorAddFunc(np *networkPolic
 
 // handleLocalPodSelectorDelFunc handles delete event for local pod, should be retriable
 func (bnc *BaseNetworkController) handleLocalPodSelectorDelFunc(np *networkPolicy, objs ...interface{}) error {
-	if !bnc.IsSecondary() && config.Metrics.EnableScaleMetrics {
+	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
@@ -1177,7 +1177,7 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 // if addNetworkPolicy fails, create or delete operation can be retried
 func (bnc *BaseNetworkController) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	klog.Infof("Adding network policy %s for network %s", getPolicyKey(policy), bnc.GetNetworkName())
-	if !bnc.IsSecondary() && config.Metrics.EnableScaleMetrics {
+	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
@@ -1384,7 +1384,7 @@ type NetworkPolicyExtraParameters struct {
 }
 
 func (bnc *BaseNetworkController) handlePeerNamespaceSelectorAdd(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
-	if !bnc.IsSecondary() && config.Metrics.EnableScaleMetrics {
+	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
@@ -1421,7 +1421,7 @@ func (bnc *BaseNetworkController) handlePeerNamespaceSelectorAdd(np *networkPoli
 }
 
 func (bnc *BaseNetworkController) handlePeerNamespaceSelectorDel(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
-	if !bnc.IsSecondary() && config.Metrics.EnableScaleMetrics {
+	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("BaseSecondaryNetworkController", func() {
+var _ = Describe("BaseUserDefinedNetworkController", func() {
 	var (
 		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
@@ -79,8 +79,8 @@ var _ = Describe("BaseSecondaryNetworkController", func() {
 		)
 		defer fakeOVN.shutdown()
 
-		Expect(fakeOVN.NewSecondaryNetworkController(layer2NAD)).To(Succeed())
-		controller, ok := fakeOVN.secondaryControllers["bluenet"]
+		Expect(fakeOVN.NewUserDefinedNetworkController(layer2NAD)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
 		Expect(ok).To(BeTrue())
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -221,8 +221,8 @@ var _ = Describe("BaseSecondaryNetworkController", func() {
 				},
 			},
 		)
-		Expect(fakeOVN.NewSecondaryNetworkController(nad)).To(Succeed())
-		controller, ok := fakeOVN.secondaryControllers["bluenet"]
+		Expect(fakeOVN.NewUserDefinedNetworkController(nad)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
 		Expect(ok).To(BeTrue())
 		// inject a real networkManager instead of a fake one, so getActiveNetworkForNamespace will get called
 		nadController, err := networkmanager.NewForZone("dummyZone", nil, fakeOVN.watcher)
@@ -240,7 +240,7 @@ var _ = Describe("BaseSecondaryNetworkController", func() {
 		var initialPodList []interface{}
 		initialPodList = append(initialPodList, podWithNoNamespace)
 
-		err = controller.bnc.syncPodsForSecondaryNetwork(initialPodList)
+		err = controller.bnc.syncPodsForUserDefinedNetwork(initialPodList)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -43,7 +43,6 @@ const (
 // taken from k8s controller guidelines
 type Controller struct {
 	// name of the controller that starts the ANP controller
-	// (values are default-network-controller, secondary-network-controller etc..)
 	controllerName string
 	sync.RWMutex
 	anpClientSet anpclientset.Interface

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos.go
@@ -337,7 +337,7 @@ func (c *Controller) networkManagedByMe(networkSelectors crdtypes.NetworkSelecto
 				return false, err
 			}
 		case crdtypes.SecondaryUserDefinedNetworks:
-			if !c.IsSecondary() {
+			if !c.IsUserDefinedNetwork() {
 				return false, nil
 			}
 			if networkSelector.SecondaryUserDefinedNetworkSelector == nil {
@@ -395,7 +395,7 @@ func (c *Controller) getLogicalSwitchName(nodeName string) string {
 		return c.GetNetworkScopedSwitchName(types.OVNLayer2Switch)
 	case c.TopologyType() == types.LocalnetTopology:
 		return c.GetNetworkScopedSwitchName(types.OVNLocalnetSwitch)
-	case !c.IsSecondary() || c.TopologyType() == types.Layer3Topology:
+	case !c.IsUserDefinedNetwork() || c.TopologyType() == types.Layer3Topology:
 		return c.GetNetworkScopedSwitchName(nodeName)
 	default:
 		return ""

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
@@ -45,7 +45,7 @@ func (c *Controller) addQoSToLogicalSwitch(qosState *networkQoSState, switchName
 			Match:       generateNetworkQoSMatch(qosState, rule, ipv4Enabled, ipv6Enabled),
 			Priority:    rule.Priority,
 		}
-		if c.IsSecondary() {
+		if c.IsUserDefinedNetwork() {
 			qos.ExternalIDs[types.NetworkExternalID] = c.GetNetworkName()
 		}
 		if rule.Dscp >= 0 {

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
@@ -44,7 +44,7 @@ func (n *primaryNetInfoWrapper) IsPrimaryNetwork() bool {
 	return true
 }
 
-func (n *primaryNetInfoWrapper) IsSecondary() bool {
+func (n *primaryNetInfoWrapper) IsUserDefinedNetwork() bool {
 	return false
 }
 
@@ -64,7 +64,7 @@ func (n *secondaryNetInfoWrapper) IsPrimaryNetwork() bool {
 	return false
 }
 
-func (n *secondaryNetInfoWrapper) IsSecondary() bool {
+func (n *secondaryNetInfoWrapper) IsUserDefinedNetwork() bool {
 	return true
 }
 
@@ -1011,7 +1011,7 @@ var _ = Describe("NetworkQoS Controller", func() {
 					err = libovsdbops.CreateOrUpdateLogicalSwitch(nbClient, secondarySwitch)
 					Expect(err).NotTo(HaveOccurred())
 
-					// Wrap the NetInfo with our custom implementation that returns true for IsSecondary()
+					// Wrap the NetInfo with our custom implementation that returns true for IsUserDefinedNetwork()
 					secNetWrapper := &secondaryNetInfoWrapper{NetInfo: secondaryNadInfo}
 					initNetworkQoSController(secNetWrapper, addressset.NewFakeAddressSetFactory("secondary-controller"), "secondary-controller", enableInterconnect)
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -312,9 +312,14 @@ func (oc *DefaultNetworkController) syncDb() error {
 	}
 
 	// NAT syncer must only be run once. It performs OVN NAT updates.
-	nadSyncer := nat.NewNATSyncer(oc.nbClient, oc.controllerName)
-	if err = nadSyncer.Sync(); err != nil {
+	natSyncer := nat.NewNATSyncer(oc.nbClient, oc.controllerName)
+	if err = natSyncer.Sync(); err != nil {
 		return fmt.Errorf("failed to sync NATs: %v", err)
+	}
+
+	// Find ACLs with legacy DBIDs and update them from secondary -> user-defined
+	if err := oc.syncUDNIsolation(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -808,7 +808,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 	}
 	var remainingAssignments []egressipv1.EgressIPStatusItem
 	nadName := ni.GetNetworkName()
-	if ni.IsSecondary() {
+	if ni.IsUserDefinedNetwork() {
 		nadNames := ni.GetNADs()
 		if len(nadNames) == 0 {
 			return fmt.Errorf("expected at least one NAD name for Namespace %s", pod.Namespace)
@@ -1151,7 +1151,7 @@ type egressIPCache struct {
 	egressNodeRedirectsCache nodeNetworkRedirects
 	// network name -> OVN cluster router name
 	networkToRouter map[string]string
-	// packet mark for primary secondary networks
+	// packet mark for primary UDNs
 	// EgressIP name -> mark
 	markCache map[string]string
 }
@@ -1993,7 +1993,7 @@ func (e *EgressIPController) generateCacheForEgressIP() (egressIPCache, error) {
 				egressRemotePods: map[string]sets.Set[string]{},
 			}
 			nadName := types.DefaultNetworkName
-			if ni.IsSecondary() {
+			if ni.IsUserDefinedNetwork() {
 				nadNames := ni.GetNADs()
 				if len(nadNames) == 0 {
 					klog.Errorf("Network %s: error build egress IP sync cache, expected at least one NAD name for Namespace %s", ni.GetNetworkName(), namespace.Name)
@@ -2297,7 +2297,7 @@ func (e *EgressIPController) addStandByEgressIPAssignment(ni util.NetInfo, podKe
 			continue
 		}
 		eipToAssign = eipName // use the first EIP we find successfully
-		if ni.IsSecondary() {
+		if ni.IsUserDefinedNetwork() {
 			mark = getEgressIPPktMark(eip.Name, eip.Annotations)
 		}
 		break
@@ -2308,7 +2308,7 @@ func (e *EgressIPController) addStandByEgressIPAssignment(ni util.NetInfo, podKe
 	}
 	// get IPs
 	nadName := ni.GetNetworkName()
-	if ni.IsSecondary() {
+	if ni.IsUserDefinedNetwork() {
 		nadNames := ni.GetNADs()
 		if len(nadNames) == 0 {
 			return fmt.Errorf("expected at least one NAD name for Namespace %s", pod.Namespace)
@@ -2391,7 +2391,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 					return fmt.Errorf("unable to create NAT rule ops for status: %v, err: %v", status, err)
 				}
 
-			} else if ni.IsSecondary() && ni.TopologyType() == types.Layer3Topology {
+			} else if ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer3Topology {
 				// not required for L2 because we always have LRPs using reroute action to pkt mark
 				ops, err = e.createGWMarkPolicyOps(ni, ops, podIPs, status, mark, pod.Namespace, pod.Name, egressIPName)
 				if err != nil {
@@ -2415,7 +2415,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 
 	// For L2, we always attach an LRP with reroute action to the Nodes gateway router. If the pod is remote, use the local zone Node name to generate the GW router name.
 	nodeName := pod.Spec.NodeName
-	if loadedEgressNode && loadedPodNode && !isLocalZonePod && isLocalZoneEgressNode && ni.IsSecondary() && ni.TopologyType() == types.Layer2Topology {
+	if loadedEgressNode && loadedPodNode && !isLocalZonePod && isLocalZoneEgressNode && ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer2Topology {
 		nodeName = status.Node
 	}
 	routerName, err := getTopologyScopedRouterName(ni, nodeName)
@@ -2426,7 +2426,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 	// exec when node is local OR when pods are local or L2 UDN
 	// don't add a reroute policy if the egress node towards which we are adding this doesn't exist
 	if loadedEgressNode && loadedPodNode {
-		if isLocalZonePod || (isLocalZoneEgressNode && ni.IsSecondary() && ni.TopologyType() == types.Layer2Topology) {
+		if isLocalZonePod || (isLocalZoneEgressNode && ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer2Topology) {
 			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
 			if err != nil {
 				return fmt.Errorf("unable to create logical router policy ops, err: %v", err)
@@ -2483,7 +2483,7 @@ func (e *EgressIPController) deletePodEgressIPAssignment(ni util.NetInfo, egress
 	}
 	// For L2, we always attach an LRP with reroute action to the Nodes gateway router. If the pod is remote, use the local zone Node name to generate the GW router name.
 	nodeName := pod.Spec.NodeName
-	if !isLocalZonePod && isLocalZoneEgressNode && ni.IsSecondary() && ni.TopologyType() == types.Layer2Topology {
+	if !isLocalZonePod && isLocalZoneEgressNode && ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer2Topology {
 		nodeName = status.Node
 	}
 	routerName, err := getTopologyScopedRouterName(ni, nodeName)
@@ -2502,7 +2502,7 @@ func (e *EgressIPController) deletePodEgressIPAssignment(ni util.NetInfo, egress
 	// Case 1 - node where pod is hosted is not known
 	// Case 2 - pod is within the local zone
 	// case 3 - a local zone node is egress node and pod is attached to layer 2. For layer2, there is always an LRP attached to the egress Node GW router
-	if !loadedPodNode || isLocalZonePod || (isLocalZoneEgressNode && ni.IsSecondary() && ni.TopologyType() == types.Layer2Topology) {
+	if !loadedPodNode || isLocalZonePod || (isLocalZoneEgressNode && ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer2Topology) {
 		ops, err = e.deleteReroutePolicyOps(ni, ops, status, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
 		if errors.Is(err, libovsdbclient.ErrNotFound) {
 			// if the gateway router join IP setup is already gone, then don't count it as error.
@@ -2525,7 +2525,7 @@ func (e *EgressIPController) deletePodEgressIPAssignment(ni util.NetInfo, egress
 			if err != nil {
 				return fmt.Errorf("unable to delete NAT rule for status: %v, err: %v", status, err)
 			}
-		} else if ni.IsSecondary() && ni.TopologyType() == types.Layer3Topology {
+		} else if ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer3Topology {
 			ops, err = e.deleteGWMarkPolicyOps(ni, ops, status, pod.Namespace, pod.Name, egressIPName)
 			if err != nil {
 				return fmt.Errorf("unable to create GW router packet mark LRPs delete ops for pod %s/%s: %v", pod.Namespace, pod.Name, err)
@@ -2788,7 +2788,7 @@ func (e *EgressIPController) getNextHop(ni util.NetInfo, egressNodeName, egressI
 			return gatewayRouterIP.String(), nil
 		} else {
 			// for an egress IP assigned to a host secondary interface, next hop IP is the networks management port IP
-			if ni.IsSecondary() {
+			if ni.IsUserDefinedNetwork() {
 				return "", fmt.Errorf("egress IP assigned to a host secondary interface for a user defined network (network name %s) is unsupported", ni.GetNetworkName())
 			}
 			return e.getLocalMgmtPortNextHop(ni, egressNodeName, egressIPName, egressIP, isEgressIPv6)
@@ -2826,7 +2826,7 @@ func (e *EgressIPController) createReroutePolicyOps(ni util.NetInfo, ops []ovsdb
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	ipFamily := getEIPIPFamily(isEgressIPv6)
 	options := make(map[string]string)
-	if ni.IsSecondary() {
+	if ni.IsUserDefinedNetwork() {
 		if !mark.IsAvailable() {
 			return nil, fmt.Errorf("egressIP %s object must contain a mark for user defined networks", egressIPName)
 		}
@@ -3025,7 +3025,7 @@ func (e *EgressIPController) deleteEgressIPStatusSetup(ni util.NetInfo, name str
 			if err != nil {
 				return fmt.Errorf("error removing egress ip %s nats on router %s: %v", name, routerName, err)
 			}
-		} else if ni.IsSecondary() {
+		} else if ni.IsUserDefinedNetwork() {
 			if ops, err = e.deleteGWMarkPolicyForStatusOps(ni, ops, status, name); err != nil {
 				return fmt.Errorf("failed to delete gateway mark policy: %v", err)
 			}
@@ -3582,7 +3582,7 @@ func (e *EgressIPController) getPodIPs(ni util.NetInfo, pod *corev1.Pod, nadName
 				return nil, fmt.Errorf("failed to get pod %s/%s IPs", pod.Namespace, pod.Name)
 			}
 			podIPs = getIPFromIPNetFn(podIPNets)
-		} else if ni.IsSecondary() {
+		} else if ni.IsUserDefinedNetwork() {
 			podIPNets := util.GetPodCIDRsWithFullMaskOfNetwork(pod, nadName)
 			if len(podIPNets) == 0 {
 				return nil, fmt.Errorf("failed to get pod %s/%s IPs", pod.Namespace, pod.Name)

--- a/go-controller/pkg/ovn/egressip_udn_l2_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l2_test.go
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 		layer2SwitchName        = "ovn_layer2_switch"
 		gwIP                    = "192.168.126.1"
 		gwIP2                   = "192.168.127.1"
-		secondaryNetworkID      = "2"
+		userDefinedNetworkID    = "2"
 	)
 
 	getEgressIPStatusLen := func(egressIPName string) func() int {
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -524,7 +524,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -662,14 +662,14 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				fakeOvn.controller.zone = node1.Name
 				fakeOvn.eIPController.zone = node1.Name
 				fakeOvn.controller.logicalPortCache.add(&egressPodCDNLocal, "", ovntypes.DefaultNetworkName, "", nil, []*net.IPNet{nCDN})
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				fakeOvn.controller.eIPC.nodeZoneState.Store(node1Name, true)
 				fakeOvn.controller.eIPC.nodeZoneState.Store(node2Name, false)
 				err = fakeOvn.networkManager.Start()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer fakeOvn.networkManager.Stop()
-				// simulate Start() of secondary network controller
+				// simulate Start() of UDN controller
 				err = fakeOvn.eIPController.ensureRouterPoliciesForNetwork(secConInfo.bnc.GetNetInfo(), &node1)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.eIPController.ensureSwitchPoliciesForNode(secConInfo.bnc.GetNetInfo(), node1Name)
@@ -1030,7 +1030,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1181,7 +1181,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				// Add pod IPs to UDN cache
 				iUDN, nUDN, _ := net.ParseCIDR(v4Pod1IPNode1Net1 + "/23")
@@ -1512,7 +1512,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1672,7 +1672,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				// Add pod IPs to UDN cache
 				iUDN, nUDN, _ := net.ParseCIDR(v4Pod1IPNode1Net1 + "/23")
@@ -1876,7 +1876,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2229,7 +2229,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2383,7 +2383,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				// Add pod IPs to UDN cache
 				iUDN, nUDN, _ := net.ParseCIDR(v4Pod1IPNode1Net1 + "/23")
@@ -2597,7 +2597,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2734,7 +2734,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				fakeOvn.controller.logicalPortCache.add(&egressPodCDNLocal, "", ovntypes.DefaultNetworkName, "", nil, []*net.IPNet{nCDN})
 				fakeOvn.controller.zone = node1Name
 				fakeOvn.eIPController.zone = node1Name
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				err = fakeOvn.eIPController.SyncLocalNodeZonesCache()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -41,26 +41,26 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 	)
 
 	const (
-		nadName1           = "nad1"
-		networkName1       = "network1"
-		networkName1_      = networkName1 + "_"
-		node1Name          = "node1"
-		v4Net1             = "20.128.0.0/14"
-		v4Node1Net1        = "20.128.0.0/16"
-		v4Pod1IPNode1Net1  = "20.128.0.5"
-		podName3           = "egress-pod3"
-		v4Pod2IPNode1Net1  = "20.128.0.6"
-		v4Node1Tsp         = "100.88.0.2"
-		node2Name          = "node2"
-		v4Node2Net1        = "20.129.0.0/16"
-		v4Node2Tsp         = "100.88.0.3"
-		podName4           = "egress-pod4"
-		v4Pod1IPNode2Net1  = "20.129.0.2"
-		v4Pod2IPNode2Net1  = "20.129.0.3"
-		eIP1Mark           = 50000
-		eIP2Mark           = 50001
-		secondaryNetworkID = "2"
-		//tnlKey = zoneinterconnect.BaseTransitSwitchTunnelKey + secondaryNetworkID
+		nadName1             = "nad1"
+		networkName1         = "network1"
+		networkName1_        = networkName1 + "_"
+		node1Name            = "node1"
+		v4Net1               = "20.128.0.0/14"
+		v4Node1Net1          = "20.128.0.0/16"
+		v4Pod1IPNode1Net1    = "20.128.0.5"
+		podName3             = "egress-pod3"
+		v4Pod2IPNode1Net1    = "20.128.0.6"
+		v4Node1Tsp           = "100.88.0.2"
+		node2Name            = "node2"
+		v4Node2Net1          = "20.129.0.0/16"
+		v4Node2Tsp           = "100.88.0.3"
+		podName4             = "egress-pod4"
+		v4Pod1IPNode2Net1    = "20.129.0.2"
+		v4Pod2IPNode2Net1    = "20.129.0.3"
+		eIP1Mark             = 50000
+		eIP2Mark             = 50001
+		userDefinedNetworkID = "2"
+		//tnlKey = zoneinterconnect.BaseTransitSwitchTunnelKey + userDefinedNetworkID
 		tnlKey = "16711685"
 	)
 
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -534,7 +534,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -672,14 +672,14 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				fakeOvn.controller.zone = node1.Name
 				fakeOvn.eIPController.zone = node1.Name
 				fakeOvn.controller.logicalPortCache.add(&egressPodCDNLocal, "", ovntypes.DefaultNetworkName, "", nil, []*net.IPNet{nCDN})
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				fakeOvn.controller.eIPC.nodeZoneState.Store(node1Name, true)
 				fakeOvn.controller.eIPC.nodeZoneState.Store(node2Name, false)
 				err = fakeOvn.networkManager.Start()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer fakeOvn.networkManager.Stop()
-				// simulate Start() of secondary network controller
+				// simulate Start() of UDN controller
 				err = fakeOvn.eIPController.ensureRouterPoliciesForNetwork(secConInfo.bnc.GetNetInfo(), &node1)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.eIPController.ensureSwitchPoliciesForNode(secConInfo.bnc.GetNetInfo(), node1Name)
@@ -1055,7 +1055,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1204,7 +1204,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				// Add pod IPs to UDN cache
 				iUDN, nUDN, _ := net.ParseCIDR(v4Pod1IPNode1Net1 + "/23")
@@ -1791,7 +1791,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1949,7 +1949,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				// Add pod IPs to UDN cache
 				iUDN, nUDN, _ := net.ParseCIDR(v4Pod1IPNode1Net1 + "/23")
@@ -2161,7 +2161,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2522,7 +2522,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 					netconf,
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: secondaryNetworkID}
+				nad.Annotations = map[string]string{ovntypes.OvnNetworkIDAnnotation: userDefinedNetworkID}
 				netInfo, err := util.NewNetInfo(&netconf)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2674,7 +2674,7 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = fakeOvn.controller.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				secConInfo, ok := fakeOvn.secondaryControllers[networkName1]
+				secConInfo, ok := fakeOvn.userDefinedNetworkControllers[networkName1]
 				gomega.Expect(ok).To(gomega.BeTrue())
 				secConInfo.bnc.zone = node1.Name
 				gomega.Expect(secConInfo.bnc.WatchNodes()).To(gomega.Succeed())

--- a/go-controller/pkg/ovn/external_ids_syncer/logical_router_policy/logical_router_policy_sync.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/logical_router_policy/logical_router_policy_sync.go
@@ -139,7 +139,7 @@ func (ps podsNetInfo) getPod(ip net.IP) (podNetInfo, error) {
 
 func (syncer *LRPSyncer) buildCDNPodCache() (podsNetInfo, podsNetInfo, error) {
 	p := func(item *nbdb.LogicalSwitchPort) bool {
-		return item.ExternalIDs["pod"] == "true" && item.ExternalIDs[ovntypes.NADExternalID] == "" // ignore secondary network LSPs
+		return item.ExternalIDs["pod"] == "true" && item.ExternalIDs[ovntypes.NADExternalID] == "" // ignore UDN LSPs
 	}
 	lsps, err := libovsdbops.FindLogicalSwitchPortWithPredicate(syncer.nbClient, p)
 	if err != nil {

--- a/go-controller/pkg/ovn/external_ids_syncer/nat/nat_sync.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/nat/nat_sync.go
@@ -124,7 +124,7 @@ func (n *NATSyncer) syncEgressIPNATs() error {
 
 func (n *NATSyncer) buildPodCache() (podsNetInfo, podsNetInfo, error) {
 	p := func(item *nbdb.LogicalSwitchPort) bool {
-		return item.ExternalIDs["pod"] == "true" && item.ExternalIDs[ovntypes.NADExternalID] == "" // ignore secondary network LSPs
+		return item.ExternalIDs["pod"] == "true" && item.ExternalIDs[ovntypes.NADExternalID] == "" // ignore UDN LSPs
 	}
 	lsps, err := libovsdbops.FindLogicalSwitchPortWithPredicate(n.nbClient, p)
 	if err != nil {

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -282,7 +282,7 @@ func (gw *GatewayManager) createGWRouter(l3GatewayConfig *util.L3GatewayConfig, 
 		"physical_ips": strings.Join(physicalIPs, ","),
 	}
 
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		maps.Copy(logicalRouterExternalIDs, util.GenerateExternalIDsForSwitchOrRouter(gw.netInfo))
 	}
 
@@ -344,7 +344,7 @@ func (gw *GatewayManager) createGWRouterPeerPort(nodeName string) error {
 			libovsdbops.RouterPort: gwRouterPortName,
 		},
 	}
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		logicalSwitchPort.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -408,7 +408,7 @@ func (gw *GatewayManager) createGWRouterPort(hostSubnets []*net.IPNet, gwLRPJoin
 		Networks: gwLRPNetworks,
 		Options:  options,
 	}
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		gwRouterPort.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -465,7 +465,7 @@ func (gw *GatewayManager) updateGWRouterStaticRoutes(clusterIPSubnet, drLRPIfAdd
 				IPPrefix: entry.String(),
 				Nexthop:  drLRPIfAddr.IP.String(),
 			}
-			if gw.netInfo.IsSecondary() {
+			if gw.netInfo.IsUserDefinedNetwork() {
 				lrsr.ExternalIDs = map[string]string{
 					types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 					types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -495,7 +495,7 @@ func (gw *GatewayManager) updateGWRouterStaticRoutes(clusterIPSubnet, drLRPIfAdd
 			OutputPort:  &externalRouterPort,
 			ExternalIDs: map[string]string{util.OvnNodeMasqCIDR: ""},
 		}
-		if gw.netInfo.IsSecondary() {
+		if gw.netInfo.IsUserDefinedNetwork() {
 			lrsr.ExternalIDs = map[string]string{
 				types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 				types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -527,7 +527,7 @@ func (gw *GatewayManager) updateGWRouterStaticRoutes(clusterIPSubnet, drLRPIfAdd
 			Nexthop:    nextHop.String(),
 			OutputPort: &externalRouterPort,
 		}
-		if gw.netInfo.IsSecondary() {
+		if gw.netInfo.IsUserDefinedNetwork() {
 			lrsr.ExternalIDs = map[string]string{
 				types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 				types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -559,7 +559,7 @@ func (gw *GatewayManager) updateClusterRouterStaticRoutes(hostSubnets []*net.IPN
 			IPPrefix: gwLRPIP.String(),
 			Nexthop:  gwLRPIP.String(),
 		}
-		if gw.netInfo.IsSecondary() {
+		if gw.netInfo.IsUserDefinedNetwork() {
 			lrsr.ExternalIDs = map[string]string{
 				types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 				types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -599,7 +599,7 @@ func (gw *GatewayManager) updateClusterRouterStaticRoutes(hostSubnets []*net.IPN
 		}
 
 		if config.Gateway.Mode != config.GatewayModeLocal {
-			if gw.netInfo.IsSecondary() {
+			if gw.netInfo.IsUserDefinedNetwork() {
 				lrsr.ExternalIDs = map[string]string{
 					types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 					types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -651,8 +651,8 @@ func (gw *GatewayManager) updateClusterRouterStaticRoutes(hostSubnets []*net.IPN
 // - DefaultNetworkController.updateNamespace
 // - EgressIPController.addExternalGWPodSNATOps
 // - EgressIPController.addPodEgressIPAssignment
-// - SecondaryLayer2NetworkController.buildUDNEgressSNAT
-// - SecondaryLayer3NetworkController.addUDNNodeSubnetEgressSNAT
+// - Layer2UserDefinedNetworkController.buildUDNEgressSNAT
+// - Layer3UserDefinedNetworkController.addUDNNodeSubnetEgressSNAT
 // use gateway config parameters to create SNAT rules on the gateway router, but some of them (not all) don't watch
 // gateway config changes and rely on the GatewayManager to update their SNAT rules.
 // Is it racy? Yes!
@@ -736,7 +736,7 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, clusterIPSubnet []*
 	externalIPs, gwLRPIPs []net.IP, gwRouter *nbdb.LogicalRouter) error {
 	// REMOVEME(trozet) workaround - create join subnet SNAT to handle ICMP needs frag return
 	var extIDs map[string]string
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		extIDs = map[string]string{
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -967,7 +967,7 @@ func (gw *GatewayManager) addExternalSwitch(prefix, interfaceID, gatewayRouter, 
 		Networks: externalRouterPortNetworks,
 		Name:     externalRouterPort,
 	}
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		externalLogicalRouterPort.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -996,7 +996,7 @@ func (gw *GatewayManager) addExternalSwitch(prefix, interfaceID, gatewayRouter, 
 		},
 		Name: interfaceID,
 	}
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		externalLogicalSwitchPort.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
@@ -1033,14 +1033,14 @@ func (gw *GatewayManager) addExternalSwitch(prefix, interfaceID, gatewayRouter, 
 		Addresses: []string{macAddress},
 	}
 
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		externalLogicalSwitchPortToRouter.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
 		}
 	}
 	sw := nbdb.LogicalSwitch{Name: externalSwitch}
-	if gw.netInfo.IsSecondary() {
+	if gw.netInfo.IsUserDefinedNetwork() {
 		sw.ExternalIDs = util.GenerateExternalIDsForSwitchOrRouter(gw.netInfo)
 	}
 
@@ -1281,8 +1281,8 @@ func (gw *GatewayManager) staticRouteCleanup(nextHops []net.IP, ipPrefix *net.IP
 		ips.Insert(nextHop.String())
 	}
 	p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-		networkName, isSecondaryNetwork := item.ExternalIDs[types.NetworkExternalID]
-		if !isSecondaryNetwork {
+		networkName, isUserDefinedNetwork := item.ExternalIDs[types.NetworkExternalID]
+		if !isUserDefinedNetwork {
 			networkName = types.DefaultNetworkName
 		}
 		if networkName != gw.netInfo.GetNetworkName() {
@@ -1309,8 +1309,8 @@ func (gw *GatewayManager) policyRouteCleanup(nextHops []net.IP) {
 	for _, nextHop := range nextHops {
 		gwIP := nextHop.String()
 		policyPred := func(item *nbdb.LogicalRouterPolicy) bool {
-			networkName, isSecondaryNetwork := item.ExternalIDs[types.NetworkExternalID]
-			if !isSecondaryNetwork {
+			networkName, isUserDefinedNetwork := item.ExternalIDs[types.NetworkExternalID]
+			if !isUserDefinedNetwork {
 				networkName = types.DefaultNetworkName
 			}
 			if networkName != gw.netInfo.GetNetworkName() {
@@ -1343,8 +1343,8 @@ func (gw *GatewayManager) removeLRPolicies(nodeName string) {
 
 	managedNetworkName := gw.netInfo.GetNetworkName()
 	p := func(item *nbdb.LogicalRouterPolicy) bool {
-		networkName, isSecondaryNetwork := item.ExternalIDs[types.NetworkExternalID]
-		if !isSecondaryNetwork {
+		networkName, isUserDefinedNetwork := item.ExternalIDs[types.NetworkExternalID]
+		if !isUserDefinedNetwork {
 			networkName = types.DefaultNetworkName
 		}
 		if networkName != managedNetworkName {

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
@@ -238,7 +238,7 @@ func (pbr *PolicyBasedRoutesManager) createPolicyBasedRoutes(match, priority, ne
 		Nexthops: []string{nexthops},
 		Action:   nbdb.LogicalRouterPolicyActionReroute,
 	}
-	if pbr.netInfo.IsSecondary() {
+	if pbr.netInfo.IsUserDefinedNetwork() {
 		lrp.ExternalIDs = map[string]string{
 			ovntypes.NetworkExternalID:  pbr.netInfo.GetNetworkName(),
 			ovntypes.TopologyExternalID: pbr.netInfo.TopologyType(),

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -47,7 +47,7 @@ func (n network) generateTestData(nodeName string) []libovsdbtest.TestData {
 	for _, lrp := range n.initialLRPs {
 		lrpUUIDs = append(lrpUUIDs, lrp.UUID)
 		var extID map[string]string
-		if n.info.IsSecondary() {
+		if n.info.IsUserDefinedNetwork() {
 			extID = map[string]string{
 				types.NetworkExternalID:  n.info.GetNetworkName(),
 				types.TopologyExternalID: n.info.TopologyType(),

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -37,15 +37,15 @@ import (
 
 // method/structure shared by all layer 2 network controller, including localnet and layer2 network controllres.
 
-type secondaryLayer2NetworkControllerEventHandler struct {
+type layer2UserDefinedNetworkControllerEventHandler struct {
 	baseHandler  baseNetworkControllerEventHandler
 	watchFactory *factory.WatchFactory
 	objType      reflect.Type
-	oc           *SecondaryLayer2NetworkController
+	oc           *Layer2UserDefinedNetworkController
 	syncFunc     func([]interface{}) error
 }
 
-func (h *secondaryLayer2NetworkControllerEventHandler) FilterOutResource(obj interface{}) bool {
+func (h *layer2UserDefinedNetworkControllerEventHandler) FilterOutResource(obj interface{}) bool {
 	return h.oc.FilterOutResource(h.objType, obj)
 }
 
@@ -53,56 +53,56 @@ func (h *secondaryLayer2NetworkControllerEventHandler) FilterOutResource(obj int
 // type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
 // equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update
 // function or with a delete on the old obj followed by an add on the new obj).
-func (h *secondaryLayer2NetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
 	return h.baseHandler.areResourcesEqual(h.objType, obj1, obj2)
 }
 
 // GetInternalCacheEntry returns the internal cache entry for this object, given an object and its type.
 // This is now used only for pods, which will get their the logical port cache entry.
-func (h *secondaryLayer2NetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
-	return h.oc.GetInternalCacheEntryForSecondaryNetwork(h.objType, obj)
+func (h *layer2UserDefinedNetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
+	return h.oc.GetInternalCacheEntryForUserDefinedNetwork(h.objType, obj)
 }
 
 // GetResourceFromInformerCache returns the latest state of the object, given an object key and its type.
 // from the informers cache.
-func (h *secondaryLayer2NetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
 	return h.baseHandler.getResourceFromInformerCache(h.objType, h.watchFactory, key)
 }
 
 // RecordAddEvent records the add event on this given object.
-func (h *secondaryLayer2NetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
 	h.baseHandler.recordAddEvent(h.objType, obj)
 }
 
 // RecordUpdateEvent records the udpate event on this given object.
-func (h *secondaryLayer2NetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
 	h.baseHandler.recordUpdateEvent(h.objType, obj)
 }
 
 // RecordDeleteEvent records the delete event on this given object.
-func (h *secondaryLayer2NetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
 	h.baseHandler.recordDeleteEvent(h.objType, obj)
 }
 
 // RecordSuccessEvent records the success event on this given object.
-func (h *secondaryLayer2NetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
 	h.baseHandler.recordSuccessEvent(h.objType, obj)
 }
 
 // RecordErrorEvent records the error event on this given object.
-func (h *secondaryLayer2NetworkControllerEventHandler) RecordErrorEvent(_ interface{}, _ string, _ error) {
+func (h *layer2UserDefinedNetworkControllerEventHandler) RecordErrorEvent(_ interface{}, _ string, _ error) {
 }
 
 // IsResourceScheduled returns true if the given object has been scheduled.
 // Only applied to pods for now. Returns true for all other types.
-func (h *secondaryLayer2NetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
+func (h *layer2UserDefinedNetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
 	return h.baseHandler.isResourceScheduled(h.objType, obj)
 }
 
 // AddResource adds the specified object to the cluster according to its type and returns the error,
 // if any, yielded during object creation.
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
-func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
+func (h *layer2UserDefinedNetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
 	switch h.objType {
 	case factory.NodeType:
 		node, ok := obj.(*corev1.Node)
@@ -131,14 +131,14 @@ func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface
 		}
 		return h.oc.addUpdateRemoteNodeEvent(node, config.OVNKubernetesFeature.EnableInterconnect)
 	default:
-		return h.oc.AddSecondaryNetworkResourceCommon(h.objType, obj)
+		return h.oc.AddUserDefinedNetworkResourceCommon(h.objType, obj)
 	}
 }
 
 // DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
 // Given an object and optionally a cachedObj; cachedObj is the internal cache entry for this object,
 // used for now for pods and network policies.
-func (h *secondaryLayer2NetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
+func (h *layer2UserDefinedNetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
 	switch h.objType {
 	case factory.NodeType:
 		node, ok := obj.(*corev1.Node)
@@ -147,7 +147,7 @@ func (h *secondaryLayer2NetworkControllerEventHandler) DeleteResource(obj, cache
 		}
 		return h.oc.deleteNodeEvent(node)
 	default:
-		return h.oc.DeleteSecondaryNetworkResourceCommon(h.objType, obj, cachedObj)
+		return h.oc.DeleteUserDefinedNetworkResourceCommon(h.objType, obj, cachedObj)
 	}
 }
 
@@ -155,7 +155,7 @@ func (h *secondaryLayer2NetworkControllerEventHandler) DeleteResource(obj, cache
 // type and returns the error, if any, yielded during the object update.
 // Given an old and a new object; The inRetryCache boolean argument is to indicate if the given resource
 // is in the retryCache or not.
-func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
+func (h *layer2UserDefinedNetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
 	switch h.objType {
 	case factory.NodeType:
 		newNode, ok := newObj.(*corev1.Node)
@@ -205,7 +205,7 @@ func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, ne
 	case factory.PodType:
 		newPod := newObj.(*corev1.Pod)
 		oldPod := oldObj.(*corev1.Pod)
-		if err := h.oc.ensurePodForSecondaryNetwork(newPod, shouldAddPort(oldPod, newPod, inRetryCache)); err != nil {
+		if err := h.oc.ensurePodForUserDefinedNetwork(newPod, shouldAddPort(oldPod, newPod, inRetryCache)); err != nil {
 			return err
 		}
 
@@ -214,11 +214,11 @@ func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, ne
 		}
 		return nil
 	default:
-		return h.oc.UpdateSecondaryNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
+		return h.oc.UpdateUserDefinedNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
 	}
 }
 
-func (h *secondaryLayer2NetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
+func (h *layer2UserDefinedNetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
 	var syncFunc func([]interface{}) error
 
 	if h.syncFunc != nil {
@@ -230,7 +230,7 @@ func (h *secondaryLayer2NetworkControllerEventHandler) SyncFunc(objs []interface
 			syncFunc = h.oc.syncNodes
 
 		case factory.PodType:
-			syncFunc = h.oc.syncPodsForSecondaryNetwork
+			syncFunc = h.oc.syncPodsForUserDefinedNetwork
 
 		case factory.NamespaceType:
 			syncFunc = h.oc.syncNamespaces
@@ -256,14 +256,14 @@ func (h *secondaryLayer2NetworkControllerEventHandler) SyncFunc(objs []interface
 
 // IsObjectInTerminalState returns true if the given object is a in terminal state.
 // This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
-func (h *secondaryLayer2NetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
+func (h *layer2UserDefinedNetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
 	return h.baseHandler.isObjectInTerminalState(h.objType, obj)
 }
 
-// SecondaryLayer2NetworkController is created for logical network infrastructure and policy
-// for a secondary layer2 network
-type SecondaryLayer2NetworkController struct {
-	BaseSecondaryLayer2NetworkController
+// Layer2UserDefinedNetworkController is created for logical network infrastructure and policy
+// for a layer2 UDN
+type Layer2UserDefinedNetworkController struct {
+	BaseLayer2UserDefinedNetworkController
 
 	// Node-specific syncMaps used by node event handler
 	mgmtPortFailed           sync.Map
@@ -298,14 +298,14 @@ type SecondaryLayer2NetworkController struct {
 	defaultGatewayReconciler *kubevirt.DefaultGatewayReconciler
 }
 
-// NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
-func NewSecondaryLayer2NetworkController(
+// NewLayer2UserDefinedNetworkController create a new OVN controller for the given layer2 NAD
+func NewLayer2UserDefinedNetworkController(
 	cnci *CommonNetworkControllerInfo,
 	netInfo util.NetInfo,
 	networkManager networkmanager.Interface,
 	routeImportManager routeimport.Manager,
 	portCache *PortCache,
-	eIPController *EgressIPController) (*SecondaryLayer2NetworkController, error) {
+	eIPController *EgressIPController) (*Layer2UserDefinedNetworkController, error) {
 
 	stopChan := make(chan struct{})
 
@@ -327,10 +327,10 @@ func NewSecondaryLayer2NetworkController(
 		lsManager = lsm.NewL2SwitchManagerForUserDefinedPrimaryNetwork(gatewayIPs, mgmtIPs)
 	}
 
-	oc := &SecondaryLayer2NetworkController{
-		BaseSecondaryLayer2NetworkController: BaseSecondaryLayer2NetworkController{
+	oc := &Layer2UserDefinedNetworkController{
+		BaseLayer2UserDefinedNetworkController: BaseLayer2UserDefinedNetworkController{
 
-			BaseSecondaryNetworkController: BaseSecondaryNetworkController{
+			BaseUserDefinedNetworkController: BaseUserDefinedNetworkController{
 				BaseNetworkController: BaseNetworkController{
 					CommonNetworkControllerInfo: *cnci,
 					controllerName:              getNetworkControllerName(netInfo.GetNetworkName()),
@@ -405,13 +405,13 @@ func NewSecondaryLayer2NetworkController(
 	return oc, nil
 }
 
-// Start starts the secondary layer2 controller, handles all events and creates all needed logical entities
-func (oc *SecondaryLayer2NetworkController) Start(_ context.Context) error {
-	klog.Infof("Starting controller for secondary network %s", oc.GetNetworkName())
+// Start starts the layer2 UDN controller, handles all events and creates all needed logical entities
+func (oc *Layer2UserDefinedNetworkController) Start(_ context.Context) error {
+	klog.Infof("Starting controller for UDN %s", oc.GetNetworkName())
 
 	start := time.Now()
 	defer func() {
-		klog.Infof("Starting controller for secondary network %s took %v", oc.GetNetworkName(), time.Since(start))
+		klog.Infof("Starting controller for UDN %s took %v", oc.GetNetworkName(), time.Since(start))
 	}()
 
 	if err := oc.init(); err != nil {
@@ -421,8 +421,8 @@ func (oc *SecondaryLayer2NetworkController) Start(_ context.Context) error {
 	return oc.run()
 }
 
-func (oc *SecondaryLayer2NetworkController) run() error {
-	err := oc.BaseSecondaryLayer2NetworkController.run()
+func (oc *Layer2UserDefinedNetworkController) run() error {
+	err := oc.BaseLayer2UserDefinedNetworkController.run()
 	if err != nil {
 		return err
 	}
@@ -442,9 +442,9 @@ func (oc *SecondaryLayer2NetworkController) run() error {
 
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
-func (oc *SecondaryLayer2NetworkController) Cleanup() error {
+func (oc *Layer2UserDefinedNetworkController) Cleanup() error {
 	networkName := oc.GetNetworkName()
-	if err := oc.BaseSecondaryLayer2NetworkController.cleanup(); err != nil {
+	if err := oc.BaseLayer2UserDefinedNetworkController.cleanup(); err != nil {
 		return fmt.Errorf("failed to cleanup network %q: %w", networkName, err)
 	}
 
@@ -476,7 +476,7 @@ func (oc *SecondaryLayer2NetworkController) Cleanup() error {
 	return nil
 }
 
-func (oc *SecondaryLayer2NetworkController) init() error {
+func (oc *Layer2UserDefinedNetworkController) init() error {
 	// Create default Control Plane Protection (COPP) entry for routers
 	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
 	if err != nil {
@@ -520,19 +520,19 @@ func (oc *SecondaryLayer2NetworkController) init() error {
 	return err
 }
 
-func (oc *SecondaryLayer2NetworkController) Stop() {
-	klog.Infof("Stoping controller for secondary network %s", oc.GetNetworkName())
-	oc.BaseSecondaryLayer2NetworkController.stop()
+func (oc *Layer2UserDefinedNetworkController) Stop() {
+	klog.Infof("Stoping controller for UDN %s", oc.GetNetworkName())
+	oc.BaseLayer2UserDefinedNetworkController.stop()
 }
 
-func (oc *SecondaryLayer2NetworkController) Reconcile(netInfo util.NetInfo) error {
+func (oc *Layer2UserDefinedNetworkController) Reconcile(netInfo util.NetInfo) error {
 	return oc.BaseNetworkController.reconcile(
 		netInfo,
 		func(node string) { oc.gatewaysFailed.Store(node, true) },
 	)
 }
 
-func (oc *SecondaryLayer2NetworkController) initRetryFramework() {
+func (oc *Layer2UserDefinedNetworkController) initRetryFramework() {
 	oc.retryNodes = oc.newRetryFramework(factory.NodeType)
 	oc.retryPods = oc.newRetryFramework(factory.PodType)
 	if oc.allocatesPodAnnotation() && oc.AllowsPersistentIPs() {
@@ -556,9 +556,9 @@ func (oc *SecondaryLayer2NetworkController) initRetryFramework() {
 }
 
 // newRetryFramework builds and returns a retry framework for the input resource type;
-func (oc *SecondaryLayer2NetworkController) newRetryFramework(
+func (oc *Layer2UserDefinedNetworkController) newRetryFramework(
 	objectType reflect.Type) *retry.RetryFramework {
-	eventHandler := &secondaryLayer2NetworkControllerEventHandler{
+	eventHandler := &layer2UserDefinedNetworkControllerEventHandler{
 		baseHandler:  baseNetworkControllerEventHandler{},
 		objType:      objectType,
 		watchFactory: oc.watchFactory,
@@ -579,7 +579,7 @@ func (oc *SecondaryLayer2NetworkController) newRetryFramework(
 	)
 }
 
-func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1.Node, nSyncs *nodeSyncs) error {
+func (oc *Layer2UserDefinedNetworkController) addUpdateLocalNodeEvent(node *corev1.Node, nSyncs *nodeSyncs) error {
 	var errs []error
 
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
@@ -659,7 +659,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 		}
 	}
 
-	errs = append(errs, oc.BaseSecondaryLayer2NetworkController.addUpdateLocalNodeEvent(node))
+	errs = append(errs, oc.BaseLayer2UserDefinedNetworkController.addUpdateLocalNodeEvent(node))
 
 	err := utilerrors.Join(errs...)
 	if err != nil {
@@ -668,7 +668,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 	return err
 }
 
-func (oc *SecondaryLayer2NetworkController) addUpdateRemoteNodeEvent(node *corev1.Node, syncZoneIC bool) error {
+func (oc *Layer2UserDefinedNetworkController) addUpdateRemoteNodeEvent(node *corev1.Node, syncZoneIC bool) error {
 	var errs []error
 
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
@@ -683,7 +683,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateRemoteNodeEvent(node *corev
 		}
 	}
 
-	errs = append(errs, oc.BaseSecondaryLayer2NetworkController.addUpdateRemoteNodeEvent(node))
+	errs = append(errs, oc.BaseLayer2UserDefinedNetworkController.addUpdateRemoteNodeEvent(node))
 
 	err := utilerrors.Join(errs...)
 	if err != nil {
@@ -692,7 +692,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateRemoteNodeEvent(node *corev
 	return err
 }
 
-func (oc *SecondaryLayer2NetworkController) addPortForRemoteNodeGR(node *corev1.Node) error {
+func (oc *Layer2UserDefinedNetworkController) addPortForRemoteNodeGR(node *corev1.Node) error {
 	nodeJoinSubnetIPs, err := udn.GetGWRouterIPs(node, oc.GetNetInfo())
 	if err != nil {
 		if util.IsAnnotationNotSetError(err) {
@@ -745,7 +745,7 @@ func (oc *SecondaryLayer2NetworkController) addPortForRemoteNodeGR(node *corev1.
 	return nil
 }
 
-func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) error {
+func (oc *Layer2UserDefinedNetworkController) deleteNodeEvent(node *corev1.Node) error {
 	if err := oc.gatewayManagerForNode(node.Name).Cleanup(); err != nil {
 		return fmt.Errorf("failed to cleanup gateway on node %q: %w", node.Name, err)
 	}
@@ -770,7 +770,7 @@ func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) e
 // If isUDNAdvertised is true, then we want to SNAT all packets that are coming from pods on this network
 // leaving towards nodeIPs on the cluster to masqueradeIP. If network is advertise then the SNAT looks like this:
 // "eth.dst == 0a:58:5d:5d:00:02 && (ip4.dst == $a712973235162149816)" "169.254.0.36" "93.93.0.0/16"
-func (oc *SecondaryLayer2NetworkController) addOrUpdateUDNClusterSubnetEgressSNAT(localPodSubnets []*net.IPNet, gwRouterName string, isUDNAdvertised bool) error {
+func (oc *Layer2UserDefinedNetworkController) addOrUpdateUDNClusterSubnetEgressSNAT(localPodSubnets []*net.IPNet, gwRouterName string, isUDNAdvertised bool) error {
 	outputPort := types.GWRouterToJoinSwitchPrefix + gwRouterName
 	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort, isUDNAdvertised)
 	if err != nil {
@@ -789,7 +789,7 @@ func (oc *SecondaryLayer2NetworkController) addOrUpdateUDNClusterSubnetEgressSNA
 	return nil
 }
 
-func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node) (*GatewayConfig, error) {
+func (oc *Layer2UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Node) (*GatewayConfig, error) {
 	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node %s network %s L3 gateway config: %v", node.Name, oc.GetNetworkName(), err)
@@ -840,7 +840,7 @@ func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node)
 	}, nil
 }
 
-func (oc *SecondaryLayer2NetworkController) newGatewayManager(nodeName string) *GatewayManager {
+func (oc *Layer2UserDefinedNetworkController) newGatewayManager(nodeName string) *GatewayManager {
 	return NewGatewayManagerForLayer2Topology(
 		nodeName,
 		oc.defaultCOPPUUID,
@@ -852,7 +852,7 @@ func (oc *SecondaryLayer2NetworkController) newGatewayManager(nodeName string) *
 	)
 }
 
-func (oc *SecondaryLayer2NetworkController) gatewayManagerForNode(nodeName string) *GatewayManager {
+func (oc *Layer2UserDefinedNetworkController) gatewayManagerForNode(nodeName string) *GatewayManager {
 	obj, isFound := oc.gatewayManagers.Load(nodeName)
 	if !isFound {
 		return oc.newGatewayManager(nodeName)
@@ -870,7 +870,7 @@ func (oc *SecondaryLayer2NetworkController) gatewayManagerForNode(nodeName strin
 	}
 }
 
-func (oc *SecondaryLayer2NetworkController) gatewayOptions() []GatewayOption {
+func (oc *Layer2UserDefinedNetworkController) gatewayOptions() []GatewayOption {
 	var opts []GatewayOption
 	if oc.clusterLoadBalancerGroupUUID != "" {
 		opts = append(opts, WithLoadBalancerGroups(
@@ -882,7 +882,7 @@ func (oc *SecondaryLayer2NetworkController) gatewayOptions() []GatewayOption {
 	return opts
 }
 
-func (oc *SecondaryLayer2NetworkController) StartServiceController(wg *sync.WaitGroup, runRepair bool) error {
+func (oc *Layer2UserDefinedNetworkController) StartServiceController(wg *sync.WaitGroup, runRepair bool) error {
 	useLBGroups := oc.clusterLoadBalancerGroupUUID != ""
 	// use 5 workers like most of the kubernetes controllers in the kubernetes controller-manager
 	// do not use LB templates for UDNs - OVN bug https://issues.redhat.com/browse/FDP-988
@@ -893,7 +893,7 @@ func (oc *SecondaryLayer2NetworkController) StartServiceController(wg *sync.Wait
 	return nil
 }
 
-func (oc *SecondaryLayer2NetworkController) updateLocalPodEvent(pod *corev1.Pod) error {
+func (oc *Layer2UserDefinedNetworkController) updateLocalPodEvent(pod *corev1.Pod) error {
 	if kubevirt.IsPodAllowedForMigration(pod, oc.GetNetInfo()) {
 		kubevirtLiveMigrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(oc.watchFactory, pod)
 		if err != nil {
@@ -908,7 +908,7 @@ func (oc *SecondaryLayer2NetworkController) updateLocalPodEvent(pod *corev1.Pod)
 	return nil
 }
 
-func (oc *SecondaryLayer2NetworkController) reconcileLiveMigrationTargetZone(kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus) error {
+func (oc *Layer2UserDefinedNetworkController) reconcileLiveMigrationTargetZone(kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus) error {
 	if oc.defaultGatewayReconciler == nil {
 		return nil
 	}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -35,15 +35,15 @@ import (
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
-type secondaryLayer3NetworkControllerEventHandler struct {
+type Layer3UserDefinedNetworkControllerEventHandler struct {
 	baseHandler  baseNetworkControllerEventHandler
 	watchFactory *factory.WatchFactory
 	objType      reflect.Type
-	oc           *SecondaryLayer3NetworkController
+	oc           *Layer3UserDefinedNetworkController
 	syncFunc     func([]interface{}) error
 }
 
-func (h *secondaryLayer3NetworkControllerEventHandler) FilterOutResource(obj interface{}) bool {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) FilterOutResource(obj interface{}) bool {
 	return h.oc.FilterOutResource(h.objType, obj)
 }
 
@@ -51,56 +51,56 @@ func (h *secondaryLayer3NetworkControllerEventHandler) FilterOutResource(obj int
 // type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
 // equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update
 // function or with a delete on the old obj followed by an add on the new obj).
-func (h *secondaryLayer3NetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
 	return h.baseHandler.areResourcesEqual(h.objType, obj1, obj2)
 }
 
 // GetInternalCacheEntry returns the internal cache entry for this object, given an object and its type.
 // This is now used only for pods, which will get their the logical port cache entry.
-func (h *secondaryLayer3NetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
-	return h.oc.GetInternalCacheEntryForSecondaryNetwork(h.objType, obj)
+func (h *Layer3UserDefinedNetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
+	return h.oc.GetInternalCacheEntryForUserDefinedNetwork(h.objType, obj)
 }
 
 // GetResourceFromInformerCache returns the latest state of the object, given an object key and its type.
 // from the informers cache.
-func (h *secondaryLayer3NetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
 	return h.baseHandler.getResourceFromInformerCache(h.objType, h.watchFactory, key)
 }
 
 // RecordAddEvent records the add event on this given object.
-func (h *secondaryLayer3NetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
 	h.baseHandler.recordAddEvent(h.objType, obj)
 }
 
 // RecordUpdateEvent records the udpate event on this given object.
-func (h *secondaryLayer3NetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
 	h.baseHandler.recordUpdateEvent(h.objType, obj)
 }
 
 // RecordDeleteEvent records the delete event on this given object.
-func (h *secondaryLayer3NetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
 	h.baseHandler.recordDeleteEvent(h.objType, obj)
 }
 
 // RecordSuccessEvent records the success event on this given object.
-func (h *secondaryLayer3NetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
 	h.baseHandler.recordSuccessEvent(h.objType, obj)
 }
 
 // RecordErrorEvent records the error event on this given object.
-func (h *secondaryLayer3NetworkControllerEventHandler) RecordErrorEvent(_ interface{}, _ string, _ error) {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) RecordErrorEvent(_ interface{}, _ string, _ error) {
 }
 
 // IsResourceScheduled returns true if the given object has been scheduled.
 // Only applied to pods for now. Returns true for all other types.
-func (h *secondaryLayer3NetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
 	return h.baseHandler.isResourceScheduled(h.objType, obj)
 }
 
 // AddResource adds the specified object to the cluster according to its type and returns the error,
 // if any, yielded during object creation.
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
-func (h *secondaryLayer3NetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
 	switch h.objType {
 	case factory.NodeType:
 		node, ok := obj.(*corev1.Node)
@@ -145,7 +145,7 @@ func (h *secondaryLayer3NetworkControllerEventHandler) AddResource(obj interface
 			}
 		}
 	default:
-		return h.oc.AddSecondaryNetworkResourceCommon(h.objType, obj)
+		return h.oc.AddUserDefinedNetworkResourceCommon(h.objType, obj)
 	}
 	return nil
 }
@@ -154,7 +154,7 @@ func (h *secondaryLayer3NetworkControllerEventHandler) AddResource(obj interface
 // type and returns the error, if any, yielded during the object update.
 // Given an old and a new object; The inRetryCache boolean argument is to indicate if the given resource
 // is in the retryCache or not.
-func (h *secondaryLayer3NetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
 	switch h.objType {
 	case factory.NodeType:
 		newNode, ok := newObj.(*corev1.Node)
@@ -223,14 +223,14 @@ func (h *secondaryLayer3NetworkControllerEventHandler) UpdateResource(oldObj, ne
 			return h.oc.addUpdateRemoteNodeEvent(newNode, syncZoneIC)
 		}
 	default:
-		return h.oc.UpdateSecondaryNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
+		return h.oc.UpdateUserDefinedNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
 	}
 }
 
 // DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
 // Given an object and optionally a cachedObj; cachedObj is the internal cache entry for this object,
 // used for now for pods and network policies.
-func (h *secondaryLayer3NetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
 	switch h.objType {
 	case factory.NodeType:
 		node, ok := obj.(*corev1.Node)
@@ -240,11 +240,11 @@ func (h *secondaryLayer3NetworkControllerEventHandler) DeleteResource(obj, cache
 		return h.oc.deleteNodeEvent(node)
 
 	default:
-		return h.oc.DeleteSecondaryNetworkResourceCommon(h.objType, obj, cachedObj)
+		return h.oc.DeleteUserDefinedNetworkResourceCommon(h.objType, obj, cachedObj)
 	}
 }
 
-func (h *secondaryLayer3NetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
 	var syncFunc func([]interface{}) error
 
 	if h.syncFunc != nil {
@@ -253,7 +253,7 @@ func (h *secondaryLayer3NetworkControllerEventHandler) SyncFunc(objs []interface
 	} else {
 		switch h.objType {
 		case factory.PodType:
-			syncFunc = h.oc.syncPodsForSecondaryNetwork
+			syncFunc = h.oc.syncPodsForUserDefinedNetwork
 
 		case factory.NodeType:
 			syncFunc = h.oc.syncNodes
@@ -279,14 +279,14 @@ func (h *secondaryLayer3NetworkControllerEventHandler) SyncFunc(objs []interface
 
 // IsObjectInTerminalState returns true if the given object is a in terminal state.
 // This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
-func (h *secondaryLayer3NetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
+func (h *Layer3UserDefinedNetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
 	return h.baseHandler.isObjectInTerminalState(h.objType, obj)
 }
 
-// SecondaryLayer3NetworkController is created for logical network infrastructure and policy
-// for a secondary l3 network
-type SecondaryLayer3NetworkController struct {
-	BaseSecondaryNetworkController
+// Layer3UserDefinedNetworkController is created for logical network infrastructure and policy
+// for a l3 UDN
+type Layer3UserDefinedNetworkController struct {
+	BaseUserDefinedNetworkController
 
 	// Node-specific syncMaps used by node event handler
 	mgmtPortFailed              sync.Map
@@ -321,23 +321,23 @@ type SecondaryLayer3NetworkController struct {
 	eIPController *EgressIPController
 }
 
-// NewSecondaryLayer3NetworkController create a new OVN controller for the given secondary layer3 NAD
-func NewSecondaryLayer3NetworkController(
+// NewLayer3UserDefinedNetworkController create a new OVN controller for the given layer3 NAD
+func NewLayer3UserDefinedNetworkController(
 	cnci *CommonNetworkControllerInfo,
 	netInfo util.NetInfo,
 	networkManager networkmanager.Interface,
 	routeImportManager routeimport.Manager,
 	eIPController *EgressIPController,
 	portCache *PortCache,
-) (*SecondaryLayer3NetworkController, error) {
+) (*Layer3UserDefinedNetworkController, error) {
 
 	stopChan := make(chan struct{})
 	ipv4Mode, ipv6Mode := netInfo.IPMode()
 
 	addressSetFactory := addressset.NewOvnAddressSetFactory(cnci.nbClient, ipv4Mode, ipv6Mode)
 
-	oc := &SecondaryLayer3NetworkController{
-		BaseSecondaryNetworkController: BaseSecondaryNetworkController{
+	oc := &Layer3UserDefinedNetworkController{
+		BaseUserDefinedNetworkController: BaseUserDefinedNetworkController{
 			BaseNetworkController: BaseNetworkController{
 				CommonNetworkControllerInfo: *cnci,
 				controllerName:              getNetworkControllerName(netInfo.GetNetworkName()),
@@ -405,7 +405,7 @@ func NewSecondaryLayer3NetworkController(
 	return oc, nil
 }
 
-func (oc *SecondaryLayer3NetworkController) initRetryFramework() {
+func (oc *Layer3UserDefinedNetworkController) initRetryFramework() {
 	oc.retryPods = oc.newRetryFramework(factory.PodType)
 	oc.retryNodes = oc.newRetryFramework(factory.NodeType)
 
@@ -426,9 +426,9 @@ func (oc *SecondaryLayer3NetworkController) initRetryFramework() {
 }
 
 // newRetryFramework builds and returns a retry framework for the input resource type;
-func (oc *SecondaryLayer3NetworkController) newRetryFramework(
+func (oc *Layer3UserDefinedNetworkController) newRetryFramework(
 	objectType reflect.Type) *retry.RetryFramework {
-	eventHandler := &secondaryLayer3NetworkControllerEventHandler{
+	eventHandler := &Layer3UserDefinedNetworkControllerEventHandler{
 		baseHandler:  baseNetworkControllerEventHandler{},
 		objType:      objectType,
 		watchFactory: oc.watchFactory,
@@ -449,9 +449,9 @@ func (oc *SecondaryLayer3NetworkController) newRetryFramework(
 	)
 }
 
-// Start starts the secondary layer3 controller, handles all events and creates all needed logical entities
-func (oc *SecondaryLayer3NetworkController) Start(_ context.Context) error {
-	klog.Infof("Start secondary %s network controller of network %s", oc.TopologyType(), oc.GetNetworkName())
+// Start starts the UDN layer3 controller, handles all events and creates all needed logical entities
+func (oc *Layer3UserDefinedNetworkController) Start(_ context.Context) error {
+	klog.Infof("Start %s UDN controller for network %s", oc.TopologyType(), oc.GetNetworkName())
 	if err := oc.init(); err != nil {
 		return err
 	}
@@ -459,8 +459,8 @@ func (oc *SecondaryLayer3NetworkController) Start(_ context.Context) error {
 }
 
 // Stop gracefully stops the controller, and delete all logical entities for this network if requested
-func (oc *SecondaryLayer3NetworkController) Stop() {
-	klog.Infof("Stop secondary %s network controller of network %s", oc.TopologyType(), oc.GetNetworkName())
+func (oc *Layer3UserDefinedNetworkController) Stop() {
+	klog.Infof("Stop %s UDN controller of network %s", oc.TopologyType(), oc.GetNetworkName())
 	close(oc.stopChan)
 	oc.cancelableCtx.Cancel()
 	oc.wg.Wait()
@@ -487,7 +487,7 @@ func (oc *SecondaryLayer3NetworkController) Stop() {
 
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
-func (oc *SecondaryLayer3NetworkController) Cleanup() error {
+func (oc *Layer3UserDefinedNetworkController) Cleanup() error {
 	// cleans up related OVN logical entities
 	var ops []ovsdb.Operation
 	var err error
@@ -557,7 +557,7 @@ func (oc *SecondaryLayer3NetworkController) Cleanup() error {
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) run() error {
+func (oc *Layer3UserDefinedNetworkController) run() error {
 	klog.Infof("Starting all the Watchers for network %s ...", oc.GetNetworkName())
 	start := time.Now()
 
@@ -628,7 +628,7 @@ func (oc *SecondaryLayer3NetworkController) run() error {
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) Reconcile(netInfo util.NetInfo) error {
+func (oc *Layer3UserDefinedNetworkController) Reconcile(netInfo util.NetInfo) error {
 	return oc.BaseNetworkController.reconcile(
 		netInfo,
 		func(node string) {
@@ -640,7 +640,7 @@ func (oc *SecondaryLayer3NetworkController) Reconcile(netInfo util.NetInfo) erro
 
 // WatchNodes starts the watching of node resource and calls
 // back the appropriate handler logic
-func (oc *SecondaryLayer3NetworkController) WatchNodes() error {
+func (oc *Layer3UserDefinedNetworkController) WatchNodes() error {
 	if oc.nodeHandler != nil {
 		return nil
 	}
@@ -651,7 +651,7 @@ func (oc *SecondaryLayer3NetworkController) WatchNodes() error {
 	return err
 }
 
-func (oc *SecondaryLayer3NetworkController) init() error {
+func (oc *Layer3UserDefinedNetworkController) init() error {
 	if err := oc.gatherJoinSwitchIPs(); err != nil {
 		return fmt.Errorf("failed to gather join switch IPs for network %s: %v", oc.GetNetworkName(), err)
 	}
@@ -699,7 +699,7 @@ func (oc *SecondaryLayer3NetworkController) init() error {
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *corev1.Node, nSyncs *nodeSyncs) error {
+func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *corev1.Node, nSyncs *nodeSyncs) error {
 	var hostSubnets []*net.IPNet
 	var errs []error
 	var err error
@@ -835,7 +835,7 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *corev1
 	return err
 }
 
-func (oc *SecondaryLayer3NetworkController) addUpdateRemoteNodeEvent(node *corev1.Node, syncZoneIc bool) error {
+func (oc *Layer3UserDefinedNetworkController) addUpdateRemoteNodeEvent(node *corev1.Node, syncZoneIc bool) error {
 	_, present := oc.localZoneNodes.Load(node.Name)
 
 	if present {
@@ -870,7 +870,7 @@ func (oc *SecondaryLayer3NetworkController) addUpdateRemoteNodeEvent(node *corev
 // If isUDNAdvertised is true, then we want to SNAT all packets that are coming from pods on this network
 // leaving towards nodeIPs on the cluster to masqueradeIP. If network is advertise then the SNAT looks like this:
 // "eth.dst == 0a:58:5d:5d:00:02 && (ip4.dst == $a712973235162149816)" "169.254.0.36" "93.93.0.0/24"
-func (oc *SecondaryLayer3NetworkController) addOrUpdateUDNNodeSubnetEgressSNAT(localPodSubnets []*net.IPNet, node *corev1.Node, isUDNAdvertised bool) error {
+func (oc *Layer3UserDefinedNetworkController) addOrUpdateUDNNodeSubnetEgressSNAT(localPodSubnets []*net.IPNet, node *corev1.Node, isUDNAdvertised bool) error {
 	outputPort := types.RouterToSwitchPrefix + oc.GetNetworkScopedName(node.Name)
 	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort, isUDNAdvertised)
 	if err != nil {
@@ -890,13 +890,13 @@ func (oc *SecondaryLayer3NetworkController) addOrUpdateUDNNodeSubnetEgressSNAT(l
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) addNode(node *corev1.Node) ([]*net.IPNet, error) {
-	// Node subnet for the secondary layer3 network is allocated by cluster manager.
+func (oc *Layer3UserDefinedNetworkController) addNode(node *corev1.Node) ([]*net.IPNet, error) {
+	// Node subnet for the layer3 UDN is allocated by cluster manager.
 	// Make sure that the node is allocated with the subnet before proceeding
 	// to create OVN Northbound resources.
 	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
 	if err != nil || len(hostSubnets) < 1 {
-		return nil, fmt.Errorf("subnet annotation in the node %q for the layer3 secondary network %s is missing : %w", node.Name, oc.GetNetworkName(), err)
+		return nil, fmt.Errorf("subnet annotation in the node %q for the layer3 UDN %s is missing : %w", node.Name, oc.GetNetworkName(), err)
 	}
 
 	err = oc.createNodeLogicalSwitch(node.Name, hostSubnets, oc.clusterLoadBalancerGroupUUID, oc.switchLoadBalancerGroupUUID)
@@ -922,7 +922,7 @@ func (oc *SecondaryLayer3NetworkController) addNode(node *corev1.Node) ([]*net.I
 	return hostSubnets, nil
 }
 
-func (oc *SecondaryLayer3NetworkController) deleteNodeEvent(node *corev1.Node) error {
+func (oc *Layer3UserDefinedNetworkController) deleteNodeEvent(node *corev1.Node) error {
 	klog.V(5).Infof("Deleting Node %q for network %s. Removing the node from "+
 		"various caches", node.Name, oc.GetNetworkName())
 
@@ -950,7 +950,7 @@ func (oc *SecondaryLayer3NetworkController) deleteNodeEvent(node *corev1.Node) e
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) deleteNode(nodeName string) error {
+func (oc *Layer3UserDefinedNetworkController) deleteNode(nodeName string) error {
 	if err := oc.deleteNodeLogicalNetwork(nodeName); err != nil {
 		return fmt.Errorf("error deleting node %s logical network: %v", nodeName, err)
 	}
@@ -962,7 +962,7 @@ func (oc *SecondaryLayer3NetworkController) deleteNode(nodeName string) error {
 // watchNodes() will be called for all existing nodes at startup anyway.
 // Note that this list will include the 'join' cluster switch, which we
 // do not want to delete.
-func (oc *SecondaryLayer3NetworkController) syncNodes(nodes []interface{}) error {
+func (oc *Layer3UserDefinedNetworkController) syncNodes(nodes []interface{}) error {
 	foundNodes := sets.New[string]()
 	for _, tmp := range nodes {
 		node, ok := tmp.(*corev1.Node)
@@ -1005,7 +1005,7 @@ func (oc *SecondaryLayer3NetworkController) syncNodes(nodes []interface{}) error
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) gatherJoinSwitchIPs() error {
+func (oc *Layer3UserDefinedNetworkController) gatherJoinSwitchIPs() error {
 	// Allocate IPs for logical router port prefixed with
 	// `GwRouterToJoinSwitchPrefix` for the network managed by this controller.
 	// This should always allocate the first IPs in the join switch subnets.
@@ -1017,7 +1017,7 @@ func (oc *SecondaryLayer3NetworkController) gatherJoinSwitchIPs() error {
 	return nil
 }
 
-func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *corev1.Node) (*GatewayConfig, error) {
+func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Node) (*GatewayConfig, error) {
 	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node %s network %s L3 gateway config: %v", node.Name, oc.GetNetworkName(), err)
@@ -1078,7 +1078,7 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *corev1.Node)
 	}, nil
 }
 
-func (oc *SecondaryLayer3NetworkController) newClusterRouter() (*nbdb.LogicalRouter, error) {
+func (oc *Layer3UserDefinedNetworkController) newClusterRouter() (*nbdb.LogicalRouter, error) {
 	if oc.multicastSupport {
 		return oc.gatewayTopologyFactory.NewClusterRouterWithMulticastSupport(
 			oc.GetNetworkScopedClusterRouterName(),
@@ -1093,7 +1093,7 @@ func (oc *SecondaryLayer3NetworkController) newClusterRouter() (*nbdb.LogicalRou
 	)
 }
 
-func (oc *SecondaryLayer3NetworkController) newGatewayManager(nodeName string) *GatewayManager {
+func (oc *Layer3UserDefinedNetworkController) newGatewayManager(nodeName string) *GatewayManager {
 	return NewGatewayManager(
 		nodeName,
 		oc.defaultCOPPUUID,
@@ -1105,7 +1105,7 @@ func (oc *SecondaryLayer3NetworkController) newGatewayManager(nodeName string) *
 	)
 }
 
-func (oc *SecondaryLayer3NetworkController) gatewayOptions() []GatewayOption {
+func (oc *Layer3UserDefinedNetworkController) gatewayOptions() []GatewayOption {
 	var opts []GatewayOption
 	if oc.clusterLoadBalancerGroupUUID != "" {
 		opts = append(opts, WithLoadBalancerGroups(
@@ -1117,7 +1117,7 @@ func (oc *SecondaryLayer3NetworkController) gatewayOptions() []GatewayOption {
 	return opts
 }
 
-func (oc *SecondaryLayer3NetworkController) gatewayManagerForNode(nodeName string) *GatewayManager {
+func (oc *Layer3UserDefinedNetworkController) gatewayManagerForNode(nodeName string) *GatewayManager {
 	obj, isFound := oc.gatewayManagers.Load(nodeName)
 	if !isFound {
 		return oc.newGatewayManager(nodeName)
@@ -1135,7 +1135,7 @@ func (oc *SecondaryLayer3NetworkController) gatewayManagerForNode(nodeName strin
 	}
 }
 
-func (oc *SecondaryLayer3NetworkController) StartServiceController(wg *sync.WaitGroup, runRepair bool) error {
+func (oc *Layer3UserDefinedNetworkController) StartServiceController(wg *sync.WaitGroup, runRepair bool) error {
 	useLBGroups := oc.clusterLoadBalancerGroupUUID != ""
 	// use 5 workers like most of the kubernetes controllers in the kubernetes controller-manager
 	// do not use LB templates for UDNs - OVN bug https://issues.redhat.com/browse/FDP-988

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -320,8 +320,8 @@ func startBaseNetworkController(fakeOvn *FakeOVN, nad *nadapi.NetworkAttachmentD
 	if nad != nil {
 		netInfo, err := util.ParseNADInfo(nad)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(fakeOvn.NewSecondaryNetworkController(nad)).To(Succeed())
-		controller, ok := fakeOvn.secondaryControllers[netInfo.GetNetworkName()]
+		Expect(fakeOvn.NewUserDefinedNetworkController(nad)).To(Succeed())
+		controller, ok := fakeOvn.userDefinedNetworkControllers[netInfo.GetNetworkName()]
 		Expect(ok).To(BeTrue())
 		return &controller.bnc.BaseNetworkController, controller.asf
 	} else {

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -29,9 +29,9 @@ func (p testPod) addNetwork(
 	tunnelID int,
 	routes []util.PodRoute,
 ) {
-	podInfo, ok := p.secondaryPodInfos[netName]
+	podInfo, ok := p.udnPodInfos[netName]
 	if !ok {
-		podInfo = &secondaryPodInfo{
+		podInfo = &udnPodInfo{
 			nodeSubnet:  nodeSubnet,
 			nodeMgtIP:   nodeMgtIP,
 			nodeGWIP:    nodeGWIP,
@@ -39,12 +39,12 @@ func (p testPod) addNetwork(
 			routes:      routes,
 			allportInfo: map[string]portInfo{},
 		}
-		p.secondaryPodInfos[netName] = podInfo
+		p.udnPodInfos[netName] = podInfo
 	}
 
 	prefixLen, ip := splitPodIPMaskLength(podIP)
 
-	portName := util.GetSecondaryNetworkLogicalPortName(p.namespace, p.podName, nadName)
+	portName := util.GetUserDefinedNetworkLogicalPortName(p.namespace, p.podName, nadName)
 	podInfo.allportInfo[nadName] = portInfo{
 		portUUID:  portName + "-UUID",
 		podIP:     ip,
@@ -56,7 +56,7 @@ func (p testPod) addNetwork(
 }
 
 func (p testPod) getNetworkPortInfo(netName, nadName string) *portInfo {
-	podInfo, ok := p.secondaryPodInfos[netName]
+	podInfo, ok := p.udnPodInfos[netName]
 	if !ok {
 		return nil
 	}
@@ -78,9 +78,9 @@ func splitPodIPMaskLength(podIP string) (int, string) {
 	return prefixLen, ip.String()
 }
 
-type option func(machine *secondaryNetworkExpectationMachine)
+type option func(machine *userDefinedNetworkExpectationMachine)
 
-type secondaryNetworkExpectationMachine struct {
+type userDefinedNetworkExpectationMachine struct {
 	fakeOvn               *FakeOVN
 	pods                  []testPod
 	gatewayConfig         *util.L3GatewayConfig
@@ -88,8 +88,8 @@ type secondaryNetworkExpectationMachine struct {
 	hasClusterPortGroup   bool
 }
 
-func newSecondaryNetworkExpectationMachine(fakeOvn *FakeOVN, pods []testPod, opts ...option) *secondaryNetworkExpectationMachine {
-	machine := &secondaryNetworkExpectationMachine{
+func newUserDefinedNetworkExpectationMachine(fakeOvn *FakeOVN, pods []testPod, opts ...option) *userDefinedNetworkExpectationMachine {
+	machine := &userDefinedNetworkExpectationMachine{
 		fakeOvn: fakeOvn,
 		pods:    pods,
 	}
@@ -101,37 +101,37 @@ func newSecondaryNetworkExpectationMachine(fakeOvn *FakeOVN, pods []testPod, opt
 }
 
 func withGatewayConfig(config *util.L3GatewayConfig) option {
-	return func(machine *secondaryNetworkExpectationMachine) {
+	return func(machine *userDefinedNetworkExpectationMachine) {
 		machine.gatewayConfig = config
 	}
 }
 
 func withInterconnectCluster() option {
-	return func(machine *secondaryNetworkExpectationMachine) {
+	return func(machine *userDefinedNetworkExpectationMachine) {
 		machine.isInterconnectCluster = true
 	}
 }
 
 func withClusterPortGroup() option {
-	return func(machine *secondaryNetworkExpectationMachine) {
+	return func(machine *userDefinedNetworkExpectationMachine) {
 		machine.hasClusterPortGroup = true
 	}
 }
 
-func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(isPrimary bool) []libovsdbtest.TestData {
+func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(isPrimary bool) []libovsdbtest.TestData {
 	return em.expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary, nil)
 }
 
-func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary bool, expectedPodLspEnabled map[string]*bool) []libovsdbtest.TestData {
+func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary bool, expectedPodLspEnabled map[string]*bool) []libovsdbtest.TestData {
 	data := []libovsdbtest.TestData{}
-	for _, ocInfo := range em.fakeOvn.secondaryControllers {
+	for _, ocInfo := range em.fakeOvn.userDefinedNetworkControllers {
 		nodeslsps := make(map[string][]string)
 		acls := make(map[string][]string)
 		var switchName string
 		switchNodeMap := make(map[string]*nbdb.LogicalSwitch)
 		alreadyAddedManagementElements := make(map[string]struct{})
 		for _, pod := range em.pods {
-			podInfo, ok := pod.secondaryPodInfos[ocInfo.bnc.GetNetworkName()]
+			podInfo, ok := pod.udnPodInfos[ocInfo.bnc.GetNetworkName()]
 			if !ok {
 				continue
 			}
@@ -252,7 +252,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPortsWit
 				}
 			}
 
-			// TODO: once we start the "full" SecondaryLayer2NetworkController (instead of just Base)
+			// TODO: once we start the "full" Layer2UserDefinedNetworkController (instead of just Base)
 			// we can drop this, and compare all objects created by the controller (right now we're
 			// missing all the meters, and the COPP)
 			if ocInfo.bnc.TopologyType() == ovntypes.Layer2Topology {
@@ -453,7 +453,7 @@ func nonICClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
 	return config
 }
 
-func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...secondaryNetInfo) *corev1.Pod {
+func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...userDefinedNetInfo) *corev1.Pod {
 	pod := newMultiHomedPod(testPod, multiHomingConfigs...)
 	pod.Labels[kubevirtv1.VirtualMachineNameLabel] = vmName
 	pod.Status.Phase = liveMigrationInfo.podPhase
@@ -464,7 +464,7 @@ func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodI
 	return pod
 }
 
-func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *corev1.Pod {
+func newMultiHomedPod(testPod testPod, multiHomingConfigs ...userDefinedNetInfo) *corev1.Pod {
 	pod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 	var secondaryNetworks []nadapi.NetworkSelectionElement
 	if len(pod.Annotations) == 0 {
@@ -494,7 +494,7 @@ func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *
 	serializedNetworkSelectionElements, _ := json.Marshal(secondaryNetworks)
 	pod.Annotations[nadapi.NetworkAttachmentAnnot] = string(serializedNetworkSelectionElements)
 	if config.OVNKubernetesFeature.EnableInterconnect {
-		dummyOVNNetAnnotations := dummyOVNPodNetworkAnnotations(testPod.secondaryPodInfos, multiHomingConfigs)
+		dummyOVNNetAnnotations := dummyOVNPodNetworkAnnotations(testPod.udnPodInfos, multiHomingConfigs)
 		if dummyOVNNetAnnotations != "{}" {
 			pod.Annotations["k8s.ovn.org/pod-networks"] = dummyOVNNetAnnotations
 		}
@@ -502,7 +502,7 @@ func newMultiHomedPod(testPod testPod, multiHomingConfigs ...secondaryNetInfo) *
 	return pod
 }
 
-func dummyOVNPodNetworkAnnotations(secondaryPodInfos map[string]*secondaryPodInfo, multiHomingConfigs []secondaryNetInfo) string {
+func dummyOVNPodNetworkAnnotations(secondaryPodInfos map[string]*udnPodInfo, multiHomingConfigs []userDefinedNetInfo) string {
 	var ovnPodNetworksAnnotations []byte
 	podAnnotations := map[string]podAnnotation{}
 	for i, netConfig := range multiHomingConfigs {
@@ -523,7 +523,7 @@ func dummyOVNPodNetworkAnnotations(secondaryPodInfos map[string]*secondaryPodInf
 	return string(ovnPodNetworksAnnotations)
 }
 
-func dummyOVNPodNetworkAnnotationForNetwork(portInfo portInfo, netConfig secondaryNetInfo, tunnelID int) podAnnotation {
+func dummyOVNPodNetworkAnnotationForNetwork(portInfo portInfo, netConfig userDefinedNetInfo, tunnelID int) podAnnotation {
 	role := ovntypes.NetworkRoleSecondary
 	if netConfig.isPrimary {
 		role = ovntypes.NetworkRolePrimary

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -587,7 +587,8 @@ func (o *FakeOVN) NewUserDefinedNetworkController(netattachdef *nettypes.Network
 	ginkgo.By(fmt.Sprintf("OVN test init: add NAD %s to user-defined network controller of %s network %s", nadName, topoType, netName))
 	mutableNetInfo := util.NewMutableNetInfo(userDefinedNetworkController.GetNetInfo())
 	mutableNetInfo.AddNADs(nadName)
-	_ = util.ReconcileNetInfo(userDefinedNetworkController.ReconcilableNetInfo, mutableNetInfo)
+	err = util.ReconcileNetInfo(userDefinedNetworkController.ReconcilableNetInfo, mutableNetInfo)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return nil
 }
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -67,8 +67,8 @@ const (
 	ovnClusterPortGroupUUID     = fakePgUUID
 )
 
-type secondaryControllerInfo struct {
-	bnc *BaseSecondaryNetworkController
+type userDefinedNetworkControllerInfo struct {
+	bnc *BaseUserDefinedNetworkController
 	asf *addressset.FakeAddressSetFactory
 }
 
@@ -91,9 +91,9 @@ type FakeOVN struct {
 	eIPController  *EgressIPController
 	portCache      *PortCache
 
-	// information map of all secondary network controllers
-	secondaryControllers       map[string]secondaryControllerInfo
-	fullSecondaryL2Controllers map[string]*SecondaryLayer2NetworkController
+	// information map of all UDN controllers
+	userDefinedNetworkControllers map[string]userDefinedNetworkControllerInfo
+	fullL2UDNControllers          map[string]*Layer2UserDefinedNetworkController
 }
 
 // NOTE: the FakeAddressSetFactory is no longer needed and should no longer be used. starting to phase out FakeAddressSetFactory
@@ -109,8 +109,8 @@ func NewFakeOVN(useFakeAddressSet bool) *FakeOVN {
 		egressSVCWg:  &sync.WaitGroup{},
 		anpWg:        &sync.WaitGroup{},
 
-		secondaryControllers:       map[string]secondaryControllerInfo{},
-		fullSecondaryL2Controllers: map[string]*SecondaryLayer2NetworkController{},
+		userDefinedNetworkControllers: map[string]userDefinedNetworkControllerInfo{},
+		fullL2UDNControllers:          map[string]*Layer2UserDefinedNetworkController{},
 	}
 }
 
@@ -196,7 +196,7 @@ func (o *FakeOVN) shutdown() {
 	o.egressSVCWg.Wait()
 	o.anpWg.Wait()
 	o.nbsbCleanup.Cleanup()
-	for _, ocInfo := range o.secondaryControllers {
+	for _, ocInfo := range o.userDefinedNetworkControllers {
 		close(ocInfo.bnc.stopChan)
 		ocInfo.bnc.cancelableCtx.Cancel()
 		ocInfo.bnc.wg.Wait()
@@ -266,7 +266,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 	setupCOPP := false
 	setupClusterController(o.controller, setupCOPP)
 	for _, n := range nadList {
-		err := o.NewSecondaryNetworkController(&n)
+		err := o.NewUserDefinedNetworkController(&n)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
@@ -280,9 +280,9 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 	if err == nil {
 		for _, node := range existingNodes {
 			o.controller.localZoneNodes.Store(node.Name, true)
-			for _, secondaryController := range o.secondaryControllers {
-				if secondaryController.bnc.localZoneNodes != nil {
-					secondaryController.bnc.localZoneNodes.Store(node.Name, true)
+			for _, udnController := range o.userDefinedNetworkControllers {
+				if udnController.bnc.localZoneNodes != nil {
+					udnController.bnc.localZoneNodes.Store(node.Name, true)
 				}
 			}
 		}
@@ -497,9 +497,9 @@ func newNetworkAttachmentDefinition(namespace, name string, netconf ovncnitypes.
 	}, nil
 }
 
-func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAttachmentDefinition) error {
-	var ocInfo secondaryControllerInfo
-	var secondaryController *BaseSecondaryNetworkController
+func (o *FakeOVN) NewUserDefinedNetworkController(netattachdef *nettypes.NetworkAttachmentDefinition) error {
+	var ocInfo userDefinedNetworkControllerInfo
+	var userDefinedNetworkController *BaseUserDefinedNetworkController
 	var ok bool
 
 	nadName := util.GetNADName(netattachdef.Namespace, netattachdef.Name)
@@ -509,7 +509,7 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 	}
 	netName := nInfo.GetNetworkName()
 	topoType := nInfo.TopologyType()
-	ocInfo, ok = o.secondaryControllers[netName]
+	ocInfo, ok = o.userDefinedNetworkControllers[netName]
 	if !ok {
 		nbZoneFailed := false
 		// Try to get the NBZone.  If there is an error, create NB_Global record.
@@ -548,31 +548,31 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 
 		switch topoType {
 		case types.Layer3Topology:
-			l3Controller, err := NewSecondaryLayer3NetworkController(cnci, nInfo, o.networkManager.Interface(), nil, o.eIPController, o.portCache)
+			l3Controller, err := NewLayer3UserDefinedNetworkController(cnci, nInfo, o.networkManager.Interface(), nil, o.eIPController, o.portCache)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if o.asf != nil { // use fake asf only when enabled
 				l3Controller.addressSetFactory = asf
 			}
-			secondaryController = &l3Controller.BaseSecondaryNetworkController
+			userDefinedNetworkController = &l3Controller.BaseUserDefinedNetworkController
 		case types.Layer2Topology:
-			l2Controller, err := NewSecondaryLayer2NetworkController(cnci, nInfo, o.networkManager.Interface(), nil, o.portCache, o.eIPController)
+			l2Controller, err := NewLayer2UserDefinedNetworkController(cnci, nInfo, o.networkManager.Interface(), nil, o.portCache, o.eIPController)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if o.asf != nil { // use fake asf only when enabled
 				l2Controller.addressSetFactory = asf
 			}
-			secondaryController = &l2Controller.BaseSecondaryNetworkController
-			o.fullSecondaryL2Controllers[netName] = l2Controller
+			userDefinedNetworkController = &l2Controller.BaseUserDefinedNetworkController
+			o.fullL2UDNControllers[netName] = l2Controller
 		case types.LocalnetTopology:
-			localnetController := NewSecondaryLocalnetNetworkController(cnci, nInfo, o.networkManager.Interface())
+			localnetController := NewLocalnetUserDefinedNetworkController(cnci, nInfo, o.networkManager.Interface())
 			if o.asf != nil { // use fake asf only when enabled
 				localnetController.addressSetFactory = asf
 			}
-			secondaryController = &localnetController.BaseSecondaryNetworkController
+			userDefinedNetworkController = &localnetController.BaseUserDefinedNetworkController
 		default:
 			return fmt.Errorf("topology type %s not supported", topoType)
 		}
-		ocInfo = secondaryControllerInfo{bnc: secondaryController, asf: asf}
-		o.secondaryControllers[netName] = ocInfo
+		ocInfo = userDefinedNetworkControllerInfo{bnc: userDefinedNetworkController, asf: asf}
+		o.userDefinedNetworkControllers[netName] = ocInfo
 
 		if nbZoneFailed {
 			// Delete the NBGlobal row as this function created it.  Otherwise many tests would fail while
@@ -581,13 +581,13 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	} else {
-		secondaryController = ocInfo.bnc
+		userDefinedNetworkController = ocInfo.bnc
 	}
 
-	ginkgo.By(fmt.Sprintf("OVN test init: add NAD %s to secondary network controller of %s network %s", nadName, topoType, netName))
-	mutableNetInfo := util.NewMutableNetInfo(secondaryController.GetNetInfo())
+	ginkgo.By(fmt.Sprintf("OVN test init: add NAD %s to user-defined network controller of %s network %s", nadName, topoType, netName))
+	mutableNetInfo := util.NewMutableNetInfo(userDefinedNetworkController.GetNetInfo())
 	mutableNetInfo.AddNADs(nadName)
-	_ = util.ReconcileNetInfo(secondaryController.ReconcilableNetInfo, mutableNetInfo)
+	_ = util.ReconcileNetInfo(userDefinedNetworkController.ReconcilableNetInfo, mutableNetInfo)
 	return nil
 }
 

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -47,7 +47,7 @@ func (c *PortCache) get(pod *corev1.Pod, nadName string) (*lpInfo, error) {
 	if nadName == types.DefaultNetworkName {
 		logicalPort = util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		logicalPort = util.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
 	}
 	c.RLock()
 	defer c.RUnlock()
@@ -82,7 +82,7 @@ func (c *PortCache) add(pod *corev1.Pod, logicalSwitch, nadName, uuid string, ma
 	if nadName == types.DefaultNetworkName {
 		logicalPort = util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		logicalPort = util.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
 	}
 	c.Lock()
 	defer c.Unlock()
@@ -112,7 +112,7 @@ func (c *PortCache) remove(pod *corev1.Pod, nadName string) {
 	if nadName == types.DefaultNetworkName {
 		logicalPort = util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		logicalPort = util.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
 	}
 
 	c.Lock()

--- a/go-controller/pkg/ovn/topology/topologyfactory.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory.go
@@ -55,7 +55,7 @@ func (gtf *GatewayTopologyFactory) newClusterRouter(
 		Options: routerOptions,
 		Copp:    &coopUUID,
 	}
-	if netInfo.IsSecondary() {
+	if netInfo.IsUserDefinedNetwork() {
 		logicalRouter.ExternalIDs[types.NetworkExternalID] = netInfo.GetNetworkName()
 		logicalRouter.ExternalIDs[types.TopologyExternalID] = netInfo.TopologyType()
 	}
@@ -84,7 +84,7 @@ func (gtf *GatewayTopologyFactory) NewJoinSwitch(
 	logicalSwitch := nbdb.LogicalSwitch{
 		Name: joinSwitchName,
 	}
-	if netInfo.IsSecondary() {
+	if netInfo.IsUserDefinedNetwork() {
 		logicalSwitch.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  netInfo.GetNetworkName(),
 			types.TopologyExternalID: netInfo.TopologyType(),
@@ -111,7 +111,7 @@ func (gtf *GatewayTopologyFactory) NewJoinSwitch(
 		MAC:      gwLRPMAC.String(),
 		Networks: gwLRPNetworks,
 	}
-	if netInfo.IsSecondary() {
+	if netInfo.IsUserDefinedNetwork() {
 		logicalRouterPort.ExternalIDs = map[string]string{
 			types.NetworkExternalID:  netInfo.GetNetworkName(),
 			types.TopologyExternalID: netInfo.TopologyType(),

--- a/go-controller/pkg/ovn/udn_isolation_test.go
+++ b/go-controller/pkg/ovn/udn_isolation_test.go
@@ -25,7 +25,7 @@ var _ = Describe("UDN Isolation", func() {
 		// build port group with one ACL that has default tier
 		pgIDs := fakeController.getSecondaryPodsPortGroupDbIDs()
 		pgName := libovsdbutil.GetPortGroupName(pgIDs)
-		egressDenyIDs := fakeController.getUDNACLDbIDs(DenySecondaryACL, libovsdbutil.ACLEgress)
+		egressDenyIDs := fakeController.getUDNACLDbIDs(denyPrimaryUDNACL, libovsdbutil.ACLEgress)
 		match := libovsdbutil.GetACLMatch(pgName, "", libovsdbutil.ACLEgress)
 		// in the real code we use BuildACL here instead of BuildACLWithDefaultTier
 		egressDenyACL := libovsdbutil.BuildACLWithDefaultTier(egressDenyIDs, types.PrimaryUDNDenyPriority, match, nbdb.ACLActionDrop,
@@ -49,5 +49,44 @@ var _ = Describe("UDN Isolation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(acls).To(HaveLen(1))
 		Expect(acls[0].Tier).To(Equal(types.PrimaryACLTier))
+	})
+
+	It("Should handle syncing legacy DBIDs", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		fakeController := getFakeController(DefaultNetworkControllerName)
+
+		By("initializing the database with legacy secondary IDs")
+		pgIDs := fakeController.getSecondaryPodsPortGroupDbIDs()
+		pgName := libovsdbutil.GetPortGroupName(pgIDs)
+		egressDenyIDs := fakeController.getUDNACLDbIDs(denySecondaryACL, libovsdbutil.ACLEgress)
+		match := libovsdbutil.GetACLMatch(pgName, "", libovsdbutil.ACLEgress)
+		egressDenyACL := libovsdbutil.BuildACL(egressDenyIDs, types.PrimaryUDNDenyPriority, match, nbdb.ACLActionDrop,
+			nil, libovsdbutil.LportEgress, isolationTier)
+		// required to make sure port group correctly references the ACL
+		egressDenyACL.UUID = egressDenyIDs.String() + "-UUID"
+
+		pg := libovsdbutil.BuildPortGroup(pgIDs, nil, []*nbdb.ACL{egressDenyACL})
+
+		nbClient, nbCleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{egressDenyACL, pg},
+		}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		defer nbCleanup.Cleanup()
+		fakeController.nbClient = nbClient
+		By("running UDN Isolation sync to update ACLs")
+		Expect(fakeController.syncUDNIsolation()).To(Succeed())
+		By("expect updated port group with proper external_ids")
+		pgs, err := libovsdbops.FindPortGroupsWithPredicate(nbClient, func(_ *nbdb.PortGroup) bool { return true })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pgs).To(HaveLen(1))
+		Expect(pgs[0].ExternalIDs).To(Equal(fakeController.getSecondaryPodsPortGroupDbIDs().GetExternalIDs()))
+		By("expect updated ACL with proper external_ids")
+		acls, err := libovsdbops.FindACLsWithPredicate(nbClient, func(_ *nbdb.ACL) bool { return true })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(acls).To(HaveLen(1))
+		Expect(acls[0].ExternalIDs).To(Equal(fakeController.getUDNACLDbIDs(denyPrimaryUDNACL, libovsdbutil.ACLEgress).GetExternalIDs()))
+		By("expect updated ACL with proper name")
+		Expect(*acls[0].Name).To(BeEmpty())
 	})
 })

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -72,7 +72,7 @@ func getNetworkScopedName(netName, name string) string {
 	if netName == types.DefaultNetworkName {
 		return name
 	}
-	return fmt.Sprintf("%s%s", util.GetSecondaryNetworkPrefix(netName), name)
+	return fmt.Sprintf("%s%s", util.GetUserDefinedNetworkPrefix(netName), name)
 }
 
 func invokeICHandlerAddNodeFunction(zone string, icHandler *ZoneInterconnectHandler, nodes ...*corev1.Node) error {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -225,19 +225,19 @@ const (
 	// RequiredUDNNamespaceLabel is the required namespace label for enabling primary UDNs
 	RequiredUDNNamespaceLabel = "k8s.ovn.org/primary-user-defined-network"
 
-	// different secondary network topology type defined in CNI netconf
+	// different user-defined network topology types defined in CNI netconf
 	Layer3Topology   = "layer3"
 	Layer2Topology   = "layer2"
 	LocalnetTopology = "localnet"
 
 	// different types of network roles
-	// defined in CNI netconf as a user defined network
+	// defined in CNI netconf as a user-defined network
 	NetworkRolePrimary   = "primary"
 	NetworkRoleSecondary = "secondary"
 	NetworkRoleDefault   = "default"
 	// NetworkRoleInfrastructure is defined internally by ovnkube to recognize "default"
 	// network's role as an "infrastructure-locked" network
-	// when a user defined network is the primary network for
+	// when a user-defined network is the primary network for
 	// the pod which makes "default" network neither primary
 	// nor secondary
 	NetworkRoleInfrastructure = "infrastructure-locked"

--- a/go-controller/pkg/util/mocks/multinetwork/NetInfo.go
+++ b/go-controller/pkg/util/mocks/multinetwork/NetInfo.go
@@ -651,11 +651,11 @@ func (_m *NetInfo) IsPrimaryNetwork() bool {
 }
 
 // IsSecondary provides a mock function with given fields:
-func (_m *NetInfo) IsSecondary() bool {
+func (_m *NetInfo) IsUserDefinedNetwork() bool {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for IsSecondary")
+		panic("no return value specified for IsUserDefinedNetwork")
 	}
 
 	var r0 bool

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -713,7 +713,7 @@ func (nInfo *userDefinedNetInfo) GetNetworkScopedName(name string) string {
 // by a previous call to GetNetworkScopedName
 func (nInfo *userDefinedNetInfo) RemoveNetworkScopeFromName(name string) string {
 	// for the default network, names are not scoped
-	return strings.Trim(name, nInfo.getPrefix())
+	return strings.TrimPrefix(name, nInfo.getPrefix())
 }
 
 func (nInfo *userDefinedNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -36,7 +36,7 @@ type NetInfo interface {
 	GetNetworkID() int
 	IsDefault() bool
 	IsPrimaryNetwork() bool
-	IsSecondary() bool
+	IsUserDefinedNetwork() bool
 	TopologyType() string
 	MTU() int
 	IPMode() (bool, bool)
@@ -197,7 +197,7 @@ func copyNetInfo(netInfo NetInfo) any {
 	switch t := netInfo.GetNetInfo().(type) {
 	case *DefaultNetInfo:
 		return t.copy()
-	case *secondaryNetInfo:
+	case *userDefinedNetInfo:
 		return t.copy()
 	default:
 		panic(fmt.Errorf("unrecognized type %T", t))
@@ -208,7 +208,7 @@ func reconcilable(netInfo NetInfo) ReconcilableNetInfo {
 	switch t := netInfo.GetNetInfo().(type) {
 	case *DefaultNetInfo:
 		return t
-	case *secondaryNetInfo:
+	case *userDefinedNetInfo:
 		return t
 	default:
 		panic(fmt.Errorf("unrecognized type %T", t))
@@ -237,7 +237,7 @@ func mutable(netInfo NetInfo) *mutableNetInfo {
 	switch t := netInfo.GetNetInfo().(type) {
 	case *DefaultNetInfo:
 		return &t.mutableNetInfo
-	case *secondaryNetInfo:
+	case *userDefinedNetInfo:
 		return &t.mutableNetInfo
 	default:
 		panic(fmt.Errorf("unrecognized type %T", t))
@@ -482,16 +482,16 @@ func (nInfo *DefaultNetInfo) IsDefault() bool {
 }
 
 // IsPrimaryNetwork always returns false for default network.
-// The boolean indicates if this secondary network is
+// The boolean indicates if the default network is
 // meant to be the primary network for the pod. Since default
-// network is never a secondary network this is always false.
-// This cannot be true if IsSecondary() is not true.
+// network is never a User Defined Network this is always false.
+// This cannot be true if IsUserDefinedNetwork() is not true.
 func (nInfo *DefaultNetInfo) IsPrimaryNetwork() bool {
 	return false
 }
 
-// IsSecondary returns if this network is secondary
-func (nInfo *DefaultNetInfo) IsSecondary() bool {
+// IsUserDefinedNetwork returns if this network is secondary
+func (nInfo *DefaultNetInfo) IsUserDefinedNetwork() bool {
 	return false
 }
 
@@ -610,7 +610,7 @@ func (nInfo *DefaultNetInfo) JoinSubnetV6() *net.IPNet {
 	return cidr
 }
 
-// JoinSubnets returns the secondaryNetInfo's joinsubnet values (both v4&v6)
+// JoinSubnets returns the userDefinedNetInfo's joinsubnet values (both v4&v6)
 // used from Equals
 func (nInfo *DefaultNetInfo) JoinSubnets() []*net.IPNet {
 	var defaultJoinSubnets []*net.IPNet
@@ -652,12 +652,12 @@ func (nInfo *DefaultNetInfo) GetNodeManagementIP(hostSubnet *net.IPNet) *net.IPN
 	return GetNodeManagementIfAddr(hostSubnet)
 }
 
-// SecondaryNetInfo holds the network name information for secondary network if non-nil
-type secondaryNetInfo struct {
+// userDefinedNetInfo holds the network name information for a User Defined Network if non-nil
+type userDefinedNetInfo struct {
 	mutableNetInfo
 
 	netName string
-	// Should this secondary network be used
+	// Should this User Defined Network be used
 	// as the pod's primary network?
 	primaryNetwork     bool
 	topology           string
@@ -677,58 +677,58 @@ type secondaryNetInfo struct {
 	managementIPs       []net.IP
 }
 
-func (nInfo *secondaryNetInfo) GetNetInfo() NetInfo {
+func (nInfo *userDefinedNetInfo) GetNetInfo() NetInfo {
 	return nInfo
 }
 
 // GetNetworkName returns the network name
-func (nInfo *secondaryNetInfo) GetNetworkName() string {
+func (nInfo *userDefinedNetInfo) GetNetworkName() string {
 	return nInfo.netName
 }
 
-// IsDefault always returns false for all secondary networks.
-func (nInfo *secondaryNetInfo) IsDefault() bool {
+// IsDefault always returns false for all User Defined Networks.
+func (nInfo *userDefinedNetInfo) IsDefault() bool {
 	return false
 }
 
-// IsPrimaryNetwork returns if this secondary network
+// IsPrimaryNetwork returns if this User Defined Network
 // should be used as the primaryNetwork for the pod
 // to achieve native network segmentation
-func (nInfo *secondaryNetInfo) IsPrimaryNetwork() bool {
+func (nInfo *userDefinedNetInfo) IsPrimaryNetwork() bool {
 	return nInfo.primaryNetwork
 }
 
-// IsSecondary returns if this network is secondary
-func (nInfo *secondaryNetInfo) IsSecondary() bool {
+// IsUserDefinedNetwork returns if this network is a User Defined Network
+func (nInfo *userDefinedNetInfo) IsUserDefinedNetwork() bool {
 	return true
 }
 
 // GetNetworkScopedName returns a network scoped name from the provided one
 // appropriate to use globally.
-func (nInfo *secondaryNetInfo) GetNetworkScopedName(name string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedName(name string) string {
 	return fmt.Sprintf("%s%s", nInfo.getPrefix(), name)
 }
 
 // RemoveNetworkScopeFromName removes the name without the network scope added
 // by a previous call to GetNetworkScopedName
-func (nInfo *secondaryNetInfo) RemoveNetworkScopeFromName(name string) string {
+func (nInfo *userDefinedNetInfo) RemoveNetworkScopeFromName(name string) string {
 	// for the default network, names are not scoped
 	return strings.Trim(name, nInfo.getPrefix())
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {
 	return GetK8sMgmtIntfName(nInfo.GetNetworkScopedName(nodeName))
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedClusterRouterName() string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedClusterRouterName() string {
 	return nInfo.GetNetworkScopedName(types.OVNClusterRouter)
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedGWRouterName(nodeName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedGWRouterName(nodeName string) string {
 	return GetGatewayRouterFromNode(nInfo.GetNetworkScopedName(nodeName))
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
 	// In Layer2Topology there is just one global switch
 	if nInfo.TopologyType() == types.Layer2Topology {
 		return nInfo.GetNetworkScopedName(types.OVNLayer2Switch)
@@ -736,61 +736,61 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) strin
 	return nInfo.GetNetworkScopedName(nodeName)
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedJoinSwitchName() string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedJoinSwitchName() string {
 	return nInfo.GetNetworkScopedName(types.OVNJoinSwitch)
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedExtSwitchName(nodeName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedExtSwitchName(nodeName string) string {
 	return GetExtSwitchFromNode(nInfo.GetNetworkScopedName(nodeName))
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedPatchPortName(bridgeID, nodeName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedPatchPortName(bridgeID, nodeName string) string {
 	return GetPatchPortName(bridgeID, nInfo.GetNetworkScopedName(nodeName))
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedExtPortName(bridgeID, nodeName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedExtPortName(bridgeID, nodeName string) string {
 	return GetExtPortName(bridgeID, nInfo.GetNetworkScopedName(nodeName))
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedLoadBalancerName(lbName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedLoadBalancerName(lbName string) string {
 	return nInfo.GetNetworkScopedName(lbName)
 }
 
-func (nInfo *secondaryNetInfo) GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string {
+func (nInfo *userDefinedNetInfo) GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string {
 	return nInfo.GetNetworkScopedName(lbGroupName)
 }
 
 // getPrefix returns if the logical entities prefix for this network
-func (nInfo *secondaryNetInfo) getPrefix() string {
-	return GetSecondaryNetworkPrefix(nInfo.netName)
+func (nInfo *userDefinedNetInfo) getPrefix() string {
+	return GetUserDefinedNetworkPrefix(nInfo.netName)
 }
 
 // TopologyType returns the topology type
-func (nInfo *secondaryNetInfo) TopologyType() string {
+func (nInfo *userDefinedNetInfo) TopologyType() string {
 	return nInfo.topology
 }
 
 // MTU returns the layer3NetConfInfo's MTU value
-func (nInfo *secondaryNetInfo) MTU() int {
+func (nInfo *userDefinedNetInfo) MTU() int {
 	return nInfo.mtu
 }
 
 // Vlan returns the Vlan value
-func (nInfo *secondaryNetInfo) Vlan() uint {
+func (nInfo *userDefinedNetInfo) Vlan() uint {
 	return nInfo.vlan
 }
 
 // AllowsPersistentIPs returns the defaultNetConfInfo's AllowPersistentIPs value
-func (nInfo *secondaryNetInfo) AllowsPersistentIPs() bool {
+func (nInfo *userDefinedNetInfo) AllowsPersistentIPs() bool {
 	return nInfo.allowPersistentIPs
 }
 
 // PhysicalNetworkName returns the user provided physical network name value
-func (nInfo *secondaryNetInfo) PhysicalNetworkName() string {
+func (nInfo *userDefinedNetInfo) PhysicalNetworkName() string {
 	return nInfo.physicalNetworkName
 }
 
-func (nInfo *secondaryNetInfo) GetNodeGatewayIP(hostSubnet *net.IPNet) *net.IPNet {
+func (nInfo *userDefinedNetInfo) GetNodeGatewayIP(hostSubnet *net.IPNet) *net.IPNet {
 	if IsPreconfiguredUDNAddressesEnabled() && nInfo.TopologyType() == types.Layer2Topology && nInfo.IsPrimaryNetwork() {
 		isIPV6 := knet.IsIPv6CIDR(hostSubnet)
 		gwIP, _ := MatchFirstIPFamily(isIPV6, nInfo.defaultGatewayIPs)
@@ -802,7 +802,7 @@ func (nInfo *secondaryNetInfo) GetNodeGatewayIP(hostSubnet *net.IPNet) *net.IPNe
 	return GetNodeGatewayIfAddr(hostSubnet)
 }
 
-func (nInfo *secondaryNetInfo) GetNodeManagementIP(hostSubnet *net.IPNet) *net.IPNet {
+func (nInfo *userDefinedNetInfo) GetNodeManagementIP(hostSubnet *net.IPNet) *net.IPNet {
 	if IsPreconfiguredUDNAddressesEnabled() && nInfo.TopologyType() == types.Layer2Topology && nInfo.IsPrimaryNetwork() {
 		isIPV6 := knet.IsIPv6CIDR(hostSubnet)
 		mgmtIP, _ := MatchFirstIPFamily(isIPV6, nInfo.managementIPs)
@@ -815,56 +815,56 @@ func (nInfo *secondaryNetInfo) GetNodeManagementIP(hostSubnet *net.IPNet) *net.I
 }
 
 // IPMode returns the ipv4/ipv6 mode
-func (nInfo *secondaryNetInfo) IPMode() (bool, bool) {
+func (nInfo *userDefinedNetInfo) IPMode() (bool, bool) {
 	return nInfo.ipv4mode, nInfo.ipv6mode
 }
 
 // Subnets returns the Subnets value
-func (nInfo *secondaryNetInfo) Subnets() []config.CIDRNetworkEntry {
+func (nInfo *userDefinedNetInfo) Subnets() []config.CIDRNetworkEntry {
 	return nInfo.subnets
 }
 
 // ExcludeSubnets returns the ExcludeSubnets value
-func (nInfo *secondaryNetInfo) ExcludeSubnets() []*net.IPNet {
+func (nInfo *userDefinedNetInfo) ExcludeSubnets() []*net.IPNet {
 	return nInfo.excludeSubnets
 }
 
 // ReservedSubnets returns the ReservedSubnets value
-func (nInfo *secondaryNetInfo) ReservedSubnets() []*net.IPNet {
+func (nInfo *userDefinedNetInfo) ReservedSubnets() []*net.IPNet {
 	return nInfo.reservedSubnets
 }
 
 // InfrastructureSubnets returns the InfrastructureSubnets value
-func (nInfo *secondaryNetInfo) InfrastructureSubnets() []*net.IPNet {
+func (nInfo *userDefinedNetInfo) InfrastructureSubnets() []*net.IPNet {
 	return nInfo.infrastructureSubnets
 }
 
 // JoinSubnetV4 returns the defaultNetConfInfo's JoinSubnetV4 value
 // call when ipv4mode=true
-func (nInfo *secondaryNetInfo) JoinSubnetV4() *net.IPNet {
+func (nInfo *userDefinedNetInfo) JoinSubnetV4() *net.IPNet {
 	if len(nInfo.joinSubnets) == 0 {
 		return nil // localnet topology
 	}
 	return nInfo.joinSubnets[0]
 }
 
-// JoinSubnetV6 returns the secondaryNetInfo's JoinSubnetV6 value
+// JoinSubnetV6 returns the userDefinedNetInfo's JoinSubnetV6 value
 // call when ipv6mode=true
-func (nInfo *secondaryNetInfo) JoinSubnetV6() *net.IPNet {
+func (nInfo *userDefinedNetInfo) JoinSubnetV6() *net.IPNet {
 	if len(nInfo.joinSubnets) <= 1 {
 		return nil // localnet topology
 	}
 	return nInfo.joinSubnets[1]
 }
 
-// JoinSubnets returns the secondaryNetInfo's joinsubnet values (both v4&v6)
+// JoinSubnets returns the userDefinedNetInfo's joinsubnet values (both v4&v6)
 // used from Equals (since localnet doesn't have joinsubnets to compare nil v/s nil
 // we need this util)
-func (nInfo *secondaryNetInfo) JoinSubnets() []*net.IPNet {
+func (nInfo *userDefinedNetInfo) JoinSubnets() []*net.IPNet {
 	return nInfo.joinSubnets
 }
 
-func (nInfo *secondaryNetInfo) canReconcile(other NetInfo) bool {
+func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
 	if (nInfo == nil) != (other == nil) {
 		return false
 	}
@@ -916,9 +916,9 @@ func (nInfo *secondaryNetInfo) canReconcile(other NetInfo) bool {
 	return cmp.Equal(nInfo.joinSubnets, other.JoinSubnets(), cmpopts.SortSlices(lessIPNet))
 }
 
-func (nInfo *secondaryNetInfo) copy() *secondaryNetInfo {
+func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 	// everything here is immutable
-	c := &secondaryNetInfo{
+	c := &userDefinedNetInfo{
 		netName:               nInfo.netName,
 		primaryNetwork:        nInfo.primaryNetwork,
 		topology:              nInfo.topology,
@@ -951,7 +951,7 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 	if err != nil {
 		return nil, err
 	}
-	ni := &secondaryNetInfo{
+	ni := &userDefinedNetInfo{
 		netName:        netconf.Name,
 		primaryNetwork: netconf.Role == types.NetworkRolePrimary,
 		topology:       types.Layer3Topology,
@@ -1014,7 +1014,7 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		}
 	}
 
-	ni := &secondaryNetInfo{
+	ni := &userDefinedNetInfo{
 		netName:               netconf.Name,
 		primaryNetwork:        netconf.Role == types.NetworkRolePrimary,
 		topology:              types.Layer2Topology,
@@ -1051,7 +1051,7 @@ func newLocalnetNetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error
 		return nil, err
 	}
 
-	ni := &secondaryNetInfo{
+	ni := &userDefinedNetInfo{
 		netName:             netconf.Name,
 		topology:            types.LocalnetTopology,
 		subnets:             subnets,
@@ -1175,12 +1175,12 @@ func GetNADName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
-// GetSecondaryNetworkPrefix gets the string used as prefix of the logical entities
-// of the secondary network of the given network name, in the form of <netName>_.
+// GetUserDefinedNetworkPrefix gets the string used as prefix of the logical entities
+// of the User Defined Network of the given network name, in the form of <netName>_.
 //
 // Note that for port_group and address_set, it does not allow the '-' character,
 // which will be replaced with ".". Also replace "/" in the nadName with "."
-func GetSecondaryNetworkPrefix(netName string) string {
+func GetUserDefinedNetworkPrefix(netName string) string {
 	name := strings.ReplaceAll(netName, "-", ".")
 	name = strings.ReplaceAll(name, "/", ".")
 	return name + "_"
@@ -1210,7 +1210,7 @@ func newNetInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ni.IsPrimaryNetwork() && ni.IsSecondary() {
+	if ni.IsPrimaryNetwork() && ni.IsUserDefinedNetwork() {
 		ipv4Mode, ipv6Mode := ni.IPMode()
 		if ipv4Mode && !config.IPv4Mode {
 			return nil, fmt.Errorf("network %s is attempting to use ipv4 subnets but the cluster does not support ipv4", ni.GetNetworkName())
@@ -1234,7 +1234,7 @@ func GetAnnotatedNetworkName(netattachdef *nettypes.NetworkAttachmentDefinition)
 	return netattachdef.Annotations[types.OvnNetworkNameAnnotation]
 }
 
-// ParseNADInfo parses config in NAD spec and return a NetAttachDefInfo object for secondary networks
+// ParseNADInfo parses config in NAD spec and return a NetAttachDefInfo object for User Defined Networks
 func ParseNADInfo(nad *nettypes.NetworkAttachmentDefinition) (NetInfo, error) {
 	netconf, err := ParseNetConf(nad)
 	if err != nil {
@@ -1267,7 +1267,7 @@ func ParseNADInfo(nad *nettypes.NetworkAttachmentDefinition) (NetInfo, error) {
 	return n, nil
 }
 
-// ParseNetConf parses config in NAD spec for secondary networks
+// ParseNetConf parses config in NAD spec for User Defined Networks
 func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnitypes.NetConf, error) {
 	netconf, err := config.ParseNetConf([]byte(netattachdef.Spec.Config))
 	if err != nil {
@@ -1408,7 +1408,7 @@ func GetPodNADToNetworkMapping(pod *corev1.Pod, nInfo NetInfo) (bool, map[string
 
 	networkSelections := map[string]*nettypes.NetworkSelectionElement{}
 	podDesc := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-	if !nInfo.IsSecondary() {
+	if !nInfo.IsUserDefinedNetwork() {
 		network, err := GetK8sPodDefaultNetworkSelection(pod)
 		if err != nil {
 			// multus won't add this Pod if this fails, should never happen
@@ -1561,7 +1561,7 @@ func AllowsPersistentIPs(netInfo NetInfo) bool {
 	case netInfo.IsPrimaryNetwork():
 		return netInfo.TopologyType() == types.Layer2Topology && netInfo.AllowsPersistentIPs()
 
-	case netInfo.IsSecondary():
+	case netInfo.IsUserDefinedNetwork():
 		return (netInfo.TopologyType() == types.Layer2Topology || netInfo.TopologyType() == types.LocalnetTopology) &&
 			netInfo.AllowsPersistentIPs()
 
@@ -1702,8 +1702,8 @@ func GetNetworkRole(controllerNetInfo NetInfo, getActiveNetworkForNamespace func
 
 // (C)UDN network name generation functions must ensure the absence of name conflicts between all (C)UDNs.
 // We use underscore as a separator as it is not allowed in k8s namespaces and names.
-// Network name is then used by GetSecondaryNetworkPrefix function to generate db object names.
-// GetSecondaryNetworkPrefix replaces some characters in the network name to ensure correct db object names,
+// Network name is then used by GetUserDefinedNetworkPrefix function to generate db object names.
+// GetUserDefinedNetworkPrefix replaces some characters in the network name to ensure correct db object names,
 // so the network name must be also unique after these replacements.
 
 func GenerateUDNNetworkName(namespace, name string) string {

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1582,8 +1582,8 @@ func TestAreNetworksCompatible(t *testing.T) {
 	}{
 		{
 			desc:                   "physical network name update",
-			aNetwork:               &secondaryNetInfo{physicalNetworkName: "A"},
-			anotherNetwork:         &secondaryNetInfo{physicalNetworkName: "B"},
+			aNetwork:               &userDefinedNetInfo{physicalNetworkName: "A"},
+			anotherNetwork:         &userDefinedNetInfo{physicalNetworkName: "B"},
 			expectedResult:         false,
 			expectationDescription: "we should reconcile on physical network name updates",
 		},

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -338,7 +338,7 @@ func GetPodCIDRsWithFullMask(pod *corev1.Pod, nInfo NetInfo) ([]*net.IPNet, erro
 // and then falling back to the Pod Status IPs. This function is intended to
 // also return IPs for HostNetwork and other non-OVN-IPAM-ed pods.
 func GetPodIPsOfNetwork(pod *corev1.Pod, nInfo NetInfo) ([]net.IP, error) {
-	if nInfo.IsSecondary() {
+	if nInfo.IsUserDefinedNetwork() {
 		return SecondaryNetworkPodIPs(pod, nInfo)
 	}
 	return DefaultNetworkPodIPs(pod)

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -416,7 +416,7 @@ func GetUserDefinedNetworkRole(isPrimary bool) string {
 // when on the default cluster network, for backward compatibility.
 func GenerateExternalIDsForSwitchOrRouter(netInfo NetInfo) map[string]string {
 	externalIDs := make(map[string]string)
-	if netInfo.IsSecondary() {
+	if netInfo.IsUserDefinedNetwork() {
 		externalIDs[types.NetworkExternalID] = netInfo.GetNetworkName()
 		externalIDs[types.NetworkRoleExternalID] = GetUserDefinedNetworkRole(netInfo.IsPrimaryNetwork())
 		externalIDs[types.TopologyExternalID] = netInfo.TopologyType()
@@ -424,8 +424,8 @@ func GenerateExternalIDsForSwitchOrRouter(netInfo NetInfo) map[string]string {
 	return externalIDs
 }
 
-func GetSecondaryNetworkLogicalPortName(podNamespace, podName, nadName string) string {
-	return GetSecondaryNetworkPrefix(nadName) + composePortName(podNamespace, podName)
+func GetUserDefinedNetworkLogicalPortName(podNamespace, podName, nadName string) string {
+	return GetUserDefinedNetworkPrefix(nadName) + composePortName(podNamespace, podName)
 }
 
 func GetLogicalPortName(podNamespace, podName string) string {
@@ -436,8 +436,8 @@ func GetNamespacePodFromCDNPortName(portName string) (string, string) {
 	return decomposePortName(portName)
 }
 
-func GetSecondaryNetworkIfaceId(podNamespace, podName, nadName string) string {
-	return GetSecondaryNetworkPrefix(nadName) + composePortName(podNamespace, podName)
+func GetUDNIfaceId(podNamespace, podName, nadName string) string {
+	return GetUserDefinedNetworkPrefix(nadName) + composePortName(podNamespace, podName)
 }
 
 func GetIfaceId(podNamespace, podName string) string {


### PR DESCRIPTION
When multiple networks support was first added, all controllers that were added used the label "Secondary" to indicate they were not "Default". When UDN was added, it allowed "Secondary" networks to function as the primary network for a pod, creating terminology confusion. We now treat non-default networks all as "User Defined Networks". This commit changes all naming to conform to the latter.

The only places secondary is used now is for distinguishing whether or not a UDN is acting as a primary or secondary network for a pod (it's role).

The only exception to this is udn-isolation. I did not touch this because it relies on dbIDs, which would impact functionality for upgrade.

There is no functional change in this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - User Defined Networks (UDN) replace “secondary networks” across L2/L3/Localnet controllers.
  - Automatic migration of legacy ACL IDs to UDN naming during startup.
  - Consistent ExternalIDs tagging and logical port/iface ID naming for UDN objects.

- Refactor
  - Metrics, EgressIP, QoS, gateways, multicast, policy, and zone interconnect now uniformly honor UDN semantics.
  - Pod annotation, routing, and port-cache logic updated to UDN-aware flows.

- Documentation
  - UDN feature docs and terminology updated.

- Tests
  - Test suites migrated to UDN terminology and controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->