### PR TITLE
fix: make the order of cli --help categories determinate

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -58,27 +58,31 @@ COMMANDS:{{range .VisibleCategories}}{{if .Name}}
    {{.Name}}:{{end}}{{range .VisibleCommands}}
      {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}
 
-GLOBAL OPTIONS:{{range $title, $category := getFlagsByCategory}}
-   {{upper $title}}
-   {{range $index, $option := $category}}{{if $index}}
+GLOBAL OPTIONS:{{range getFlagsByCategory}}
+   {{upper .Title}}
+   {{range $index, $option := .Flags}}{{if $index}}
    {{end}}{{$option}}{{end}}
    {{end}}`
 )
 
-func getFlagsByCategory() map[string][]cli.Flag {
-	m := map[string][]cli.Flag{}
-	m["Generic Options"] = config.CommonFlags
-	m["CNI Options"] = config.CNIFlags
-	m["K8s-related Options"] = config.K8sFlags
-	m["OVN Northbound DB Options"] = config.OvnNBFlags
-	m["OVN Southbound DB Options"] = config.OvnSBFlags
-	m["OVN Gateway Options"] = config.OVNGatewayFlags
-	m["Master HA Options"] = config.MasterHAFlags
-	m["OVN Kube Node Options"] = config.OvnKubeNodeFlags
-	m["Monitoring Options"] = config.MonitoringFlags
-	m["IPFIX Flow Tracing Options"] = config.IPFIXFlags
+type flagCategory struct {
+	Title string
+	Flags []cli.Flag
+}
 
-	return m
+func getFlagsByCategory() []flagCategory {
+	return []flagCategory{
+		{"Generic Options", config.CommonFlags},
+		{"CNI Options", config.CNIFlags},
+		{"K8s-related Options", config.K8sFlags},
+		{"OVN Northbound DB Options", config.OvnNBFlags},
+		{"OVN Southbound DB Options", config.OvnSBFlags},
+		{"OVN Gateway Options", config.OVNGatewayFlags},
+		{"Master HA Options", config.MasterHAFlags},
+		{"OVN Kube Node Options", config.OvnKubeNodeFlags},
+		{"Monitoring Options", config.MonitoringFlags},
+		{"IPFIX Flow Tracing Options", config.IPFIXFlags},
+	}
 }
 
 // borrowed from cli packages' printHelpCustom()


### PR DESCRIPTION
as per https://go.dev/ref/spec ...

```
 iteration order over maps is not specified and is not guaranteed to be
 the same from one iteration to the next
```

Signed-off-by: Ihar Hrachyshka <ihrachyshka@nvidia.com>
Assisted-By: Claude Code; claude-sonnet-4-20250514

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
