### PR TITLE
Node controller shutdown: do not ref gateway if not set

### DIFF
--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -259,7 +259,7 @@ func (ncm *NodeControllerManager) Stop(isOVNKubeControllerSyncd *atomic.Bool) {
 	close(ncm.stopChan)
 
 	if ncm.defaultNodeNetworkController != nil {
-		if isOVNKubeControllerSyncd != nil {
+		if isOVNKubeControllerSyncd != nil && ncm.defaultNodeNetworkController.Gateway != nil {
 			ncm.defaultNodeNetworkController.Gateway.SetDefaultBridgeGARPDropFlows(true)
 			if err := ncm.defaultNodeNetworkController.Gateway.Reconcile(); err != nil {
 				klog.Errorf("Failed to reconcile gateway after attempting to add flows to the external bridge to drop GARPs: %v", err)


### PR DESCRIPTION
PR 5373 to drop the GARP flows didnt consider that we set the default network controller and later we set the gateway obj. In-between this period, ovnkube node may receive a stop signal and we do not guard against accessing the gateway if its not yet set.

There is nothing to reconcile if the gateway is not set.

This code will be removed when ovn has native support for silencing garps on shutdown next march.
