### PR TITLE
Revert "multi-homing, tests: do not use OVN provided IPAM in L3 nets"

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -505,11 +505,22 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 	logicalSwitch.OtherConfig = map[string]string{}
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := bnc.GetNodeGatewayIP(hostSubnet)
+		mgmtIfAddr := bnc.GetNodeManagementIP(hostSubnet)
 
 		if utilnet.IsIPv6CIDR(hostSubnet) {
 			v6Gateway = gwIfAddr.IP
+
+			logicalSwitch.OtherConfig["ipv6_prefix"] =
+				hostSubnet.IP.String()
 		} else {
 			v4Gateway = gwIfAddr.IP
+			excludeIPs := mgmtIfAddr.IP.String()
+			if config.HybridOverlay.Enabled {
+				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)
+				excludeIPs += ".." + hybridOverlayIfAddr.IP.String()
+			}
+			logicalSwitch.OtherConfig["subnet"] = hostSubnet.String()
+			logicalSwitch.OtherConfig["exclude_ips"] = excludeIPs
 		}
 	}
 

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -1439,7 +1439,11 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Ports:       []string{"k8s-" + networkName1_ + node1Name + "-UUID", "stor-" + networkName1_ + node1Name + "-UUID"},
 						ExternalIDs: map[string]string{ovntypes.NetworkExternalID: netInfo.GetNetworkName(), ovntypes.TopologyExternalID: ovntypes.Layer3Topology},
 						QOSRules:    []string{fmt.Sprintf("%s-QoS-UUID", netInfo.GetNetworkName())},
-						ACLs:        []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
+						OtherConfig: map[string]string{
+							"exclude_ips": util.GetNodeManagementIfAddr(node1UDNSubnet).IP.String(),
+							"subnet":      node1UDNSubnet.String(),
+						},
+						ACLs: []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      netInfo.GetNetworkScopedName(ovntypes.TransitSwitchToRouterPrefix+node1.Name) + "-UUID",
@@ -1684,7 +1688,11 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Ports:       []string{"k8s-" + networkName1_ + node1Name + "-UUID", "stor-" + networkName1_ + node1Name + "-UUID"},
 						ExternalIDs: map[string]string{ovntypes.NetworkExternalID: netInfo.GetNetworkName(), ovntypes.TopologyExternalID: ovntypes.Layer3Topology},
 						QOSRules:    []string{fmt.Sprintf("%s-QoS-UUID", netInfo.GetNetworkName())},
-						ACLs:        []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
+						OtherConfig: map[string]string{
+							"exclude_ips": util.GetNodeManagementIfAddr(node1UDNSubnet).IP.String(),
+							"subnet":      node1UDNSubnet.String(),
+						},
+						ACLs: []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      netInfo.GetNetworkScopedName(ovntypes.TransitSwitchToRouterPrefix+node1.Name) + "-UUID",
@@ -2905,7 +2913,11 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 						Ports:       []string{"k8s-" + networkName1_ + node1Name + "-UUID", "stor-" + networkName1_ + node1Name + "-UUID"},
 						ExternalIDs: map[string]string{ovntypes.NetworkExternalID: netInfo.GetNetworkName(), ovntypes.TopologyExternalID: ovntypes.Layer3Topology},
 						QOSRules:    []string{fmt.Sprintf("%s-QoS-UUID", netInfo.GetNetworkName())},
-						ACLs:        []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
+						OtherConfig: map[string]string{
+							"exclude_ips": util.GetNodeManagementIfAddr(node1UDNSubnet).IP.String(),
+							"subnet":      node1UDNSubnet.String(),
+						},
+						ACLs: []string{netInfo.GetNetworkScopedSwitchName(node1.Name) + "-NetpolNode-UUID"},
 					},
 					&nbdb.LogicalSwitchPort{
 						UUID:      netInfo.GetNetworkScopedName(ovntypes.TransitSwitchToRouterPrefix+node1.Name) + "-UUID",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -121,6 +121,7 @@ func (n tNode) logicalSwitch(loadBalancerGroupUUIDs []string) *nbdb.LogicalSwitc
 	return &nbdb.LogicalSwitch{
 		UUID:              n.Name + "-UUID",
 		Name:              n.Name,
+		OtherConfig:       map[string]string{"subnet": n.NodeSubnet},
 		LoadBalancerGroup: loadBalancerGroupUUIDs,
 	}
 }
@@ -1815,8 +1816,17 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			// Ensure that the node's switch is eventually created once the annotations
 			// are reconciled by the network cluster controller
 			gomega.Eventually(func() bool {
-				_, err = libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: newNode.Name})
-				return err == nil
+				newNodeLS, err := libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: newNode.Name})
+				if err != nil {
+					return false
+				}
+				if newNodeLS.OtherConfig["subnet"] != newNodeIpv4Subnet {
+					return false
+				}
+				if newNodeLS.OtherConfig["ipv6_prefix"] != newNodeIpv6SubnetPrefix {
+					return false
+				}
+				return true
 			}, 10).Should(gomega.BeTrue())
 
 			return nil


### PR DESCRIPTION
Reverts ovn-kubernetes/ovn-kubernetes#4885

Breaks windows jobs/hybrid overlay downstream, feel free to re-revert and do a proper fix later

Blocks merges downstream: https://github.com/openshift/ovn-kubernetes/pull/2750

The .3 IP is always used for hybrid overlay. When that IP get's provided to the pod, we run into troubles. We need the .3 reserved on the switch if hybrid overlay is enabled, otherwise the first pod that comes up struggles and breaks.

cc @maiqueb 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Node switches now include IPv4 subnet and IPv6 prefix metadata.
  - Management IPs (and Hybrid Overlay addresses when enabled) are automatically excluded from allocation.

- Bug Fixes
  - Improved reliability of node-subnet updates with egress firewall sequencing to reduce transient inconsistencies.

- Tests
  - Expanded coverage validating node switch metadata (subnet, IPv6 prefix, exclude IPs) across default, UDN, and multihoming scenarios and topologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->