### PR TITLE
fix: Skip node-encap-ips annotation in DPU host mode

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -944,10 +944,14 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
 	}
 
-	encapIPList := sets.New[string]()
-	encapIPList.Insert(strings.Split(config.Default.EffectiveEncapIP, ",")...)
-	if err := util.SetNodeEncapIPs(nodeAnnotator, encapIPList); err != nil {
-		return fmt.Errorf("failed to set node-encap-ips annotation for node %s: %w", nc.name, err)
+	// Set the node-encap-ips annotation with the configured encap IP.
+	// This encap IP is unavailable on the DPU host mode, so we don't need to set it there.
+	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		encapIPList := sets.New[string]()
+		encapIPList.Insert(strings.Split(config.Default.EffectiveEncapIP, ",")...)
+		if err := util.SetNodeEncapIPs(nodeAnnotator, encapIPList); err != nil {
+			return fmt.Errorf("failed to set node-encap-ips annotation for node %s: %w", nc.name, err)
+		}
 	}
 
 	if err := nodeAnnotator.Run(); err != nil {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -243,7 +243,7 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
 		return
 	}
-	if nodePrimaryAddrChanged && config.Default.EncapIP == "" {
+	if nodePrimaryAddrChanged && config.Default.EncapIP == "" && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
 		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
 		c.updateOVNEncapIPAndReconnect(c.nodePrimaryAddr)
 	}


### PR DESCRIPTION
The node-encap-ips annotation should not be set when running in DPU host mode since the encap IP is not available on the DPU host. This prevents errors during node initialization when the encap IP cannot be determined.

- Add conditional check for NodeModeDPUHost before setting encap IP annotation
- Maintain existing behavior for non-DPU host modes
- Fixes initialization errors in DPU host mode deployments


--

Cherry-pick from master to release-1.1
