### PR TITLE
keep k8s.ovn.org/node-encap-ips ordering consistent with ovs external_ids:ovn-encap-ip

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -568,7 +568,7 @@ func (c *addressManager) updateOVNEncapIPAndReconnect(newIP net.IP) {
 	}
 
 	// Update node-encap-ips annotation
-	encapIPList := sets.New[string](config.Default.EffectiveEncapIP)
+	encapIPList := []string{config.Default.EffectiveEncapIP}
 	if err := util.SetNodeEncapIPs(c.nodeAnnotator, encapIPList); err != nil {
 		klog.Errorf("Failed to set node-encap-ips annotation for node %s: %v", c.nodeName, err)
 		return

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -1313,8 +1313,8 @@ func filterIPVersion(cidrs []netip.Prefix, v6 bool) []netip.Prefix {
 	return validCIDRs
 }
 
-func SetNodeEncapIPs(nodeAnnotator kube.Annotator, encapips sets.Set[string]) error {
-	return nodeAnnotator.Set(OVNNodeEncapIPs, sets.List(encapips))
+func SetNodeEncapIPs(nodeAnnotator kube.Annotator, encapips []string) error {
+	return nodeAnnotator.Set(OVNNodeEncapIPs, encapips)
 }
 
 // ParseNodeEncapIPsAnnotation returns the encap IPs set on a node


### PR DESCRIPTION
## 📑 Description

The previous implementation used a set for k8s.ovn.org/node-encap-ips, which changed the IP order. This update preserves the original order while deduplicating, keeping it consistent with external_ids:ovn-encap-ip.
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified processing of node encapsulation IPs: deduplication now preserves original order and uses direct list handling.
  * Reduced internal conversions when updating node annotations for encapsulation IPs.
  * No user-facing behavior or configuration changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->