### PR TITLE
WIP: Delete conntrack entries related to external gateways

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -1068,7 +1068,7 @@ func (pr *PodRequest) deletePodConntrack(podLister corev1listers.PodLister, pod 
 				pr.PodNamespace, pr.PodName, ip.Address.IP.String())
 			continue
 		}
-		_, err = util.DeleteConntrack(ip.Address.IP.String(), 0, "", netlink.ConntrackReplyAnyIP, nil)
+		_, err = util.DeleteConntrack(map[string]netlink.ConntrackFilterType{ip.Address.IP.String(): netlink.ConntrackReplyAnyIP}, 0, "", nil)
 		if err != nil {
 			klog.Errorf("Failed to delete Conntrack Entry for %s: %v", ip.Address.IP.String(), err)
 			continue

--- a/go-controller/pkg/util/external_gw_conntrack.go
+++ b/go-controller/pkg/util/external_gw_conntrack.go
@@ -322,6 +322,10 @@ func SyncConntrackForExternalGateways(gwIPsToKeep sets.Set[string], isPodInLocal
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete conntrack entry for pod %s: %v", podIP.String(), err))
 			}
+			_, err = DeleteConntrack(podIP.String(), 0, "", netlink.ConntrackOrigSrcIP, validNextHopMACs)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to delete conntrack entry for pod %s: %v", podIP.String(), err))
+			}
 		}
 	}
 

--- a/go-controller/pkg/util/external_gw_conntrack.go
+++ b/go-controller/pkg/util/external_gw_conntrack.go
@@ -302,6 +302,15 @@ func SyncConntrackForExternalGateways(gwIPsToKeep sets.Set[string], isPodInLocal
 		return fmt.Errorf("unable to get pods from informer: %v", err)
 	}
 
+	// matchedFlows are the labeled conntrack entries whose MAC labels do not
+	// match any remaining gateway. ConntrackListUnmatchLabelEntries dumps IPv4 and
+	// IPv6 tables once and returns only those matches. Per-pod work below
+	// filters this set by pod IP.
+	matchedFlows, err := ConntrackListUnmatchLabelEntries(validNextHopMACs)
+	if err != nil {
+		return fmt.Errorf("failed to list conntrack entries: %v", err)
+	}
+
 	var errs []error
 	for _, pod := range pods {
 		pod := pod
@@ -319,14 +328,47 @@ func SyncConntrackForExternalGateways(gwIPsToKeep sets.Set[string], isPodInLocal
 			errs = append(errs, fmt.Errorf("unable to fetch IP for pod %s/%s: %v", pod.Namespace, pod.Name, err))
 		}
 		for _, podIP := range podIPs {
-			// for this pod, we check if the conntrack entry has a label that is not in the provided allowlist of MACs
-			// only caveat here is we assume egressGW served pods shouldn't have conntrack entries with other labels set
-			_, err := DeleteConntrack(podIP.String(), 0, "", netlink.ConntrackOrigDstIP, validNextHopMACs)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to delete conntrack entry for pod %s: %v", podIP.String(), err))
-			}
+			// OrigDstIP: pod as server (ingress from next hop). OrigSrcIP: pod as client (egress).
+			errs = append(errs, deletePodConntrackEntriesForGW(podIP.String(), validNextHopMACs, matchedFlows, netlink.ConntrackOrigDstIP)...)
+			errs = append(errs, deletePodConntrackEntriesForGW(podIP.String(), validNextHopMACs, matchedFlows, netlink.ConntrackOrigSrcIP)...)
 		}
 	}
 
 	return utilerrors.Join(errs...)
+}
+
+func deletePodConntrackEntriesForGW(podIP string, validNextHopMACs [][]byte, flows []*netlink.ConntrackFlow, filterType netlink.ConntrackFilterType) []error {
+	var errs []error
+	podIPFilter := map[string]netlink.ConntrackFilterType{podIP: filterType}
+	// For each stale flow that involves this pod in the given orig direction,
+	// ConntrackDeleteFilters (raw dump replay) is used twice: once with
+	// UnmatchLabels to drop labeled unmatched entries, then with no labels so
+	// unlabeled copies of the same IP pair in other zones are also removed and
+	// traffic can hand off to a remaining gateway.
+	for _, flow := range flows {
+		match, err := ConntrackFlowMatchesFilter(flow, podIPFilter, 0, "", nil)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to match conntrack entry for pod %s: %v", podIP, err))
+			continue
+		}
+		if !match {
+			continue
+		}
+		ipFilter := make(map[string]netlink.ConntrackFilterType)
+		ipFilter[flow.Forward.SrcIP.String()] = netlink.ConntrackOrigSrcIP
+		ipFilter[flow.Forward.DstIP.String()] = netlink.ConntrackOrigDstIP
+		ipFilter[flow.Reverse.SrcIP.String()] = netlink.ConntrackReplySrcIP
+		ipFilter[flow.Reverse.DstIP.String()] = netlink.ConntrackReplyDstIP
+		// Delete the conntrack entry not matching any of the remaining gateway MACs
+		_, err = DeleteConntrack(ipFilter, 0, "", validNextHopMACs)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete conntrack entry for pod %s: %v", podIP, err))
+		}
+		// Delete the conntrack entry same as the above entry but without the MAC label
+		_, err = DeleteConntrack(ipFilter, 0, "", nil)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete conntrack entry for pod %s: %v", podIP, err))
+		}
+	}
+	return errs
 }

--- a/go-controller/pkg/util/external_gw_conntrack_test.go
+++ b/go-controller/pkg/util/external_gw_conntrack_test.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
+)
+
+func TestDeletePodConntrackEntriesForGW(t *testing.T) {
+	podIP := "10.128.0.2"
+	allowedMAC := [][]byte{{0x0a, 0x0b, 0x0c}}
+	staleLabel := []byte{0xff, 0xee, 0xdd}
+
+	matchingFlow := &netlink.ConntrackFlow{
+		FamilyType: uint8(netlink.FAMILY_V4),
+		Forward: netlink.IPTuple{
+			SrcIP:    net.ParseIP(podIP),
+			DstIP:    net.ParseIP("1.2.3.4"),
+			SrcPort:  12345,
+			DstPort:  80,
+			Protocol: 6,
+		},
+		Reverse: netlink.IPTuple{
+			SrcIP:    net.ParseIP("1.2.3.4"),
+			DstIP:    net.ParseIP(podIP),
+			SrcPort:  80,
+			DstPort:  12345,
+			Protocol: 6,
+		},
+		Labels: staleLabel,
+	}
+	otherPodFlow := *matchingFlow
+	otherPodFlow.Forward.SrcIP = net.ParseIP("10.128.0.99")
+	otherPodFlow.Reverse.DstIP = net.ParseIP("10.128.0.99")
+
+	podAsServerFlow := *matchingFlow
+	podAsServerFlow.Forward.SrcIP = matchingFlow.Forward.DstIP
+	podAsServerFlow.Forward.DstIP = net.ParseIP(podIP)
+	podAsServerFlow.Reverse.SrcIP = net.ParseIP(podIP)
+	podAsServerFlow.Reverse.DstIP = matchingFlow.Forward.DstIP
+
+	unlabeledCopy := func(flow netlink.ConntrackFlow) *netlink.ConntrackFlow {
+		flow.Labels = nil
+		return &flow
+	}
+
+	expectLabeledThenUnlabeledPodDeletes := func(t *testing.T, mockNetLinkOps *mocks.NetLinkOps, labeledPodFlow *netlink.ConntrackFlow) {
+		t.Helper()
+		unlabeledPodFlow := unlabeledCopy(*labeledPodFlow)
+		remainingGWLabeled := *labeledPodFlow
+		remainingGWLabeled.Labels = allowedMAC[0]
+
+		mockNetLinkOps.On("ConntrackDeleteFilters",
+			netlink.ConntrackTableType(netlink.ConntrackTable),
+			mock.AnythingOfType("netlink.InetFamily"),
+			mock.AnythingOfType("*netlink.ConntrackFilter"),
+		).Run(func(args mock.Arguments) {
+			filter := args.Get(2).(*netlink.ConntrackFilter)
+			require.True(t, filter.MatchConntrackFlow(labeledPodFlow), "first delete (UnmatchLabels) must match the pod's stale labeled flow")
+			require.False(t, filter.MatchConntrackFlow(unlabeledPodFlow), "first delete must not match the unlabeled copy")
+			require.False(t, filter.MatchConntrackFlow(&remainingGWLabeled), "first delete must not match a remaining-gateway MAC label")
+			require.False(t, filter.MatchConntrackFlow(&otherPodFlow), "first delete must not match another pod")
+		}).Return(uint(1), nil).Once()
+
+		mockNetLinkOps.On("ConntrackDeleteFilters",
+			netlink.ConntrackTableType(netlink.ConntrackTable),
+			mock.AnythingOfType("netlink.InetFamily"),
+			mock.AnythingOfType("*netlink.ConntrackFilter"),
+		).Run(func(args mock.Arguments) {
+			filter := args.Get(2).(*netlink.ConntrackFilter)
+			require.True(t, filter.MatchConntrackFlow(unlabeledPodFlow), "second delete (no MAC labels) must match the unlabeled copy of the same 5-tuple")
+			require.True(t, filter.MatchConntrackFlow(labeledPodFlow), "second delete still matches the same pod IP 5-tuple")
+			require.False(t, filter.MatchConntrackFlow(&otherPodFlow), "second delete must not match another pod")
+		}).Return(uint(1), nil).Once()
+	}
+
+	t.Run("orig-src: removes podIP flows with unmatched MAC labels then unlabeled copies", func(t *testing.T) {
+		mockNetLinkOps := new(mocks.NetLinkOps)
+		origNetLinkOps := netLinkOps
+		netLinkOps = mockNetLinkOps
+		t.Cleanup(func() { netLinkOps = origNetLinkOps })
+
+		expectLabeledThenUnlabeledPodDeletes(t, mockNetLinkOps, matchingFlow)
+		errs := deletePodConntrackEntriesForGW(podIP, allowedMAC, []*netlink.ConntrackFlow{matchingFlow, &otherPodFlow}, netlink.ConntrackOrigSrcIP)
+		require.Empty(t, errs)
+		mockNetLinkOps.AssertExpectations(t)
+		mockNetLinkOps.AssertNotCalled(t, "ConntrackTableList", mock.Anything, mock.Anything)
+	})
+
+	t.Run("orig-dst: removes podIP flows with unmatched MAC labels then unlabeled copies", func(t *testing.T) {
+		mockNetLinkOps := new(mocks.NetLinkOps)
+		origNetLinkOps := netLinkOps
+		netLinkOps = mockNetLinkOps
+		t.Cleanup(func() { netLinkOps = origNetLinkOps })
+
+		expectLabeledThenUnlabeledPodDeletes(t, mockNetLinkOps, &podAsServerFlow)
+		errs := deletePodConntrackEntriesForGW(podIP, allowedMAC, []*netlink.ConntrackFlow{&podAsServerFlow, &otherPodFlow}, netlink.ConntrackOrigDstIP)
+		require.Empty(t, errs)
+		mockNetLinkOps.AssertExpectations(t)
+		mockNetLinkOps.AssertNotCalled(t, "ConntrackTableList", mock.Anything, mock.Anything)
+	})
+
+	t.Run("skips orig-dst delete when the listed flow only matches orig-src", func(t *testing.T) {
+		mockNetLinkOps := new(mocks.NetLinkOps)
+		origNetLinkOps := netLinkOps
+		netLinkOps = mockNetLinkOps
+		t.Cleanup(func() { netLinkOps = origNetLinkOps })
+
+		errs := deletePodConntrackEntriesForGW(podIP, allowedMAC, []*netlink.ConntrackFlow{matchingFlow}, netlink.ConntrackOrigDstIP)
+		require.Empty(t, errs)
+		mockNetLinkOps.AssertNotCalled(t, "ConntrackDeleteFilters")
+	})
+
+	t.Run("skips delete when no listed flows match the pod IP on orig-src", func(t *testing.T) {
+		mockNetLinkOps := new(mocks.NetLinkOps)
+		origNetLinkOps := netLinkOps
+		netLinkOps = mockNetLinkOps
+		t.Cleanup(func() { netLinkOps = origNetLinkOps })
+
+		errs := deletePodConntrackEntriesForGW(podIP, allowedMAC, []*netlink.ConntrackFlow{&otherPodFlow}, netlink.ConntrackOrigSrcIP)
+		require.Empty(t, errs)
+		mockNetLinkOps.AssertNotCalled(t, "ConntrackDeleteFilters")
+	})
+
+	t.Run("collects labeled and unlabeled delete errors", func(t *testing.T) {
+		mockNetLinkOps := new(mocks.NetLinkOps)
+		origNetLinkOps := netLinkOps
+		netLinkOps = mockNetLinkOps
+		t.Cleanup(func() { netLinkOps = origNetLinkOps })
+
+		deleteFilterErrCall := ovntest.TestifyMockHelper{
+			OnCallMethodName:    "ConntrackDeleteFilters",
+			OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily", "*netlink.ConntrackFilter"},
+			RetArgList:          []interface{}{uint(0), fmt.Errorf("delete failed")},
+			CallTimes:           2,
+		}
+		ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, []ovntest.TestifyMockHelper{deleteFilterErrCall})
+
+		errs := deletePodConntrackEntriesForGW(podIP, allowedMAC, []*netlink.ConntrackFlow{matchingFlow}, netlink.ConntrackOrigSrcIP)
+		require.Len(t, errs, 2)
+		mockNetLinkOps.AssertExpectations(t)
+	})
+}

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -317,6 +317,36 @@ func (_m *NetLinkOps) ConntrackDeleteFilters(table netlink.ConntrackTableType, f
 	return r0, r1
 }
 
+// ConntrackTableList provides a mock function with given fields: table, family
+func (_m *NetLinkOps) ConntrackTableList(table netlink.ConntrackTableType, family netlink.InetFamily) ([]*netlink.ConntrackFlow, error) {
+	ret := _m.Called(table, family)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConntrackTableList")
+	}
+
+	var r0 []*netlink.ConntrackFlow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(netlink.ConntrackTableType, netlink.InetFamily) ([]*netlink.ConntrackFlow, error)); ok {
+		return rf(table, family)
+	}
+	if rf, ok := ret.Get(0).(func(netlink.ConntrackTableType, netlink.InetFamily) []*netlink.ConntrackFlow); ok {
+		r0 = rf(table, family)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*netlink.ConntrackFlow)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(netlink.ConntrackTableType, netlink.InetFamily) error); ok {
+		r1 = rf(table, family)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsAlreadyExistsError provides a mock function with given fields: err
 func (_m *NetLinkOps) IsAlreadyExistsError(err error) bool {
 	ret := _m.Called(err)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -66,6 +66,7 @@ type NetLinkOps interface {
 	NeighSet(neigh *netlink.Neigh) error
 	NeighDel(neigh *netlink.Neigh) error
 	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
+	ConntrackTableList(table netlink.ConntrackTableType, family netlink.InetFamily) ([]*netlink.ConntrackFlow, error)
 	ConntrackDeleteFilters(table netlink.ConntrackTableType, family netlink.InetFamily, filters ...netlink.CustomConntrackFilter) (uint, error)
 	LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hwaddr net.HardwareAddr) error
 	RouteSubscribeWithOptions(ch chan<- netlink.RouteUpdate, done <-chan struct{}, options netlink.RouteSubscribeOptions) error
@@ -262,6 +263,10 @@ func (defaultNetLinkOps) NeighDel(neigh *netlink.Neigh) error {
 
 func (defaultNetLinkOps) NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
 	return netlink.NeighList(linkIndex, family)
+}
+
+func (defaultNetLinkOps) ConntrackTableList(table netlink.ConntrackTableType, family netlink.InetFamily) ([]*netlink.ConntrackFlow, error) {
+	return netlink.ConntrackTableList(table, family)
 }
 
 func (defaultNetLinkOps) ConntrackDeleteFilters(table netlink.ConntrackTableType, family netlink.InetFamily, filters ...netlink.CustomConntrackFilter) (uint, error) {
@@ -751,52 +756,119 @@ func LinkNeighIPExists(link netlink.Link, neighIP net.IP) (bool, error) {
 	return false, nil
 }
 
-func DeleteConntrack(ip string, port int32, protocol corev1.Protocol, ipFilterType netlink.ConntrackFilterType, labels [][]byte) (uint, error) {
-	ipAddress := net.ParseIP(ip)
-	if ipAddress == nil {
-		return 0, fmt.Errorf("value %q passed to DeleteConntrack is not an IP address", ip)
+func getConntrackFilter(ipFilter map[string]netlink.ConntrackFilterType, port int32, protocol corev1.Protocol, labels [][]byte) (*netlink.ConntrackFilter, netlink.InetFamily, error) {
+	if len(ipFilter) == 0 {
+		return nil, netlink.FAMILY_V4, fmt.Errorf("empty IP filter passed to DeleteConntrack")
 	}
 
 	filter := &netlink.ConntrackFilter{}
-	if protocol == corev1.ProtocolUDP {
+	family := netlink.InetFamily(netlink.FAMILY_V4)
+	familySet := false
+	for ip, ipFilterType := range ipFilter {
+		ipAddress := net.ParseIP(ip)
+		if ipAddress == nil {
+			return nil, netlink.FAMILY_V4, fmt.Errorf("value %q passed to DeleteConntrack is not an IP address", ip)
+		}
+		thisFamily := netlink.InetFamily(netlink.FAMILY_V4)
+		if ipAddress.To4() == nil {
+			thisFamily = netlink.InetFamily(netlink.FAMILY_V6)
+		}
+		if !familySet {
+			family = thisFamily
+			familySet = true
+		} else if family != thisFamily {
+			return nil, family, fmt.Errorf("mixed IP families in conntrack filter")
+		}
+		if err := filter.AddIP(ipFilterType, ipAddress); err != nil {
+			return nil, family, fmt.Errorf("could not add IP: %s to conntrack filter: %v", ipAddress, err)
+		}
+	}
+	switch protocol {
+	case corev1.ProtocolUDP:
 		// 17 = UDP protocol
 		if err := filter.AddProtocol(17); err != nil {
-			return 0, fmt.Errorf("could not add Protocol UDP to conntrack filter %v", err)
+			return nil, family, fmt.Errorf("could not add Protocol UDP to conntrack filter %v", err)
 		}
-	} else if protocol == corev1.ProtocolSCTP {
+	case corev1.ProtocolSCTP:
 		// 132 = SCTP protocol
 		if err := filter.AddProtocol(132); err != nil {
-			return 0, fmt.Errorf("could not add Protocol SCTP to conntrack filter %v", err)
+			return nil, family, fmt.Errorf("could not add Protocol SCTP to conntrack filter %v", err)
 		}
-	} else if protocol == corev1.ProtocolTCP {
+	case corev1.ProtocolTCP:
 		// 6 = TCP protocol
 		if err := filter.AddProtocol(6); err != nil {
-			return 0, fmt.Errorf("could not add Protocol TCP to conntrack filter %v", err)
+			return nil, family, fmt.Errorf("could not add Protocol TCP to conntrack filter %v", err)
 		}
 	}
 	if port > 0 {
 		if err := filter.AddPort(netlink.ConntrackOrigDstPort, uint16(port)); err != nil {
-			return 0, fmt.Errorf("could not add port %d to conntrack filter: %v", port, err)
+			return nil, family, fmt.Errorf("could not add port %d to conntrack filter: %v", port, err)
 		}
-	}
-	if err := filter.AddIP(ipFilterType, ipAddress); err != nil {
-		return 0, fmt.Errorf("could not add IP: %s to conntrack filter: %v", ipAddress, err)
 	}
 
 	if len(labels) > 0 {
 		// for now we only need unmatch label, we can add match label later if needed
 		if err := filter.AddLabels(netlink.ConntrackUnmatchLabels, labels); err != nil {
-			return 0, fmt.Errorf("could not add label %s to conntrack filter: %v", labels, err)
+			return nil, family, fmt.Errorf("could not add label %s to conntrack filter: %v", labels, err)
 		}
 	}
-	klog.V(5).Infof("Deleting conntrack entry for IP %s, port %d, protocol %s, conntrack filter type %v, labels %x", ip, port, protocol, ipFilterType, labels)
-	var matched uint
-	var err error
-	if ipAddress.To4() != nil {
-		matched, err = netLinkOps.ConntrackDeleteFilters(netlink.ConntrackTable, netlink.FAMILY_V4, filter)
-	} else {
-		matched, err = netLinkOps.ConntrackDeleteFilters(netlink.ConntrackTable, netlink.FAMILY_V6, filter)
+	return filter, family, nil
+}
+
+// ConntrackFlowMatchesFilter reports whether flow matches a conntrack filter
+// built from the same arguments as DeleteConntrack.
+func ConntrackFlowMatchesFilter(flow *netlink.ConntrackFlow, ipFilter map[string]netlink.ConntrackFilterType, port int32, protocol corev1.Protocol, labels [][]byte) (bool, error) {
+	if flow == nil {
+		return false, nil
 	}
+	filter, _, err := getConntrackFilter(ipFilter, port, protocol, labels)
+	if err != nil {
+		return false, err
+	}
+	return filter.MatchConntrackFlow(flow), nil
+}
+
+// ConntrackListUnmatchLabelEntries dumps IPv4 and IPv6 conntrack tables once and
+// returns labeled flows whose MAC labels do not contain any of the provided
+// labels (netlink ConntrackUnmatchLabels). Unlabeled flows are not returned.
+func ConntrackListUnmatchLabelEntries(labels [][]byte) ([]*netlink.ConntrackFlow, error) {
+	filter := &netlink.ConntrackFilter{}
+	if len(labels) > 0 {
+		if err := filter.AddLabels(netlink.ConntrackUnmatchLabels, labels); err != nil {
+			return nil, fmt.Errorf("could not add label %s to conntrack filter: %v", labels, err)
+		}
+	}
+
+	matchingFlows := make([]*netlink.ConntrackFlow, 0)
+	var errs []error
+	for _, family := range []netlink.InetFamily{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+		flows, err := netLinkOps.ConntrackTableList(netlink.ConntrackTable, family)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to list conntrack entries: %v", err))
+			continue
+		}
+		for _, flow := range flows {
+			if filter.MatchConntrackFlow(flow) {
+				matchingFlows = append(matchingFlows, flow)
+			}
+		}
+	}
+	if len(matchingFlows) == 0 && len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	if len(errs) > 0 {
+		klog.Errorf("Failed to list some conntrack entries: %v", errors.Join(errs...))
+	}
+	return matchingFlows, nil
+}
+
+func DeleteConntrack(ipFilter map[string]netlink.ConntrackFilterType, port int32, protocol corev1.Protocol, labels [][]byte) (uint, error) {
+	filter, family, err := getConntrackFilter(ipFilter, port, protocol, labels)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get conntrack filter: %v", err)
+	}
+	klog.V(5).Infof("Deleting conntrack entries matching IP filter %v, port %d, protocol %s, labels %x", ipFilter, port, protocol, labels)
+	matched, err := netLinkOps.ConntrackDeleteFilters(netlink.ConntrackTable, family, filter)
 	return matched, err
 }
 
@@ -810,7 +882,7 @@ func DeleteConntrackServicePort(ip string, port int32, protocol corev1.Protocol,
 			ip, protocol, port, err)
 		return 0, nil
 	}
-	return DeleteConntrack(ip, port, protocol, ipFilterType, labels)
+	return DeleteConntrack(map[string]netlink.ConntrackFilterType{ip: ipFilterType}, port, protocol, labels)
 }
 
 // GetFilteredInterfaceV4V6IPs returns the IP addresses for the network interface 'iface' for ipv4 and ipv6.

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -1057,7 +1057,7 @@ func TestDeleteConntrack(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 
-			_, err := DeleteConntrack(tc.inputIPStr, tc.inputPort, tc.inputProtocol, netlink.ConntrackReplyAnyIP, tc.labels)
+			_, err := DeleteConntrack(map[string]netlink.ConntrackFilterType{tc.inputIPStr: netlink.ConntrackReplyAnyIP}, tc.inputPort, tc.inputProtocol, tc.labels)
 			if tc.errExp {
 				require.Error(t, err)
 			} else {
@@ -1070,7 +1070,7 @@ func TestDeleteConntrack(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 
-			_, err := DeleteConntrack(tc.inputIPStr, tc.inputPort, tc.inputProtocol, netlink.ConntrackOrigDstIP, tc.labels)
+			_, err := DeleteConntrack(map[string]netlink.ConntrackFilterType{tc.inputIPStr: netlink.ConntrackOrigDstIP}, tc.inputPort, tc.inputProtocol, tc.labels)
 			if tc.errExp {
 				require.Error(t, err)
 			} else {
@@ -1079,6 +1079,107 @@ func TestDeleteConntrack(t *testing.T) {
 			mockNetLinkOps.AssertExpectations(t)
 		})
 	}
+}
+
+func TestConntrackFlowMatchesFilter(t *testing.T) {
+	podIP := "10.128.0.2"
+	allowedMAC := [][]byte{{0x0a, 0x0b, 0x0c}}
+	flow := &netlink.ConntrackFlow{
+		Forward: netlink.IPTuple{
+			SrcIP: net.ParseIP(podIP),
+			DstIP: net.ParseIP("1.2.3.4"),
+		},
+		Labels: []byte{0xff, 0xee, 0xdd},
+	}
+
+	match, err := ConntrackFlowMatchesFilter(flow, map[string]netlink.ConntrackFilterType{podIP: netlink.ConntrackOrigSrcIP}, 0, "", allowedMAC)
+	require.NoError(t, err)
+	require.True(t, match)
+
+	match, err = ConntrackFlowMatchesFilter(flow, map[string]netlink.ConntrackFilterType{podIP: netlink.ConntrackOrigDstIP}, 0, "", allowedMAC)
+	require.NoError(t, err)
+	require.False(t, match)
+
+	match, err = ConntrackFlowMatchesFilter(nil, map[string]netlink.ConntrackFilterType{podIP: netlink.ConntrackOrigSrcIP}, 0, "", allowedMAC)
+	require.NoError(t, err)
+	require.False(t, match)
+
+	_, err = ConntrackFlowMatchesFilter(flow, map[string]netlink.ConntrackFilterType{"not-an-ip": netlink.ConntrackOrigSrcIP}, 0, "", allowedMAC)
+	require.Error(t, err)
+}
+
+func TestConntrackListUnmatchLabelEntries(t *testing.T) {
+	allowedMAC := [][]byte{{0x0a, 0x0b, 0x0c}}
+	staleLabel := []byte{0xff, 0xee, 0xdd}
+	staleFlow := &netlink.ConntrackFlow{
+		FamilyType: uint8(netlink.FAMILY_V4),
+		Forward: netlink.IPTuple{
+			SrcIP: net.ParseIP("10.128.0.2"),
+			DstIP: net.ParseIP("1.2.3.4"),
+		},
+		Labels: staleLabel,
+	}
+	keepFlow := *staleFlow
+	keepFlow.Labels = allowedMAC[0]
+	v6StaleFlow := &netlink.ConntrackFlow{
+		FamilyType: uint8(netlink.FAMILY_V6),
+		Forward: netlink.IPTuple{
+			SrcIP: net.ParseIP("fd00::2"),
+			DstIP: net.ParseIP("2001:db8::1"),
+		},
+		Labels: staleLabel,
+	}
+
+	mockNetLinkOps := new(mocks.NetLinkOps)
+	origNetLinkOps := netLinkOps
+	netLinkOps = mockNetLinkOps
+	t.Cleanup(func() {
+		netLinkOps = origNetLinkOps
+	})
+
+	t.Run("dumps IPv4 and IPv6 tables once and returns unmatched-label flows", func(t *testing.T) {
+		mockNetLinkOps.ExpectedCalls = nil
+		mockNetLinkOps.Calls = nil
+		ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, []ovntest.TestifyMockHelper{
+			{
+				OnCallMethodName:    "ConntrackTableList",
+				OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily"},
+				RetArgList:          []interface{}{[]*netlink.ConntrackFlow{staleFlow, &keepFlow}, nil},
+			},
+			{
+				OnCallMethodName:    "ConntrackTableList",
+				OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily"},
+				RetArgList:          []interface{}{[]*netlink.ConntrackFlow{v6StaleFlow}, nil},
+			},
+		})
+
+		flows, err := ConntrackListUnmatchLabelEntries(allowedMAC)
+		require.NoError(t, err)
+		require.Equal(t, []*netlink.ConntrackFlow{staleFlow, v6StaleFlow}, flows)
+		mockNetLinkOps.AssertExpectations(t)
+	})
+
+	t.Run("returns an error when both family dumps fail", func(t *testing.T) {
+		mockNetLinkOps.ExpectedCalls = nil
+		mockNetLinkOps.Calls = nil
+		ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, []ovntest.TestifyMockHelper{
+			{
+				OnCallMethodName:    "ConntrackTableList",
+				OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily"},
+				RetArgList:          []interface{}{[]*netlink.ConntrackFlow(nil), fmt.Errorf("dump failed")},
+			},
+			{
+				OnCallMethodName:    "ConntrackTableList",
+				OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily"},
+				RetArgList:          []interface{}{[]*netlink.ConntrackFlow(nil), fmt.Errorf("dump failed")},
+			},
+		})
+
+		flows, err := ConntrackListUnmatchLabelEntries(allowedMAC)
+		require.Error(t, err)
+		require.Nil(t, flows)
+		mockNetLinkOps.AssertExpectations(t)
+	})
 }
 
 func TestGetIPv6OnSubnet(t *testing.T) {

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -649,7 +649,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 				updateAPBExternalRouteCRWithStaticHop(defaultPolicyName, f.Namespace.Name, false, addresses.gatewayIPs[0])
 
 				podConnEntriesWithMACLabelsSet = 1 // we still have the conntrack entry for the remaining gateway
-				totalPodConnEntries = 3            // 4-1
+				totalPodConnEntries = 2            // remaining hop: 1 labeled + 1 unlabeled zone copy
 
 				gomega.Eventually(func() int {
 					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
@@ -664,7 +664,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 
 				podConnEntriesWithMACLabelsSet = 0 // we don't have any remaining gateways left
-				totalPodConnEntries = 2            // 4-2
+				totalPodConnEntries = 0            // labeled and unlabeled copies of both hops are deleted
 
 				gomega.Eventually(func() int {
 					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
@@ -734,7 +734,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 
 				podConnEntriesWithMACLabelsSet = 1 // we still have the conntrack entry for the remaining gateway
-				totalPodConnEntries = 3            // 4-1
+				totalPodConnEntries = 2            // remaining hop: 1 labeled + 1 unlabeled zone copy
 
 				gomega.Eventually(func() int {
 					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
@@ -751,7 +751,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 
 				podConnEntriesWithMACLabelsSet = 0 //we don't have any remaining gateways left
-				totalPodConnEntries = 2
+				totalPodConnEntries = 0            // labeled and unlabeled copies of both hops are deleted
 				gomega.Eventually(func() int {
 					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
 					klog.Infof("Number of entries with macAddressGW %s:%d", macAddressGW, n)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

When an external gateway pod is no longer available as a gateway (deleted, not ready, terminating) then the conntrack entries related to the external gateway are deleted. However, only the conntrack entries are deleted which are targeted for the pods in the target namespace of the external gateways. The conntrack entries for the traffic which originates from the pods in the target namespace are not deleted.

In this PR, the conntrack entries for the traffic originating from the pods in the target namespace are deleted. New e2e tests are added to verify this change works correctly.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
