### PR TITLE
[DNM] fix: add sync.Once to prevent concurrent metrics registration race

### DIFF
--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -110,6 +111,8 @@ var ovnNorthdStopwatchShowMetricsMap = map[string]*stopwatchMetricDetails{
 	"ovnsb_db_run":     {},
 }
 
+var registerOvnNorthdMetricsOnce sync.Once
+
 func RegisterOvnNorthdMetrics(
 	waitTimeoutFunc func() bool,
 	stopChan <-chan struct{},
@@ -118,79 +121,81 @@ func RegisterOvnNorthdMetrics(
 		klog.Info("OVN northd metrics registration skipped: readiness gate not satisfied")
 		return
 	}
-	klog.Info("Registering OVN northd metrics")
+	registerOvnNorthdMetricsOnce.Do(func() {
+		klog.Info("Registering OVN northd metrics")
 
-	// ovn-northd metrics
-	getOvnNorthdVersionInfo()
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "build_info",
-			Help: "A metric with a constant '1' value labeled by version and library " +
-				"from which ovn binaries were built",
-			ConstLabels: prometheus.Labels{
-				"version":         ovnNorthdVersion,
-				"ovs_lib_version": ovnNorthdOvsLibVersion,
+		// ovn-northd metrics
+		getOvnNorthdVersionInfo()
+		ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: types.MetricOvnNamespace,
+				Subsystem: types.MetricOvnSubsystemNorthd,
+				Name:      "build_info",
+				Help: "A metric with a constant '1' value labeled by version and library " +
+					"from which ovn binaries were built",
+				ConstLabels: prometheus.Labels{
+					"version":         ovnNorthdVersion,
+					"ovs_lib_version": ovnNorthdOvsLibVersion,
+				},
 			},
-		},
-		func() float64 { return 1 },
-	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "status",
-			Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
-		}, func() float64 {
-			stdout, stderr, err := util.RunOVNNorthAppCtl("status")
-			if err != nil {
-				klog.Errorf("Failed to get ovn-northd status "+
-					"stderr(%s) :(%v)", stderr, err)
-				return -1
-			}
-			northdStatusMap := map[string]float64{
-				"standby": 0,
-				"active":  1,
-				"paused":  2,
-			}
-			if strings.HasPrefix(stdout, "Status:") {
-				output := strings.TrimSpace(strings.Split(stdout, ":")[1])
-				if value, ok := northdStatusMap[output]; ok {
-					return value
+			func() float64 { return 1 },
+		))
+		ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: types.MetricOvnNamespace,
+				Subsystem: types.MetricOvnSubsystemNorthd,
+				Name:      "status",
+				Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
+			}, func() float64 {
+				stdout, stderr, err := util.RunOVNNorthAppCtl("status")
+				if err != nil {
+					klog.Errorf("Failed to get ovn-northd status "+
+						"stderr(%s) :(%v)", stderr, err)
+					return -1
 				}
-			}
-			return -1
-		},
-	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "nb_connection_status",
-			Help:      "Specifies nb-connection-status of ovn-northd, not connected(0) or connected(1).",
-		}, func() float64 {
-			return getOvnNorthdConnectionStatusInfo(nbConnectionStatus)
-		},
-	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "sb_connection_status",
-			Help:      "Specifies sb-connection-status of ovn-northd, not connected(0) or connected(1).",
-		}, func() float64 {
-			return getOvnNorthdConnectionStatusInfo(sbConnectionStatus)
-		},
-	))
+				northdStatusMap := map[string]float64{
+					"standby": 0,
+					"active":  1,
+					"paused":  2,
+				}
+				if strings.HasPrefix(stdout, "Status:") {
+					output := strings.TrimSpace(strings.Split(stdout, ":")[1])
+					if value, ok := northdStatusMap[output]; ok {
+						return value
+					}
+				}
+				return -1
+			},
+		))
+		ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: types.MetricOvnNamespace,
+				Subsystem: types.MetricOvnSubsystemNorthd,
+				Name:      "nb_connection_status",
+				Help:      "Specifies nb-connection-status of ovn-northd, not connected(0) or connected(1).",
+			}, func() float64 {
+				return getOvnNorthdConnectionStatusInfo(nbConnectionStatus)
+			},
+		))
+		ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: types.MetricOvnNamespace,
+				Subsystem: types.MetricOvnSubsystemNorthd,
+				Name:      "sb_connection_status",
+				Help:      "Specifies sb-connection-status of ovn-northd, not connected(0) or connected(1).",
+			}, func() float64 {
+				return getOvnNorthdConnectionStatusInfo(sbConnectionStatus)
+			},
+		))
 
-	// Register the ovn-northd coverage/show metrics with prometheus
-	componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
-	registerCoverageShowMetrics(ovnNorthd, types.MetricOvnNamespace, types.MetricOvnSubsystemNorthd)
-	go coverageShowMetricsUpdater(ovnNorthd, stopChan)
+		// Register the ovn-northd coverage/show metrics with prometheus
+		componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
+		registerCoverageShowMetrics(ovnNorthd, types.MetricOvnNamespace, types.MetricOvnSubsystemNorthd)
+		go coverageShowMetricsUpdater(ovnNorthd, stopChan)
 
-	// Register the ovn-northd stopwatch/show metrics with prometheus
-	componentStopwatchShowMetricsMap[ovnNorthd] = ovnNorthdStopwatchShowMetricsMap
-	registerStopwatchShowMetrics(ovnNorthd, types.MetricOvnNamespace, types.MetricOvnSubsystemNorthd)
-	go stopwatchShowMetricsUpdater(ovnNorthd, stopChan)
+		// Register the ovn-northd stopwatch/show metrics with prometheus
+		componentStopwatchShowMetricsMap[ovnNorthd] = ovnNorthdStopwatchShowMetricsMap
+		registerStopwatchShowMetrics(ovnNorthd, types.MetricOvnNamespace, types.MetricOvnSubsystemNorthd)
+		go stopwatchShowMetricsUpdater(ovnNorthd, stopChan)
+	})
 }


### PR DESCRIPTION
This is based on AI's analysis, not mine.. I will keep this in DRAFT till I am convinced.

## 📑 Description

This fixes a race condition where multiple goroutines could concurrently call MustRegister on the prometheus registry, causing a 'concurrent map writes' fatal error.

The following functions are now protected with sync.Once:
- RegisterOvnControllerMetrics
- RegisterOvnNorthdMetrics
- RegisterOvnDBMetrics

This matches the pattern already used by RegisterNodeMetrics and RegisterOvsMetrics which have sync.Once protection.

The race was triggered when these registration functions were called as goroutines from RegisterOvnMetrics in metrics.go:
  go RegisterOvnControllerMetrics(...)
  go RegisterOvnNorthdMetrics(...)


Fixes #5876 

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
