### PR TITLE
Configure sec nic EIPv6 address with NODAD and maximum lifetime

### DIFF
--- a/go-controller/pkg/node/egressip/gateway_egressip.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip.go
@@ -123,6 +123,7 @@ func (mic *MarkIPsCache) deleteMarkIP(pktMark util.EgressIPMark, ip net.IP) {
 func (mic *MarkIPsCache) replaceAll(markIPs markIPs) {
 	mic.mu.Lock()
 	mic.markToIPs = markIPs
+	mic.IPToMark = make(map[string]int, len(markIPs.v4)+len(markIPs.v6))
 	for mark, ipv4 := range markIPs.v4 {
 		mic.IPToMark[ipv4] = mark
 	}

--- a/go-controller/pkg/util/egressip/net.go
+++ b/go-controller/pkg/util/egressip/net.go
@@ -1,0 +1,39 @@
+package egressip
+
+import (
+	"math"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// GetNetlinkAddress returns a netlink address configured with specific
+// egress ip parameters
+func GetNetlinkAddress(ip net.IP, ifindex int) *netlink.Addr {
+	return &netlink.Addr{
+		IPNet:     &net.IPNet{IP: ip, Mask: util.GetIPFullMask(ip)},
+		Flags:     getNetlinkAddressFlag(ip),
+		Scope:     int(netlink.SCOPE_UNIVERSE),
+		ValidLft:  getNetlinkAddressValidLft(ip),
+		LinkIndex: ifindex,
+	}
+}
+
+func getNetlinkAddressFlag(ip net.IP) int {
+	// isV6?
+	if ip != nil && ip.To4() == nil && ip.To16() != nil {
+		return unix.IFA_F_NODAD
+	}
+	return 0
+}
+
+func getNetlinkAddressValidLft(ip net.IP) int {
+	// isV6?
+	if ip != nil && ip.To4() == nil && ip.To16() != nil {
+		return math.MaxUint32
+	}
+	return 0
+}


### PR DESCRIPTION
Aligning it to what we do for primary nic EIPv6 addresses. NODAD is required since it is possible for an EIPv6 to be configured in two nodes at the same time during a short failover time window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - EgressIP processing now treats addresses as plain IPs and consistently passes parsed IPs through pod- and egress-wide config generation; address construction centralized in a shared utility, unifying IPv4/IPv6 handling and simplifying network checks.
  - No changes to public APIs.

- Tests
  - Updated tests to use the shared egress IP address utility for consistent assertions.

- Chores
  - Removed duplicate internal helpers and streamlined imports for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->