### PR TITLE
Prevent inbound NodePort traffic from being forward to kernel

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -331,9 +331,16 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 					// case2 (see function description for details)
 					npw.ofm.updateFlowCacheEntry(key, []string{
 						// table=0, matches on service traffic towards nodePort and sends it to OVN pipeline
+						// setting the ct_mark to '0x1' to indicate that this is OVN traffic
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
-							"actions=%s",
-							cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, actions),
+							"actions=ct(commit, zone=64000, exec(set_field:%s->ct_mark)),%s",
+							cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, nodetypes.CtMarkOVN, actions),
+						// table=0, matches on service traffic towards nodePort from OVN and drops it, to prevent the traffic goes to the host.
+						// match on ct_state=+est+trk and ct_mark=0x1 to ensure that this rule only applies to return traffic from OVN.
+						// This is to prevent traffic to nodePort from being forwarded to the host accidentally during GR OVN LB resyncs.
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, ct_state=+est+trk, ct_mark=%s,"+
+							"actions=drop",
+							cookie, netConfig.OfPortPatch, flowProtocol, svcPort.NodePort, nodetypes.CtMarkOVN),
 						// table=0, matches on return traffic from service nodePort and sends it out to primary node interface (br-ex)
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, dl_src=%s, %s, tp_src=%d, "+
 							"actions=output:%s",


### PR DESCRIPTION
Set ct_mark 0x1 for inbound traffic to NodePort service. Added a new flow to drop the traffic from OVN to NodePort service to prevent traffic to nodePort from being forwarded to the host accidentally during GR OVN LB resyncs.

Fix flake for the test "[sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
