### PR TITLE
api, udn: subnets must be masked

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -313,6 +313,14 @@ spec:
                       rule: '!has(self.infrastructureSubnets) || !has(self.reservedSubnets)
                         || self.infrastructureSubnets.all(infra, !self.reservedSubnets.exists(reserved,
                         cidr(infra).containsCIDR(reserved) || cidr(reserved).containsCIDR(infra)))'
+                    - message: infrastructureSubnets must be a masked network address
+                        (no host bits set)
+                      rule: '!has(self.infrastructureSubnets) || self.infrastructureSubnets.all(s,
+                        isCIDR(s) && cidr(s) == cidr(s).masked())'
+                    - message: reservedSubnets must be a masked network address (no
+                        host bits set)
+                      rule: '!has(self.reservedSubnets) || self.reservedSubnets.all(s,
+                        isCIDR(s) && cidr(s) == cidr(s).masked())'
                   layer3:
                     description: Layer3 is the Layer3 topology configuration.
                     properties:

--- a/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
@@ -257,6 +257,14 @@ spec:
                   rule: '!has(self.infrastructureSubnets) || !has(self.reservedSubnets)
                     || self.infrastructureSubnets.all(infra, !self.reservedSubnets.exists(reserved,
                     cidr(infra).containsCIDR(reserved) || cidr(reserved).containsCIDR(infra)))'
+                - message: infrastructureSubnets must be a masked network address
+                    (no host bits set)
+                  rule: '!has(self.infrastructureSubnets) || self.infrastructureSubnets.all(s,
+                    isCIDR(s) && cidr(s) == cidr(s).masked())'
+                - message: reservedSubnets must be a masked network address (no host
+                    bits set)
+                  rule: '!has(self.reservedSubnets) || self.reservedSubnets.all(s,
+                    isCIDR(s) && cidr(s) == cidr(s).masked())'
               layer3:
                 description: Layer3 is the Layer3 topology configuration.
                 properties:

--- a/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
@@ -102,6 +102,8 @@ type Layer3Subnet struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.reservedSubnets) || self.reservedSubnets.all(e, self.subnets.exists(s, cidr(s).containsCIDR(cidr(e))))",message="reservedSubnets must be subnetworks of the networks specified in the subnets field",fieldPath=".reservedSubnets"
 // +kubebuilder:validation:XValidation:rule="!has(self.infrastructureSubnets) || self.infrastructureSubnets.all(e, self.subnets.exists(s, cidr(s).containsCIDR(cidr(e))))",message="infrastructureSubnets must be subnetworks of the networks specified in the subnets field",fieldPath=".infrastructureSubnets"
 // +kubebuilder:validation:XValidation:rule="!has(self.infrastructureSubnets) || !has(self.reservedSubnets) || self.infrastructureSubnets.all(infra, !self.reservedSubnets.exists(reserved, cidr(infra).containsCIDR(reserved) || cidr(reserved).containsCIDR(infra)))", message="infrastructureSubnets and reservedSubnets must not overlap"
+// +kubebuilder:validation:XValidation:rule="!has(self.infrastructureSubnets) || self.infrastructureSubnets.all(s, isCIDR(s) && cidr(s) == cidr(s).masked())", message="infrastructureSubnets must be a masked network address (no host bits set)"
+// +kubebuilder:validation:XValidation:rule="!has(self.reservedSubnets) || self.reservedSubnets.all(s, isCIDR(s) && cidr(s) == cidr(s).masked())", message="reservedSubnets must be a masked network address (no host bits set)"
 type Layer2Config struct {
 	// Role describes the network role in the pod.
 	//

--- a/test/e2e/network_segmentation_preconfigured_layer2.go
+++ b/test/e2e/network_segmentation_preconfigured_layer2.go
@@ -121,7 +121,7 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 				role:                "primary",
 				defaultGatewayIPs:   joinStrings("172.31.0.10", "2014:100:200::100"),
 				reservedCIDRs:       joinStrings("172.31.1.0/24", "2014:100:200::/122"),
-				infrastructureCIDRs: joinStrings("172.31.0.10/30", "2014:100:200::100/122"),
+				infrastructureCIDRs: joinStrings("172.31.0.8/30", "2014:100:200::100/122"),
 			},
 			expectedGatewayIPs: []string{"172.31.0.10", "2014:100:200::100"},
 		}),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
The OVN-K API was allowing unmasked CIDRs to be used in the UDN API. This led to some misleading error messages, for instance:

Imagine the user would provision this C-UDN manifest:
```yaml
cat <<EOF | kubectl apply -f -
apiVersion: k8s.ovn.org/v1
kind: ClusterUserDefinedNetwork
metadata:
  name: l2-network
spec:
  namespaceSelector:
    matchLabels:
      cudn-group: l2-net
  network:
    topology: Layer2
    layer2:
      role: Primary
      subnets: ["192.168.40.0/24"]
      reservedSubnets: ["192.168.40.4/24"]
      defaultGatewayIPs:
        - "192.168.40.3"
EOF
```
The C-UDN would be provisioned, but, when a workload was created, attaching to this UDN, it would fail with the following error msg:
> 14:19:07.462812 3361 controller.go:258] Controller [zone-nad-controller network controller]: error found while processing cluster_udn_l2-network: [zone-nad-controller network controller]: failed to ensure network cluster_udn_l2-network: failed to start network cluster_udn_l2-network: failed to exclude subnet 192.168.40.0/24 for cluster_udn_l2.network_ovn_layer2_switch: failed to reserve IP 192.168.40.1: provided IP is already allocated

The reason is the API would then mask the CIDR on the `reservedSubnets` attribute - i.e. 192.168.40.0/24 - , and would 
**reserve** the entire subnet. The controller would then fail to reserve any IP address within the subnet.

After this patch, OVN-Kubernetes fails when provisioning said C-UDN, with the following error:
```sh
cat <<EOF | kubectl apply -f -
apiVersion: k8s.ovn.org/v1
kind: ClusterUserDefinedNetwork
metadata:
  name: l2-network
spec:
  namespaceSelector:
    matchLabels:
      cudn-group: l2-net
  network:
    topology: Layer2
    layer2:
      role: Primary
      subnets: ["192.168.40.0/24"] 
      reservedSubnets: ["192.168.40.4/24"]         
      defaultGatewayIPs:
        - "192.168.40.3"
EOF
The ClusterUserDefinedNetwork "l2-network" is invalid: spec.network.layer2.reservedSubnets[0]: Invalid value: "string": CIDR is invalid
```


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced that Layer 2 infrastructure and reserved subnets must be masked network addresses (no host bits) and surface clear validation errors when unmasked CIDRs are provided.

* **Tests**
  * Updated Layer 2 tests and added negative cases to confirm unmasked infrastructure/reserved subnets are rejected with the expected error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->