### PR TITLE
Fixes for flaky lb service test

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -483,7 +483,7 @@ func isNeighborEntryStable(externalContainer infraapi.ExternalContainer, targetH
 
 // wgetInExternalContainer issues a request to target host and port at endpoint.
 // Returns a pair of either result, nil or "", error in case of an error.
-func wgetInExternalContainer(externalContainer infraapi.ExternalContainer, targetHost string, targetPort int32, endPoint string, maxTime int) (string, error) {
+func wgetInExternalContainer(externalContainer infraapi.ExternalContainer, targetHost string, targetPort int32, endPoint string) (string, error) {
 	if utilnet.IsIPv6String(targetHost) {
 		targetHost = fmt.Sprintf("[%s]", targetHost)
 	}


### PR DESCRIPTION
This PR contains required changes to fix flakiness with LB service E2E tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched end-to-end service readiness checks to use EndpointSlices instead of Endpoints, aligning with newer Kubernetes discovery APIs.
  * Improved readiness accuracy by counting only unique, ready, non-terminating endpoint addresses across slices and deduplicating duplicates.
  * Added a reusable polling helper with interval/timeout controls to wait for an expected number of ready endpoints.
  * Simplified an external-container test utility by removing an unused timing parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->