### PR TITLE
Adds CNI unprivileged mode unit and e2e testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -461,7 +461,7 @@ jobs:
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
-          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones", "cni-mode": "unprivileged"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "multi-homing-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "network-segmentation": "enable-network-segmentation"}
           - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
@@ -479,7 +479,7 @@ jobs:
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "cni-mode": "unprivileged"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "bgp", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "bgp", "ha": "noHA", "gateway-mode": "shared",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "dns-name-resolver": "enable-dns-name-resolver"}
@@ -516,6 +516,7 @@ jobs:
       ADVERTISE_DEFAULT_NETWORK:  "${{ matrix.routeadvertisements == 'advertise-default' }}"
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (matrix.target == 'network-segmentation' || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
+      OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"
     steps:
 
     - name: Install VRF kernel module

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -35,7 +35,15 @@ type podRequestInterfaceOpsStub struct {
 	unconfiguredInterfaces []*PodInterfaceInfo
 }
 
-func (stub *podRequestInterfaceOpsStub) ConfigureInterface(*PodRequest, PodInfoGetter, *PodInterfaceInfo) ([]*current.Interface, error) {
+func (stub *podRequestInterfaceOpsStub) ConfigureInterface(pr *PodRequest, _ PodInfoGetter, pii *PodInterfaceInfo) ([]*current.Interface, error) {
+	if len(pii.IPs) > 0 {
+		return []*current.Interface{
+			{
+				Name:    pr.IfName,
+				Sandbox: "/var/run/netns/" + pr.PodNamespace + "_" + pr.PodName,
+			},
+		}, nil
+	}
 	return nil, nil
 }
 func (stub *podRequestInterfaceOpsStub) UnconfigureInterface(_ *PodRequest, ifInfo *PodInterfaceInfo) error {

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -56,20 +56,18 @@ var _ = Describe("Network Segmentation", func() {
 		obtainedPodIterfaceInfos []*PodInterfaceInfo
 		getCNIResultStub         = func(_ *PodRequest, _ PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
 			obtainedPodIterfaceInfos = append(obtainedPodIterfaceInfos, podInterfaceInfo)
-			return nil, nil
+			return &current.Result{}, nil
 		}
-		prInterfaceOpsStub                            = &podRequestInterfaceOpsStub{}
-		enableMultiNetwork, enableNetworkSegmentation bool
+		prInterfaceOpsStub = &podRequestInterfaceOpsStub{}
 	)
 
 	BeforeEach(func() {
-
+		Expect(config.PrepareTestConfig()).To(Succeed())
 		config.IPv4Mode = true
 		config.IPv6Mode = true
-		enableMultiNetwork = config.OVNKubernetesFeature.EnableMultiNetwork
-		enableNetworkSegmentation = config.OVNKubernetesFeature.EnableNetworkSegmentation
 
 		podRequestInterfaceOps = prInterfaceOpsStub
+		obtainedPodIterfaceInfos = []*PodInterfaceInfo{}
 
 		fakeClientset = fake.NewSimpleClientset()
 		pr = PodRequest{
@@ -107,8 +105,6 @@ var _ = Describe("Network Segmentation", func() {
 		podLister.On("Pods", pr.PodNamespace).Return(&podNamespaceLister)
 	})
 	AfterEach(func() {
-		config.OVNKubernetesFeature.EnableMultiNetwork = enableMultiNetwork
-		config.OVNKubernetesFeature.EnableNetworkSegmentation = enableNetworkSegmentation
 
 		podRequestInterfaceOps = &defaultPodRequestInterfaceOps{}
 	})
@@ -160,17 +156,48 @@ var _ = Describe("Network Segmentation", func() {
 					},
 				}
 			})
-			It("should not fail at cmdAdd", func() {
-				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-				ovsClient, err := newOVSClientWithExternalIDs(map[string]string{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, networkmanager.Default().Interface(), ovsClient)).NotTo(BeNil())
-				Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
+
+			Context("with CNI Privileged Mode", func() {
+				It("should not fail at cmdAdd", func() {
+					podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+					ovsClient, err := newOVSClientWithExternalIDs(map[string]string{})
+					Expect(err).NotTo(HaveOccurred())
+					response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, networkmanager.Default().Interface(), ovsClient)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response.Result).NotTo(BeNil())
+					Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
+					Expect(response.PrimaryUDNPodInfo).To(BeNil())
+					Expect(response.PrimaryUDNPodReq).To(BeNil())
+				})
+				It("should not fail at cmdDel", func() {
+					podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+					Expect(pr.cmdDel(clientSet)).NotTo(BeNil())
+					Expect(prInterfaceOpsStub.unconfiguredInterfaces).To(HaveLen(2))
+				})
 			})
-			It("should not fail at cmdDel", func() {
-				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-				Expect(pr.cmdDel(clientSet)).NotTo(BeNil())
-				Expect(prInterfaceOpsStub.unconfiguredInterfaces).To(HaveLen(2))
+
+			Context("with CNI Unprivileged Mode", func() {
+				BeforeEach(func() {
+					config.UnprivilegedMode = true
+				})
+				It("should not fail at cmdAdd", func() {
+					podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+					ovsClient, err := newOVSClientWithExternalIDs(map[string]string{})
+					Expect(err).NotTo(HaveOccurred())
+					response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, networkmanager.Default().Interface(), ovsClient)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response.Result).To(BeNil())
+					Expect(obtainedPodIterfaceInfos).To(BeEmpty())
+					Expect(response.PrimaryUDNPodReq).To(BeNil())
+					Expect(response.PrimaryUDNPodInfo).To(BeNil())
+				})
+				It("should not fail at cmdDel", func() {
+					podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+					response, err := pr.cmdDel(clientSet)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response.Result).To(BeNil())
+					Expect(response.PodIFInfo).ToNot(BeNil())
+				})
 			})
 		})
 
@@ -236,81 +263,107 @@ var _ = Describe("Network Segmentation", func() {
 					PrimaryNetworks: make(map[string]util.NetInfo),
 				}
 				fakeNetworkManager.PrimaryNetworks[nadMegaNet.Namespace] = nadNetwork
-				getCNIResultStub = dummyGetCNIResult
 			})
 
-			It("should return the information of both the default net and the primary UDN in the result", func() {
-				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-				ovsClient, err := newOVSClientWithExternalIDs(map[string]string{})
-				Expect(err).NotTo(HaveOccurred())
-				response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, fakeNetworkManager, ovsClient)
-				Expect(err).NotTo(HaveOccurred())
-				// for every interface added, we return 2 interfaces; the host side of the
-				// veth, then the pod side of the veth.
-				// thus, the UDN interface idx will be 3:
-				// idx: iface
-				//   0: host side primary UDN
-				//   1: pod side default network
-				//   2: host side default network
-				//   3: pod side primary UDN
-				podDefaultClusterNetIfaceIDX := 1
-				podUDNIfaceIDX := 3
-				Expect(response.Result).To(Equal(
-					&current.Result{
-						CNIVersion: "0.3.1",
-						Interfaces: []*current.Interface{
-							{
-								Name: "host_eth0",
-								Mac:  dummyMACHostSide,
+			Context("with CNI Privileged Mode", func() {
+				It("should return the information of both the default net and the primary UDN in the result", func() {
+					podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+					ovsClient, err := newOVSClientWithExternalIDs(map[string]string{})
+					Expect(err).NotTo(HaveOccurred())
+					response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, dummyGetCNIResult, fakeNetworkManager, ovsClient)
+					Expect(err).NotTo(HaveOccurred())
+					// for every interface added, we return 2 interfaces; the host side of the
+					// veth, then the pod side of the veth.
+					// thus, the UDN interface idx will be 3:
+					// idx: iface
+					//   0: host side primary UDN
+					//   1: pod side default network
+					//   2: host side default network
+					//   3: pod side primary UDN
+					podDefaultClusterNetIfaceIDX := 1
+					podUDNIfaceIDX := 3
+					Expect(response.Result).To(Equal(
+						&current.Result{
+							CNIVersion: "0.3.1",
+							Interfaces: []*current.Interface{
+								{
+									Name: "host_eth0",
+									Mac:  dummyMACHostSide,
+								},
+								{
+									Name:    "eth0",
+									Mac:     "0a:58:fd:98:00:01",
+									Sandbox: "bobloblaw",
+								},
+								{
+									Name: "host_ovn-udn1",
+									Mac:  dummyMACHostSide,
+								},
+								{
+									Name:    "ovn-udn1",
+									Mac:     "02:03:04:05:06:07",
+									Sandbox: "bobloblaw",
+								},
 							},
-							{
-								Name:    "eth0",
-								Mac:     "0a:58:fd:98:00:01",
-								Sandbox: "bobloblaw",
-							},
-							{
-								Name: "host_ovn-udn1",
-								Mac:  dummyMACHostSide,
-							},
-							{
-								Name:    "ovn-udn1",
-								Mac:     "02:03:04:05:06:07",
-								Sandbox: "bobloblaw",
+							IPs: []*current.IPConfig{
+								{
+									Address: net.IPNet{
+										IP:   net.ParseIP("100.10.10.3"),
+										Mask: net.CIDRMask(24, 32),
+									},
+									Interface: &podDefaultClusterNetIfaceIDX,
+								},
+								{
+									Address: net.IPNet{
+										IP:   net.ParseIP("fd44::33"),
+										Mask: net.CIDRMask(64, 128),
+									},
+									Interface: &podDefaultClusterNetIfaceIDX,
+								},
+								{
+									Address: net.IPNet{
+										IP:   net.ParseIP("10.10.10.30"),
+										Mask: net.CIDRMask(24, 32),
+									},
+									Interface: &podUDNIfaceIDX,
+								},
+								{
+									Address: net.IPNet{
+										IP:   net.ParseIP("fd10::3"),
+										Mask: net.CIDRMask(64, 128),
+									},
+									Interface: &podUDNIfaceIDX,
+								},
 							},
 						},
-						IPs: []*current.IPConfig{
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("100.10.10.3"),
-									Mask: net.CIDRMask(24, 32),
-								},
-								Interface: &podDefaultClusterNetIfaceIDX,
-							},
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("fd44::33"),
-									Mask: net.CIDRMask(64, 128),
-								},
-								Interface: &podDefaultClusterNetIfaceIDX,
-							},
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("10.10.10.30"),
-									Mask: net.CIDRMask(24, 32),
-								},
-								Interface: &podUDNIfaceIDX,
-							},
-							{
-								Address: net.IPNet{
-									IP:   net.ParseIP("fd10::3"),
-									Mask: net.CIDRMask(64, 128),
-								},
-								Interface: &podUDNIfaceIDX,
-							},
-						},
-					},
-				))
+					))
+				})
 			})
+			Context("with CNI Unprivileged Mode", func() {
+				BeforeEach(func() {
+					config.UnprivilegedMode = true
+				})
+				It("should return the information of both the default net and the primary UDN in the result", func() {
+					podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+					ovsClient, err := newOVSClientWithExternalIDs(map[string]string{})
+					Expect(err).NotTo(HaveOccurred())
+					response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, dummyGetCNIResult, fakeNetworkManager, ovsClient)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response.Result).To(BeNil())
+					podNADAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, "foo-ns/meganet")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response.PrimaryUDNPodInfo).To(Equal(
+						&PodInterfaceInfo{
+							PodAnnotation: *podNADAnnotation,
+							MTU:           1400,
+							NetName:       "tenantred",
+							NADName:       "foo-ns/meganet",
+						}))
+					Expect(response.PrimaryUDNPodReq.IfName).To(Equal("ovn-udn1"))
+					Expect(response.PodIFInfo.NetName).To(Equal("default"))
+				})
+			})
+
 		})
 	})
 

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -83,7 +84,10 @@ func TestCNIServer(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	socketPath := filepath.Join(tmpDir, serverSocketName)
 	fakeClient := fake.NewSimpleClientset()
-
+	err = config.PrepareTestConfig()
+	if err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
 	fakeClientset := &util.OVNNodeClientset{
 		KubeClient: fakeClient,
 	}

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -39,6 +39,7 @@ import (
 // functions to use it
 type Plugin struct {
 	socketPath string
+	doCNIFunc  func(url string, req interface{}) ([]byte, error)
 }
 
 // NewCNIPlugin creates the internal Plugin object
@@ -46,7 +47,9 @@ func NewCNIPlugin(socketPath string) *Plugin {
 	if len(socketPath) == 0 {
 		socketPath = serverSocketPath
 	}
-	return &Plugin{socketPath: socketPath}
+	p := &Plugin{socketPath: socketPath}
+	p.doCNIFunc = p.doCNI
+	return p
 }
 
 // Create and fill a Request with this Plugin's environment and stdin which
@@ -209,7 +212,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 
 	req := newCNIRequest(args, deviceInfo)
 
-	body, errB := p.doCNI("http://dummy/", req)
+	body, errB := p.doCNIFunc("http://dummy/", req)
 	if errB != nil {
 		err = errB
 		klog.Error(err.Error())
@@ -301,7 +304,7 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 
 	var deviceInfo = nadapi.DeviceInfo{}
 	req := newCNIRequest(args, deviceInfo)
-	body, err = p.doCNI("http://dummy/", req)
+	body, err = p.doCNIFunc("http://dummy/", req)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/cni/cnishim_test.go
+++ b/go-controller/pkg/cni/cnishim_test.go
@@ -1,0 +1,321 @@
+package cni
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func TestCmdAdd_PrivilegedMode(t *testing.T) {
+	// Setup: CNI server returns non-nil Result
+	p := &Plugin{}
+
+	// Patch doCNI to return a response with non-nil Result that indicates server wired
+	result := &current.Result{Interfaces: []*current.Interface{{Name: "serverWired"}}}
+
+	kubeAuth := &KubeAPIAuth{
+		Kubeconfig:       config.Kubernetes.Kubeconfig,
+		KubeAPIServer:    config.Kubernetes.APIServer,
+		KubeAPIToken:     config.Kubernetes.Token,
+		KubeAPITokenFile: config.Kubernetes.TokenFile,
+	}
+	body, _ := json.Marshal(&Response{
+		Result:    result,
+		PodIFInfo: &PodInterfaceInfo{},
+		KubeAuth:  kubeAuth,
+	})
+	p.doCNIFunc = func(_ string, _ interface{}) ([]byte, error) {
+		return body, nil
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	args := &skel.CmdArgs{
+		StdinData:   []byte(`{"cniVersion":"1.0.0","name":"mynet","type":"ovn-k8s-cni-overlay"}`),
+		ContainerID: "cid",
+		Netns:       "/var/run/netns/test",
+		IfName:      "eth0",
+	}
+	err := p.CmdAdd(args)
+	require.NoError(t, err)
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+	var got, want map[string]any
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to unmarshal output: %v", err)
+	}
+
+	expected := `{
+    "cniVersion": "1.0.0",
+    "interfaces": [
+        {
+            "name": "serverWired"
+        }
+    ]
+}`
+	if err := json.Unmarshal([]byte(expected), &want); err != nil {
+		t.Fatalf("failed to unmarshal expected: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected CmdAdd output:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestCmdAdd_UnprivilegedMode(t *testing.T) {
+	withCNIEnv(t, func() {
+		p := &Plugin{}
+		err := config.PrepareTestConfig()
+		require.NoError(t, err, "failed to prepare test config")
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+		podRequestInterfaceOps = &podRequestInterfaceOpsStub{}
+		defer func() { podRequestInterfaceOps = &defaultPodRequestInterfaceOps{} }()
+		pr := PodRequest{
+			PodNamespace: "foo-ns",
+			PodName:      "bar-pod",
+			timestamp:    time.Time{},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pr.PodName,
+				Namespace: pr.PodNamespace,
+				Annotations: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["100.10.10.3/24","fd44::33/64"],"mac_address":
+"0a:58:fd:98:00:01", "role":"infrastructure-locked"}, "foo-ns/meganet":{"ip_addresses":["10.10.10.30/24","fd10::3/64"],
+"mac_address":"02:03:04:05:06:07", "role":"primary"}}`,
+				},
+			},
+		}
+		defaultPodNADAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, "default")
+		require.NoError(t, err)
+		udnPodNADAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, "foo-ns/meganet")
+		require.NoError(t, err)
+
+		// Fake Response: no Result, but PrimaryUDNPodInfo + PrimaryUDNPodRequest populated
+		resp := &Response{
+			Result: nil,
+			PodIFInfo: &PodInterfaceInfo{
+				PodAnnotation: *defaultPodNADAnnotation,
+				MTU:           1400,
+				NetName:       "default",
+				NADName:       "foo-ns/default",
+				// hack to bypass OVS exec check
+				IsDPUHostMode: true,
+			},
+			PrimaryUDNPodInfo: &PodInterfaceInfo{
+				PodAnnotation: *udnPodNADAnnotation,
+				MTU:           1400,
+				NetName:       "tenantred",
+				NADName:       "foo-ns/meganet",
+				// hack to bypass OVS exec check
+				IsDPUHostMode: true,
+			},
+			PrimaryUDNPodReq: &PodRequest{
+				PodNamespace: "default",
+				PodName:      "testpod",
+				IfName:       "dummy1",
+			},
+			KubeAuth: &KubeAPIAuth{},
+		}
+
+		body, _ := json.Marshal(resp)
+
+		// Mock doCNI to return our fake response
+		p.doCNIFunc = func(_ string, _ interface{}) ([]byte, error) {
+			return body, nil
+		}
+
+		// Capture stdout (CmdAdd prints)
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		defer func() {
+			os.Stdout = oldStdout
+		}()
+
+		args := &skel.CmdArgs{
+			StdinData:   []byte(`{"cniVersion":"1.0.0","name":"mynet","type":"ovn-k8s-cni-overlay"}`),
+			ContainerID: "cid",
+			Netns:       "/var/run/netns/test",
+			IfName:      "eth0",
+		}
+		err = p.CmdAdd(args)
+		require.NoError(t, err)
+
+		// Collect stdout
+		w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		output := buf.String()
+
+		// Unmarshal output for comparison
+		var got map[string]any
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to unmarshal output: %v", err)
+		}
+
+		// Expected output includes both interfaces wired by CNIShim
+		expected := `{
+  "cniVersion": "1.0.0",
+  "interfaces": [
+    {
+      "name": "eth0",
+      "sandbox": "/var/run/netns/test-ns_test-pod"
+    },
+    {
+      "name": "dummy1",
+      "sandbox": "/var/run/netns/default_testpod"
+    }
+  ],
+  "ips": [
+    { "address": "100.10.10.3/24", "interface": 1 },
+    { "address": "fd44::33/64", "interface": 1 },
+    { "address": "10.10.10.30/24", "interface": 2 },
+    { "address": "fd10::3/64", "interface": 2 }
+  ]
+}`
+
+		var want map[string]any
+		if err := json.Unmarshal([]byte(expected), &want); err != nil {
+			t.Fatalf("failed to unmarshal expected: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("unexpected CmdAdd output:\n got=%v\nwant=%v", got, want)
+		}
+	})
+}
+
+func TestCmdDel_PrivilegedMode(t *testing.T) {
+	p := &Plugin{}
+
+	// Patch doCNI to return a response with non-nil Result that indicates server handled delete
+	result := &current.Result{}
+
+	kubeAuth := &KubeAPIAuth{
+		Kubeconfig:       config.Kubernetes.Kubeconfig,
+		KubeAPIServer:    config.Kubernetes.APIServer,
+		KubeAPIToken:     config.Kubernetes.Token,
+		KubeAPITokenFile: config.Kubernetes.TokenFile,
+	}
+	body, _ := json.Marshal(&Response{
+		Result:    result,
+		PodIFInfo: &PodInterfaceInfo{},
+		KubeAuth:  kubeAuth,
+	})
+
+	// Mock a doCNI that succeeds for CmdDel
+	p.doCNIFunc = func(_ string, _ interface{}) ([]byte, error) {
+		return body, nil
+	}
+
+	args := &skel.CmdArgs{
+		StdinData:   []byte(`{"cniVersion":"1.0.0","name":"mynet","type":"ovn-k8s-cni-overlay"}`),
+		ContainerID: "cid",
+		Netns:       "/var/run/netns/test",
+		IfName:      "eth0",
+	}
+	err := p.CmdDel(args)
+	require.NoError(t, err)
+}
+
+func TestCmdDel_UnprivilegedMode(t *testing.T) {
+	withCNIEnv(t, func() {
+		p := &Plugin{}
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+		stub := &podRequestInterfaceOpsStub{}
+		podRequestInterfaceOps = stub
+		defer func() { podRequestInterfaceOps = &defaultPodRequestInterfaceOps{} }()
+
+		resp := &Response{
+			Result: nil,
+			PodIFInfo: &PodInterfaceInfo{
+				NetName:       "default",
+				NADName:       "foo-ns/default",
+				IsDPUHostMode: true,
+			},
+			PrimaryUDNPodInfo: &PodInterfaceInfo{
+				NetName:       "tenantred",
+				NADName:       "foo-ns/meganet",
+				IsDPUHostMode: true,
+			},
+			PrimaryUDNPodReq: &PodRequest{
+				PodNamespace: "default",
+				PodName:      "testpod",
+				IfName:       "dummy1",
+			},
+			KubeAuth: &KubeAPIAuth{},
+		}
+
+		body, _ := json.Marshal(resp)
+		p.doCNIFunc = func(_ string, _ interface{}) ([]byte, error) {
+			return body, nil
+		}
+
+		args := &skel.CmdArgs{
+			StdinData:   []byte(`{"cniVersion":"1.0.0","name":"mynet","type":"ovn-k8s-cni-overlay"}`),
+			ContainerID: "cid",
+			Netns:       "/var/run/netns/test",
+			IfName:      "eth0",
+		}
+		err := p.CmdDel(args)
+		require.NoError(t, err)
+
+		if len(stub.unconfiguredInterfaces) <= 0 {
+			t.Fatalf("no unconfigured interfaces found")
+		}
+	})
+}
+
+func withCNIEnv(t *testing.T, fn func()) {
+	t.Helper()
+
+	vars := map[string]string{
+		"CNI_COMMAND":     "ADD",
+		"CNI_CONTAINERID": "dummy-containerid",
+		"CNI_NETNS":       "/var/run/netns/testns",
+		"CNI_IFNAME":      "eth0",
+		"CNI_PATH":        "/opt/cni/bin",
+		"CNI_ARGS":        "K8S_POD_NAME=test-pod;K8S_POD_NAMESPACE=test-ns;K8S_POD_UID=12345",
+	}
+
+	old := make(map[string]string, len(vars))
+	for k := range vars {
+		old[k] = os.Getenv(k)
+		_ = os.Setenv(k, vars[k])
+	}
+
+	fn()
+
+	for k, v := range old {
+		if v == "" {
+			_ = os.Unsetenv(k)
+		} else {
+			_ = os.Setenv(k, v)
+		}
+	}
+}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -679,6 +679,7 @@ func PrepareTestConfig() error {
 	ClusterManager = savedClusterManager
 	Kubernetes.DisableRequestedChassis = false
 	EnableMulticast = false
+	UnprivilegedMode = false
 	Default.OVSDBTxnTimeout = 5 * time.Second
 	if Gateway.Mode != GatewayModeDisabled {
 		Gateway.EphemeralPortRange = DefaultEphemeralPortRange


### PR DESCRIPTION
1. Adds unprivileged unit testing to cni server
2. Adds unprivileged unit testing to cni shim
3. Enables unprivileged mode for E2Es: one control-plane ipv6 lane, and one UDN ipv4 lane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * CI e2e matrix now includes unprivileged CNI scenarios and exposes an OVN_UNPRIVILEGED_MODE env var to upgrade tests.
* Tests
  * Expanded CNI add/del coverage for privileged and unprivileged paths, including user-defined network scenarios and realistic interface/IP results.
  * Tests now prepare and reset test config for more stable initialization.
* Refactor
  * CNI plugin supports injecting the CNI call for easier testing without changing behavior.
* Configuration
  * Test config explicitly defaults unprivileged mode to off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->