### PR TITLE
Allow specifying custom ClusterIP for Services

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -1814,22 +1814,6 @@ func withServiceNameAndNoHeadlessServiceSelector() func(options *metav1.ListOpti
 	}
 }
 
-// noHeadlessServiceSelector returns a LabelSelector (added to the
-// watcher for EndpointSlices) that will only choose EndpointSlices without "service.kubernetes.io/headless"
-// label.
-func noHeadlessServiceSelector() func(options *metav1.ListOptions) {
-	// headless service label must not be there
-	noHeadlessService, err := labels.NewRequirement(corev1.IsHeadlessService, selection.DoesNotExist, nil)
-	if err != nil {
-		// cannot occur
-		panic(err)
-	}
-
-	return func(options *metav1.ListOptions) {
-		options.LabelSelector = noHeadlessService.String()
-	}
-}
-
 // noAlternateProxySelector is a LabelSelector added to the watch for
 // services that excludes services with a well-known label indicating
 // proxying is via an alternate proxy.
@@ -1897,11 +1881,10 @@ func waitForCacheSyncWithTimeout(factory waitForCacheSyncer, stopCh <-chan struc
 // When network segmentation is enabled it returns a selector that ignores EndpointSlices for headless services.
 // Otherwise, it returns a selector that excludes EndpointSlices a with missing default service name too.
 func getEndpointSliceSelector() func(options *metav1.ListOptions) {
-	endpointSliceSelector := withServiceNameAndNoHeadlessServiceSelector()
 	if util.IsNetworkSegmentationSupportEnabled() {
 		// When network segmentation is enabled we need to watch for mirrored EndpointSlices that do not contain the
 		// default service name.
-		endpointSliceSelector = noHeadlessServiceSelector()
+		return nil
 	}
-	return endpointSliceSelector
+	return withServiceNameAndNoHeadlessServiceSelector()
 }

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -270,7 +270,10 @@ func buildClusterLBs(service *corev1.Service, configs []lbConfig, nodeInfos []no
 			// The node may not have a gateway router - it might be waiting initialization, or
 			// might have disabled GWR creation via the k8s.ovn.org/l3-gateway-config annotation
 			if node.gatewayRouterName != "" {
-				nodeRouters = append(nodeRouters, node.gatewayRouterName)
+				// Do not set routerTargets for a custom service IP
+				if customIP := util.GetServiceCustomIP(service); customIP == "" {
+					nodeRouters = append(nodeRouters, node.gatewayRouterName)
+				}
 			}
 		}
 	}
@@ -527,16 +530,19 @@ func buildTemplateLBs(service *corev1.Service, configs []lbConfig, nodes []nodeI
 					Templates:   getTemplatesFromRulesTargets(switchV4Rules),
 				})
 			}
-			if len(routerV4Rules) > 0 {
-				out = append(out, LB{
-					Name:        makeLBNameForNetwork(service, proto, "node_router_template_IPv4", netInfo),
-					Protocol:    string(proto),
-					ExternalIDs: eids,
-					Opts:        optsV4,
-					Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterRouterLBGroupName)},
-					Rules:       routerV4Rules,
-					Templates:   getTemplatesFromRulesTargets(routerV4Rules),
-				})
+			// Do not set routerTargets for a custom service IP
+			if customIP := util.GetServiceCustomIP(service); customIP == "" {
+				if len(routerV4Rules) > 0 {
+					out = append(out, LB{
+						Name:        makeLBNameForNetwork(service, proto, "node_router_template_IPv4", netInfo),
+						Protocol:    string(proto),
+						ExternalIDs: eids,
+						Opts:        optsV4,
+						Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterRouterLBGroupName)},
+						Rules:       routerV4Rules,
+						Templates:   getTemplatesFromRulesTargets(routerV4Rules),
+					})
+				}
 			}
 		}
 
@@ -553,15 +559,18 @@ func buildTemplateLBs(service *corev1.Service, configs []lbConfig, nodes []nodeI
 				})
 			}
 			if len(routerV6Rules) > 0 {
-				out = append(out, LB{
-					Name:        makeLBNameForNetwork(service, proto, "node_router_template_IPv6", netInfo),
-					Protocol:    string(proto),
-					ExternalIDs: eids,
-					Opts:        optsV6,
-					Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterRouterLBGroupName)},
-					Rules:       routerV6Rules,
-					Templates:   getTemplatesFromRulesTargets(routerV6Rules),
-				})
+				// Do not set routerTargets for a custom service IP
+				if customIP := util.GetServiceCustomIP(service); customIP == "" {
+					out = append(out, LB{
+						Name:        makeLBNameForNetwork(service, proto, "node_router_template_IPv6", netInfo),
+						Protocol:    string(proto),
+						ExternalIDs: eids,
+						Opts:        optsV6,
+						Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterRouterLBGroupName)},
+						Rules:       routerV6Rules,
+						Templates:   getTemplatesFromRulesTargets(routerV6Rules),
+					})
+				}
 			}
 		}
 	}
@@ -665,7 +674,7 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 							Targets: targetsETP,
 						})
 					}
-					if cfg.internalTrafficLocal && util.IsClusterIP(vip) { // ITP only applicable to CIP
+					if cfg.internalTrafficLocal && util.IsClusterIP(vip, service) { // ITP only applicable to CIP
 						targetsITP := joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port)
 						if isv6 {
 							targetsITP = joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port)
@@ -698,7 +707,10 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 					if cfg.externalTrafficLocal && len(targets) > 0 {
 						noSNATRouterRules = append(noSNATRouterRules, rule)
 					} else {
-						routerRules = append(routerRules, rule)
+						// Do not set routerTargets for a custom service IP
+						if customIP := util.GetServiceCustomIP(service); customIP == "" {
+							routerRules = append(routerRules, rule)
+						}
 					}
 				}
 			}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -205,6 +205,8 @@ const (
 	ClusterSwitchLBGroupName = "clusterSwitchLBGroup"
 	ClusterRouterLBGroupName = "clusterRouterLBGroup"
 
+	CustomServiceIP = OvnK8sPrefix + "/" + "cluster-ip"
+
 	// key for network name external-id
 	NetworkExternalID = OvnK8sPrefix + "/" + "network"
 	// key for node name external-id


### PR DESCRIPTION
Introduces new behavior, where if a Headless Service is created with k8s.ovn.org/cluster-ip annotated with an custom IP address, then a service will be created using that custom IP address.

The custom IP address may not be in the range of the Kubernetes Service CIDR.

Additionally, the load balancer is not placed on the Gateway Router (GR). This is intentional to avoid exposing this Custom IP address anywhere other than inside the SDN. The load balancer is only configured on the worker switches.

**Why would you want this?**

With VMs (kubevirt) there exists a case where a VM may need to cloud-init to get information to bootstrap a VM. Usually it is recommended in kubevirt to use a noseed approach, where a volume is mounted for cloud-init to inspect and find the data:
https://github.com/kubevirt/kubevirt/blob/9c2c41e64a0979cc3a5920729f9ae8ee03affeb5/examples/vmi-masquerade.yaml#L38

However, there may be cases where a VM needs to access a metadata server, similar to the standard convention AWS and OpenStack use of web access to 169.254.169.254. For this use case, we can create a metadata service to handle this. However, we cannot specify 169.254.169.254 for LoadBalancer IP or External IP, Kubernetes forbids it:

```
trozet@fedora:~$ oc create -f ~/externalip_service_udn.yaml The Service "metadata-service" is invalid: spec.externalIPs[0]: Invalid value: "169.254.169.254": may not be in the link-local range (169.254.0.0/16, fe80::/10)
```

So with this commit, we can leverage it as a cluster IP, and use ITP=Local so that VMs access a metadata service on their own node:

```
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/go-controller$ cat ~/metadata_service_udn.yaml 
apiVersion: v1
kind: Service
metadata:
  name: metadata-service
  namespace: udn-test
  annotations:
    k8s.ovn.org/cluster-ip: 169.254.169.254 
spec:
  clusterIP: None
  selector:
      pod-name: metadata-server      
  ports:
    - protocol: TCP
      port: 80
      targetPort: 80
      name: blah2  
  type: ClusterIP
  internalTrafficPolicy: Local
```

@tssurya @npinaeva @jcaamano looking for feedback on this idea. It probably needs a small okep and and e2e test as well.