### PR TITLE
[IC][EIP] OCPBUGS-42303: Fix race between SB DB and OVN-Controller at startup

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -528,12 +528,12 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			metrics.MetricOVNKubeControllerReadyDuration.Set(time.Since(startTime).Seconds())
 
 			if isOVNKubeControllerSyncd != nil {
-				klog.Infof("Waiting for OVN northbound database changes to sync to OVN Southbound database")
-				if err = libovsdbutil.WaitUntilNorthdSyncOnce(ctx, libovsdbOvnNBClient, libovsdbOvnSBClient); err != nil {
-					controllerErr = fmt.Errorf("failed waiting for northd to sync OVN Northbound DB to Southbound: %v", err)
+				klog.Infof("Waiting for OVN northbound database changes to be processed by ovn-controller")
+				if err = libovsdbutil.WaitUntilFlowsInstalled(ctx, libovsdbOvnNBClient); err != nil {
+					controllerErr = fmt.Errorf("failed waiting for OVN northbound database changes to be processed by ovn-controller: %v", err)
 					return
 				} else {
-					klog.Infof("OVN northbound database changes synced to OVN Southbound database")
+					klog.Infof("Finished waiting for OVN northbound database changes to be processed by ovn-controller")
 					isOVNKubeControllerSyncd.Store(true)
 				}
 			}

--- a/go-controller/pkg/libovsdb/util/northd_sync.go
+++ b/go-controller/pkg/libovsdb/util/northd_sync.go
@@ -14,26 +14,26 @@ import (
 
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 )
 
-// WaitUntilNorthdSyncOnce ensures northd has sync'd at least once by increments nb_cfg value in NB DB and waiting
-// for northd to copy it to SB DB. Poll SB DB until context is cancelled.
-// The expectation is that the data you wish to be sync'd to SB DB has already been written to NB DB so when we get the initial
-// nb_cfg value, we know that if we increment that by one and see that value or greater in SB DB, then the data has sync'd.
-// All other processes interacting with nb_cfg increment it. This function depends on other processes respecting that.
-// No guarantee of any changes in SB DB made after this func.
-func WaitUntilNorthdSyncOnce(ctx context.Context, nbClient, sbClient client.Client) error {
+// WaitUntilFlowsInstalled ensures that ovn-controller has sync'd at least once by incrementing nb_cfg value in NB DB
+// and waiting for northd to write back a value equal or greater to the hv_cfg field in NB_Global.
+// See https://www.ovn.org/support/dist-docs/ovn-nb.5.html for more info regarding nb_cfg / hv_cfg fields.
+// The expectation is that the data you wish to be sync'd is already written to NB DB.
+// Note: if the ovn-controller is down, this will block until it comes back up, therefore this func should only
+// be used with IC mode and one node per zone.
+func WaitUntilFlowsInstalled(ctx context.Context, nbClient client.Client) error {
 	// 1. Get value of nb_cfg
 	// 2. Increment value of nb_cfg
-	// 3. Wait until value appears in SB DB after northd copies it.
+	// 3. Wait until value appears in hv_cfg field thus ensuring ovn-controller has processed the changes
 	nbGlobal := &nbdb.NBGlobal{}
 	nbGlobal, err := libovsdbops.GetNBGlobal(nbClient, nbGlobal)
 	if err != nil {
 		return fmt.Errorf("failed to find OVN Northbound NB_Global table"+
 			" entry: %w", err)
 	}
-	// increment nb_cfg value by 1. When northd consumes updates from NB DB, it will copy this value to SB DBs SB_Global table nb_cfg field.
+	// increment nb_cfg value by 1. When northd consumes updates from NB DB, it will copy this value to SB DBs SB_Global
+	// table nb_cfg field.
 	ops, err := nbClient.Where(nbGlobal).Mutate(nbGlobal, model.Mutation{
 		Field:   &nbGlobal.NbCfg,
 		Mutator: ovsdb.MutateOperationAdd,
@@ -42,24 +42,31 @@ func WaitUntilNorthdSyncOnce(ctx context.Context, nbClient, sbClient client.Clie
 	if err != nil {
 		return fmt.Errorf("failed to generate ops to mutate nb_cfg: %w", err)
 	}
-	expectedNbCfgValue := nbGlobal.NbCfg + 1
 	if _, err = libovsdbops.TransactAndCheck(nbClient, ops); err != nil {
 		return fmt.Errorf("failed to transact to increment nb_cfg: %w", err)
 	}
-	sbGlobal := &sbdb.SBGlobal{}
-	// poll until we see the expected value in SB DB every 5 milliseconds until context is cancelled.
-	err = wait.PollUntilContextCancel(ctx, time.Millisecond*5, true, func(_ context.Context) (done bool, err error) {
-		if sbGlobal, err = libovsdbops.GetSBGlobal(sbClient, sbGlobal); err != nil {
+	expectedHvCfgValue := nbGlobal.NbCfg + 1
+	if expectedHvCfgValue < 0 { // handle overflow
+		expectedHvCfgValue = 0
+	}
+	nbGlobal = &nbdb.NBGlobal{}
+	// ovn-northd sets hv_cfg to the lowest int value found for all chassis in the system (IC mode,
+	// we support a single chassis per zone) as reported in the Chassis_Private table in the southbound database.
+	// Thus, hv_cfg equals nb_cfg for the single chassis once it is caught up with NB DB we want.
+	// poll until we see the expected value in NB DB every 5 milliseconds until context is cancelled.
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*5, true, func(_ context.Context) (done bool, err2 error) {
+		if nbGlobal, err2 = libovsdbops.GetNBGlobal(nbClient, nbGlobal); err2 != nil {
 			// northd hasn't added an entry yet
-			if errors.Is(err, client.ErrNotFound) {
+			if errors.Is(err2, client.ErrNotFound) {
 				return false, nil
 			}
-			return false, fmt.Errorf("failed to get sb_global table entry from SB DB: %w", err)
+			return false, fmt.Errorf("failed to get nb_global table entry from NB DB: %w", err2)
 		}
-		return sbGlobal.NbCfg >= expectedNbCfgValue, nil // we only need to ensure it is greater than or equal to the expected value
+		return nbGlobal.HvCfg >= expectedHvCfgValue, nil // we only need to ensure it is greater than or equal to the expected value
 	})
 	if err != nil {
-		return fmt.Errorf("failed while waiting for nb_cfg value greater than or equal %d in sb db sb_global table: %w", expectedNbCfgValue, err)
+		return fmt.Errorf("failed while waiting for hv_cfg value greater than or equal %d in NB DB nb_global table: %w",
+			expectedHvCfgValue, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Ensure ovn-controller has processed the SB DB updates before removing the GARP drop flows by utilizing the hv_cfg field in NB_Global [1]

OVNKube controller increments the nb_cfg value post sync, which is copied to SB DB by northd. OVN-Controllers copy this nb_cfg value from SB DB and write it to their chassis_private tables nb_cfg field after they have processed the SB DB changes. Northd will then look at all the chassis_private tables nb_cfg value and set the NB DBs Nb_global hv_cfg value to the min integer found.

Since IC currently only supports one node per zone, we can be sure ovn-controller is running locally and therefore its ok to block removing the drop GARP flows.

[1] https://man7.org/linux/man-pages/man5/ovn-nb.5.html

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improves startup reliability by waiting for northbound changes to be processed and resulting flows to be installed, reducing transient connectivity issues.

- Refactor
  - Simplifies synchronization to rely on a single readiness signal from the northbound processing flow rather than cross-checking multiple DB sources.

- Chores
  - Clarifies startup logs and error messages to reflect waiting for northbound changes to be processed by the controller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->