### PR TITLE
check the external server CIDRs are imported as static routes into the OVN CUDN gateway router

### DIFF
--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -23,6 +23,7 @@ import (
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	udnclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
@@ -186,13 +187,13 @@ var _ = ginkgo.Describe("BGP: When default podNetwork is advertised", feature.Ro
 
 			var expectedV4IP, expectedV6IP string
 			snatEnabled := isNoOverlayOutboundSNATEnabled(f)
-			
+
 			if snatEnabled {
 				ginkgo.By("queries to the external server are SNATed (uses node IP)")
 				// Get the node where the client pod is running
 				clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPodNodeName, metav1.GetOptions{})
 				framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPodNodeName, err))
-				
+
 				// Get node IPs
 				nodeV4Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
 				nodeV6Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
@@ -801,6 +802,22 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnTemplate.Spec.Network.Layer2.Subnets)
 					} else {
 						ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
+					}
+				}
+			}
+
+			if cudnTemplate.Spec.Network.Layer3 != nil {
+				ginkgo.By("ensure external server CIDRs are imported as static routes into the OVN CUDN gateway router")
+				for _, node := range nodes.Items {
+					// GetUserDefinedNetworkPrefix replaces '-' and '/' with '.' in the network name,
+					// so the GR name is e.g. GR_cluster_udn_bgp.udn.layer3.network_ovn-worker
+					cudnPrefix := util.GetUserDefinedNetworkPrefix(types.CUDNPrefix + cUDN.Name)
+					grName := fmt.Sprintf("%s%s%s", types.GWRouterPrefix, cudnPrefix, node.Name)
+					if isIPv4Supported(f.ClientSet) {
+						checkCIDRInOVNCUDNGatewayRouter(node, grName, externalServerV4CIDR)
+					}
+					if isIPv6Supported(f.ClientSet) {
+						checkCIDRInOVNCUDNGatewayRouter(node, grName, externalServerV6CIDR)
 					}
 				}
 			}
@@ -3148,4 +3165,32 @@ func checkRouteInFRR(node corev1.Node, podCIDR, routerContainerName string, isIP
 		framework.Logf("Routes in FRR for %s: %s", podCIDR, routes)
 		return strings.Contains(routes, nodeIP[0])
 	}, 30*time.Second).Should(gomega.BeTrue(), "route for %s via %s not found on %s", podCIDR, nodeIP[0], routerContainerName)
+}
+
+// checkCIDRInOVNCUDNGatewayRouter verifies that a CIDR (typically an external BGP-imported
+// network) is present as a static route in the given OVN CUDN gateway router.
+func checkCIDRInOVNCUDNGatewayRouter(node corev1.Node, grName, cidr string) {
+	ovnKubeNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+
+	ovnkubeNodePodName, err := e2ekubectl.RunKubectl(ovnKubeNamespace, "get", "pods",
+		"-l", "app=ovnkube-node",
+		"--field-selector", fmt.Sprintf("spec.nodeName=%s", node.Name),
+		"-o=jsonpath={.items[0].metadata.name}")
+	framework.ExpectNoError(err, "failed to get ovnkube-node pod for node %s", node.Name)
+	ovnkubeNodePodName = strings.Trim(ovnkubeNodePodName, "'")
+	gomega.Expect(ovnkubeNodePodName).NotTo(gomega.BeEmpty(), "no ovnkube-node pod found for node %s", node.Name)
+
+	framework.Logf("Checking external CIDR %s is a static route in CUDN gateway router %s on node %s", cidr, grName, node.Name)
+	gomega.Eventually(func() bool {
+		routes, err := e2ekubectl.RunKubectl(ovnKubeNamespace,
+			"exec", ovnkubeNodePodName, "--",
+			"ovn-nbctl", "--no-leader-only", "lr-route-list", grName)
+		if err != nil {
+			framework.Logf("failed to list routes in %s: %v", grName, err)
+			return false
+		}
+		framework.Logf("Routes in %s:\n%s", grName, routes)
+		return strings.Contains(routes, cidr)
+	}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+		"external CIDR %s not found as a static route in CUDN gateway router %s", cidr, grName)
 }


### PR DESCRIPTION
Trying to debug this issue https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end tests to validate that Layer3 gateway routers import external IPv4/IPv6 CIDRs as static routes on each node; added a helper to locate gateway routers, query their route lists, and wait for expected routes to appear. Existing SNAT and route checks preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->