### PR TITLE
Limit CPU usage for lint job

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 VERSION=v2.5.0
 : "${GOLANGCI_LINT_VERSION:=$VERSION}"
-extra_flags=(--verbose --modules-download-mode=vendor --timeout=15m0s)
+: "${LINT_CONCURRENCY:=$(( $(nproc) * 2 / 3 ))}"
+extra_flags=(--verbose --modules-download-mode=vendor --timeout=15m0s --concurrency="${LINT_CONCURRENCY}")
 if [ "$#" -ne 1 ]; then
   if [ "$#" -eq 2 ] && [ "$2" == "fix" ]; then
     extra_flags+=(--fix)
@@ -31,7 +32,7 @@ if [ "$1" = "run-natively" ]; then
   /tmp/local/bin/golangci-lint run "${extra_flags[@]}" && \
   echo "lint OK!"
 else
-  $1 run --security-opt label=disable --rm \
+  $1 run --security-opt label=disable --rm --cpus "${LINT_CONCURRENCY}" \
     -v  "${HOME}"/.cache/golangci-lint:/cache -e GOLANGCI_LINT_CACHE=/cache \
     -v "$(pwd)":/app -w /app -e GO111MODULE=on docker.io/golangci/golangci-lint:"${VERSION}" \
     golangci-lint run "${extra_flags[@]}" && \


### PR DESCRIPTION
By default, golangci-lint uses all available CPUs, which can freeze the machine when other workloads are running. 

Limit concurrency to half the available CPUs via `--concurrency` flag, and apply `--cpus` to the container runtime as well. The default can be overridden by setting the `LINT_CONCURRENCY` environment variable.

The CI lint job is unaffected as it uses the golangci-lint-action GitHub Action directly, not hack/lint.sh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linting infrastructure with enhanced concurrency handling and Docker resource constraints for more efficient development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->