### PR TITLE
Update maintainers affiliation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,9 +4,9 @@ The current Maintainers Group for the ovn-kubernetes Project consists of:
 | ---- | -------- | ---------------- |
 | [Girish Moodalbail](https://github.com/girishmg) | NVIDIA | All things ovnkube |
 | [Jaime Caamaño Ruiz](https://github.com/jcaamano) | Red Hat | All things ovnkube |
-| [Nadia Pinaeva](https://github.com/npinaeva) | Red Hat  | All things ovnkube |
+| [Nadia Pinaeva](https://github.com/npinaeva) | NVIDIA  | All things ovnkube |
 | [Surya Seetharaman](https://github.com/tssurya)   | Red Hat | All things ovnkube |
-| [Tim Rozet](https://github.com/trozet)   | Red Hat | All things ovnkube |
+| [Tim Rozet](https://github.com/trozet)   | NVIDIA | All things ovnkube |
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
 See [GOVERNANCE.md](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Maintainers page to reflect employer affiliation updates: Nadia Pinaeva and Tim Rozet now listed as NVIDIA (previously Red Hat). No other entries changed, and the Emeritus Maintainers section remains the same. This is a documentation-only update; no product functionality, interfaces, or behavior are affected. No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->