### PR TITLE
Enable eBGP mode infra setup & enable non-isolation BGP/EVPN cases to run on both iBGP and eBGP modes

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1569,7 +1569,7 @@ FEOF
   $OCI_BIN rm -f frr-ebgp 2>/dev/null || true
   $OCI_BIN run -d --privileged --network kind --rm --name frr-ebgp \
     --volume "${frr_conf_dir}:/etc/frr" \
-    quay.io/frrouting/frr:10.4.2
+    "${FRR_DEPLOYED_IMAGE}"
 
   if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
     $OCI_BIN exec frr-ebgp sysctl -w net.ipv6.conf.all.forwarding=1

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1477,15 +1477,14 @@ deploy_ebgp_frr_external_container() {
 
   # Discover kind cluster node IPs to configure as BGP neighbors
   local node_ips_v4="" node_ips_v6=""
+  local v4 v6
   KIND_NODES=$(kind_get_nodes)
   for node in $KIND_NODES; do
     if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
-      local v4
       v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$node") || return 1
       [ -n "$v4" ] && node_ips_v4="${node_ips_v4} ${v4}"
     fi
     if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-      local v6
       v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' "$node") || return 1
       [ -n "$v6" ] && node_ips_v6="${node_ips_v6} ${v6}"
     fi

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1347,9 +1347,17 @@ fi\
     # Neighbors are already configured by demo.sh; extract them from the running config.
     # This is cluster-level infrastructure shared across all EVPN tests; configured once
     # at install time so individual tests don't need to manage it.
-    # Wait for FRR daemons to be ready ("Not all daemons are up, cannot write config").
+    # Ensure vtysh.conf exists: demo.sh volume-mounts the frr config dir as /etc/frr,
+    # hiding the image's built-in vtysh.conf.  Without it vtysh prints a harmless warning
+    # but we create it here to keep output clean, matching deploy_bgp_external_server.
+    $OCI_BIN exec frr sh -c \
+      "[ -f /etc/frr/vtysh.conf ] || echo 'service integrated-vtysh-config' > /etc/frr/vtysh.conf"
+    # Wait for FRR daemons to be ready. vtysh exits 0 even while bgpd is still loading
+    # frr.conf (EAGAIN / "processing failure: 11"), so check the output too.
     local attempts=0 daemon_status
-    while ! daemon_status=$($OCI_BIN exec frr vtysh -c "show daemons" 2>&1); do
+    while true; do
+      daemon_status=$($OCI_BIN exec frr vtysh -c "show daemons" 2>&1)
+      [[ $? -eq 0 && ! "$daemon_status" =~ "processing failure" ]] && break
       if (( ++attempts > 30 )); then
         echo "error: FRR daemons did not become ready after 30 attempts"
         echo "last daemon status: $daemon_status"

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -138,6 +138,10 @@ set_common_default_params() {
   BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.26.0.0/16}
   BGP_SERVER_NET_SUBNET_IPV6=${BGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e796::/64}
   BGP_SERVER_HOST_PORT=${BGP_SERVER_HOST_PORT:-18080}
+  BGP_EBGP_SERVER_NET_SUBNET_IPV4=${BGP_EBGP_SERVER_NET_SUBNET_IPV4:-172.28.0.0/16}
+  BGP_EBGP_SERVER_NET_SUBNET_IPV6=${BGP_EBGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e798::/64}
+  BGP_CLUSTER_ASN=${BGP_CLUSTER_ASN:-64512}
+  BGP_EBGP_ASN=${BGP_EBGP_ASN:-64513}
   OVN_OBSERV_ENABLE=${OVN_OBSERV_ENABLE:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_NETWORK_QOS_ENABLE=${OVN_NETWORK_QOS_ENABLE:-false}
@@ -1366,9 +1370,78 @@ fi\
   fi
 }
 
+# _deploy_bgp_server_for creates an external agnhost server container connected to a given FRR
+# router container via a dedicated bridge network, and configures routing so the server can
+# reach pods inside the cluster via FRR.
+#
+# Parameters:
+#   $1  frr_container  - name of the FRR router container to connect to (e.g. "frr" or "frr-ebgp")
+#   $2  server_name    - name for the agnhost server container (e.g. "bgpserver" or "bgpserver-ebgp")
+#   $3  network_name   - name for the bridge network (e.g. "bgpnet" or "bgpnet-ebgp")
+#   $4  subnet_v4      - IPv4 subnet for the bridge network (e.g. "172.26.0.0/16")
+#   $5  subnet_v6      - IPv6 subnet for the bridge network (e.g. "fc00:f853:ccd:e797::/64")
+#   $6+ extra_run_args - optional extra arguments passed to "docker run" (e.g. "-p 8080:8080")
+_deploy_bgp_server_for() {
+  local frr_container="$1"
+  local server_name="$2"
+  local network_name="$3"
+  local subnet_v4="$4"
+  local subnet_v6="$5"
+  shift 5
+  local extra_run_args=("$@")
+
+  local ipv6_network=""
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    ipv6_network="--ipv6 --subnet=${subnet_v6}"
+  fi
+
+  $OCI_BIN rm -f "$server_name" 2>/dev/null || true
+  $OCI_BIN network rm -f "$network_name" 2>/dev/null || true
+  $OCI_BIN network create --subnet="${subnet_v4}" ${ipv6_network} --driver bridge "$network_name"
+  $OCI_BIN network connect "$network_name" "$frr_container"
+  $OCI_BIN run --cap-add NET_ADMIN --user 0 -d --network "$network_name" --rm \
+    --name "$server_name" "${extra_run_args[@]}" \
+    registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
+
+  # Point the server's default route at FRR so return traffic to cluster pods works without
+  # having to add per-test routes.
+  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6
+  bgp_network_frr_v4=$($OCI_BIN inspect \
+    -f "{{(index .NetworkSettings.Networks \"${network_name}\").IPAddress}}" "$frr_container")
+  echo "${frr_container} bgp network IPv4: ${bgp_network_frr_v4}"
+  $OCI_BIN exec "$server_name" ip route replace default via "$bgp_network_frr_v4"
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    bgp_network_frr_v6=$($OCI_BIN inspect \
+      -f "{{(index .NetworkSettings.Networks \"${network_name}\").GlobalIPv6Address}}" "$frr_container")
+    echo "${frr_container} bgp network IPv6: ${bgp_network_frr_v6}"
+    $OCI_BIN exec "$server_name" ip -6 route replace default via "$bgp_network_frr_v6"
+  fi
+
+  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ]; then
+    # In loose isolation mode the cluster nodes need a default gateway pointing at FRR so
+    # that cross-UDN traffic can be routed back to pods.
+    kind_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$frr_container")
+    echo "${frr_container} kind network IPv4: ${kind_network_frr_v4}"
+    echo "Setting default gateway for nodes in the cluster to FRR router IPv4: ${kind_network_frr_v4}"
+    set_nodes_default_gw "$kind_network_frr_v4"
+    if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+      kind_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' "$frr_container")
+      echo "${frr_container} kind network IPv6: ${kind_network_frr_v6}"
+      set_nodes_default_gw "$kind_network_frr_v6"
+    fi
+  else
+    # Disable the default route so FRR only forwards via directly connected or learnt networks.
+    # Done last because docker alters the routing table when a new network is connected.
+    $OCI_BIN exec "$frr_container" ip route delete default 2>/dev/null || true
+    $OCI_BIN exec "$frr_container" ip route
+    $OCI_BIN exec "$frr_container" ip -6 route delete default 2>/dev/null || true
+    $OCI_BIN exec "$frr_container" ip -6 route
+  fi
+}
+
 deploy_bgp_external_server() {
   # We create an external docker container that acts as the server (or client) outside the cluster
-  # in the e2e tests that levergae router advertisements.
+  # in the e2e tests that leverage router advertisements.
   # This container will be connected to the frr container deployed above to simulate a realistic
   # network topology
   # -----------------               ------------------                         ---------------------
@@ -1378,54 +1451,9 @@ deploy_bgp_external_server() {
   # -----------------               ------------------                         ---------------------    using RouteAdvertisements
   #                                                                            |    ovn-worker2    |    from default pod network)
   #                                                                            ---------------------
-  local ip_family ipv6_network
-  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    ip_family="dual"
-    ipv6_network="--ipv6 --subnet=${BGP_SERVER_NET_SUBNET_IPV6}"
-  elif  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    ip_family="ipv6"
-    ipv6_network="--ipv6 --subnet=${BGP_SERVER_NET_SUBNET_IPV6}"
-  else
-    ip_family="ipv4"
-    ipv6_network=""
-  fi
-  $OCI_BIN rm -f bgpserver
-  $OCI_BIN network rm -f bgpnet
-  $OCI_BIN network create --subnet="${BGP_SERVER_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge bgpnet
-  $OCI_BIN network connect bgpnet frr
-  $OCI_BIN run  --cap-add NET_ADMIN --user 0  -d --network bgpnet  --rm  --name bgpserver -p "${BGP_SERVER_HOST_PORT}:8080"  registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
-  # let's make the bgp external server have its default route towards FRR router so that we don't need to add routes during tests back to the pods in the
-  # cluster for return traffic
-  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6
-  bgp_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.IPAddress}}' frr)
-  echo "FRR bgp network IPv4: ${bgp_network_frr_v4}"
-  $OCI_BIN exec bgpserver ip route replace default via "$bgp_network_frr_v4"
-  if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
-    bgp_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.GlobalIPv6Address}}' frr)
-    echo "FRR bgp network IPv6: ${bgp_network_frr_v6}"
-    $OCI_BIN exec bgpserver ip -6 route replace default via "$bgp_network_frr_v6"
-  fi
-  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ]; then
-    kind_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr)
-    echo "FRR kind network IPv4: ${kind_network_frr_v4}"
-    # If UDN isolation is in loose disabled, we need to set the default gateway for the nodes in the cluster
-    # to the FRR router so that cross-UDN traffic can be routed back to the pods in the cluster in the loose mode.
-    echo "Setting default gateway for nodes in the cluster to FRR router IPv4: ${kind_network_frr_v4}"
-    set_nodes_default_gw "$kind_network_frr_v4"
-    if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
-      kind_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' frr)
-      echo "FRR kind network IPv6: ${kind_network_frr_v6}"
-      set_nodes_default_gw "$kind_network_frr_v6"
-    fi
-  else
-    # disable the default route to make sure the container only routes accross
-    # directly connected or learnt networks (doing this at the very end since
-    # docker changes the routing table when a new network is connected)
-    $OCI_BIN exec frr ip route delete default
-    $OCI_BIN exec frr ip route
-    $OCI_BIN exec frr ip -6 route delete default
-    $OCI_BIN exec frr ip -6 route
-  fi
+  _deploy_bgp_server_for frr bgpserver bgpnet \
+    "${BGP_SERVER_NET_SUBNET_IPV4}" "${BGP_SERVER_NET_SUBNET_IPV6}" \
+    -p "${BGP_SERVER_HOST_PORT}:8080"
 }
 
 set_nodes_default_gw() {
@@ -1444,6 +1472,153 @@ set_nodes_default_gw() {
   done
 }
 
+deploy_ebgp_frr_external_container() {
+  echo "Deploying eBGP FRR external container (ASN ${BGP_EBGP_ASN})..."
+
+  # Discover kind cluster node IPs to configure as BGP neighbors
+  local node_ips_v4="" node_ips_v6=""
+  KIND_NODES=$(kind_get_nodes)
+  for node in $KIND_NODES; do
+    if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
+      local v4
+      v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$node") || return 1
+      [ -n "$v4" ] && node_ips_v4="${node_ips_v4} ${v4}"
+    fi
+    if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+      local v6
+      v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' "$node") || return 1
+      [ -n "$v6" ] && node_ips_v6="${node_ips_v6} ${v6}"
+    fi
+  done
+
+  # Generate eBGP FRR config (ASN differs from cluster ASN, no route-reflector-client)
+  local frr_conf_dir
+  frr_conf_dir=$(mktemp -d)
+
+  # Write daemons file
+  cat > "${frr_conf_dir}/daemons" <<'DEOF'
+bgpd=yes
+zebra=yes
+DEOF
+
+  # vtysh.conf is required because the entire frr_conf_dir is volume-mounted
+  # as /etc/frr, hiding the image's built-in copy.
+  cat > "${frr_conf_dir}/vtysh.conf" <<'VEOF'
+service integrated-vtysh-config
+VEOF
+
+  # Write FRR config
+  cat > "${frr_conf_dir}/frr.conf" <<FEOF
+router bgp ${BGP_EBGP_ASN}
+ no bgp default ipv4-unicast
+ no bgp default ipv6-unicast
+ no bgp network import-check
+ no bgp ebgp-requires-policy
+FEOF
+
+  for ip in $node_ips_v4; do
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ neighbor ${ip} remote-as ${BGP_CLUSTER_ASN}
+ neighbor ${ip} timers connect 10
+ neighbor ${ip} timers 3 15
+FEOF
+  done
+  for ip in $node_ips_v6; do
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ neighbor ${ip} remote-as ${BGP_CLUSTER_ASN}
+ neighbor ${ip} timers connect 10
+ neighbor ${ip} timers 3 15
+FEOF
+  done
+
+  if [ -n "$node_ips_v4" ]; then
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ address-family ipv4 unicast
+FEOF
+    for ip in $node_ips_v4; do
+      cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  neighbor ${ip} activate
+  neighbor ${ip} next-hop-self
+FEOF
+    done
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  network ${BGP_EBGP_SERVER_NET_SUBNET_IPV4}
+ exit-address-family
+FEOF
+  fi
+
+  if [ -n "$node_ips_v6" ]; then
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ address-family ipv6 unicast
+FEOF
+    for ip in $node_ips_v6; do
+      cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  neighbor ${ip} activate
+  neighbor ${ip} next-hop-self
+FEOF
+    done
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  network ${BGP_EBGP_SERVER_NET_SUBNET_IPV6}
+ exit-address-family
+FEOF
+  fi
+
+  echo "eBGP FRR config:"
+  cat "${frr_conf_dir}/frr.conf"
+
+  # Start the eBGP FRR container
+  $OCI_BIN rm -f frr-ebgp 2>/dev/null || true
+  $OCI_BIN run -d --privileged --network kind --rm --name frr-ebgp \
+    --volume "${frr_conf_dir}:/etc/frr" \
+    quay.io/frrouting/frr:10.4.2
+
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    $OCI_BIN exec frr-ebgp sysctl -w net.ipv6.conf.all.forwarding=1
+    $OCI_BIN exec frr-ebgp sysctl -w net.ipv6.conf.all.keep_addr_on_down=1
+  fi
+
+  if [ "$ENABLE_EVPN" == true ]; then
+    echo "Configuring global EVPN BGP on eBGP external FRR..."
+    # Wait for bgpd to finish loading the neighbor configuration
+    local retries=0 bgp_neighbors
+    while true; do
+      bgp_neighbors=$($OCI_BIN exec frr-ebgp vtysh -c "show running-config" 2>/dev/null | grep "^ neighbor.*remote-as" | awk '{print $2}' || true)
+      [ -n "$bgp_neighbors" ] && break
+      retries=$((retries + 1))
+      if [ "$retries" -ge 30 ]; then
+        echo "ERROR: frr-ebgp BGP neighbors not found in running-config after 30 seconds"
+        return 1
+      fi
+      sleep 1
+    done
+    local vtysh_cmds
+    vtysh_cmds=(-c "configure terminal" -c "router bgp ${BGP_EBGP_ASN}" -c "address-family l2vpn evpn")
+    for neighbor in $bgp_neighbors; do
+      vtysh_cmds+=(-c "neighbor $neighbor activate")
+    done
+    vtysh_cmds+=(-c "advertise-all-vni" -c "exit-address-family" -c "end")
+    $OCI_BIN exec frr-ebgp vtysh "${vtysh_cmds[@]}"
+    # write memory requires all daemons (zebra) to be fully up; retry separately
+    retries=0
+    while ! $OCI_BIN exec frr-ebgp vtysh -c "write memory" 2>/dev/null; do
+      retries=$((retries + 1))
+      if [ "$retries" -ge 30 ]; then
+        echo "WARNING: frr-ebgp write memory failed after 30 seconds, continuing anyway"
+        break
+      fi
+      sleep 1
+    done
+    echo "Global EVPN BGP config complete on eBGP external FRR"
+  fi
+
+  echo "eBGP FRR external container deployed"
+}
+
+deploy_ebgp_external_server() {
+  _deploy_bgp_server_for frr-ebgp bgpserver-ebgp bgpnet-ebgp \
+    "${BGP_EBGP_SERVER_NET_SUBNET_IPV4}" "${BGP_EBGP_SERVER_NET_SUBNET_IPV6}"
+}
+
 destroy_bgp() {
   if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^bgpserver$'; then
       $OCI_BIN stop bgpserver
@@ -1453,6 +1628,15 @@ destroy_bgp() {
   fi
   if $OCI_BIN network ls --format '{{.Name}}' | grep -q '^bgpnet$'; then
       $OCI_BIN network rm bgpnet
+  fi
+  if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^bgpserver-ebgp$'; then
+      $OCI_BIN stop bgpserver-ebgp
+  fi
+  if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^frr-ebgp$'; then
+      $OCI_BIN stop frr-ebgp
+  fi
+  if $OCI_BIN network ls --format '{{.Name}}' | grep -q '^bgpnet-ebgp$'; then
+      $OCI_BIN network rm bgpnet-ebgp
   fi
 }
 
@@ -1576,6 +1760,52 @@ EOF
     kubectl_cmd=(kubectl --kubeconfig "$(frr_k8s_host_kubeconfig)")
   fi
   "${kubectl_cmd[@]}" apply -n frr-k8s-system -f receive_filtered.yaml
+
+  # If eBGP FRR container is running, create an FRRConfiguration for the eBGP peer
+  if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^frr-ebgp$'; then
+    echo "Creating FRRConfiguration for eBGP peer..."
+    local ebgp_frr_v4 ebgp_frr_v6
+    ebgp_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr-ebgp)
+
+    cat > receive_ebgp_filtered.yaml <<EOFEBGP
+apiVersion: frrk8s.metallb.io/v1beta1
+kind: FRRConfiguration
+metadata:
+  name: receive-ebgp-filtered
+  namespace: frr-k8s-system
+  labels:
+    name: receive-all
+spec:
+  bgp:
+    routers:
+    - asn: ${BGP_CLUSTER_ASN}
+      neighbors:
+      - address: ${ebgp_frr_v4}
+        asn: ${BGP_EBGP_ASN}
+        disableMP: true
+        toReceive:
+          allowed:
+            mode: filtered
+            prefixes:
+            - prefix: ${BGP_EBGP_SERVER_NET_SUBNET_IPV4}
+EOFEBGP
+    if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+      ebgp_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' frr-ebgp)
+      # Add IPv6 neighbor and prefix
+      cat >> receive_ebgp_filtered.yaml <<EOFEBGP6
+      - address: ${ebgp_frr_v6}
+        asn: ${BGP_EBGP_ASN}
+        disableMP: true
+        toReceive:
+          allowed:
+            mode: filtered
+            prefixes:
+            - prefix: ${BGP_EBGP_SERVER_NET_SUBNET_IPV6}
+EOFEBGP6
+    fi
+    "${kubectl_cmd[@]}" apply -n frr-k8s-system -f receive_ebgp_filtered.yaml
+  fi
+
   popd || exit 1
 }
 

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -151,6 +151,10 @@ set_common_default_params() {
   BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.26.0.0/16}
   BGP_SERVER_NET_SUBNET_IPV6=${BGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e796::/64}
   BGP_SERVER_HOST_PORT=${BGP_SERVER_HOST_PORT:-18080}
+  BGP_EBGP_SERVER_NET_SUBNET_IPV4=${BGP_EBGP_SERVER_NET_SUBNET_IPV4:-172.28.0.0/16}
+  BGP_EBGP_SERVER_NET_SUBNET_IPV6=${BGP_EBGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e798::/64}
+  BGP_CLUSTER_ASN=${BGP_CLUSTER_ASN:-64512}
+  BGP_EBGP_ASN=${BGP_EBGP_ASN:-64513}
   OVN_OBSERV_ENABLE=${OVN_OBSERV_ENABLE:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_NETWORK_QOS_ENABLE=${OVN_NETWORK_QOS_ENABLE:-false}
@@ -1708,9 +1712,78 @@ fi\
   fi
 }
 
+# _deploy_bgp_server_for creates an external agnhost server container connected to a given FRR
+# router container via a dedicated bridge network, and configures routing so the server can
+# reach pods inside the cluster via FRR.
+#
+# Parameters:
+#   $1  frr_container  - name of the FRR router container to connect to (e.g. "frr" or "frr-ebgp")
+#   $2  server_name    - name for the agnhost server container (e.g. "bgpserver" or "bgpserver-ebgp")
+#   $3  network_name   - name for the bridge network (e.g. "bgpnet" or "bgpnet-ebgp")
+#   $4  subnet_v4      - IPv4 subnet for the bridge network (e.g. "172.26.0.0/16")
+#   $5  subnet_v6      - IPv6 subnet for the bridge network (e.g. "fc00:f853:ccd:e797::/64")
+#   $6+ extra_run_args - optional extra arguments passed to "docker run" (e.g. "-p 8080:8080")
+_deploy_bgp_server_for() {
+  local frr_container="$1"
+  local server_name="$2"
+  local network_name="$3"
+  local subnet_v4="$4"
+  local subnet_v6="$5"
+  shift 5
+  local extra_run_args=("$@")
+
+  local ipv6_network=""
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    ipv6_network="--ipv6 --subnet=${subnet_v6}"
+  fi
+
+  $OCI_BIN rm -f "$server_name" 2>/dev/null || true
+  $OCI_BIN network rm -f "$network_name" 2>/dev/null || true
+  $OCI_BIN network create --subnet="${subnet_v4}" ${ipv6_network} --driver bridge "$network_name"
+  $OCI_BIN network connect "$network_name" "$frr_container"
+  $OCI_BIN run --cap-add NET_ADMIN --user 0 -d --network "$network_name" --rm \
+    --name "$server_name" "${extra_run_args[@]}" \
+    registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
+
+  # Point the server's default route at FRR so return traffic to cluster pods works without
+  # having to add per-test routes.
+  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6
+  bgp_network_frr_v4=$($OCI_BIN inspect \
+    -f "{{(index .NetworkSettings.Networks \"${network_name}\").IPAddress}}" "$frr_container")
+  echo "${frr_container} bgp network IPv4: ${bgp_network_frr_v4}"
+  $OCI_BIN exec "$server_name" ip route replace default via "$bgp_network_frr_v4"
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    bgp_network_frr_v6=$($OCI_BIN inspect \
+      -f "{{(index .NetworkSettings.Networks \"${network_name}\").GlobalIPv6Address}}" "$frr_container")
+    echo "${frr_container} bgp network IPv6: ${bgp_network_frr_v6}"
+    $OCI_BIN exec "$server_name" ip -6 route replace default via "$bgp_network_frr_v6"
+  fi
+
+  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ]; then
+    # In loose isolation mode the cluster nodes need a default gateway pointing at FRR so
+    # that cross-UDN traffic can be routed back to pods.
+    kind_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$frr_container")
+    echo "${frr_container} kind network IPv4: ${kind_network_frr_v4}"
+    echo "Setting default gateway for nodes in the cluster to FRR router IPv4: ${kind_network_frr_v4}"
+    set_nodes_default_gw "$kind_network_frr_v4"
+    if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+      kind_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' "$frr_container")
+      echo "${frr_container} kind network IPv6: ${kind_network_frr_v6}"
+      set_nodes_default_gw "$kind_network_frr_v6"
+    fi
+  else
+    # Disable the default route so FRR only forwards via directly connected or learnt networks.
+    # Done last because docker alters the routing table when a new network is connected.
+    $OCI_BIN exec "$frr_container" ip route delete default 2>/dev/null || true
+    $OCI_BIN exec "$frr_container" ip route
+    $OCI_BIN exec "$frr_container" ip -6 route delete default 2>/dev/null || true
+    $OCI_BIN exec "$frr_container" ip -6 route
+  fi
+}
+
 deploy_bgp_external_server() {
   # We create an external docker container that acts as the server (or client) outside the cluster
-  # in the e2e tests that levergae router advertisements.
+  # in the e2e tests that leverage router advertisements.
   # This container will be connected to the frr container deployed above to simulate a realistic
   # network topology
   # -----------------               ------------------                         ---------------------
@@ -1720,54 +1793,9 @@ deploy_bgp_external_server() {
   # -----------------               ------------------                         ---------------------    using RouteAdvertisements
   #                                                                            |    ovn-worker2    |    from default pod network)
   #                                                                            ---------------------
-  local ip_family ipv6_network
-  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    ip_family="dual"
-    ipv6_network="--ipv6 --subnet=${BGP_SERVER_NET_SUBNET_IPV6}"
-  elif  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    ip_family="ipv6"
-    ipv6_network="--ipv6 --subnet=${BGP_SERVER_NET_SUBNET_IPV6}"
-  else
-    ip_family="ipv4"
-    ipv6_network=""
-  fi
-  $OCI_BIN rm -f bgpserver
-  $OCI_BIN network rm -f bgpnet
-  $OCI_BIN network create --subnet="${BGP_SERVER_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge bgpnet
-  $OCI_BIN network connect bgpnet frr
-  $OCI_BIN run  --cap-add NET_ADMIN --user 0  -d --network bgpnet  --rm  --name bgpserver -p "${BGP_SERVER_HOST_PORT}:8080"  registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
-  # let's make the bgp external server have its default route towards FRR router so that we don't need to add routes during tests back to the pods in the
-  # cluster for return traffic
-  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6
-  bgp_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.IPAddress}}' frr)
-  echo "FRR bgp network IPv4: ${bgp_network_frr_v4}"
-  $OCI_BIN exec bgpserver ip route replace default via "$bgp_network_frr_v4"
-  if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
-    bgp_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.GlobalIPv6Address}}' frr)
-    echo "FRR bgp network IPv6: ${bgp_network_frr_v6}"
-    $OCI_BIN exec bgpserver ip -6 route replace default via "$bgp_network_frr_v6"
-  fi
-  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ]; then
-    kind_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr)
-    echo "FRR kind network IPv4: ${kind_network_frr_v4}"
-    # If UDN isolation is in loose disabled, we need to set the default gateway for the nodes in the cluster
-    # to the FRR router so that cross-UDN traffic can be routed back to the pods in the cluster in the loose mode.
-    echo "Setting default gateway for nodes in the cluster to FRR router IPv4: ${kind_network_frr_v4}"
-    set_nodes_default_gw "$kind_network_frr_v4"
-    if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
-      kind_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' frr)
-      echo "FRR kind network IPv6: ${kind_network_frr_v6}"
-      set_nodes_default_gw "$kind_network_frr_v6"
-    fi
-  else
-    # disable the default route to make sure the container only routes accross
-    # directly connected or learnt networks (doing this at the very end since
-    # docker changes the routing table when a new network is connected)
-    $OCI_BIN exec frr ip route delete default
-    $OCI_BIN exec frr ip route
-    $OCI_BIN exec frr ip -6 route delete default
-    $OCI_BIN exec frr ip -6 route
-  fi
+  _deploy_bgp_server_for frr bgpserver bgpnet \
+    "${BGP_SERVER_NET_SUBNET_IPV4}" "${BGP_SERVER_NET_SUBNET_IPV6}" \
+    -p "${BGP_SERVER_HOST_PORT}:8080"
 }
 
 set_nodes_default_gw() {
@@ -1786,6 +1814,153 @@ set_nodes_default_gw() {
   done
 }
 
+deploy_ebgp_frr_external_container() {
+  echo "Deploying eBGP FRR external container (ASN ${BGP_EBGP_ASN})..."
+
+  # Discover kind cluster node IPs to configure as BGP neighbors
+  local node_ips_v4="" node_ips_v6=""
+  KIND_NODES=$(kind_get_nodes)
+  for node in $KIND_NODES; do
+    if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
+      local v4
+      v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$node") || return 1
+      [ -n "$v4" ] && node_ips_v4="${node_ips_v4} ${v4}"
+    fi
+    if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+      local v6
+      v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' "$node") || return 1
+      [ -n "$v6" ] && node_ips_v6="${node_ips_v6} ${v6}"
+    fi
+  done
+
+  # Generate eBGP FRR config (ASN differs from cluster ASN, no route-reflector-client)
+  local frr_conf_dir
+  frr_conf_dir=$(mktemp -d)
+
+  # Write daemons file
+  cat > "${frr_conf_dir}/daemons" <<'DEOF'
+bgpd=yes
+zebra=yes
+DEOF
+
+  # vtysh.conf is required because the entire frr_conf_dir is volume-mounted
+  # as /etc/frr, hiding the image's built-in copy.
+  cat > "${frr_conf_dir}/vtysh.conf" <<'VEOF'
+service integrated-vtysh-config
+VEOF
+
+  # Write FRR config
+  cat > "${frr_conf_dir}/frr.conf" <<FEOF
+router bgp ${BGP_EBGP_ASN}
+ no bgp default ipv4-unicast
+ no bgp default ipv6-unicast
+ no bgp network import-check
+ no bgp ebgp-requires-policy
+FEOF
+
+  for ip in $node_ips_v4; do
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ neighbor ${ip} remote-as ${BGP_CLUSTER_ASN}
+ neighbor ${ip} timers connect 10
+ neighbor ${ip} timers 3 15
+FEOF
+  done
+  for ip in $node_ips_v6; do
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ neighbor ${ip} remote-as ${BGP_CLUSTER_ASN}
+ neighbor ${ip} timers connect 10
+ neighbor ${ip} timers 3 15
+FEOF
+  done
+
+  if [ -n "$node_ips_v4" ]; then
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ address-family ipv4 unicast
+FEOF
+    for ip in $node_ips_v4; do
+      cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  neighbor ${ip} activate
+  neighbor ${ip} next-hop-self
+FEOF
+    done
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  network ${BGP_EBGP_SERVER_NET_SUBNET_IPV4}
+ exit-address-family
+FEOF
+  fi
+
+  if [ -n "$node_ips_v6" ]; then
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+ address-family ipv6 unicast
+FEOF
+    for ip in $node_ips_v6; do
+      cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  neighbor ${ip} activate
+  neighbor ${ip} next-hop-self
+FEOF
+    done
+    cat >> "${frr_conf_dir}/frr.conf" <<FEOF
+  network ${BGP_EBGP_SERVER_NET_SUBNET_IPV6}
+ exit-address-family
+FEOF
+  fi
+
+  echo "eBGP FRR config:"
+  cat "${frr_conf_dir}/frr.conf"
+
+  # Start the eBGP FRR container
+  $OCI_BIN rm -f frr-ebgp 2>/dev/null || true
+  $OCI_BIN run -d --privileged --network kind --rm --name frr-ebgp \
+    --volume "${frr_conf_dir}:/etc/frr" \
+    quay.io/frrouting/frr:10.4.2
+
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    $OCI_BIN exec frr-ebgp sysctl -w net.ipv6.conf.all.forwarding=1
+    $OCI_BIN exec frr-ebgp sysctl -w net.ipv6.conf.all.keep_addr_on_down=1
+  fi
+
+  if [ "$ENABLE_EVPN" == true ]; then
+    echo "Configuring global EVPN BGP on eBGP external FRR..."
+    # Wait for bgpd to finish loading the neighbor configuration
+    local retries=0 bgp_neighbors
+    while true; do
+      bgp_neighbors=$($OCI_BIN exec frr-ebgp vtysh -c "show running-config" 2>/dev/null | grep "^ neighbor.*remote-as" | awk '{print $2}' || true)
+      [ -n "$bgp_neighbors" ] && break
+      retries=$((retries + 1))
+      if [ "$retries" -ge 30 ]; then
+        echo "ERROR: frr-ebgp BGP neighbors not found in running-config after 30 seconds"
+        return 1
+      fi
+      sleep 1
+    done
+    local vtysh_cmds
+    vtysh_cmds=(-c "configure terminal" -c "router bgp ${BGP_EBGP_ASN}" -c "address-family l2vpn evpn")
+    for neighbor in $bgp_neighbors; do
+      vtysh_cmds+=(-c "neighbor $neighbor activate")
+    done
+    vtysh_cmds+=(-c "advertise-all-vni" -c "exit-address-family" -c "end")
+    $OCI_BIN exec frr-ebgp vtysh "${vtysh_cmds[@]}"
+    # write memory requires all daemons (zebra) to be fully up; retry separately
+    retries=0
+    while ! $OCI_BIN exec frr-ebgp vtysh -c "write memory" 2>/dev/null; do
+      retries=$((retries + 1))
+      if [ "$retries" -ge 30 ]; then
+        echo "WARNING: frr-ebgp write memory failed after 30 seconds, continuing anyway"
+        break
+      fi
+      sleep 1
+    done
+    echo "Global EVPN BGP config complete on eBGP external FRR"
+  fi
+
+  echo "eBGP FRR external container deployed"
+}
+
+deploy_ebgp_external_server() {
+  _deploy_bgp_server_for frr-ebgp bgpserver-ebgp bgpnet-ebgp \
+    "${BGP_EBGP_SERVER_NET_SUBNET_IPV4}" "${BGP_EBGP_SERVER_NET_SUBNET_IPV6}"
+}
+
 destroy_bgp() {
   if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^bgpserver$'; then
       $OCI_BIN stop bgpserver
@@ -1795,6 +1970,15 @@ destroy_bgp() {
   fi
   if $OCI_BIN network ls --format '{{.Name}}' | grep -q '^bgpnet$'; then
       $OCI_BIN network rm bgpnet
+  fi
+  if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^bgpserver-ebgp$'; then
+      $OCI_BIN stop bgpserver-ebgp
+  fi
+  if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^frr-ebgp$'; then
+      $OCI_BIN stop frr-ebgp
+  fi
+  if $OCI_BIN network ls --format '{{.Name}}' | grep -q '^bgpnet-ebgp$'; then
+      $OCI_BIN network rm bgpnet-ebgp
   fi
 }
 
@@ -1936,6 +2120,52 @@ EOF
     kubectl_cmd=(kubectl --kubeconfig "$(frr_k8s_host_kubeconfig)")
   fi
   "${kubectl_cmd[@]}" apply -n frr-k8s-system -f receive_filtered.yaml
+
+  # If eBGP FRR container is running, create an FRRConfiguration for the eBGP peer
+  if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^frr-ebgp$'; then
+    echo "Creating FRRConfiguration for eBGP peer..."
+    local ebgp_frr_v4 ebgp_frr_v6
+    ebgp_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr-ebgp)
+
+    cat > receive_ebgp_filtered.yaml <<EOFEBGP
+apiVersion: frrk8s.metallb.io/v1beta1
+kind: FRRConfiguration
+metadata:
+  name: receive-ebgp-filtered
+  namespace: frr-k8s-system
+  labels:
+    name: receive-all
+spec:
+  bgp:
+    routers:
+    - asn: ${BGP_CLUSTER_ASN}
+      neighbors:
+      - address: ${ebgp_frr_v4}
+        asn: ${BGP_EBGP_ASN}
+        disableMP: true
+        toReceive:
+          allowed:
+            mode: filtered
+            prefixes:
+            - prefix: ${BGP_EBGP_SERVER_NET_SUBNET_IPV4}
+EOFEBGP
+    if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+      ebgp_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' frr-ebgp)
+      # Add IPv6 neighbor and prefix
+      cat >> receive_ebgp_filtered.yaml <<EOFEBGP6
+      - address: ${ebgp_frr_v6}
+        asn: ${BGP_EBGP_ASN}
+        disableMP: true
+        toReceive:
+          allowed:
+            mode: filtered
+            prefixes:
+            - prefix: ${BGP_EBGP_SERVER_NET_SUBNET_IPV6}
+EOFEBGP6
+    fi
+    "${kubectl_cmd[@]}" apply -n frr-k8s-system -f receive_ebgp_filtered.yaml
+  fi
+
   popd || exit 1
 }
 

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1911,7 +1911,7 @@ FEOF
   $OCI_BIN rm -f frr-ebgp 2>/dev/null || true
   $OCI_BIN run -d --privileged --network kind --rm --name frr-ebgp \
     --volume "${frr_conf_dir}:/etc/frr" \
-    quay.io/frrouting/frr:10.4.2
+    "${FRR_DEPLOYED_IMAGE}"
 
   if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
     $OCI_BIN exec frr-ebgp sysctl -w net.ipv6.conf.all.forwarding=1

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1819,15 +1819,14 @@ deploy_ebgp_frr_external_container() {
 
   # Discover kind cluster node IPs to configure as BGP neighbors
   local node_ips_v4="" node_ips_v6=""
+  local v4 v6
   KIND_NODES=$(kind_get_nodes)
   for node in $KIND_NODES; do
     if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
-      local v4
       v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$node") || return 1
       [ -n "$v4" ] && node_ips_v4="${node_ips_v4} ${v4}"
     fi
     if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-      local v6
       v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' "$node") || return 1
       [ -n "$v6" ] && node_ips_v6="${node_ips_v6} ${v6}"
     fi

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1689,9 +1689,17 @@ fi\
     # Neighbors are already configured by demo.sh; extract them from the running config.
     # This is cluster-level infrastructure shared across all EVPN tests; configured once
     # at install time so individual tests don't need to manage it.
-    # Wait for FRR daemons to be ready ("Not all daemons are up, cannot write config").
+    # Ensure vtysh.conf exists: demo.sh volume-mounts the frr config dir as /etc/frr,
+    # hiding the image's built-in vtysh.conf.  Without it vtysh prints a harmless warning
+    # but we create it here to keep output clean, matching deploy_bgp_external_server.
+    $OCI_BIN exec frr sh -c \
+      "[ -f /etc/frr/vtysh.conf ] || echo 'service integrated-vtysh-config' > /etc/frr/vtysh.conf"
+    # Wait for FRR daemons to be ready. vtysh exits 0 even while bgpd is still loading
+    # frr.conf (EAGAIN / "processing failure: 11"), so check the output too.
     local attempts=0 daemon_status
-    while ! daemon_status=$($OCI_BIN exec frr vtysh -c "show daemons" 2>&1); do
+    while true; do
+      daemon_status=$($OCI_BIN exec frr vtysh -c "show daemons" 2>&1)
+      [[ $? -eq 0 && ! "$daemon_status" =~ "processing failure" ]] && break
       if (( ++attempts > 30 )); then
         echo "error: FRR daemons did not become ready after 30 attempts"
         echo "last daemon status: $daemon_status"

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -727,6 +727,8 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
     # external FRR is required for unmanaged mode where the FRR-K8S speakers run.
     deploy_frr_external_container
     deploy_bgp_external_server
+    deploy_ebgp_frr_external_container
+    deploy_ebgp_external_server
   fi
   if [ "${DPU_MODE}" == "host" ]; then
     install_frr_k8s_crds

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -756,6 +756,8 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
     # external FRR is required for unmanaged mode where the FRR-K8S speakers run.
     deploy_frr_external_container
     deploy_bgp_external_server
+    deploy_ebgp_frr_external_container
+    deploy_ebgp_external_server
   fi
   if [ "${DPU_MODE}" == "host" ]; then
     install_frr_k8s_crds

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -83,10 +83,6 @@ import (
 // =============================================================================
 
 const (
-	// externalFRRContainerName is the name of the external FRR container
-	// created during KIND cluster setup with BGP enabled (./contrib/kind.sh -rae)
-	externalFRRContainerName = "frr"
-	// agnhostHTTPPort is the HTTP port for agnhost netexec
 	agnhostHTTPPort = 8080
 	// sharedNodeIPsVTEPName is the name of the shared VTEP CR used across
 	// EVPN tests that reference node IP CIDRs. Created idempotently by the
@@ -109,12 +105,12 @@ const (
 //   - vnifilter: Enable per-VLAN VNI mapping (SVD mode)
 //
 // Cleanup is automatically registered via ictx.AddCleanUpFn().
-func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrVTEPIPAddress, bridgeName, vxlanName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrContainerName, frrVTEPIPAddress, bridgeName, vxlanName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 	// Idempotent: if the bridge already exists, skip creation.
 	if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, []string{"ip", "link", "show", bridgeName}); err == nil {
-		framework.Logf("EVPN bridge %s already exists on %s, reusing", bridgeName, externalFRRContainerName)
+		framework.Logf("EVPN bridge %s already exists on %s, reusing", bridgeName, frrContainerName)
 		return nil
 	}
 
@@ -187,7 +183,7 @@ func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrVTEPIPAddress, bridg
 	// Idempotent: checks existence before deleting so multiple cleanups are safe
 	// (e.g. when shared bridge is cleaned up by first test, second finds it gone).
 	ictx.AddCleanUpFn(func() error {
-		frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+		frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 		if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, []string{"ip", "link", "show", vxlanName}); err == nil {
 			if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, []string{"ip", "link", "del", vxlanName}); err != nil {
@@ -201,18 +197,18 @@ func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrVTEPIPAddress, bridg
 			}
 		}
 
-		framework.Logf("EVPN bridge cleanup complete on %s", externalFRRContainerName)
+		framework.Logf("EVPN bridge cleanup complete on %s", frrContainerName)
 		return nil
 	})
 
-	framework.Logf("EVPN bridge setup complete on %s (%s + %s with local IP %s)", externalFRRContainerName, bridgeName, vxlanName, frrVTEPIPAddress)
+	framework.Logf("EVPN bridge setup complete on %s (%s + %s with local IP %s)", frrContainerName, bridgeName, vxlanName, frrVTEPIPAddress)
 	return nil
 }
 
 // setupVNIVIDMappingsOnExternalFRR sets up VLAN/VNI mappings for the given
 // bridge and vxlan interfaces
-func setupVNIVIDMappingsOnExternalFRR(vni, vid int, bridgeName, vxlanName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupVNIVIDMappingsOnExternalFRR(frrContainerName string, vni, vid int, bridgeName, vxlanName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vidStr := fmt.Sprintf("%d", vid)
 	vniStr := fmt.Sprintf("%d", vni)
 	commands := [][]string{
@@ -231,14 +227,14 @@ func setupVNIVIDMappingsOnExternalFRR(vni, vid int, bridgeName, vxlanName string
 		}
 	}
 
-	framework.Logf("VLAN/VNI mappings setup complete on %s (VNI %d, VID %d)", externalFRRContainerName, vni, vid)
+	framework.Logf("VLAN/VNI mappings setup complete on %s (VNI %d, VID %d)", frrContainerName, vni, vid)
 	return nil
 }
 
 // setupSVIOnExternalFRR sets up a SVI on the provided VLAN and VLAN aware
 // bridge and optionally attaches it to a VRF
-func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupSVIOnExternalFRR(ictx infraapi.Context, frrContainerName string, vid int, bridgeName, vrfName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vidStr := fmt.Sprintf("%d", vid)
 	sviName := fmt.Sprintf("%s.%d", bridgeName, vid)
 
@@ -256,7 +252,7 @@ func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName s
 			return fmt.Errorf("failed to delete SVI %s: %v", sviName, err)
 		}
 
-		framework.Logf("SVI %s cleanup complete on %s (VID %d, VRF: %q)", sviName, externalFRRContainerName, vid, vrfName)
+		framework.Logf("SVI %s cleanup complete on %s (VID %d, VRF: %q)", sviName, frrContainerName, vid, vrfName)
 		return nil
 	})
 
@@ -283,7 +279,7 @@ func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName s
 		return fmt.Errorf("failed to bring up SVI %s: %w", sviName, err)
 	}
 
-	framework.Logf("SVI %s setup complete on %s (VID %d, VRF: %q)", sviName, externalFRRContainerName, vid, vrfName)
+	framework.Logf("SVI %s setup complete on %s (VID %d, VRF: %q)", sviName, frrContainerName, vid, vrfName)
 	return nil
 }
 
@@ -299,18 +295,18 @@ func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName s
 //   - vid: VLAN ID for local bridging (e.g., 100)
 //   - bridgeName: name of the bridge device (e.g., "brevpn7a3f")
 //   - vxlanName: name of the VXLAN device (e.g., "vxevpn7a3f")
-func setupMACVRFOnExternalFRR(ictx infraapi.Context, vni, vid int, bridgeName, vxlanName string) error {
-	err := setupVNIVIDMappingsOnExternalFRR(vni, vid, bridgeName, vxlanName)
+func setupMACVRFOnExternalFRR(ictx infraapi.Context, frrContainerName string, vni, vid int, bridgeName, vxlanName string) error {
+	err := setupVNIVIDMappingsOnExternalFRR(frrContainerName, vni, vid, bridgeName, vxlanName)
 	if err != nil {
 		return fmt.Errorf("failed to configure VLAN/VNI mapping on bridge %s: %w", bridgeName, err)
 	}
 
-	err = setupSVIOnExternalFRR(ictx, vid, bridgeName, "")
+	err = setupSVIOnExternalFRR(ictx, frrContainerName, vid, bridgeName, "")
 	if err != nil {
 		return fmt.Errorf("failed to configure SVI for VID %d: %w", vid, err)
 	}
 
-	framework.Logf("MAC-VRF setup complete on %s (VNI %d)", externalFRRContainerName, vni)
+	framework.Logf("MAC-VRF setup complete on %s (VNI %d)", frrContainerName, vni)
 	return nil
 }
 
@@ -328,8 +324,8 @@ func setupMACVRFOnExternalFRR(ictx infraapi.Context, vni, vid int, bridgeName, v
 //
 // Cleanup is automatically registered via ictx.AddCleanUpFn().
 // Note: VLAN/VNI mappings are cleaned up when bridgeName/vxlanName are deleted.
-func setupIPVRFOnExternalFRR(ictx infraapi.Context, vrfName string, vni, vid int, bridgeName, vxlanName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupIPVRFOnExternalFRR(ictx infraapi.Context, frrContainerName, vrfName string, vni, vid int, bridgeName, vxlanName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vniStr := fmt.Sprintf("%d", vni)
 
 	// Create Linux VRF with routing table = VNI
@@ -363,21 +359,21 @@ func setupIPVRFOnExternalFRR(ictx infraapi.Context, vrfName string, vni, vid int
 			return fmt.Errorf("failed to delete FRR VRF definition %s: %v", vrfName, err)
 		}
 
-		framework.Logf("IP-VRF cleanup complete on %s (VNI %d)", externalFRRContainerName, vni)
+		framework.Logf("IP-VRF cleanup complete on %s (VNI %d)", frrContainerName, vni)
 		return nil
 	})
 
-	err = setupVNIVIDMappingsOnExternalFRR(vni, vid, bridgeName, vxlanName)
+	err = setupVNIVIDMappingsOnExternalFRR(frrContainerName, vni, vid, bridgeName, vxlanName)
 	if err != nil {
 		return fmt.Errorf("failed to configure VLAN/VNI mapping on bridge %s: %w", bridgeName, err)
 	}
 
-	err = setupSVIOnExternalFRR(ictx, vid, bridgeName, vrfName)
+	err = setupSVIOnExternalFRR(ictx, frrContainerName, vid, bridgeName, vrfName)
 	if err != nil {
 		return fmt.Errorf("failed to configure SVI for VID %d: %w", vid, err)
 	}
 
-	framework.Logf("IP-VRF setup complete on %s (VNI %d)", externalFRRContainerName, vni)
+	framework.Logf("IP-VRF setup complete on %s (VNI %d)", frrContainerName, vni)
 	return nil
 }
 
@@ -399,18 +395,22 @@ func vtyshCommand(args ...string) []string {
 // with ENABLE_EVPN.
 //
 // Parameters:
-//   - asn: BGP Autonomous System Number (e.g., 64512)
+//   - frrContainerName: Name of the external FRR container (e.g., "frr" or "frr-ebgp")
+//   - asn: BGP Autonomous System Number of the external FRR (e.g., 64512 for iBGP, 64513 for eBGP)
 //   - neighborIPs: List of cluster node IPs to peer with
+//   - isIBGP: Whether this is an iBGP session (determines if route-reflector-client is configured)
 //
 // No cleanup is registered: these are shared cluster-level settings that must persist
 // across all parallel EVPN tests.
-func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, asn int, neighborIPs []string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, frrContainerName string, asn int, neighborIPs []string, isIBGP bool) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 	args := []string{"configure terminal", fmt.Sprintf("router bgp %d", asn), "address-family l2vpn evpn", "advertise-all-vni"}
 	for _, ip := range neighborIPs {
 		args = append(args, fmt.Sprintf("neighbor %s activate", ip))
-		args = append(args, fmt.Sprintf("neighbor %s route-reflector-client", ip))
+		if isIBGP {
+			args = append(args, fmt.Sprintf("neighbor %s route-reflector-client", ip))
+		}
 	}
 	args = append(args, "exit-address-family", "end")
 
@@ -426,11 +426,11 @@ func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, asn int, neighborIPs []str
 	// and must persist for the duration of the test suite.
 	// IP-VRF per-VRF BGP config is cleaned up by setupIPVRFBGPOnExternalFRR.
 	ictx.AddCleanUpFn(func() error {
-		framework.Logf("EVPN BGP cleanup complete on %s (no-op: global BGP settings are shared infrastructure)", externalFRRContainerName)
+		framework.Logf("EVPN BGP cleanup complete on %s (no-op: global BGP settings are shared infrastructure)", frrContainerName)
 		return nil
 	})
 
-	framework.Logf("EVPN BGP setup complete on %s (ASN %d, neighbors: %v)", externalFRRContainerName, asn, neighborIPs)
+	framework.Logf("EVPN BGP setup complete on %s (ASN %d, neighbors: %v, iBGP: %v)", frrContainerName, asn, neighborIPs, isIBGP)
 	return nil
 }
 
@@ -441,16 +441,19 @@ func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, asn int, neighborIPs []str
 //
 // Parameters:
 //   - vrfName: Name of the Linux VRF (must match the VRF created by setupIPVRFOnExternalFRR)
-//   - asn: BGP ASN (e.g., 64512). Must match the cluster's frr-k8s ASN and the global EVPN
-//     BGP instance. Used for both the VRF BGP instance and the Route Distinguisher/Route Target.
+//   - asn: BGP ASN of this external FRR instance (e.g., 64512 for iBGP, 64513 for eBGP).
+//     Used for the VRF BGP instance (`router bgp <asn> vrf <vrfName>`).
+//   - rtASN: ASN component of Route Distinguisher and Route Target (RT = rtASN:VNI).
+//     The cluster-side setup script always uses the cluster's own ASN for RTs,
+//     so rtASN must always be the cluster's ASN to keep both sides in sync.
 //   - vni: VXLAN Network Identifier for route-target (e.g., 20102)
 //   - ipFamilies: IP families to configure (e.g., sets.New(utilnet.IPv4) or sets.New(utilnet.IPv4, utilnet.IPv6))
 //   - subnets: Subnets to advertise via BGP (e.g., []string{"172.27.102.0/24"} or {"172.27.102.0/24", "fd00:102::/64"})
 //
 // Cleanup is automatically registered via ictx.AddCleanUpFn().
-func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, vrfName string, asn, vni int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
-	rt := fmt.Sprintf("%d:%d", asn, vni)
+func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, frrContainerName, vrfName string, asn, rtASN, vni int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
+	rt := fmt.Sprintf("%d:%d", rtASN, vni)
 
 	// Build vtysh args
 	args := []string{
@@ -501,20 +504,20 @@ func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, vrfName string, asn, vni 
 	// the Linux VRF device, which triggers FRR to auto-cleanup the VRF config. In that case,
 	// these commands may fail - that's OK, we just log warnings and won't retry that.
 	ictx.AddCleanUpFn(func() error {
-		frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+		frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 		_, err := infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(
 			"configure terminal", fmt.Sprintf("vrf %s", vrfName), fmt.Sprintf("no vni %d", vni), "exit-vrf", "end",
 		))
 		if err != nil {
-			return fmt.Errorf("failed to remove VNI binding (may already be cleaned up): %v", err)
+			framework.Logf("Warning: failed to remove VNI binding (may already be cleaned up): %v", err)
 		}
 
 		_, err = infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(
 			"configure terminal", fmt.Sprintf("no router bgp %d vrf %s", asn, vrfName), "end",
 		))
 		if err != nil {
-			return fmt.Errorf("failed to remove BGP VRF (may already be cleaned up): %v", err)
+			framework.Logf("Warning: failed to remove BGP VRF (may already be cleaned up): %v", err)
 		}
 
 		// NOTE: We intentionally do NOT run "no vrf" here.
@@ -523,11 +526,11 @@ func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, vrfName string, asn, vni 
 		// Trying to delete the FRR VRF while the Linux VRF still has interfaces
 		// attached causes "Only inactive VRFs can be deleted" errors.
 
-		framework.Logf("IP-VRF BGP cleanup complete on %s (VRF %s)", externalFRRContainerName, vrfName)
+		framework.Logf("IP-VRF BGP cleanup complete on %s (VRF %s)", frrContainerName, vrfName)
 		return nil
 	})
 
-	framework.Logf("IP-VRF BGP setup complete on %s (VRF %s, ASN %d, VNI %d, RT %s, families %v)", externalFRRContainerName, vrfName, asn, vni, rt, ipFamilies.UnsortedList())
+	framework.Logf("IP-VRF BGP setup complete on %s (VRF %s, ASN %d, VNI %d, RT %s, families %v)", frrContainerName, vrfName, asn, vni, rt, ipFamilies.UnsortedList())
 	return nil
 }
 
@@ -559,8 +562,9 @@ type evpnContainerInfo struct {
 //   - container: ExternalContainer spec (Name, Image, CmdArgs, and optionally IPv4/IPv6 for static IPs)
 //   - networkName: Name for the Docker network (e.g., "macvrf-net-100", "ipvrf-net-202")
 //   - ipFamilies: Cluster IP family support, used to filter discovered IPs
+//   - frrContainerName: name of the external FRR container to attach to the Docker network
 //   - subnets: Subnets for the Docker network (e.g., "10.100.0.0/16" for IPv4, or both for dual-stack)
-func createEVPNExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName string, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
+func createEVPNExternalContainer(ictx infraapi.Context, frrContainerName string, container infraapi.ExternalContainer, networkName string, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
 	// Step 1: Create Docker network with specific subnet(s)
 	network, err := ictx.CreateNetwork(networkName, subnets...)
 	if err != nil {
@@ -576,7 +580,7 @@ func createEVPNExternalContainer(ictx infraapi.Context, container infraapi.Exter
 	}
 
 	// Step 3: Connect FRR to the network
-	_, err = ictx.AttachNetwork(network, externalFRRContainerName)
+	_, err = ictx.AttachNetwork(network, frrContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect FRR to network %s: %w", networkName, err)
 	}
@@ -589,7 +593,7 @@ func createEVPNExternalContainer(ictx infraapi.Context, container infraapi.Exter
 	}
 
 	frrNetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-		infraapi.ExternalContainer{Name: externalFRRContainerName}, network)
+		infraapi.ExternalContainer{Name: frrContainerName}, network)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get FRR network interface: %w", err)
 	}
@@ -705,7 +709,7 @@ func getMACVRFAgnhostIPsFromSubnets(subnets []string) ([]string, error) {
 //   - vid: VLAN ID for the access port on the bridge (e.g., 100)
 //   - ipFamilies: Cluster IP family support (e.g., sets.New(utilnet.IPv4, utilnet.IPv6))
 //   - subnets: Subnets for the Docker network matching the CUDN (e.g., "10.100.0.0/16")
-func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName, bridgeName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
+func setupMACVRFExternalContainer(ictx infraapi.Context, frrContainerName string, container infraapi.ExternalContainer, networkName, bridgeName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
 	// Derive container IPs from CUDN subnets
 	containerIPs, err := getMACVRFAgnhostIPsFromSubnets(subnets)
 	if err != nil {
@@ -720,13 +724,13 @@ func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.Exte
 		container.IPv6 = ips6[0]
 	}
 
-	info, err := createEVPNExternalContainer(ictx, container, networkName, ipFamilies, subnets)
+	info, err := createEVPNExternalContainer(ictx, frrContainerName, container, networkName, ipFamilies, subnets)
 	if err != nil {
 		return nil, err
 	}
 
 	// Move FRR's interface to bridgeName and configure as access port
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vidStr := fmt.Sprintf("%d", vid)
 	sviName := fmt.Sprintf("%s.%d", bridgeName, vid)
 	frrCmds := [][]string{
@@ -776,8 +780,8 @@ func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.Exte
 //   - vrfName: Name of the VRF to put FRR's interface in (must match setupIPVRFOnExternalFRR)
 //   - ipFamilies: Cluster IP family support (e.g., sets.New(utilnet.IPv4, utilnet.IPv6))
 //   - subnets: Subnets for the Docker network (e.g., "172.27.102.0/24" for IPv4, or both for dual-stack)
-func setupIPVRFExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName, vrfName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets ...string) (*evpnContainerInfo, error) {
-	info, err := createEVPNExternalContainer(ictx, container, networkName, ipFamilies, subnets)
+func setupIPVRFExternalContainer(ictx infraapi.Context, frrContainerName string, container infraapi.ExternalContainer, networkName, vrfName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets ...string) (*evpnContainerInfo, error) {
+	info, err := createEVPNExternalContainer(ictx, frrContainerName, container, networkName, ipFamilies, subnets)
 	if err != nil {
 		return nil, err
 	}
@@ -785,7 +789,7 @@ func setupIPVRFExternalContainer(ictx infraapi.Context, container infraapi.Exter
 	// Put FRR's interface in the VRF
 	// NOTE: keep_addr_on_down=1 is set at FRR container startup (in deploy_frr_external_container)
 	// to preserve IPv6 addresses during VRF assignment. See https://github.com/FRRouting/frr/issues/1666
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 	frrCmds := [][]string{
 		{"ip", "link", "set", info.frrInterface, "master", vrfName},
@@ -1066,12 +1070,12 @@ func subnetOffsetIP(cidr string, offset int) string {
 // FRRConfiguration Utilities
 // =============================================================================
 
-func getExternalFRRIP(ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
+func getExternalFRRIP(frrContainerName string, ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
 	kindNetwork, err := infraprovider.Get().PrimaryNetwork()
 	if err != nil {
 		return "", err
 	}
-	frrNetIf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: externalFRRContainerName}, kindNetwork)
+	frrNetIf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: frrContainerName}, kindNetwork)
 	if err != nil {
 		return "", err
 	}
@@ -1099,12 +1103,13 @@ func getExternalFRRIP(ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
 //   - ictx: Infrastructure context for cleanup registration
 //   - name: Name of the FRRConfiguration CR
 //   - namespace: Namespace for the FRRConfiguration (typically frr-k8s-system)
-//   - asn: BGP Autonomous System Number (e.g., 64512)
+//   - localASN: BGP ASN for cluster-side routers in this CR
+//   - neighborASN: BGP ASN of the external FRR neighbor
 //   - neighborIP: IP address of the external FRR to peer with
 //   - labels: Labels to apply to the FRRConfiguration (used by RouteAdvertisements selector)
 func createFRRConfiguration(ictx infraapi.Context,
 	name, namespace string,
-	asn int,
+	localASN, neighborASN int,
 	neighborIP string,
 	labels map[string]string) error {
 
@@ -1117,6 +1122,24 @@ func createFRRConfiguration(ictx infraapi.Context,
 	// Generate FRRConfiguration YAML
 	// No toReceive needed - EVPN routes come via l2vpn evpn address-family
 	// and are imported via route-target matching in the VRF
+	isEBGP := localASN != neighborASN
+	rawConfigSection := ""
+	if isEBGP {
+		// For eBGP EVPN, inter-node routes transit through the external FRR peer and
+		// arrive with the local ASN in the AS_PATH, which BGP rejects as a loop.
+		// allowas-in must be configured via rawConfig because the FRRConfiguration CRD
+		// does not expose this field, and direct vtysh injection gets overwritten when
+		// frr-k8s reconciles.
+		rawConfigSection = fmt.Sprintf(`  raw:
+    priority: 10
+    rawConfig: |
+      router bgp %d
+       address-family l2vpn evpn
+        neighbor %s allowas-in
+       exit-address-family
+      !
+`, localASN, neighborIP)
+	}
 	yaml := fmt.Sprintf(`apiVersion: frrk8s.metallb.io/v1beta1
 kind: FRRConfiguration
 metadata:
@@ -1131,7 +1154,7 @@ metadata:
       - address: %s
         asn: %d
         disableMP: true
-`, name, namespace, labelsYAML, asn, neighborIP, asn)
+%s`, name, namespace, labelsYAML, localASN, neighborIP, neighborASN, rawConfigSection)
 
 	// Write to temp file
 	tmpFile, err := os.CreateTemp("", "frrconfig-*.yaml")
@@ -1196,7 +1219,9 @@ func runEVPNNetworkAndServers(
 	ipFamilySet sets.Set[utilnet.IPFamily],
 	networkSpec *udnv1.NetworkSpec,
 	bgpAlloc allocators.BGPAllocation,
-	bgpASN int,
+	externalASN int,
+	clusterASN int,
+	frrContainerName string,
 	bridgeName string,
 	vxlanName string,
 	vtepName string,
@@ -1208,27 +1233,26 @@ func runEVPNNetworkAndServers(
 	// Derive what to setup from networkSpec
 	hasMACVRF := networkSpec.EVPN != nil && networkSpec.EVPN.MACVRF != nil
 	hasIPVRF := networkSpec.EVPN != nil && networkSpec.EVPN.IPVRF != nil
+	isIBGP := externalASN == clusterASN
 
 	ipVRFAgnhostSubnets := matchCIDRStringsByIPFamilySet([]string{bgpAlloc.IPVRFSubnet, bgpAlloc.IPVRFSubnet6}, ipFamilySet)
 	vtepSubnets := matchCIDRStringsByIPFamilySet([]string{bgpAlloc.VTEPSubnet, bgpAlloc.VTEPSubnet6}, ipFamilySet)
 
-	// Extract subnets from networkSpec for MAC-VRF agnhost IP derivation
 	cudnSubnetsFromSpec := getNetworkSubnetsFromSpec(networkSpec)
 
-	externalFRRIP, err := getExternalFRRIP(ipFamilySet)
+	externalFRRIP, err := getExternalFRRIP(frrContainerName, ipFamilySet)
 	if err != nil {
 		return err
 	}
 
-	// attach BGP peer network to all nodes
 	nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list nodes: %w", err)
 	}
 	nodeIPs := e2enode.CollectAddresses(nodeList, corev1.NodeInternalIP)
 
-	framework.Logf("Setting up EVPN bridge on external FRR")
-	err = setupEVPNBridgeOnExternalFRR(ictx, externalFRRIP, bridgeName, vxlanName)
+	framework.Logf("Setting up EVPN bridge on external FRR (%s)", frrContainerName)
+	err = setupEVPNBridgeOnExternalFRR(ictx, frrContainerName, externalFRRIP, bridgeName, vxlanName)
 	if err != nil {
 		return err
 	}
@@ -1238,47 +1262,66 @@ func runEVPNNetworkAndServers(
 		macVRFVID = bgpAlloc.MACVRFVID
 		framework.Logf("Allocated VIDs for external FRR: MAC-VRF VID=%d", macVRFVID)
 		framework.Logf("Setting up MAC-VRF on external FRR")
-		err = setupMACVRFOnExternalFRR(ictx, int(networkSpec.EVPN.MACVRF.VNI), macVRFVID, bridgeName, vxlanName)
+		err = setupMACVRFOnExternalFRR(ictx, frrContainerName, int(networkSpec.EVPN.MACVRF.VNI), macVRFVID, bridgeName, vxlanName)
 		if err != nil {
 			return err
 		}
 
 		framework.Logf("Creating MAC-VRF external container")
-		macVRFInfo, err := setupMACVRFExternalContainer(ictx, *macVRFContainer, macVRFNetworkName, bridgeName, macVRFVID, ipFamilySet, cudnSubnetsFromSpec)
+		macVRFInfo, err := setupMACVRFExternalContainer(ictx, frrContainerName, *macVRFContainer, macVRFNetworkName, bridgeName, macVRFVID, ipFamilySet, cudnSubnetsFromSpec)
 		if err != nil {
 			return err
 		}
 		populateExternalContainerIPs(macVRFContainer, macVRFInfo)
 	}
 
-	framework.Logf("Setting up EVPN BGP on external FRR")
-	err = setupEVPNBGPOnExternalFRR(ictx, bgpASN, nodeIPs)
+	framework.Logf("Setting up EVPN BGP on external FRR (%s)", frrContainerName)
+	err = setupEVPNBGPOnExternalFRR(ictx, frrContainerName, externalASN, nodeIPs, isIBGP)
 	if err != nil {
 		return err
 	}
 
+	if hasMACVRF && !isIBGP {
+		macVRFVNI := int(networkSpec.EVPN.MACVRF.VNI)
+		rt := fmt.Sprintf("%d:%d", clusterASN, macVRFVNI)
+		framework.Logf("Overriding MAC-VRF VNI %d RT on external FRR to %s (eBGP RT alignment)", macVRFVNI, rt)
+		frr := infraapi.ExternalContainer{Name: frrContainerName}
+		_, err = infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(
+			"configure terminal",
+			fmt.Sprintf("router bgp %d", externalASN),
+			"address-family l2vpn evpn",
+			fmt.Sprintf("vni %d", macVRFVNI),
+			fmt.Sprintf("rd %s", rt),
+			fmt.Sprintf("route-target import %s", rt),
+			fmt.Sprintf("route-target export %s", rt),
+			"exit-vni",
+			"exit-address-family",
+			"end",
+		))
+		if err != nil {
+			return fmt.Errorf("failed to set explicit MAC-VRF RT for eBGP: %w", err)
+		}
+	}
+
 	if hasIPVRF {
-		// Derive VRF name from VNI (unique per IP-VRF)
 		ipVRFName := fmt.Sprintf("vrf%d", networkSpec.EVPN.IPVRF.VNI)
 		ipVRFVID := bgpAlloc.IPVRFVID
 		framework.Logf("Allocated VIDs for external FRR: IP-VRF VID=%d", ipVRFVID)
 		framework.Logf("Setting up IP-VRF on external FRR")
-		err = setupIPVRFOnExternalFRR(ictx, ipVRFName, int(networkSpec.EVPN.IPVRF.VNI), ipVRFVID, bridgeName, vxlanName)
+		err = setupIPVRFOnExternalFRR(ictx, frrContainerName, ipVRFName, int(networkSpec.EVPN.IPVRF.VNI), ipVRFVID, bridgeName, vxlanName)
 		if err != nil {
 			return err
 		}
 
 		framework.Logf("Creating IP-VRF external container")
-		ipVRFInfo, err := setupIPVRFExternalContainer(ictx, *ipVRFContainer, ipVRFNetworkName, ipVRFName, ipVRFVID, ipFamilySet, ipVRFAgnhostSubnets...)
+		ipVRFInfo, err := setupIPVRFExternalContainer(ictx, frrContainerName, *ipVRFContainer, ipVRFNetworkName, ipVRFName, ipVRFVID, ipFamilySet, ipVRFAgnhostSubnets...)
 		if err != nil {
 			return err
 		}
 		populateExternalContainerIPs(ipVRFContainer, ipVRFInfo)
 
-		// Configure BGP AFTER agnhost so FRR's interface is in the VRF
-		// and has a connected route for the subnet we want to advertise
 		framework.Logf("Setting up IP-VRF BGP on external FRR")
-		err = setupIPVRFBGPOnExternalFRR(ictx, ipVRFName, bgpASN, int(networkSpec.EVPN.IPVRF.VNI), ipFamilySet, ipVRFAgnhostSubnets)
+		err = setupIPVRFBGPOnExternalFRR(ictx, frrContainerName, ipVRFName, externalASN, clusterASN, int(networkSpec.EVPN.IPVRF.VNI), ipFamilySet, ipVRFAgnhostSubnets)
 		if err != nil {
 			return err
 		}
@@ -1302,12 +1345,11 @@ func runEVPNNetworkAndServers(
 		return fmt.Errorf("VTEP %s did not become healthy: %w", vtepName, err)
 	}
 
-	// Update VTEP name in network spec
 	networkSpec.EVPN.VTEP = vtepName
 
 	framework.Logf("Creating FRRConfiguration for EVPN")
 	frrConfigLabels := map[string]string{"network": testName}
-	err = createFRRConfiguration(ictx, testName, deploymentconfig.Get().FRRK8sNamespace(), bgpASN, externalFRRIP, frrConfigLabels)
+	err = createFRRConfiguration(ictx, testName, deploymentconfig.Get().FRRK8sNamespace(), clusterASN, externalASN, externalFRRIP, frrConfigLabels)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -1119,27 +1119,8 @@ func createFRRConfiguration(ictx infraapi.Context,
 		labelsYAML += fmt.Sprintf("    %s: %s\n", k, v)
 	}
 
-	// Generate FRRConfiguration YAML
 	// No toReceive needed - EVPN routes come via l2vpn evpn address-family
-	// and are imported via route-target matching in the VRF
-	isEBGP := localASN != neighborASN
-	rawConfigSection := ""
-	if isEBGP {
-		// For eBGP EVPN, inter-node routes transit through the external FRR peer and
-		// arrive with the local ASN in the AS_PATH, which BGP rejects as a loop.
-		// allowas-in must be configured via rawConfig because the FRRConfiguration CRD
-		// does not expose this field, and direct vtysh injection gets overwritten when
-		// frr-k8s reconciles.
-		rawConfigSection = fmt.Sprintf(`  raw:
-    priority: 10
-    rawConfig: |
-      router bgp %d
-       address-family l2vpn evpn
-        neighbor %s allowas-in
-       exit-address-family
-      !
-`, localASN, neighborIP)
-	}
+	// and are imported via route-target matching in the VRF.
 	yaml := fmt.Sprintf(`apiVersion: frrk8s.metallb.io/v1beta1
 kind: FRRConfiguration
 metadata:
@@ -1153,8 +1134,7 @@ metadata:
       neighbors:
       - address: %s
         asn: %d
-        disableMP: true
-%s`, name, namespace, labelsYAML, localASN, neighborIP, neighborASN, rawConfigSection)
+`, name, namespace, labelsYAML, localASN, neighborIP, neighborASN)
 
 	// Write to temp file
 	tmpFile, err := os.CreateTemp("", "frrconfig-*.yaml")

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -1135,27 +1135,8 @@ func createFRRConfiguration(ictx infraapi.Context,
 		labelsYAML += fmt.Sprintf("    %s: %s\n", k, v)
 	}
 
-	// Generate FRRConfiguration YAML
 	// No toReceive needed - EVPN routes come via l2vpn evpn address-family
-	// and are imported via route-target matching in the VRF
-	isEBGP := localASN != neighborASN
-	rawConfigSection := ""
-	if isEBGP {
-		// For eBGP EVPN, inter-node routes transit through the external FRR peer and
-		// arrive with the local ASN in the AS_PATH, which BGP rejects as a loop.
-		// allowas-in must be configured via rawConfig because the FRRConfiguration CRD
-		// does not expose this field, and direct vtysh injection gets overwritten when
-		// frr-k8s reconciles.
-		rawConfigSection = fmt.Sprintf(`  raw:
-    priority: 10
-    rawConfig: |
-      router bgp %d
-       address-family l2vpn evpn
-        neighbor %s allowas-in
-       exit-address-family
-      !
-`, localASN, neighborIP)
-	}
+	// and are imported via route-target matching in the VRF.
 	yaml := fmt.Sprintf(`apiVersion: frrk8s.metallb.io/v1beta1
 kind: FRRConfiguration
 metadata:
@@ -1169,8 +1150,7 @@ metadata:
       neighbors:
       - address: %s
         asn: %d
-        disableMP: true
-%s`, name, namespace, labelsYAML, localASN, neighborIP, neighborASN, rawConfigSection)
+`, name, namespace, labelsYAML, localASN, neighborIP, neighborASN)
 
 	// Write to temp file
 	tmpFile, err := os.CreateTemp("", "frrconfig-*.yaml")

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -83,10 +83,6 @@ import (
 // =============================================================================
 
 const (
-	// externalFRRContainerName is the name of the external FRR container
-	// created during KIND cluster setup with BGP enabled (./contrib/kind.sh -rae)
-	externalFRRContainerName = "frr"
-	// agnhostHTTPPort is the HTTP port for agnhost netexec
 	agnhostHTTPPort = 8080
 	// sharedNodeIPsVTEPName is the name of the shared VTEP CR used across
 	// EVPN tests that reference node IP CIDRs. Created idempotently by the
@@ -109,12 +105,12 @@ const (
 //   - vnifilter: Enable per-VLAN VNI mapping (SVD mode)
 //
 // Cleanup is automatically registered via ictx.AddCleanUpFn().
-func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrVTEPIPAddress, bridgeName, vxlanName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrContainerName, frrVTEPIPAddress, bridgeName, vxlanName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 	// Idempotent: if the bridge already exists, skip creation.
 	if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, []string{"ip", "link", "show", bridgeName}); err == nil {
-		framework.Logf("EVPN bridge %s already exists on %s, reusing", bridgeName, externalFRRContainerName)
+		framework.Logf("EVPN bridge %s already exists on %s, reusing", bridgeName, frrContainerName)
 		return nil
 	}
 
@@ -187,7 +183,7 @@ func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrVTEPIPAddress, bridg
 	// Idempotent: checks existence before deleting so multiple cleanups are safe
 	// (e.g. when shared bridge is cleaned up by first test, second finds it gone).
 	ictx.AddCleanUpFn(func() error {
-		frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+		frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 		if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, []string{"ip", "link", "show", vxlanName}); err == nil {
 			if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, []string{"ip", "link", "del", vxlanName}); err != nil {
@@ -201,18 +197,18 @@ func setupEVPNBridgeOnExternalFRR(ictx infraapi.Context, frrVTEPIPAddress, bridg
 			}
 		}
 
-		framework.Logf("EVPN bridge cleanup complete on %s", externalFRRContainerName)
+		framework.Logf("EVPN bridge cleanup complete on %s", frrContainerName)
 		return nil
 	})
 
-	framework.Logf("EVPN bridge setup complete on %s (%s + %s with local IP %s)", externalFRRContainerName, bridgeName, vxlanName, frrVTEPIPAddress)
+	framework.Logf("EVPN bridge setup complete on %s (%s + %s with local IP %s)", frrContainerName, bridgeName, vxlanName, frrVTEPIPAddress)
 	return nil
 }
 
 // setupVNIVIDMappingsOnExternalFRR sets up VLAN/VNI mappings for the given
 // bridge and vxlan interfaces
-func setupVNIVIDMappingsOnExternalFRR(vni, vid int, bridgeName, vxlanName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupVNIVIDMappingsOnExternalFRR(frrContainerName string, vni, vid int, bridgeName, vxlanName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vidStr := fmt.Sprintf("%d", vid)
 	vniStr := fmt.Sprintf("%d", vni)
 	commands := [][]string{
@@ -231,14 +227,14 @@ func setupVNIVIDMappingsOnExternalFRR(vni, vid int, bridgeName, vxlanName string
 		}
 	}
 
-	framework.Logf("VLAN/VNI mappings setup complete on %s (VNI %d, VID %d)", externalFRRContainerName, vni, vid)
+	framework.Logf("VLAN/VNI mappings setup complete on %s (VNI %d, VID %d)", frrContainerName, vni, vid)
 	return nil
 }
 
 // setupSVIOnExternalFRR sets up a SVI on the provided VLAN and VLAN aware
 // bridge and optionally attaches it to a VRF
-func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupSVIOnExternalFRR(ictx infraapi.Context, frrContainerName string, vid int, bridgeName, vrfName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vidStr := fmt.Sprintf("%d", vid)
 	sviName := fmt.Sprintf("%s.%d", bridgeName, vid)
 
@@ -256,7 +252,7 @@ func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName s
 			return fmt.Errorf("failed to delete SVI %s: %v", sviName, err)
 		}
 
-		framework.Logf("SVI %s cleanup complete on %s (VID %d, VRF: %q)", sviName, externalFRRContainerName, vid, vrfName)
+		framework.Logf("SVI %s cleanup complete on %s (VID %d, VRF: %q)", sviName, frrContainerName, vid, vrfName)
 		return nil
 	})
 
@@ -283,7 +279,7 @@ func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName s
 		return fmt.Errorf("failed to bring up SVI %s: %w", sviName, err)
 	}
 
-	framework.Logf("SVI %s setup complete on %s (VID %d, VRF: %q)", sviName, externalFRRContainerName, vid, vrfName)
+	framework.Logf("SVI %s setup complete on %s (VID %d, VRF: %q)", sviName, frrContainerName, vid, vrfName)
 	return nil
 }
 
@@ -299,18 +295,18 @@ func setupSVIOnExternalFRR(ictx infraapi.Context, vid int, bridgeName, vrfName s
 //   - vid: VLAN ID for local bridging (e.g., 100)
 //   - bridgeName: name of the bridge device (e.g., "brevpn7a3f")
 //   - vxlanName: name of the VXLAN device (e.g., "vxevpn7a3f")
-func setupMACVRFOnExternalFRR(ictx infraapi.Context, vni, vid int, bridgeName, vxlanName string) error {
-	err := setupVNIVIDMappingsOnExternalFRR(vni, vid, bridgeName, vxlanName)
+func setupMACVRFOnExternalFRR(ictx infraapi.Context, frrContainerName string, vni, vid int, bridgeName, vxlanName string) error {
+	err := setupVNIVIDMappingsOnExternalFRR(frrContainerName, vni, vid, bridgeName, vxlanName)
 	if err != nil {
 		return fmt.Errorf("failed to configure VLAN/VNI mapping on bridge %s: %w", bridgeName, err)
 	}
 
-	err = setupSVIOnExternalFRR(ictx, vid, bridgeName, "")
+	err = setupSVIOnExternalFRR(ictx, frrContainerName, vid, bridgeName, "")
 	if err != nil {
 		return fmt.Errorf("failed to configure SVI for VID %d: %w", vid, err)
 	}
 
-	framework.Logf("MAC-VRF setup complete on %s (VNI %d)", externalFRRContainerName, vni)
+	framework.Logf("MAC-VRF setup complete on %s (VNI %d)", frrContainerName, vni)
 	return nil
 }
 
@@ -328,8 +324,8 @@ func setupMACVRFOnExternalFRR(ictx infraapi.Context, vni, vid int, bridgeName, v
 //
 // Cleanup is automatically registered via ictx.AddCleanUpFn().
 // Note: VLAN/VNI mappings are cleaned up when bridgeName/vxlanName are deleted.
-func setupIPVRFOnExternalFRR(ictx infraapi.Context, vrfName string, vni, vid int, bridgeName, vxlanName string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupIPVRFOnExternalFRR(ictx infraapi.Context, frrContainerName, vrfName string, vni, vid int, bridgeName, vxlanName string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vniStr := fmt.Sprintf("%d", vni)
 
 	// Create Linux VRF with routing table = VNI
@@ -363,21 +359,21 @@ func setupIPVRFOnExternalFRR(ictx infraapi.Context, vrfName string, vni, vid int
 			return fmt.Errorf("failed to delete FRR VRF definition %s: %v", vrfName, err)
 		}
 
-		framework.Logf("IP-VRF cleanup complete on %s (VNI %d)", externalFRRContainerName, vni)
+		framework.Logf("IP-VRF cleanup complete on %s (VNI %d)", frrContainerName, vni)
 		return nil
 	})
 
-	err = setupVNIVIDMappingsOnExternalFRR(vni, vid, bridgeName, vxlanName)
+	err = setupVNIVIDMappingsOnExternalFRR(frrContainerName, vni, vid, bridgeName, vxlanName)
 	if err != nil {
 		return fmt.Errorf("failed to configure VLAN/VNI mapping on bridge %s: %w", bridgeName, err)
 	}
 
-	err = setupSVIOnExternalFRR(ictx, vid, bridgeName, vrfName)
+	err = setupSVIOnExternalFRR(ictx, frrContainerName, vid, bridgeName, vrfName)
 	if err != nil {
 		return fmt.Errorf("failed to configure SVI for VID %d: %w", vid, err)
 	}
 
-	framework.Logf("IP-VRF setup complete on %s (VNI %d)", externalFRRContainerName, vni)
+	framework.Logf("IP-VRF setup complete on %s (VNI %d)", frrContainerName, vni)
 	return nil
 }
 
@@ -399,18 +395,22 @@ func vtyshCommand(args ...string) []string {
 // with ENABLE_EVPN.
 //
 // Parameters:
-//   - asn: BGP Autonomous System Number (e.g., 64512)
+//   - frrContainerName: Name of the external FRR container (e.g., "frr" or "frr-ebgp")
+//   - asn: BGP Autonomous System Number of the external FRR (e.g., 64512 for iBGP, 64513 for eBGP)
 //   - neighborIPs: List of cluster node IPs to peer with
+//   - isIBGP: Whether this is an iBGP session (determines if route-reflector-client is configured)
 //
 // No cleanup is registered: these are shared cluster-level settings that must persist
 // across all parallel EVPN tests.
-func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, asn int, neighborIPs []string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, frrContainerName string, asn int, neighborIPs []string, isIBGP bool) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 	args := []string{"configure terminal", fmt.Sprintf("router bgp %d", asn), "address-family l2vpn evpn", "advertise-all-vni"}
 	for _, ip := range neighborIPs {
 		args = append(args, fmt.Sprintf("neighbor %s activate", ip))
-		args = append(args, fmt.Sprintf("neighbor %s route-reflector-client", ip))
+		if isIBGP {
+			args = append(args, fmt.Sprintf("neighbor %s route-reflector-client", ip))
+		}
 	}
 	args = append(args, "exit-address-family", "end")
 
@@ -426,11 +426,11 @@ func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, asn int, neighborIPs []str
 	// and must persist for the duration of the test suite.
 	// IP-VRF per-VRF BGP config is cleaned up by setupIPVRFBGPOnExternalFRR.
 	ictx.AddCleanUpFn(func() error {
-		framework.Logf("EVPN BGP cleanup complete on %s (no-op: global BGP settings are shared infrastructure)", externalFRRContainerName)
+		framework.Logf("EVPN BGP cleanup complete on %s (no-op: global BGP settings are shared infrastructure)", frrContainerName)
 		return nil
 	})
 
-	framework.Logf("EVPN BGP setup complete on %s (ASN %d, neighbors: %v)", externalFRRContainerName, asn, neighborIPs)
+	framework.Logf("EVPN BGP setup complete on %s (ASN %d, neighbors: %v, iBGP: %v)", frrContainerName, asn, neighborIPs, isIBGP)
 	return nil
 }
 
@@ -441,16 +441,19 @@ func setupEVPNBGPOnExternalFRR(ictx infraapi.Context, asn int, neighborIPs []str
 //
 // Parameters:
 //   - vrfName: Name of the Linux VRF (must match the VRF created by setupIPVRFOnExternalFRR)
-//   - asn: BGP ASN (e.g., 64512). Must match the cluster's frr-k8s ASN and the global EVPN
-//     BGP instance. Used for both the VRF BGP instance and the Route Distinguisher/Route Target.
+//   - asn: BGP ASN of this external FRR instance (e.g., 64512 for iBGP, 64513 for eBGP).
+//     Used for the VRF BGP instance (`router bgp <asn> vrf <vrfName>`).
+//   - rtASN: ASN component of Route Distinguisher and Route Target (RT = rtASN:VNI).
+//     The cluster-side setup script always uses the cluster's own ASN for RTs,
+//     so rtASN must always be the cluster's ASN to keep both sides in sync.
 //   - vni: VXLAN Network Identifier for route-target (e.g., 20102)
 //   - ipFamilies: IP families to configure (e.g., sets.New(utilnet.IPv4) or sets.New(utilnet.IPv4, utilnet.IPv6))
 //   - subnets: Subnets to advertise via BGP (e.g., []string{"172.27.102.0/24"} or {"172.27.102.0/24", "fd00:102::/64"})
 //
 // Cleanup is automatically registered via ictx.AddCleanUpFn().
-func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, vrfName string, asn, vni int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) error {
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
-	rt := fmt.Sprintf("%d:%d", asn, vni)
+func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, frrContainerName, vrfName string, asn, rtASN, vni int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) error {
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
+	rt := fmt.Sprintf("%d:%d", rtASN, vni)
 
 	// Build vtysh args
 	args := []string{
@@ -501,20 +504,20 @@ func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, vrfName string, asn, vni 
 	// the Linux VRF device, which triggers FRR to auto-cleanup the VRF config. In that case,
 	// these commands may fail - that's OK, we just log warnings and won't retry that.
 	ictx.AddCleanUpFn(func() error {
-		frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+		frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 		_, err := infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(
 			"configure terminal", fmt.Sprintf("vrf %s", vrfName), fmt.Sprintf("no vni %d", vni), "exit-vrf", "end",
 		))
 		if err != nil {
-			return fmt.Errorf("failed to remove VNI binding (may already be cleaned up): %v", err)
+			framework.Logf("Warning: failed to remove VNI binding (may already be cleaned up): %v", err)
 		}
 
 		_, err = infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(
 			"configure terminal", fmt.Sprintf("no router bgp %d vrf %s", asn, vrfName), "end",
 		))
 		if err != nil {
-			return fmt.Errorf("failed to remove BGP VRF (may already be cleaned up): %v", err)
+			framework.Logf("Warning: failed to remove BGP VRF (may already be cleaned up): %v", err)
 		}
 
 		// NOTE: We intentionally do NOT run "no vrf" here.
@@ -523,11 +526,11 @@ func setupIPVRFBGPOnExternalFRR(ictx infraapi.Context, vrfName string, asn, vni 
 		// Trying to delete the FRR VRF while the Linux VRF still has interfaces
 		// attached causes "Only inactive VRFs can be deleted" errors.
 
-		framework.Logf("IP-VRF BGP cleanup complete on %s (VRF %s)", externalFRRContainerName, vrfName)
+		framework.Logf("IP-VRF BGP cleanup complete on %s (VRF %s)", frrContainerName, vrfName)
 		return nil
 	})
 
-	framework.Logf("IP-VRF BGP setup complete on %s (VRF %s, ASN %d, VNI %d, RT %s, families %v)", externalFRRContainerName, vrfName, asn, vni, rt, ipFamilies.UnsortedList())
+	framework.Logf("IP-VRF BGP setup complete on %s (VRF %s, ASN %d, VNI %d, RT %s, families %v)", frrContainerName, vrfName, asn, vni, rt, ipFamilies.UnsortedList())
 	return nil
 }
 
@@ -559,8 +562,9 @@ type evpnContainerInfo struct {
 //   - container: ExternalContainer spec (Name, Image, CmdArgs, and optionally IPv4/IPv6 for static IPs)
 //   - networkName: Name for the Docker network (e.g., "macvrf-net-100", "ipvrf-net-202")
 //   - ipFamilies: Cluster IP family support, used to filter discovered IPs
+//   - frrContainerName: name of the external FRR container to attach to the Docker network
 //   - subnets: Subnets for the Docker network (e.g., "10.100.0.0/16" for IPv4, or both for dual-stack)
-func createEVPNExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName string, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
+func createEVPNExternalContainer(ictx infraapi.Context, frrContainerName string, container infraapi.ExternalContainer, networkName string, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
 	// Step 1: Create Docker network with specific subnet(s)
 	network, err := ictx.CreateNetwork(networkName, subnets...)
 	if err != nil {
@@ -576,7 +580,7 @@ func createEVPNExternalContainer(ictx infraapi.Context, container infraapi.Exter
 	}
 
 	// Step 3: Connect FRR to the network
-	_, err = ictx.AttachNetwork(network, externalFRRContainerName)
+	_, err = ictx.AttachNetwork(network, frrContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect FRR to network %s: %w", networkName, err)
 	}
@@ -589,7 +593,7 @@ func createEVPNExternalContainer(ictx infraapi.Context, container infraapi.Exter
 	}
 
 	frrNetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-		infraapi.ExternalContainer{Name: externalFRRContainerName}, network)
+		infraapi.ExternalContainer{Name: frrContainerName}, network)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get FRR network interface: %w", err)
 	}
@@ -681,7 +685,7 @@ func getMACVRFAgnhostIPsFromSubnets(subnets []string) ([]string, error) {
 //     afterward to match the CUDN subnets. This is needed when two MAC-VRF agnhosts
 //     share the same CUDN subnet because Docker rejects overlapping subnets. The Docker
 //     bridge still forwards L2 frames regardless of IP addressing.
-func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName, bridgeName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string, useProxyDockerNetwork bool) (*evpnContainerInfo, error) {
+func setupMACVRFExternalContainer(ictx infraapi.Context, frrContainerName string, container infraapi.ExternalContainer, networkName, bridgeName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string, useProxyDockerNetwork bool) (*evpnContainerInfo, error) {
 	// Derive container IPs from CUDN subnets
 	containerIPs, err := getMACVRFAgnhostIPsFromSubnets(subnets)
 	if err != nil {
@@ -703,7 +707,7 @@ func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.Exte
 	if useProxyDockerNetwork {
 		dockerSubnets = nil
 	}
-	info, err = createEVPNExternalContainer(ictx, container, networkName, ipFamilies, dockerSubnets)
+	info, err = createEVPNExternalContainer(ictx, frrContainerName, container, networkName, ipFamilies, dockerSubnets)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +746,7 @@ func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.Exte
 	}
 
 	// Move FRR's interface to bridgeName and configure as access port
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 	vidStr := fmt.Sprintf("%d", vid)
 	sviName := fmt.Sprintf("%s.%d", bridgeName, vid)
 	frrCmds := [][]string{
@@ -792,8 +796,8 @@ func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.Exte
 //   - vrfName: Name of the VRF to put FRR's interface in (must match setupIPVRFOnExternalFRR)
 //   - ipFamilies: Cluster IP family support (e.g., sets.New(utilnet.IPv4, utilnet.IPv6))
 //   - subnets: Subnets for the Docker network (e.g., "172.27.102.0/24" for IPv4, or both for dual-stack)
-func setupIPVRFExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName, vrfName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets ...string) (*evpnContainerInfo, error) {
-	info, err := createEVPNExternalContainer(ictx, container, networkName, ipFamilies, subnets)
+func setupIPVRFExternalContainer(ictx infraapi.Context, frrContainerName string, container infraapi.ExternalContainer, networkName, vrfName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets ...string) (*evpnContainerInfo, error) {
+	info, err := createEVPNExternalContainer(ictx, frrContainerName, container, networkName, ipFamilies, subnets)
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +805,7 @@ func setupIPVRFExternalContainer(ictx infraapi.Context, container infraapi.Exter
 	// Put FRR's interface in the VRF
 	// NOTE: keep_addr_on_down=1 is set at FRR container startup (in deploy_frr_external_container)
 	// to preserve IPv6 addresses during VRF assignment. See https://github.com/FRRouting/frr/issues/1666
-	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
+	frr := infraapi.ExternalContainer{Name: frrContainerName}
 
 	frrCmds := [][]string{
 		{"ip", "link", "set", info.frrInterface, "master", vrfName},
@@ -1082,12 +1086,12 @@ func subnetOffsetIP(cidr string, offset int) string {
 // FRRConfiguration Utilities
 // =============================================================================
 
-func getExternalFRRIP(ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
+func getExternalFRRIP(frrContainerName string, ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
 	kindNetwork, err := infraprovider.Get().PrimaryNetwork()
 	if err != nil {
 		return "", err
 	}
-	frrNetIf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: externalFRRContainerName}, kindNetwork)
+	frrNetIf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: frrContainerName}, kindNetwork)
 	if err != nil {
 		return "", err
 	}
@@ -1115,12 +1119,13 @@ func getExternalFRRIP(ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
 //   - ictx: Infrastructure context for cleanup registration
 //   - name: Name of the FRRConfiguration CR
 //   - namespace: Namespace for the FRRConfiguration (typically frr-k8s-system)
-//   - asn: BGP Autonomous System Number (e.g., 64512)
+//   - localASN: BGP ASN for cluster-side routers in this CR
+//   - neighborASN: BGP ASN of the external FRR neighbor
 //   - neighborIP: IP address of the external FRR to peer with
 //   - labels: Labels to apply to the FRRConfiguration (used by RouteAdvertisements selector)
 func createFRRConfiguration(ictx infraapi.Context,
 	name, namespace string,
-	asn int,
+	localASN, neighborASN int,
 	neighborIP string,
 	labels map[string]string) error {
 
@@ -1133,6 +1138,24 @@ func createFRRConfiguration(ictx infraapi.Context,
 	// Generate FRRConfiguration YAML
 	// No toReceive needed - EVPN routes come via l2vpn evpn address-family
 	// and are imported via route-target matching in the VRF
+	isEBGP := localASN != neighborASN
+	rawConfigSection := ""
+	if isEBGP {
+		// For eBGP EVPN, inter-node routes transit through the external FRR peer and
+		// arrive with the local ASN in the AS_PATH, which BGP rejects as a loop.
+		// allowas-in must be configured via rawConfig because the FRRConfiguration CRD
+		// does not expose this field, and direct vtysh injection gets overwritten when
+		// frr-k8s reconciles.
+		rawConfigSection = fmt.Sprintf(`  raw:
+    priority: 10
+    rawConfig: |
+      router bgp %d
+       address-family l2vpn evpn
+        neighbor %s allowas-in
+       exit-address-family
+      !
+`, localASN, neighborIP)
+	}
 	yaml := fmt.Sprintf(`apiVersion: frrk8s.metallb.io/v1beta1
 kind: FRRConfiguration
 metadata:
@@ -1147,7 +1170,7 @@ metadata:
       - address: %s
         asn: %d
         disableMP: true
-`, name, namespace, labelsYAML, asn, neighborIP, asn)
+%s`, name, namespace, labelsYAML, localASN, neighborIP, neighborASN, rawConfigSection)
 
 	// Write to temp file
 	tmpFile, err := os.CreateTemp("", "frrconfig-*.yaml")
@@ -1218,7 +1241,9 @@ func runEVPNNetworkAndServers(
 	ipFamilySet sets.Set[utilnet.IPFamily],
 	networkSpec *udnv1.NetworkSpec,
 	bgpAlloc allocators.BGPAllocation,
-	bgpASN int,
+	externalASN int,
+	clusterASN int,
+	frrContainerName string,
 	bridgeName string,
 	vxlanName string,
 	vtepName string,
@@ -1231,27 +1256,26 @@ func runEVPNNetworkAndServers(
 	// Derive what to setup from networkSpec
 	hasMACVRF := networkSpec.EVPN != nil && networkSpec.EVPN.MACVRF != nil
 	hasIPVRF := networkSpec.EVPN != nil && networkSpec.EVPN.IPVRF != nil
+	isIBGP := externalASN == clusterASN
 
 	ipVRFAgnhostSubnets := matchCIDRStringsByIPFamilySet([]string{bgpAlloc.IPVRFSubnet, bgpAlloc.IPVRFSubnet6}, ipFamilySet)
 	vtepSubnets := matchCIDRStringsByIPFamilySet([]string{bgpAlloc.VTEPSubnet, bgpAlloc.VTEPSubnet6}, ipFamilySet)
 
-	// Extract subnets from networkSpec for MAC-VRF agnhost IP derivation
 	cudnSubnetsFromSpec := getNetworkSubnetsFromSpec(networkSpec)
 
-	externalFRRIP, err := getExternalFRRIP(ipFamilySet)
+	externalFRRIP, err := getExternalFRRIP(frrContainerName, ipFamilySet)
 	if err != nil {
 		return err
 	}
 
-	// attach BGP peer network to all nodes
 	nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list nodes: %w", err)
 	}
 	nodeIPs := e2enode.CollectAddresses(nodeList, corev1.NodeInternalIP)
 
-	framework.Logf("Setting up EVPN bridge on external FRR")
-	err = setupEVPNBridgeOnExternalFRR(ictx, externalFRRIP, bridgeName, vxlanName)
+	framework.Logf("Setting up EVPN bridge on external FRR (%s)", frrContainerName)
+	err = setupEVPNBridgeOnExternalFRR(ictx, frrContainerName, externalFRRIP, bridgeName, vxlanName)
 	if err != nil {
 		return err
 	}
@@ -1261,47 +1285,66 @@ func runEVPNNetworkAndServers(
 		macVRFVID = bgpAlloc.MACVRFVID
 		framework.Logf("Allocated VIDs for external FRR: MAC-VRF VID=%d", macVRFVID)
 		framework.Logf("Setting up MAC-VRF on external FRR")
-		err = setupMACVRFOnExternalFRR(ictx, int(networkSpec.EVPN.MACVRF.VNI), macVRFVID, bridgeName, vxlanName)
+		err = setupMACVRFOnExternalFRR(ictx, frrContainerName, int(networkSpec.EVPN.MACVRF.VNI), macVRFVID, bridgeName, vxlanName)
 		if err != nil {
 			return err
 		}
 
 		framework.Logf("Creating MAC-VRF external container")
-		macVRFInfo, err := setupMACVRFExternalContainer(ictx, *macVRFContainer, macVRFNetworkName, bridgeName, macVRFVID, ipFamilySet, cudnSubnetsFromSpec, macVRFUseProxyDockerNetwork)
+		macVRFInfo, err := setupMACVRFExternalContainer(ictx, frrContainerName, *macVRFContainer, macVRFNetworkName, bridgeName, macVRFVID, ipFamilySet, cudnSubnetsFromSpec, macVRFUseProxyDockerNetwork)
 		if err != nil {
 			return err
 		}
 		populateExternalContainerIPs(macVRFContainer, macVRFInfo)
 	}
 
-	framework.Logf("Setting up EVPN BGP on external FRR")
-	err = setupEVPNBGPOnExternalFRR(ictx, bgpASN, nodeIPs)
+	framework.Logf("Setting up EVPN BGP on external FRR (%s)", frrContainerName)
+	err = setupEVPNBGPOnExternalFRR(ictx, frrContainerName, externalASN, nodeIPs, isIBGP)
 	if err != nil {
 		return err
 	}
 
+	if hasMACVRF && !isIBGP {
+		macVRFVNI := int(networkSpec.EVPN.MACVRF.VNI)
+		rt := fmt.Sprintf("%d:%d", clusterASN, macVRFVNI)
+		framework.Logf("Overriding MAC-VRF VNI %d RT on external FRR to %s (eBGP RT alignment)", macVRFVNI, rt)
+		frr := infraapi.ExternalContainer{Name: frrContainerName}
+		_, err = infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(
+			"configure terminal",
+			fmt.Sprintf("router bgp %d", externalASN),
+			"address-family l2vpn evpn",
+			fmt.Sprintf("vni %d", macVRFVNI),
+			fmt.Sprintf("rd %s", rt),
+			fmt.Sprintf("route-target import %s", rt),
+			fmt.Sprintf("route-target export %s", rt),
+			"exit-vni",
+			"exit-address-family",
+			"end",
+		))
+		if err != nil {
+			return fmt.Errorf("failed to set explicit MAC-VRF RT for eBGP: %w", err)
+		}
+	}
+
 	if hasIPVRF {
-		// Derive VRF name from VNI (unique per IP-VRF)
 		ipVRFName := fmt.Sprintf("vrf%d", networkSpec.EVPN.IPVRF.VNI)
 		ipVRFVID := bgpAlloc.IPVRFVID
 		framework.Logf("Allocated VIDs for external FRR: IP-VRF VID=%d", ipVRFVID)
 		framework.Logf("Setting up IP-VRF on external FRR")
-		err = setupIPVRFOnExternalFRR(ictx, ipVRFName, int(networkSpec.EVPN.IPVRF.VNI), ipVRFVID, bridgeName, vxlanName)
+		err = setupIPVRFOnExternalFRR(ictx, frrContainerName, ipVRFName, int(networkSpec.EVPN.IPVRF.VNI), ipVRFVID, bridgeName, vxlanName)
 		if err != nil {
 			return err
 		}
 
 		framework.Logf("Creating IP-VRF external container")
-		ipVRFInfo, err := setupIPVRFExternalContainer(ictx, *ipVRFContainer, ipVRFNetworkName, ipVRFName, ipVRFVID, ipFamilySet, ipVRFAgnhostSubnets...)
+		ipVRFInfo, err := setupIPVRFExternalContainer(ictx, frrContainerName, *ipVRFContainer, ipVRFNetworkName, ipVRFName, ipVRFVID, ipFamilySet, ipVRFAgnhostSubnets...)
 		if err != nil {
 			return err
 		}
 		populateExternalContainerIPs(ipVRFContainer, ipVRFInfo)
 
-		// Configure BGP AFTER agnhost so FRR's interface is in the VRF
-		// and has a connected route for the subnet we want to advertise
 		framework.Logf("Setting up IP-VRF BGP on external FRR")
-		err = setupIPVRFBGPOnExternalFRR(ictx, ipVRFName, bgpASN, int(networkSpec.EVPN.IPVRF.VNI), ipFamilySet, ipVRFAgnhostSubnets)
+		err = setupIPVRFBGPOnExternalFRR(ictx, frrContainerName, ipVRFName, externalASN, clusterASN, int(networkSpec.EVPN.IPVRF.VNI), ipFamilySet, ipVRFAgnhostSubnets)
 		if err != nil {
 			return err
 		}
@@ -1325,12 +1368,11 @@ func runEVPNNetworkAndServers(
 		return fmt.Errorf("VTEP %s did not become healthy: %w", vtepName, err)
 	}
 
-	// Update VTEP name in network spec
 	networkSpec.EVPN.VTEP = vtepName
 
 	framework.Logf("Creating FRRConfiguration for EVPN")
 	frrConfigLabels := map[string]string{"network": testName}
-	err = createFRRConfiguration(ictx, testName, deploymentconfig.Get().FRRK8sNamespace(), bgpASN, externalFRRIP, frrConfigLabels)
+	err = createFRRConfiguration(ictx, testName, deploymentconfig.Get().FRRK8sNamespace(), clusterASN, externalASN, externalFRRIP, frrConfigLabels)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1935,17 +1935,19 @@ write_files:
 				}
 
 				By("Setting up EVPN infrastructure and external containers")
-				Expect(runEVPNNetworkAndServers(
-					fr,
-					providerCtx,
-					shortName,
-					ipFamilies,
-					&cudn.Spec.Network,
-					bgpAlloc,
-					bgpASN,
-					"br"+shortName,
-					"vx"+shortName,
-					sharedNodeIPsVTEPName,
+			Expect(runEVPNNetworkAndServers(
+				fr,
+				providerCtx,
+				shortName,
+				ipFamilies,
+				&cudn.Spec.Network,
+				bgpAlloc,
+				bgpASN,
+				bgpASN,
+				"frr",
+				"br"+shortName,
+				"vx"+shortName,
+				sharedNodeIPsVTEPName,
 					&externalMACVRFContainer,
 					externalMACVRFContainer.Name,
 					&externalContainer,

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1935,19 +1935,19 @@ write_files:
 				}
 
 				By("Setting up EVPN infrastructure and external containers")
-			Expect(runEVPNNetworkAndServers(
-				fr,
-				providerCtx,
-				shortName,
-				ipFamilies,
-				&cudn.Spec.Network,
-				bgpAlloc,
-				bgpASN,
-				bgpASN,
-				"frr",
-				"br"+shortName,
-				"vx"+shortName,
-				sharedNodeIPsVTEPName,
+				Expect(runEVPNNetworkAndServers(
+					fr,
+					providerCtx,
+					shortName,
+					ipFamilies,
+					&cudn.Spec.Network,
+					bgpAlloc,
+					bgpASN,
+					bgpASN,
+					routerContainerName,
+					"br"+shortName,
+					"vx"+shortName,
+					sharedNodeIPsVTEPName,
 					&externalMACVRFContainer,
 					externalMACVRFContainer.Name,
 					&externalContainer,

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1790,19 +1790,19 @@ write_files:
 				}
 
 				By("Setting up EVPN infrastructure and external containers")
-			Expect(runEVPNNetworkAndServers(
-				fr,
-				providerCtx,
-				shortName,
-				ipFamilies,
-				&cudn.Spec.Network,
-				bgpAlloc,
-				bgpASN,
-				bgpASN,
-				"frr",
-				"br"+shortName,
-				"vx"+shortName,
-				sharedNodeIPsVTEPName,
+				Expect(runEVPNNetworkAndServers(
+					fr,
+					providerCtx,
+					shortName,
+					ipFamilies,
+					&cudn.Spec.Network,
+					bgpAlloc,
+					bgpASN,
+					bgpASN,
+					routerContainerName,
+					"br"+shortName,
+					"vx"+shortName,
+					sharedNodeIPsVTEPName,
 					&externalMACVRFContainer,
 					externalMACVRFContainer.Name,
 					&externalContainer,

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1790,17 +1790,19 @@ write_files:
 				}
 
 				By("Setting up EVPN infrastructure and external containers")
-				Expect(runEVPNNetworkAndServers(
-					fr,
-					providerCtx,
-					shortName,
-					ipFamilies,
-					&cudn.Spec.Network,
-					bgpAlloc,
-					bgpASN,
-					"br"+shortName,
-					"vx"+shortName,
-					sharedNodeIPsVTEPName,
+			Expect(runEVPNNetworkAndServers(
+				fr,
+				providerCtx,
+				shortName,
+				ipFamilies,
+				&cudn.Spec.Network,
+				bgpAlloc,
+				bgpASN,
+				bgpASN,
+				"frr",
+				"br"+shortName,
+				"vx"+shortName,
+				sharedNodeIPsVTEPName,
 					&externalMACVRFContainer,
 					externalMACVRFContainer.Name,
 					&externalContainer,

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -5,8 +5,8 @@ package e2e
 
 import (
 	"context"
-	"embed"
 	"encoding/json"
+	"embed"
 	"fmt"
 	"math/rand"
 	"net"
@@ -63,6 +63,46 @@ const (
 	echoClientPodName      = "echo-client-pod"
 	bgpExternalNetworkName = "bgpnet"
 	netexecPort            = 8080
+
+	serverContainerNameEBGP    = "bgpserver-ebgp"
+	routerContainerNameEBGP    = "frr-ebgp"
+	bgpExternalNetworkNameEBGP = "bgpnet-ebgp"
+
+	bgpClusterASN = 64512
+	bgpEBGPASN    = 64513
+)
+
+// bgpPeeringConfig holds the BGP peering parameters that differ between iBGP
+// and eBGP modes. For iBGP, externalASN equals clusterASN. For eBGP, they
+// differ and route-reflector-client is not used.
+type bgpPeeringConfig struct {
+	externalASN     int
+	clusterASN      int
+	routerContainer string
+	serverContainer string
+	externalNetwork string
+}
+
+var (
+	ibgpPeering = bgpPeeringConfig{
+		externalASN:     bgpClusterASN,
+		clusterASN:      bgpClusterASN,
+		routerContainer: routerContainerName,
+		serverContainer: serverContainerName,
+		externalNetwork: bgpExternalNetworkName,
+	}
+	ebgpPeering = bgpPeeringConfig{
+		externalASN:     bgpEBGPASN,
+		clusterASN:      bgpClusterASN,
+		routerContainer: routerContainerNameEBGP,
+		serverContainer: serverContainerNameEBGP,
+		externalNetwork: bgpExternalNetworkNameEBGP,
+	}
+
+	bgpPeeringModes = []ginkgo.TableEntry{
+		ginkgo.Entry("iBGP", ibgpPeering),
+		ginkgo.Entry("eBGP", ebgpPeering),
+	}
 )
 
 func init() {
@@ -72,1077 +112,1066 @@ func init() {
 }
 
 var _ = ginkgo.Describe("BGP: When default podNetwork is advertised", feature.RouteAdvertisements, func() {
-	var serverContainerIPs []string
-	var frrContainerIPv4, frrContainerIPv6 string
-	var nodes *corev1.NodeList
 	f := wrappedTestFramework("pod2external-route-advertisements")
 
-	ginkgo.BeforeEach(func() {
-		serverContainerIPs = getBGPServerContainerIPs(f)
-		framework.Logf("The external server IPs are: %+v", serverContainerIPs)
-		providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
-		framework.ExpectNoError(err, "provider primary network must be available")
-		externalContainerNetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: routerContainerName}, providerPrimaryNetwork)
-		framework.ExpectNoError(err, "external container %s network %s information must be available", routerContainerName, providerPrimaryNetwork.Name())
-		frrContainerIPv4, frrContainerIPv6 = externalContainerNetInf.IPv4, externalContainerNetInf.IPv6
-		framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
-	})
+	ginkgo.DescribeTableSubtree("with underlay BGP in mode",
+		func(peering bgpPeeringConfig) {
+			var serverContainerIPs []string
+			var frrContainerIPv4, frrContainerIPv6 string
+			var nodes *corev1.NodeList
 
-	ginkgo.When("a client ovnk pod is created", func() {
+			ginkgo.BeforeEach(func() {
+				serverContainerIPs = getBGPServerContainerIPsFor(f, peering.serverContainer, peering.externalNetwork)
+				framework.Logf("The external server IPs are: %+v", serverContainerIPs)
+				providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
+				framework.ExpectNoError(err, "provider primary network must be available")
+				externalContainerNetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: peering.routerContainer}, providerPrimaryNetwork)
+				framework.ExpectNoError(err, "external container %s network %s information must be available", peering.routerContainer, providerPrimaryNetwork.Name())
+				frrContainerIPv4, frrContainerIPv6 = externalContainerNetInf.IPv4, externalContainerNetInf.IPv6
+				framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
+			})
 
-		var clientPod, hostNetworkedPod *corev1.Pod
-		var clientPodNodeName string
-		var err error
+			ginkgo.When("a client ovnk pod is created", func() {
 
-		ginkgo.BeforeEach(func() {
-			if !isDefaultNetworkAdvertised() {
-				e2eskipper.Skipf(
-					"skipping pod to external server tests when podNetwork is not advertised",
-				)
-			}
-			ginkgo.By("Selecting 3 schedulable nodes")
-			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
+				var clientPod, hostNetworkedPod *corev1.Pod
+				var clientPodNodeName string
+				var err error
 
-			ginkgo.By("Selecting node for client pod")
-			clientPodNodeName = nodes.Items[1].Name
-
-			ginkgo.By("Creating client pod")
-			clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
-			clientPod.Spec.NodeName = clientPodNodeName
-			for k := range clientPod.Spec.Containers {
-				if clientPod.Spec.Containers[k].Name == "agnhost-container" {
-					clientPod.Spec.Containers[k].Command = []string{
-						"sleep",
-						"infinity",
+				ginkgo.BeforeEach(func() {
+					if !isDefaultNetworkAdvertised() {
+						e2eskipper.Skipf(
+							"skipping pod to external server tests when podNetwork is not advertised",
+						)
 					}
-				}
-			}
-			e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
-
-			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
-		})
-		// -----------------               ------------------                         ---------------------
-		// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
-		// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
-		// |    server     |               |                |                         |    ovn-worker     |   (client pod advertised
-		// -----------------               ------------------                         ---------------------    using RouteAdvertisements
-		//                                                                            |    ovn-worker2    |    from default pod network)
-		//                                                                            ---------------------
-		// The client pod inside the KIND cluster on the default network exposed using default network Router
-		// Advertisement will curl the external server container sitting outside the cluster via a FRR router
-		// This test ensures the north-south connectivity is happening through podIP
-		ginkgo.It("tests are run towards the external agnhost echo server", func() {
-			ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
-			bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-			framework.ExpectNoError(err, "network %s must be available and precreated before test run", bgpExternalNetworkName)
-			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
-			framework.ExpectNoError(err, "must get bgpnet subnets")
-			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			for _, node := range nodes.Items {
-				if isIPv4Supported(f.ClientSet) {
-					ipVer := ""
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrContainerIPv4)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-				if isIPv6Supported(f.ClientSet) {
-					ipVer := " -6"
-					nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
+					ginkgo.By("Selecting 3 schedulable nodes")
+					nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, nodeIPv6LLA)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-			}
+					gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
 
-			ginkgo.By("routes to the default pod network are advertised to external frr router")
-			// Get the first element in the advertisements array (assuming you want to check the first one)
-			gomega.Eventually(func() string {
-				podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
-				if err != nil {
-					return ""
-				}
-				return podNetworkValue
-			}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
+					ginkgo.By("Selecting node for client pod")
+					clientPodNodeName = nodes.Items[1].Name
 
-			gomega.Eventually(func() string {
-				reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
-				if err != nil {
-					return ""
-				}
-				return reason
-			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
-
-			ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
-			// sample
-			//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
-			//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
-			//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
-			for _, serverContainerIP := range serverContainerIPs {
-				for _, node := range nodes.Items {
-					checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.DefaultNetworkName)
-				}
-			}
-
-			var expectedV4IP, expectedV6IP string
-			snatEnabled := isNoOverlayOutboundSNATEnabled(f)
-
-			if snatEnabled {
-				ginkgo.By("queries to the external server are SNATed (uses node IP)")
-				// Get the node where the client pod is running
-				clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPodNodeName, metav1.GetOptions{})
-				framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPodNodeName, err))
-
-				// Get node IPs
-				nodeV4Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				nodeV6Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				if len(nodeV4Addrs) > 0 {
-					expectedV4IP = nodeV4Addrs[0]
-				}
-				if len(nodeV6Addrs) > 0 {
-					expectedV6IP = nodeV6Addrs[0]
-				}
-				framework.Logf("Client pod node IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
-			} else {
-				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
-				podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
-				framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-				expectedV4IP = podv4IP
-				expectedV6IP = podv6IP
-				framework.Logf("Client pod IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
-			}
-			for _, serverContainerIP := range serverContainerIPs {
-				ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
-					"and expecting to receive the same payload", serverContainerIP))
-				cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
-					net.JoinHostPort(serverContainerIP, "8080"),
-				)
-				framework.Logf("Testing pod to external traffic with command %q", cmd)
-				stdout, err := e2epodoutput.RunHostCmdWithRetries(
-					clientPod.Namespace,
-					clientPod.Name,
-					cmd,
-					framework.Poll,
-					60*time.Second)
-				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-				expectedIP := expectedV4IP
-				if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-					expectedIP = expectedV6IP
-					// For IPv6 addresses, need to handle the brackets in the output
-					outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-					gomega.Expect(outputIP).To(gomega.Equal(expectedIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
-				} else {
-					// Original IPv4 handling
-					gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(expectedIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
-				}
-			}
-		})
-
-		ginkgo.It("can connect to an external server and another cluster node after toggling default network advertisement off and back on", ginkgo.Serial, func() {
-			ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
-			bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-			framework.ExpectNoError(err, "network %s must be available and precreated before test run", bgpExternalNetworkName)
-			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
-			framework.ExpectNoError(err, "must get bgpnet subnets")
-			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			for _, node := range nodes.Items {
-				if isIPv4Supported(f.ClientSet) {
-					ipVer := ""
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrContainerIPv4)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-				if isIPv6Supported(f.ClientSet) {
-					ipVer := " -6"
-					nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, nodeIPv6LLA)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-			}
-
-			ginkgo.By("routes to the default pod network are advertised to external frr router")
-			// Get the first element in the advertisements array (assuming you want to check the first one)
-			gomega.Eventually(func() string {
-				podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
-				if err != nil {
-					return ""
-				}
-				return podNetworkValue
-			}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
-
-			gomega.Eventually(func() string {
-				reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
-				if err != nil {
-					return ""
-				}
-				return reason
-			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
-
-			ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
-			// sample
-			//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
-			//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
-			//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
-			for _, serverContainerIP := range serverContainerIPs {
-				for _, node := range nodes.Items {
-					checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.DefaultNetworkName)
-				}
-			}
-
-			// Get client pod IPs and its host's nodeIPs, get the nodeIPs for the node where the host networked pod is running
-			var clientPodIPs, clientPodNodeIPs, hostNetworkedPodNodeIPs []string
-
-			podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
-			framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-			framework.Logf("Client pod IP address v4=%s, v6=%s", podv4IP, podv6IP)
-			if podv4IP != "" {
-				clientPodIPs = append(clientPodIPs, podv4IP)
-			}
-			if podv6IP != "" {
-				clientPodIPs = append(clientPodIPs, podv6IP)
-			}
-
-			clientNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-
-			// Get the nodeIPs for the node where the client pod is running
-			var nodeIPv4, nodeIPv6 string
-			if isIPv4Supported(f.ClientSet) {
-				v4Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				if len(v4Addrs) > 0 {
-					nodeIPv4 = v4Addrs[0]
-				}
-			}
-			if isIPv6Supported(f.ClientSet) {
-				v6Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				if len(v6Addrs) > 0 {
-					nodeIPv6 = v6Addrs[0]
-				}
-			}
-			if nodeIPv4 != "" {
-				clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv4)
-			}
-			if nodeIPv6 != "" {
-				clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv6)
-			}
-			framework.Logf("clientPodNodeIPs: %v", clientPodNodeIPs)
-
-			ginkgo.By("Creating a host networked pod on a second node")
-			// Add labels so the service can select this pod
-			podLabels := map[string]string{
-				"app": "internal-server-pod",
-			}
-
-			// Create host networked pod on another cluster node using createPod function
-			// Use a random high port to avoid collisions on the host
-			min, max := 25000, 25999
-			hostNetPort := rand.Intn(max-min+1) + min
-			framework.Logf("host-networked netexec port: %d", hostNetPort)
-			hostNetworkedPod, err = createPod(f, "internal-server-pod", nodes.Items[2].Name, f.Namespace.Name,
-				[]string{}, podLabels, func(p *corev1.Pod) {
-					// Set host networking
-					p.Spec.HostNetwork = true
-					// Run netexec on the chosen port
-					p.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", hostNetPort)}
-
-					// Add required security context to comply with PodSecurity "restricted" policy
-					for i := range p.Spec.Containers {
-						if p.Spec.Containers[i].SecurityContext == nil {
-							p.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{}
+					ginkgo.By("Creating client pod")
+					clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
+					clientPod.Spec.NodeName = clientPodNodeName
+					for k := range clientPod.Spec.Containers {
+						if clientPod.Spec.Containers[k].Name == "agnhost-container" {
+							clientPod.Spec.Containers[k].Command = []string{
+								"sleep",
+								"infinity",
+							}
 						}
+					}
+					e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
 
-						// Set required security context fields
-						p.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
-						p.Spec.Containers[i].SecurityContext.RunAsNonRoot = ptr.To(true)
-						p.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To(int64(1000))
-						p.Spec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
+					gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
+				})
+				// -----------------               ------------------                         ---------------------
+				// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
+				// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
+				// |    server     |               |                |                         |    ovn-worker     |   (client pod advertised
+				// -----------------               ------------------                         ---------------------    using RouteAdvertisements
+				//                                                                            |    ovn-worker2    |    from default pod network)
+				//                                                                            ---------------------
+				// The client pod inside the KIND cluster on the default network exposed using default network Router
+				// Advertisement will curl the external server container sitting outside the cluster via a FRR router
+				// This test ensures the north-south connectivity is happening through podIP
+				ginkgo.It("tests are run towards the external agnhost echo server", func() {
+					ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
+					bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork)
+					framework.ExpectNoError(err, "network %s must be available and precreated before test run", peering.externalNetwork)
+					externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
+					framework.ExpectNoError(err, "must get bgpnet subnets")
+					framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
+					for _, node := range nodes.Items {
+						if isIPv4Supported(f.ClientSet) {
+							ipVer := ""
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, frrContainerIPv4)
+							}, 30*time.Second).Should(gomega.BeTrue())
 						}
-						p.Spec.Containers[i].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						if isIPv6Supported(f.ClientSet) {
+							ipVer := " -6"
+							nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(peering.routerContainer)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, nodeIPv6LLA)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+					}
+
+					ginkgo.By("routes to the default pod network are advertised to external frr router")
+					// Get the first element in the advertisements array (assuming you want to check the first one)
+					gomega.Eventually(func() string {
+						podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
+						if err != nil {
+							return ""
+						}
+						return podNetworkValue
+					}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
+
+					gomega.Eventually(func() string {
+						reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
+						if err != nil {
+							return ""
+						}
+						return reason
+					}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+					ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
+					// sample
+					//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
+					//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
+					//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
+					for _, serverContainerIP := range serverContainerIPs {
+						for _, node := range nodes.Items {
+							checkL3NodePodRoute(node, serverContainerIP, peering.routerContainer, types.DefaultNetworkName)
+						}
+					}
+
+					var expectedV4IP, expectedV6IP string
+					snatEnabled := isNoOverlayOutboundSNATEnabled(f)
+
+					if snatEnabled {
+						ginkgo.By("queries to the external server are SNATed (uses node IP)")
+						// Get the node where the client pod is running
+						clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPodNodeName, metav1.GetOptions{})
+						framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPodNodeName, err))
+
+						// Get node IPs
+						nodeV4Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						nodeV6Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						if len(nodeV4Addrs) > 0 {
+							expectedV4IP = nodeV4Addrs[0]
+						}
+						if len(nodeV6Addrs) > 0 {
+							expectedV6IP = nodeV6Addrs[0]
+						}
+						framework.Logf("Client pod node IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
+					} else {
+						ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+						podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
+						framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+						expectedV4IP = podv4IP
+						expectedV6IP = podv6IP
+						framework.Logf("Client pod IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
+					}
+					for _, serverContainerIP := range serverContainerIPs {
+						ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
+							"and expecting to receive the same payload", serverContainerIP))
+						cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
+							net.JoinHostPort(serverContainerIP, "8080"),
+						)
+						framework.Logf("Testing pod to external traffic with command %q", cmd)
+						stdout, err := e2epodoutput.RunHostCmdWithRetries(
+							clientPod.Namespace,
+							clientPod.Name,
+							cmd,
+							framework.Poll,
+							60*time.Second)
+						framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
+						expectedIP := expectedV4IP
+						if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+							expectedIP = expectedV6IP
+							// For IPv6 addresses, need to handle the brackets in the output
+							outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
+							gomega.Expect(outputIP).To(gomega.Equal(expectedIP),
+								fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+						} else {
+							// Original IPv4 handling
+							gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(expectedIP),
+								fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
 						}
 					}
 				})
-			framework.ExpectNoError(err)
 
-			hostNetworkedPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), hostNetworkedPod.Spec.NodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-
-			// reset before collecting for a different node
-			nodeIPv4, nodeIPv6 = "", ""
-
-			if isIPv4Supported(f.ClientSet) {
-				v4Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				if len(v4Addrs) > 0 {
-					nodeIPv4 = v4Addrs[0]
-				}
-			}
-			if isIPv6Supported(f.ClientSet) {
-				v6Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				if len(v6Addrs) > 0 {
-					nodeIPv6 = v6Addrs[0]
-				}
-			}
-			if nodeIPv4 != "" {
-				hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv4)
-			}
-			if nodeIPv6 != "" {
-				hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv6)
-			}
-			framework.Logf("hostNetworkedPodNodeIPs: %v", hostNetworkedPodNodeIPs)
-
-			// When SNAT is enabled, external traffic uses node IPs even when advertised
-			snatEnabled := isNoOverlayOutboundSNATEnabled(f)
-			expectedExternalSourceIPs := clientPodIPs
-			if snatEnabled {
-				expectedExternalSourceIPs = clientPodNodeIPs
-			}
-
-			if snatEnabled {
-				ginkgo.By("With default network being advertised, queries to the external server are SNATed (uses nodeIP)")
-			} else {
-				ginkgo.By("With default network being advertised, queries to the external server are not SNATed (uses podIP)")
-			}
-			gomega.Eventually(func() error {
-				for _, serverIP := range serverContainerIPs {
-					if serverIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(serverIP)
-					var expectedIP string
-					for _, srcIP := range expectedExternalSourceIPs {
-						if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
-							expectedIP = srcIP
-							break
+				ginkgo.It("can connect to an external server and another cluster node after toggling default network advertisement off and back on", ginkgo.Serial, func() {
+					ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
+					bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork)
+					framework.ExpectNoError(err, "network %s must be available and precreated before test run", peering.externalNetwork)
+					externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
+					framework.ExpectNoError(err, "must get bgpnet subnets")
+					framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
+					for _, node := range nodes.Items {
+						if isIPv4Supported(f.ClientSet) {
+							ipVer := ""
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, frrContainerIPv4)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+						if isIPv6Supported(f.ClientSet) {
+							ipVer := " -6"
+							nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(peering.routerContainer)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, nodeIPv6LLA)
+							}, 30*time.Second).Should(gomega.BeTrue())
 						}
 					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to external server test failed")
 
-			ginkgo.By("With default network being advertised, queries to the second node are SNATed (uses nodeIP)")
-			gomega.Eventually(func() error {
-				for _, nodeIP := range hostNetworkedPodNodeIPs {
-					if nodeIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(nodeIP)
-					var expectedIP string
-					for _, clientNodeIP := range clientPodNodeIPs {
-						if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-							expectedIP = clientNodeIP
-							break
+					ginkgo.By("routes to the default pod network are advertised to external frr router")
+					// Get the first element in the advertisements array (assuming you want to check the first one)
+					gomega.Eventually(func() string {
+						podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
+						if err != nil {
+							return ""
+						}
+						return podNetworkValue
+					}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
+
+					gomega.Eventually(func() string {
+						reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
+						if err != nil {
+							return ""
+						}
+						return reason
+					}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+					ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
+					// sample
+					//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
+					//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
+					//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
+					for _, serverContainerIP := range serverContainerIPs {
+						for _, node := range nodes.Items {
+							checkL3NodePodRoute(node, serverContainerIP, peering.routerContainer, types.DefaultNetworkName)
 						}
 					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to second node test failed")
 
-			// defer add default network RA back to restore to the original test setup
-			ra := &rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.DefaultNetwork,
+					// Get client pod IPs and its host's nodeIPs, get the nodeIPs for the node where the host networked pod is running
+					var clientPodIPs, clientPodNodeIPs, hostNetworkedPodNodeIPs []string
+
+					podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
+					framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+					framework.Logf("Client pod IP address v4=%s, v6=%s", podv4IP, podv6IP)
+					if podv4IP != "" {
+						clientPodIPs = append(clientPodIPs, podv4IP)
+					}
+					if podv6IP != "" {
+						clientPodIPs = append(clientPodIPs, podv6IP)
+					}
+
+					clientNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+
+					// Get the nodeIPs for the node where the client pod is running
+					var nodeIPv4, nodeIPv6 string
+					if isIPv4Supported(f.ClientSet) {
+						v4Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						if len(v4Addrs) > 0 {
+							nodeIPv4 = v4Addrs[0]
+						}
+					}
+					if isIPv6Supported(f.ClientSet) {
+						v6Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						if len(v6Addrs) > 0 {
+							nodeIPv6 = v6Addrs[0]
+						}
+					}
+					if nodeIPv4 != "" {
+						clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv4)
+					}
+					if nodeIPv6 != "" {
+						clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv6)
+					}
+					framework.Logf("clientPodNodeIPs: %v", clientPodNodeIPs)
+
+					ginkgo.By("Creating a host networked pod on a second node")
+					// Add labels so the service can select this pod
+					podLabels := map[string]string{
+						"app": "internal-server-pod",
+					}
+
+					// Create host networked pod on another cluster node using createPod function
+					// Use a random high port to avoid collisions on the host
+					min, max := 25000, 25999
+					hostNetPort := rand.Intn(max-min+1) + min
+					framework.Logf("host-networked netexec port: %d", hostNetPort)
+					hostNetworkedPod, err = createPod(f, "internal-server-pod", nodes.Items[2].Name, f.Namespace.Name,
+						[]string{}, podLabels, func(p *corev1.Pod) {
+							// Set host networking
+							p.Spec.HostNetwork = true
+							// Run netexec on the chosen port
+							p.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", hostNetPort)}
+
+							// Add required security context to comply with PodSecurity "restricted" policy
+							for i := range p.Spec.Containers {
+								if p.Spec.Containers[i].SecurityContext == nil {
+									p.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{}
+								}
+
+								// Set required security context fields
+								p.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+								p.Spec.Containers[i].SecurityContext.RunAsNonRoot = ptr.To(true)
+								p.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To(int64(1000))
+								p.Spec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								}
+								p.Spec.Containers[i].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								}
+							}
+						})
+					framework.ExpectNoError(err)
+
+					hostNetworkedPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), hostNetworkedPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+
+					// reset before collecting for a different node
+					nodeIPv4, nodeIPv6 = "", ""
+
+					if isIPv4Supported(f.ClientSet) {
+						v4Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						if len(v4Addrs) > 0 {
+							nodeIPv4 = v4Addrs[0]
+						}
+					}
+					if isIPv6Supported(f.ClientSet) {
+						v6Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						if len(v6Addrs) > 0 {
+							nodeIPv6 = v6Addrs[0]
+						}
+					}
+					if nodeIPv4 != "" {
+						hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv4)
+					}
+					if nodeIPv6 != "" {
+						hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv6)
+					}
+					framework.Logf("hostNetworkedPodNodeIPs: %v", hostNetworkedPodNodeIPs)
+
+					// When SNAT is enabled, external traffic uses node IPs even when advertised
+					snatEnabled := isNoOverlayOutboundSNATEnabled(f)
+					expectedExternalSourceIPs := clientPodIPs
+					if snatEnabled {
+						expectedExternalSourceIPs = clientPodNodeIPs
+					}
+
+					if snatEnabled {
+						ginkgo.By("With default network being advertised, queries to the external server are SNATed (uses nodeIP)")
+					} else {
+						ginkgo.By("With default network being advertised, queries to the external server are not SNATed (uses podIP)")
+					}
+					gomega.Eventually(func() error {
+						for _, serverIP := range serverContainerIPs {
+							if serverIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(serverIP)
+							var expectedIP string
+							for _, srcIP := range expectedExternalSourceIPs {
+								if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
+									expectedIP = srcIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to external server test failed")
+
+					ginkgo.By("With default network being advertised, queries to the second node are SNATed (uses nodeIP)")
+					gomega.Eventually(func() error {
+						for _, nodeIP := range hostNetworkedPodNodeIPs {
+							if nodeIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(nodeIP)
+							var expectedIP string
+							for _, clientNodeIP := range clientPodNodeIPs {
+								if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+									expectedIP = clientNodeIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to second node test failed")
+
+					// defer add default network RA back to restore to the original test setup
+					ra := &rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
 						},
-					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
-					},
-				},
-			}
-			raClient, err := raclientset.NewForConfig(f.ClientConfig())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.DefaultNetwork,
+								},
+							},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
+							},
+						},
+					}
+					raClient, err := raclientset.NewForConfig(f.ClientConfig())
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			defer func() {
-				ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					defer func() {
+						ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Wait for RouteAdvertisement to be accepted, but don't fail the test if it times out
-				// We'll handle the failure with AbortSuite instead
-				accepted := false
-				err = wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-					ra, err := raClient.K8sV1().RouteAdvertisements().Get(ctx, ra.Name, metav1.GetOptions{})
-					if err != nil {
-						return false, nil // Continue polling on error
-					}
-					condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
-					if condition == nil {
-						return false, nil // Continue polling if condition not found
-					}
-					if condition.Reason == "Accepted" {
-						accepted = true
-						return true, nil // Success - stop polling
-					}
-					return false, nil // Continue polling if not accepted yet
+						// Wait for RouteAdvertisement to be accepted, but don't fail the test if it times out
+						// We'll handle the failure with AbortSuite instead
+						accepted := false
+						err = wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+							ra, err := raClient.K8sV1().RouteAdvertisements().Get(ctx, ra.Name, metav1.GetOptions{})
+							if err != nil {
+								return false, nil // Continue polling on error
+							}
+							condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+							if condition == nil {
+								return false, nil // Continue polling if condition not found
+							}
+							if condition.Reason == "Accepted" {
+								accepted = true
+								return true, nil // Success - stop polling
+							}
+							return false, nil // Continue polling if not accepted yet
+						})
+						// Note: we ignore the error from PollImmediate since we handle timeout via the accepted variable
+
+						// Abort suite if default RA failed to reach Accepted state in defer restore
+						if !accepted {
+							ginkgo.AbortSuite("CRITICAL: Default route advertisement failed to reach Accepted state in defer cleanup - test environment is corrupted")
+						}
+
+						// repeat pod to external and pod to second node tests
+						if snatEnabled {
+							ginkgo.By("With default network being advertised again, queries to the external server are SNATed (uses nodeIP)")
+						} else {
+							ginkgo.By("With default network being advertised again, queries to the external server are not SNATed (uses podIP)")
+						}
+						gomega.Eventually(func() error {
+							for _, serverIP := range serverContainerIPs {
+								if serverIP == "" {
+									continue
+								}
+								isV6 := utilnet.IsIPv6String(serverIP)
+								var expectedIP string
+								for _, srcIP := range expectedExternalSourceIPs {
+									if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
+										expectedIP = srcIP
+										break
+									}
+								}
+								if expectedIP == "" {
+									continue
+								}
+								if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
+									return err
+								}
+							}
+							return nil
+						}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to external server test failed, test environment may be corrupted")
+
+						ginkgo.By("With default network being advertised again, queries to the second node are SNATed (uses nodeIP)")
+						gomega.Eventually(func() error {
+							for _, nodeIP := range hostNetworkedPodNodeIPs {
+								if nodeIP == "" {
+									continue
+								}
+								isV6 := utilnet.IsIPv6String(nodeIP)
+								var expectedIP string
+								for _, clientNodeIP := range clientPodNodeIPs {
+									if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+										expectedIP = clientNodeIP
+										break
+									}
+								}
+								if expectedIP == "" {
+									continue
+								}
+								if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
+									return err
+								}
+							}
+							return nil
+						}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to second node test failed, test environment may be corrupted")
+
+					}()
+
+					ginkgo.By("Delete route advertisement")
+					_, err = e2ekubectl.RunKubectl("", "delete", "ra", "default", "--ignore-not-found=true")
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					// Make sure default RA is deleted
+					_, err = e2ekubectl.RunKubectl("", "get", "ra", "default")
+					gomega.Expect(err).To(gomega.HaveOccurred())
+
+					ginkgo.By("After default network is toggled to unadvertised, run test towards the external agnhost echo server from client pod again, egressing packets should be SNATed to pod's host nodeIP")
+					gomega.Eventually(func() error {
+						for _, serverIP := range serverContainerIPs {
+							if serverIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(serverIP)
+							var expectedIP string
+							for _, clientNodeIP := range clientPodNodeIPs {
+								if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+									expectedIP = clientNodeIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to external server test failed")
+
+					ginkgo.By("After default network is toggled to unadvertised, run test towards the second node from client pod, egressing packets should be SNATed to pod's host nodeIP")
+					gomega.Eventually(func() error {
+						for _, nodeIP := range hostNetworkedPodNodeIPs {
+							if nodeIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(nodeIP)
+							var expectedIP string
+							for _, clientNodeIP := range clientPodNodeIPs {
+								if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+									expectedIP = clientNodeIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to second node test failed")
+
 				})
-				// Note: we ignore the error from PollImmediate since we handle timeout via the accepted variable
-
-				// Abort suite if default RA failed to reach Accepted state in defer restore
-				if !accepted {
-					ginkgo.AbortSuite("CRITICAL: Default route advertisement failed to reach Accepted state in defer cleanup - test environment is corrupted")
-				}
-
-				// repeat pod to external and pod to second node tests
-				if snatEnabled {
-					ginkgo.By("With default network being advertised again, queries to the external server are SNATed (uses nodeIP)")
-				} else {
-					ginkgo.By("With default network being advertised again, queries to the external server are not SNATed (uses podIP)")
-				}
-				gomega.Eventually(func() error {
-					for _, serverIP := range serverContainerIPs {
-						if serverIP == "" {
-							continue
-						}
-						isV6 := utilnet.IsIPv6String(serverIP)
-						var expectedIP string
-						for _, srcIP := range expectedExternalSourceIPs {
-							if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
-								expectedIP = srcIP
-								break
-							}
-						}
-						if expectedIP == "" {
-							continue
-						}
-						if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
-							return err
-						}
-					}
-					return nil
-				}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to external server test failed, test environment may be corrupted")
-
-				ginkgo.By("With default network being advertised again, queries to the second node are SNATed (uses nodeIP)")
-				gomega.Eventually(func() error {
-					for _, nodeIP := range hostNetworkedPodNodeIPs {
-						if nodeIP == "" {
-							continue
-						}
-						isV6 := utilnet.IsIPv6String(nodeIP)
-						var expectedIP string
-						for _, clientNodeIP := range clientPodNodeIPs {
-							if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-								expectedIP = clientNodeIP
-								break
-							}
-						}
-						if expectedIP == "" {
-							continue
-						}
-						if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
-							return err
-						}
-					}
-					return nil
-				}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to second node test failed, test environment may be corrupted")
-
-			}()
-
-			ginkgo.By("Delete route advertisement")
-			_, err = e2ekubectl.RunKubectl("", "delete", "ra", "default", "--ignore-not-found=true")
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Make sure default RA is deleted
-			_, err = e2ekubectl.RunKubectl("", "get", "ra", "default")
-			gomega.Expect(err).To(gomega.HaveOccurred())
-
-			ginkgo.By("After default network is toggled to unadvertised, run test towards the external agnhost echo server from client pod again, egressing packets should be SNATed to pod's host nodeIP")
-			gomega.Eventually(func() error {
-				for _, serverIP := range serverContainerIPs {
-					if serverIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(serverIP)
-					var expectedIP string
-					for _, clientNodeIP := range clientPodNodeIPs {
-						if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-							expectedIP = clientNodeIP
-							break
-						}
-					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to external server test failed")
-
-			ginkgo.By("After default network is toggled to unadvertised, run test towards the second node from client pod, egressing packets should be SNATed to pod's host nodeIP")
-			gomega.Eventually(func() error {
-				for _, nodeIP := range hostNetworkedPodNodeIPs {
-					if nodeIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(nodeIP)
-					var expectedIP string
-					for _, clientNodeIP := range clientPodNodeIPs {
-						if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-							expectedIP = clientNodeIP
-							break
-						}
-					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to second node test failed")
-
-		})
-	})
+			})
+		},
+		bgpPeeringModes,
+	)
 })
 
 var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advertised", feature.RouteAdvertisements, func() {
-	var serverContainerIPs []string
-	var frrContainerIPv4, frrContainerIPv6 string
-	var nodes *corev1.NodeList
-	var clientPod *corev1.Pod
-
 	f := wrappedTestFramework("pod2external-route-advertisements")
 	f.SkipNamespaceCreation = true
 
-	ginkgo.BeforeEach(func() {
-		var err error
-		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
-			"e2e-framework":           f.BaseName,
-			RequiredUDNNamespaceLabel: "",
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		f.Namespace = namespace
+	ginkgo.DescribeTableSubtree("with underlay BGP in mode",
+		func(peering bgpPeeringConfig) {
+			var serverContainerIPs []string
+			var frrContainerIPv4, frrContainerIPv6 string
+			var nodes *corev1.NodeList
+			var clientPod *corev1.Pod
 
-		serverContainerIPs = []string{}
+			ginkgo.BeforeEach(func() {
+				var err error
+				namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+					"e2e-framework":           f.BaseName,
+					RequiredUDNNamespaceLabel: "",
+				})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				f.Namespace = namespace
 
-		bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName) // pre-created network
-		framework.ExpectNoError(err, "must get bgpnet network")
-		bgpServer := infraapi.ExternalContainer{Name: serverContainerName}
-		networkInterface, err := infraprovider.Get().GetExternalContainerNetworkInterface(bgpServer, bgpNetwork)
-		framework.ExpectNoError(err, "container %s attached to network %s must contain network info", serverContainerName, bgpExternalNetworkName)
-		if isIPv4Supported(f.ClientSet) && len(networkInterface.IPv4) > 0 {
-			serverContainerIPs = append(serverContainerIPs, networkInterface.IPv4)
-		}
-		if isIPv6Supported(f.ClientSet) && len(networkInterface.IPv6) > 0 {
-			serverContainerIPs = append(serverContainerIPs, networkInterface.IPv6)
-		}
-		gomega.Expect(len(serverContainerIPs)).Should(gomega.BeNumerically(">", 0), "failed to find external container IPs")
-		framework.Logf("The external server IPs are: %+v", serverContainerIPs)
-		providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
-		framework.ExpectNoError(err, "provider primary network must be available")
-		frrContainer := infraapi.ExternalContainer{Name: routerContainerName}
-		networkInterface, err = infraprovider.Get().GetExternalContainerNetworkInterface(frrContainer, providerPrimaryNetwork)
-		framework.ExpectNoError(err, "container %s attached to network %s must contain network info", routerContainerName, providerPrimaryNetwork.Name())
-		frrContainerIPv4, frrContainerIPv6 = networkInterface.IPv4, networkInterface.IPv6
-		framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
+				serverContainerIPs = []string{}
 
-		// Select nodes here so they're available for all tests
-		ginkgo.By("Selecting 3 schedulable nodes")
-		nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
-	})
+				bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork) // pre-created network
+				framework.ExpectNoError(err, "must get bgpnet network")
+				bgpServer := infraapi.ExternalContainer{Name: peering.serverContainer}
+				networkInterface, err := infraprovider.Get().GetExternalContainerNetworkInterface(bgpServer, bgpNetwork)
+				framework.ExpectNoError(err, "container %s attached to network %s must contain network info", peering.serverContainer, peering.externalNetwork)
+				if isIPv4Supported(f.ClientSet) && len(networkInterface.IPv4) > 0 {
+					serverContainerIPs = append(serverContainerIPs, networkInterface.IPv4)
+				}
+				if isIPv6Supported(f.ClientSet) && len(networkInterface.IPv6) > 0 {
+					serverContainerIPs = append(serverContainerIPs, networkInterface.IPv6)
+				}
+				gomega.Expect(len(serverContainerIPs)).Should(gomega.BeNumerically(">", 0), "failed to find external container IPs")
+				framework.Logf("The external server IPs are: %+v", serverContainerIPs)
+				providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
+				framework.ExpectNoError(err, "provider primary network must be available")
+				frrContainer := infraapi.ExternalContainer{Name: peering.routerContainer}
+				networkInterface, err = infraprovider.Get().GetExternalContainerNetworkInterface(frrContainer, providerPrimaryNetwork)
+				framework.ExpectNoError(err, "container %s attached to network %s must contain network info", peering.routerContainer, providerPrimaryNetwork.Name())
+				frrContainerIPv4, frrContainerIPv6 = networkInterface.IPv4, networkInterface.IPv6
+				framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
 
-	ginkgo.DescribeTable("Route Advertisements",
-		func(cudnTemplate *udnv1.ClusterUserDefinedNetwork, ra *rav1.RouteAdvertisements) {
-			// set the exact selector
-			cudnTemplate.Spec.NamespaceSelector = metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "kubernetes.io/metadata.name",
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{f.Namespace.Name},
-			}}}
-
-			// Create CUDN
-			ginkgo.By("create ClusterUserDefinedNetwork")
-			udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			if cudnTemplate.Spec.Network.Layer3 != nil {
-				cudnTemplate.Spec.Network.Layer3.Subnets = filterL3Subnets(f.ClientSet, cudnTemplate.Spec.Network.Layer3.Subnets)
-			}
-			if cudnTemplate.Spec.Network.Layer2 != nil {
-				cudnTemplate.Spec.Network.Layer2.Subnets = filterDualStackCIDRs(f.ClientSet, cudnTemplate.Spec.Network.Layer2.Subnets)
-			}
-			cUDN, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudnTemplate, metav1.CreateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.DeferCleanup(func() {
-				udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), cUDN.Name, metav1.DeleteOptions{})
-			})
-			gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cUDN.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
-
-			ginkgo.DeferCleanup(func() {
-				ginkgo.By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", f.Namespace.Name))
-				gomega.Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
+				// Select nodes here so they're available for all tests
+				ginkgo.By("Selecting 3 schedulable nodes")
+				nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
 			})
 
-			// Create client pod
-			ginkgo.By("Creating client pod")
-			podSpec := e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
-			podSpec.Spec.NodeName = nodes.Items[1].Name
-			for k := range podSpec.Spec.Containers {
-				if podSpec.Spec.Containers[k].Name == "agnhost-container" {
-					podSpec.Spec.Containers[k].Command = []string{
-						"sleep",
-						"infinity",
+			ginkgo.DescribeTable("Route Advertisements",
+				func(cudnTemplate *udnv1.ClusterUserDefinedNetwork, ra *rav1.RouteAdvertisements) {
+					// set the exact selector
+					cudnTemplate.Spec.NamespaceSelector = metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{f.Namespace.Name},
+					}}}
+
+					// Create CUDN
+					ginkgo.By("create ClusterUserDefinedNetwork")
+					udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if cudnTemplate.Spec.Network.Layer3 != nil {
+						cudnTemplate.Spec.Network.Layer3.Subnets = filterL3Subnets(f.ClientSet, cudnTemplate.Spec.Network.Layer3.Subnets)
 					}
-				}
-			}
-			clientPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), podSpec)
+					if cudnTemplate.Spec.Network.Layer2 != nil {
+						cudnTemplate.Spec.Network.Layer2.Subnets = filterDualStackCIDRs(f.ClientSet, cudnTemplate.Spec.Network.Layer2.Subnets)
+					}
+					cUDN, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudnTemplate, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.DeferCleanup(func() {
+						udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), cUDN.Name, metav1.DeleteOptions{})
+					})
+					gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cUDN.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
 
-			// Create route advertisement
-			ginkgo.By("create router advertisement")
-			raClient, err := raclientset.NewForConfig(f.ClientConfig())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.DeferCleanup(func() {
+						ginkgo.By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", f.Namespace.Name))
+						gomega.Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
+					})
 
-			ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.DeferCleanup(func() { raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), ra.Name, metav1.DeleteOptions{}) })
-			ginkgo.By("ensure route advertisement matching CUDN was created successfully")
-			gomega.Eventually(func() string {
-				ra, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ra.Name, metav1.GetOptions{})
-				if err != nil {
-					return ""
-				}
-				condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
-				if condition == nil {
-					return ""
-				}
-				return condition.Reason
-			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
-
-			// Check CUDN TransportAccepted condition is True after RA is created
-			if cudnTemplate.Spec.Network.Transport != "" && cudnTemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
-				ginkgo.By("ensure CUDN TransportAccepted condition is True")
-				gomega.Eventually(func(g gomega.Gomega) {
-					cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cUDN.Name, metav1.GetOptions{}, "status")
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					conditions, err := getConditions(cudnObj)
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					for _, condition := range conditions {
-						if condition.Type == "TransportAccepted" {
-							g.Expect(string(condition.Status)).To(gomega.Equal("True"))
-							g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
-							return
+					// Create client pod
+					ginkgo.By("Creating client pod")
+					podSpec := e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
+					podSpec.Spec.NodeName = nodes.Items[1].Name
+					for k := range podSpec.Spec.Containers {
+						if podSpec.Spec.Containers[k].Name == "agnhost-container" {
+							podSpec.Spec.Containers[k].Command = []string{
+								"sleep",
+								"infinity",
+							}
 						}
 					}
-					g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cUDN.Name)
-				}, 30*time.Second, time.Second).Should(gomega.Succeed())
-			}
+					clientPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), podSpec)
 
-			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
+					// Create route advertisement
+					ginkgo.By("create router advertisement")
+					raClient, err := raclientset.NewForConfig(f.ClientConfig())
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// -----------------               ------------------                         ---------------------
-			// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
-			// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
-			// |    server     |               |                |                         |    ovn-worker     |   (client UDN pod advertised
-			// -----------------               ------------------                         ---------------------    using RouteAdvertisements
-			//                                                                            |    ovn-worker2    |    from default pod network)
-			//                                                                            ---------------------
-			// The client pod inside the KIND cluster on the default network exposed using default network Router
-			// Advertisement will curl the external server container sitting outside the cluster via a FRR router
-			// This test ensures the north-south connectivity is happening through podIP
-			ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
-			bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-			framework.ExpectNoError(err, "network %s must be available", bgpExternalNetworkName)
-			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
-			framework.ExpectNoError(err, "must get BGP network subnets")
-			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			var frrIPv6LLA string
-			if isIPv6Supported(f.ClientSet) {
-				var err error
-				frrIPv6LLA, err = GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			}
-			for _, node := range nodes.Items {
-				if isIPv4Supported(f.ClientSet) {
-					ipVer := ""
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrContainerIPv4)
-					}, 30*time.Second).Should(gomega.BeTrue())
+					ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.DeferCleanup(func() { raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), ra.Name, metav1.DeleteOptions{}) })
+					ginkgo.By("ensure route advertisement matching CUDN was created successfully")
+					gomega.Eventually(func() string {
+						ra, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ra.Name, metav1.GetOptions{})
+						if err != nil {
+							return ""
+						}
+						condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+						if condition == nil {
+							return ""
+						}
+						return condition.Reason
+					}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+					gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
+
+					// -----------------               ------------------                         ---------------------
+					// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
+					// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
+					// |    server     |               |                |                         |    ovn-worker     |   (client UDN pod advertised
+					// -----------------               ------------------                         ---------------------    using RouteAdvertisements
+					//                                                                            |    ovn-worker2    |    from default pod network)
+					//                                                                            ---------------------
+					// The client pod inside the KIND cluster on the default network exposed using default network Router
+					// Advertisement will curl the external server container sitting outside the cluster via a FRR router
+					// This test ensures the north-south connectivity is happening through podIP
+					ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
+					bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork)
+					framework.ExpectNoError(err, "network %s must be available", peering.externalNetwork)
+					externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
+					framework.ExpectNoError(err, "must get BGP network subnets")
+					framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
+					var nodeIPv6LLA string
+					if isDualStackCluster(nodes) {
+						var err error
+						nodeIPv6LLA, err = GetNodeIPv6LinkLocalAddressForEth0(peering.routerContainer)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					for _, node := range nodes.Items {
+						if isIPv4Supported(f.ClientSet) {
+							ipVer := ""
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, frrContainerIPv4)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+						if isIPv6Supported(f.ClientSet) {
+							ipVer := " -6"
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, nodeIPv6LLA)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+					}
+
+					ginkgo.By("ensure CUDN pod subnet is advertised to the external FRR router")
+					for _, serverContainerIP := range serverContainerIPs {
+						for _, node := range nodes.Items {
+							if cudnTemplate.Spec.Network.Layer3 != nil {
+								checkL3NodePodRoute(node, serverContainerIP, peering.routerContainer, types.CUDNPrefix+cUDN.Name)
+							} else if cudnTemplate.Spec.Network.Layer2 != nil {
+								checkL2NodePodRoute(node, serverContainerIP, peering.routerContainer, cudnTemplate.Spec.Network.Layer2.Subnets)
+							} else {
+								ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
+							}
+						}
 				}
-				if isIPv6Supported(f.ClientSet) {
-					ipVer := " -6"
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrIPv6LLA)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-			}
 
-			ginkgo.By("ensure CUDN pod subnet is advertised to the external FRR router")
-			for _, serverContainerIP := range serverContainerIPs {
+				layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
+				if layer2LocalGateway {
+					ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
+				} else {
+					ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
+				}
 				for _, node := range nodes.Items {
-					if cudnTemplate.Spec.Network.Layer3 != nil {
-						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cUDN.Name)
-					} else if cudnTemplate.Spec.Network.Layer2 != nil {
-						checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnTemplate.Spec.Network.Layer2.Subnets)
-					} else {
-						ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
-					}
-				}
-			}
-
-			layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
-			if layer2LocalGateway {
-				ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
-			} else {
-				ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
-			}
-			for _, node := range nodes.Items {
-				nodeName := node.Name
-				for _, tc := range []struct {
-					cidr, nextHop string
-				}{
-					{externalServerV4CIDR, frrContainerIPv4},
-					{externalServerV6CIDR, frrIPv6LLA},
-				} {
-					if tc.cidr == "" || tc.nextHop == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
-					if isV6 && !isIPv6Supported(f.ClientSet) {
-						continue
-					}
-					if !isV6 && !isIPv4Supported(f.ClientSet) {
-						continue
-					}
-					if layer2LocalGateway {
-						framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+					nodeName := node.Name
+					for _, tc := range []struct {
+						cidr, nextHop string
+					}{
+						{externalServerV4CIDR, frrContainerIPv4},
+						{externalServerV6CIDR, nodeIPv6LLA},
+					} {
+						if tc.cidr == "" || tc.nextHop == "" {
+							continue
+						}
+						isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
+						if isV6 && !isIPv6Supported(f.ClientSet) {
+							continue
+						}
+						if !isV6 && !isIPv4Supported(f.ClientSet) {
+							continue
+						}
+						if layer2LocalGateway {
+							framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+							gomega.Eventually(func() bool {
+								found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+								if err != nil {
+									framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+									return false
+								}
+								return found
+							}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+								"route for %s via %s not found in CUDN VRF %s on node %s",
+								tc.cidr, tc.nextHop, cUDN.Name, nodeName)
+							continue
+						}
 						gomega.Eventually(func() bool {
-							found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+							routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
 							if err != nil {
-								framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+								framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
 								return false
 							}
-							return found
-						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-							"route for %s via %s not found in CUDN VRF %s on node %s",
-							tc.cidr, tc.nextHop, cUDN.Name, nodeName)
-						continue
-					}
-					// Assert the GR has a static-route line matching
-					// the CIDR and the expected next hop, that is the external FRR
-					// container IP.
-					gomega.Eventually(func() bool {
-						routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
-						if err != nil {
-							framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
-							return false
-						}
-						framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
-						for _, line := range strings.Split(routes, "\n") {
-							if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
-								return true
+							framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
+							for _, line := range strings.Split(routes, "\n") {
+								if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
+									return true
+								}
 							}
-						}
-						return false
-					}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-						"CUDN %q GR on node %s is missing a route %s -> %s",
-						cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+							return false
+						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+							"CUDN %q GR on node %s is missing a route %s -> %s",
+							cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+					}
 				}
-			}
 
-			expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
-				cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+				expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+					cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 
-			if expectSNAT {
-				ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
-			} else {
-				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
-			}
-			var expectedSNATSourceIPs []string
-			if expectSNAT {
-				clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
-				framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
-				expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
-				gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
-				framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
-			}
-			for _, serverContainerIP := range serverContainerIPs {
-				podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
-					f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-				framework.Logf("Client pod IP address=%s", podIP)
-
-				ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
-					"and expecting to receive the same payload", serverContainerIP))
-				cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
-					net.JoinHostPort(serverContainerIP, "8080"),
-				)
-				framework.Logf("Testing pod to external traffic with command %q", cmd)
-				stdout, err := e2epodoutput.RunHostCmdWithRetries(
-					clientPod.Namespace,
-					clientPod.Name,
-					cmd,
-					framework.Poll,
-					60*time.Second)
-				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-
-				sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-					fmt.Sprintf("Failed to parse client address from output %q", stdout))
 				if expectSNAT {
-					// When OutboundSNAT is enabled, traffic to external destinations
-					// is masqueraded to the node IP. Verify the source is NOT the pod IP.
-					expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
-					gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
-						"Expected node %s to have an InternalIP for the external server IP family %s",
-						clientPod.Spec.NodeName, serverContainerIP)
-					gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-						fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+					ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
 				} else {
-					gomega.Expect(sourceIP).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					ginkgo.By("queries to the external server are not SNATed (uses podIP)")
 				}
-			}
-		},
-		ginkgo.Entry("layer3",
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					// Keep generated CUDN names under the Linux 15-byte interface
-					// limit so the VRF name is unique instead of network ID based.
-					GenerateName: "bgp-l3-",
-					Labels:       map[string]string{"bgp-l3": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/23",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "103.104.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/63",
-								HostSubnet: 64,
-							}, {
-								CIDR:       "2014:100:201::0/48",
-								HostSubnet: 64,
-							}},
-						},
-					},
-				},
+				var expectedSNATSourceIPs []string
+				if expectSNAT {
+					clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
+					expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
+					gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
+					framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
+				}
+				for _, serverContainerIP := range serverContainerIPs {
+					podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+						f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+					framework.Logf("Client pod IP address=%s", podIP)
+
+					ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
+						"and expecting to receive the same payload", serverContainerIP))
+					cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
+						net.JoinHostPort(serverContainerIP, "8080"),
+					)
+					framework.Logf("Testing pod to external traffic with command %q", cmd)
+					stdout, err := e2epodoutput.RunHostCmdWithRetries(
+						clientPod.Namespace,
+						clientPod.Name,
+						cmd,
+						framework.Poll,
+						60*time.Second)
+					framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
+
+					sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+						fmt.Sprintf("Failed to parse client address from output %q", stdout))
+					if expectSNAT {
+						expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
+						gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
+							"Expected node %s to have an InternalIP for the external server IP family %s",
+							clientPod.Spec.NodeName, serverContainerIP)
+						gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+							fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+					} else {
+						gomega.Expect(sourceIP).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					}
+				}
 			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l3-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l3": ""},
-								},
+			ginkgo.Entry("layer3",
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						// Keep generated CUDN names under the Linux 15-byte interface
+						// limit so the VRF name is unique instead of network ID based.
+						GenerateName: "bgp-l3-",
+						Labels:       map[string]string{"bgp-l3": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer3,
+							Layer3: &udnv1.Layer3Config{
+								Role: "Primary",
+								Subnets: []udnv1.Layer3Subnet{{
+									CIDR:       "103.103.0.0/23",
+									HostSubnet: 24,
+								}, {
+									CIDR:       "103.104.0.0/16",
+									HostSubnet: 24,
+								}, {
+									CIDR:       "2014:100:200::0/63",
+									HostSubnet: 64,
+								}, {
+									CIDR:       "2014:100:201::0/48",
+									HostSubnet: 64,
+								}},
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-l3-ra",
 					},
-				},
-			},
-		),
-		ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-l3a-",
-					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/60",
-								HostSubnet: 64,
-							}},
-						},
-						Transport: udnv1.TransportOptionNoOverlay,
-						NoOverlay: &udnv1.NoOverlayConfig{
-							OutboundSNAT: udnv1.SNATEnabled,
-							Routing:      udnv1.RoutingUnmanaged,
-						},
-					},
-				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-l3": ""},
+									},
 								},
 							},
 						},
-					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
-					},
-				},
-			},
-		),
-		ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-l3b-",
-					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/60",
-								HostSubnet: 64,
-							}},
-						},
-						Transport: udnv1.TransportOptionNoOverlay,
-						NoOverlay: &udnv1.NoOverlayConfig{
-							OutboundSNAT: udnv1.SNATDisabled,
-							Routing:      udnv1.RoutingUnmanaged,
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
 						},
 					},
 				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
-								},
+			),
+			ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "bgp-l3a-",
+						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer3,
+							Layer3: &udnv1.Layer3Config{
+								Role: "Primary",
+								Subnets: []udnv1.Layer3Subnet{{
+									CIDR:       "103.103.0.0/16",
+									HostSubnet: 24,
+								}, {
+									CIDR:       "2014:100:200::0/60",
+									HostSubnet: 64,
+								}},
+							},
+							Transport: udnv1.TransportOptionNoOverlay,
+							NoOverlay: &udnv1.NoOverlayConfig{
+								OutboundSNAT: udnv1.SNATEnabled,
+								Routing:      udnv1.RoutingUnmanaged,
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
 					},
-				},
-			},
-		),
-		ginkgo.Entry("layer2",
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-l2-",
-					Labels:       map[string]string{"bgp-l2": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer2,
-						Layer2: &udnv1.Layer2Config{
-							Role:    "Primary",
-							Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
-						},
-					},
-				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l2-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l2": ""},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+									},
 								},
 							},
 						},
-					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
+						},
 					},
 				},
-			},
-		),
+			),
+			ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "bgp-l3b-",
+						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer3,
+							Layer3: &udnv1.Layer3Config{
+								Role: "Primary",
+								Subnets: []udnv1.Layer3Subnet{{
+									CIDR:       "103.103.0.0/16",
+									HostSubnet: 24,
+								}, {
+									CIDR:       "2014:100:200::0/60",
+									HostSubnet: 64,
+								}},
+							},
+							Transport: udnv1.TransportOptionNoOverlay,
+							NoOverlay: &udnv1.NoOverlayConfig{
+								OutboundSNAT: udnv1.SNATDisabled,
+								Routing:      udnv1.RoutingUnmanaged,
+							},
+						},
+					},
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+					},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+									},
+								},
+							},
+						},
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
+						},
+					},
+				},
+			),
+			ginkgo.Entry("layer2",
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						// Keep generated CUDN names under the Linux 15-byte interface
+						// limit so the VRF name is unique instead of network ID based.
+						GenerateName: "bgp-l2-",
+						Labels:       map[string]string{"bgp-l2": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer2,
+							Layer2: &udnv1.Layer2Config{
+								Role:    "Primary",
+								Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
+							},
+						},
+					},
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-l2-ra",
+					},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-l2": ""},
+									},
+								},
+							},
+						},
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
+						},
+					},
+				},
+			),
+		)
+	},
+	bgpPeeringModes,
 	)
 })
 
@@ -1441,9 +1470,9 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				serverContainerIPs := getBGPServerContainerIPs(f)
 				for _, serverContainerIP := range serverContainerIPs {
 					for _, node := range nodes.Items {
-						if cudnA.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
-							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnA.Name)
-							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
+					if cudnA.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
+						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnA.Name)
+						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
 						} else {
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnATemplate.Spec.Network.Layer2.Subnets)
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnBTemplate.Spec.Network.Layer2.Subnets)
@@ -2183,10 +2212,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 
 var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdvertisements, func() {
 
-	// infra constants
-	const (
-		bgpASN = 64512
-	)
 
 	// configuration helper to setup infra
 	configureNetworkWithInfra := func(
@@ -2197,8 +2222,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		networkName string,
 		networkType networkType,
 		networkSpec *udnv1.NetworkSpec,
-		bgpAlloc allocators.BGPAllocation,
-	) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
+	bgpAlloc allocators.BGPAllocation,
+	externalASN int,
+	clusterASN int,
+	frrContainerName string,
+) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
 		ginkgo.GinkgoHelper()
 
 		framework.Logf("Configuring the infra for network %s of type %s with allocations %#v", networkName, networkType, bgpAlloc)
@@ -2222,6 +2250,8 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					agnhostNetworkName,
 					bgpPeerCIDRs,
 					bgpServerCIDRs,
+					externalASN,
+					clusterASN,
 				),
 			).To(gomega.Succeed())
 			servers = append(servers, agnhostName)
@@ -2244,14 +2274,15 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				vtepName = sharedNodeIPsVTEPName
 			}
 
+
 			macVRFContainer := infraapi.ExternalContainer{
-				Name:    networkName + "-macvrf-agnhost",
+				Name:    networkName + "-" + frrContainerName + "-macvrf-agnhost",
 				Image:   images.AgnHost(),
 				CmdArgs: []string{"netexec", fmt.Sprintf("--http-port=%d", agnhostHTTPPort)},
 			}
 			macVRFNetworkName := macVRFContainer.Name
 			ipVRFContainer := infraapi.ExternalContainer{
-				Name:    networkName + "-ipvrf-agnhost",
+				Name:    networkName + "-" + frrContainerName + "-ipvrf-agnhost",
 				Image:   images.AgnHost(),
 				CmdArgs: []string{"netexec", fmt.Sprintf("--http-port=%d", agnhostHTTPPort)},
 			}
@@ -2264,7 +2295,9 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					ipFamilySet,
 					networkSpec,
 					bgpAlloc,
-					bgpASN,
+					externalASN,
+					clusterASN,
+					frrContainerName,
 					bridgeName,
 					vxlanName,
 					vtepName,
@@ -2625,41 +2658,44 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
 	}
 
-	ginkgo.DescribeTableSubtree("When the tested network is of type",
-		func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-			var testNamespace *corev1.Namespace
-			var testPod *corev1.Pod
-			var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
-			var networkSpec *udnv1.NetworkSpec
+	ginkgo.DescribeTableSubtree("With underlay BGP in mode",
+		func(peering bgpPeeringConfig) {
 
-			expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
-				ginkgo.GinkgoHelper()
-				// In LGW VRF-Lite, host nftables masquerade picks the source IP
-				// from the node's egress interface in the target VRF when no-overlay
-				// outbound SNAT is enabled.
-				if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
-					testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
-					iface, ok := vrfLiteNodeInterfaces[node.Name]
-					gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
-					expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-					gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
-					return expectedIP
-				}
-				expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				if family == utilnet.IPv6 {
-					expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				}
-				gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
-				return expectedNodeIPs[0]
-			}
+		ginkgo.DescribeTableSubtree("When the tested network is of type",
+			func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+				var testNamespace *corev1.Namespace
+				var testPod *corev1.Pod
+				var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
+				var networkSpec *udnv1.NetworkSpec
 
-			getSameNode := func() string {
-				return testPod.Spec.NodeName
-			}
-			getDifferentNode := func() string {
-				ginkgo.GinkgoHelper()
-				nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get ready schedulable nodes")
+				expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
+					ginkgo.GinkgoHelper()
+					// In LGW VRF-Lite, host nftables masquerade picks the source IP
+					// from the node's egress interface in the target VRF when no-overlay
+					// outbound SNAT is enabled.
+					if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
+						testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
+						iface, ok := vrfLiteNodeInterfaces[node.Name]
+						gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
+						expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+						gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
+						return expectedIP
+					}
+					expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
+					if family == utilnet.IPv6 {
+						expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
+					}
+					gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
+					return expectedNodeIPs[0]
+				}
+
+				getSameNode := func() string {
+					return testPod.Spec.NodeName
+				}
+				getDifferentNode := func() string {
+					ginkgo.GinkgoHelper()
+					nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get ready schedulable nodes")
 				for _, node := range nodes.Items {
 					if node.Name != testPod.Spec.NodeName {
 						return node.Name
@@ -2671,8 +2707,8 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 
 			ginkgo.BeforeEach(func() {
 				bgpAlloc, err := allocators.AllocateBGP(f, ictx)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
 
 				networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
 				switch {
@@ -2691,189 +2727,168 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					testedNetworkType,
 					networkSpec,
 					bgpAlloc,
+					peering.externalASN,
+					peering.clusterASN,
+					peering.routerContainer,
 				)
-			})
-
-			ginkgo.Describe("When a pod runs on the tested network", func() {
-				ginkgo.BeforeEach(func() {
-					ginkgo.By("Running a pod on the tested network namespace")
-					testPod = e2epod.CreateExecPodOrFail(
-						context.Background(),
-						f.ClientSet,
-						testNamespace.Name,
-						testNamespace.Name+"-netexec-pod",
-						func(p *corev1.Pod) {
-							p.Spec.Containers[0].Args = []string{"netexec"}
-						},
-					)
-					var err error
-					testPod, err = f.ClientSet.CoreV1().Pods(testPod.Namespace).Get(context.Background(), testPod.Name, metav1.GetOptions{})
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(testPod.Spec.NodeName).NotTo(gomega.BeEmpty())
 				})
 
-				ginkgo.DescribeTable("It can reach external servers on the same network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
-						}
-						expectSNAT := networkSpec.NoOverlay != nil &&
-							networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
-
-						if expectSNAT {
-							ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
-						} else {
-							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
-						}
-						for _, externalServer := range externalServers {
-							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-								infraapi.ExternalContainer{Name: externalServer},
-								bgpServerNetwork,
+					ginkgo.Describe("When a pod runs on the tested network", func() {
+						ginkgo.BeforeEach(func() {
+							ginkgo.By("Running a pod on the tested network namespace")
+							testPod = e2epod.CreateExecPodOrFail(
+								context.Background(),
+								f.ClientSet,
+								testNamespace.Name,
+								testNamespace.Name+"-netexec-pod",
+								func(p *corev1.Pod) {
+									p.Spec.Containers[0].Args = []string{"netexec"}
+								},
 							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-							framework.Logf("Checking request from pod reaches server %q", externalServer)
-							testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+						})
+
+					ginkgo.DescribeTable("It can reach external servers on the same network",
+						func(family utilnet.IPFamily) {
+							if !ipFamilySet.Has(family) {
+								e2eskipper.Skipf("IP family %v not supported", family)
+							}
+							expectSNAT := networkSpec.NoOverlay != nil &&
+								networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 
 							if expectSNAT {
-								framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
-								// When OutboundSNAT is enabled, pod-to-external traffic is masqueraded
-								// to the node IP.
-								ip, err := e2epodoutput.RunHostCmdWithRetries(
-									testPod.Namespace,
-									testPod.Name,
-									fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
-									polling,
-									timeout,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								sourceIP, _, err := net.SplitHostPort(ip)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
-								gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-									fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
+								ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
 							} else {
-								testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-									f.ClientSet,
-									testPod.Namespace,
-									testPod.Name,
-									testNetworkName,
-									family,
+								ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+							}
+							for _, externalServer := range externalServers {
+								bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+									infraapi.ExternalContainer{Name: externalServer},
+									bgpServerNetwork,
 								)
 								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-								framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
-								testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+								serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+								gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+								framework.Logf("Checking request from pod reaches server %q", externalServer)
+								testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+
+								if expectSNAT {
+									framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
+									ip, err := e2epodoutput.RunHostCmdWithRetries(
+										testPod.Namespace,
+										testPod.Name,
+										fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
+										polling,
+										timeout,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									sourceIP, _, err := net.SplitHostPort(ip)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
+									gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+										fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
+								} else {
+									testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										f.ClientSet,
+										testPod.Namespace,
+										testPod.Name,
+										testNetworkName,
+										family,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+									framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
+									testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+								}
 							}
-						}
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
-
-				ginkgo.DescribeTable("It can be reached by an external server on the same network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
-						}
-						ginkgo.By("Ensuring a request from the external servers can reach the pod")
-						for _, externalServer := range externalServers {
-							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-								infraapi.ExternalContainer{Name: externalServer},
-								bgpServerNetwork,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-							podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-								f.ClientSet,
-								testPod.Namespace,
-								testPod.Name,
-								testNetworkName,
-								family,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-							framework.Logf("Checking request from server %q reaches pod", externalServer)
-							testContainerToClientIPAndExpect(externalServer, podIP, serverIP)
-						}
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
-
-				ginkgo.It("Can reach KAPI service", func() {
-					ginkgo.By("Ensuring a request from the pod can reach KAPI service")
-					output, err := e2epodoutput.RunHostCmdWithRetries(
-						testPod.Namespace,
-						testPod.Name,
-						fmt.Sprintf("curl --max-time %d -g -q -s -k https://kubernetes.default/healthz", curlMaxTime),
-						polling,
-						timeout,
+						},
+						ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+						ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
 					)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(output).To(gomega.Equal("ok"))
-				})
 
-				ginkgo.DescribeTable("It cannot reach an external server on a different network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
-						}
-						ginkgo.By("Ensuring a request from the pod cannot reach the external server")
-						// using the external server setup for the default network
-						bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-							infraapi.ExternalContainer{Name: serverContainerName},
-							bgpServerNetwork,
-						)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-						gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-						testPodToClientIPNOK(testPod, serverIP)
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
-
-				ginkgo.DescribeTable("It cannot be reached by an external server on a different network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
-						}
-						ginkgo.By("Ensuring a request from the external server cannot reach the pod")
-						podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-							f.ClientSet,
-							testPod.Namespace,
-							testPod.Name,
-							testNetworkName,
-							family,
-						)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-						// using the external server setup for the default network
-						testContainerToClientIPNOK(serverContainerName, podIP)
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
-
-				ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
-					func(getNode func() string) {
-						ginkgo.DescribeTable("",
+						ginkgo.DescribeTable("It can be reached by an external server on the same network",
 							func(family utilnet.IPFamily) {
 								if !ipFamilySet.Has(family) {
 									e2eskipper.Skipf("IP family %v not supported", family)
 								}
-								ginkgo.By("Ensuring a request from the node cannot reach the tested network pod")
+								ginkgo.By("Ensuring a request from the external servers can reach the pod")
+								for _, externalServer := range externalServers {
+									bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+										infraapi.ExternalContainer{Name: externalServer},
+										bgpServerNetwork,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+									gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+									podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										f.ClientSet,
+										testPod.Namespace,
+										testPod.Name,
+										testNetworkName,
+										family,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+									framework.Logf("Checking request from server %q reaches pod", externalServer)
+									testContainerToClientIPAndExpect(externalServer, podIP, serverIP)
+								}
+							},
+							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+						)
+
+						ginkgo.It("Can reach KAPI service", func() {
+							ginkgo.By("Ensuring a request from the pod can reach KAPI service")
+							output, err := e2epodoutput.RunHostCmdWithRetries(
+								testPod.Namespace,
+								testPod.Name,
+								fmt.Sprintf("curl --max-time %d -g -q -s -k https://kubernetes.default/healthz", curlMaxTime),
+								polling,
+								timeout,
+							)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(output).To(gomega.Equal("ok"))
+						})
+
+						ginkgo.DescribeTable("It cannot reach an external server on a different network",
+							func(family utilnet.IPFamily) {
+								if peering.externalASN != peering.clusterASN {
+									e2eskipper.Skipf("Isolation tests only run in iBGP mode")
+								}
+								if !ipFamilySet.Has(family) {
+									e2eskipper.Skipf("IP family %v not supported", family)
+								}
+								ginkgo.By("Ensuring a request from the pod cannot reach the external server")
+								// using the external server setup for the default network
+								bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+									infraapi.ExternalContainer{Name: serverContainerName},
+									bgpServerNetwork,
+								)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+								gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+								testPodToClientIPNOK(testPod, serverIP)
+							},
+							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+						)
+
+						ginkgo.DescribeTable("It cannot be reached by an external server on a different network",
+							func(family utilnet.IPFamily) {
+								if peering.externalASN != peering.clusterASN {
+									e2eskipper.Skipf("Isolation tests only run in iBGP mode")
+								}
+								if !ipFamilySet.Has(family) {
+									e2eskipper.Skipf("IP family %v not supported", family)
+								}
+								ginkgo.By("Ensuring a request from the external server cannot reach the pod")
 								podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 									f.ClientSet,
 									testPod.Namespace,
@@ -2883,303 +2898,339 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 								)
 								gomega.Expect(err).NotTo(gomega.HaveOccurred())
 								gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-								testNodeToClientIPNOK(getNode(), podIP)
+								// using the external server setup for the default network
+								testContainerToClientIPNOK(serverContainerName, podIP)
 							},
 							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
 							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
 						)
-					},
-					ginkgo.Entry("When it is the same node", getSameNode),
-					ginkgo.Entry("When it is a different node", getDifferentNode),
-				)
 
-				ginkgo.DescribeTableSubtree("When other pod runs on the tested network",
-					func(getNode func() string) {
-						var otherPod *corev1.Pod
-
-						ginkgo.BeforeEach(func() {
-							ginkgo.By("Running other pod on the tested network namespace")
-							otherPod = e2epod.CreateExecPodOrFail(
-								context.Background(),
-								f.ClientSet,
-								testNamespace.Name,
-								testNamespace.Name+"-netexec-pod",
-								func(p *corev1.Pod) {
-									p.Spec.Containers[0].Args = []string{"netexec"}
-									p.Spec.NodeName = getNode()
-									p.Labels = map[string]string{"app": "netexec-pod"}
-								},
-							)
-						})
-
-						ginkgo.DescribeTable("The pods on the tested network can reach each other",
+			ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
+				func(getNode func() string) {
+				ginkgo.DescribeTable("",
 							func(family utilnet.IPFamily) {
-								if !ipFamilySet.Has(family) {
-									e2eskipper.Skipf("IP family %v not supported", family)
-								}
-								ginkgo.By("Ensuring a request from the first pod can reach the second pod")
-								otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-									f.ClientSet,
-									otherPod.Namespace,
-									otherPod.Name,
-									testNetworkName,
-									family,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-								testPodToClientIP(testPod, otherPodIP)
-							},
-							ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
-							ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
-						)
-
-						ginkgo.Describe("Backing a ClusterIP service", func() {
-							var service *corev1.Service
-
-							ginkgo.BeforeEach(func() {
-								ginkgo.By("Creating a service backed by the other network pod")
-								service = e2eservice.CreateServiceSpec(
-									"service-for-netexec",
-									"",
-									false,
-									otherPod.Labels,
-								)
-								service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
-								familyPolicy := corev1.IPFamilyPolicyPreferDualStack
-								service.Spec.IPFamilyPolicy = &familyPolicy
-								var err error
-								service, err = f.ClientSet.CoreV1().Services(otherPod.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							})
-
-							ginkgo.DescribeTable("The first pod can reach the ClusterIP service on the same network",
-								func(family utilnet.IPFamily) {
-									if !ipFamilySet.Has(family) {
-										e2eskipper.Skipf("IP family %v not supported", family)
-									}
-									ginkgo.By("Ensuring a request from the first pod can reach the ClusterIP service")
-									clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
-									gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-									testPodToClientIP(testPod, clusterIP)
-								},
-								ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
-								ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
-							)
-						})
-					},
-					ginkgo.Entry("On the same node", getSameNode),
-					ginkgo.Entry("On a different node", getDifferentNode),
-				)
-
-				ginkgo.Describe("When there is other network", func() {
-
-					nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
-						return nil
-					}
-
-					otherNetworksToTest := []ginkgo.TableEntry{
-						ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
-						ginkgo.Entry("Layer 3 UDN", udn, layer3NetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
-						ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-					}
-
-					ginkgo.DescribeTableSubtree("Of type",
-						func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-							var otherNamespace *corev1.Namespace
-							var otherNetworkName string
-
-							ginkgo.BeforeEach(func() {
-								otherNetworkName = testBaseName + "o"
-								otherNamespaceName := otherNetworkName
-
-								otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
-
-								otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
-								switch {
-								case otherNetworkSpec == nil:
-									otherNetworkName = "default"
-								case otherNetworkSpec.Layer3 != nil:
-									otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
-								case otherNetworkSpec.Layer2 != nil:
-									otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
-								}
-
-								otherNamespace, _, _ = configureNetworkWithInfra(
-									f,
-									ictx,
-									testBaseName,
-									ipFamilySet,
-									otherNamespaceName,
-									networkType,
-									otherNetworkSpec,
-									otherBGPAlloc,
-								)
-							})
-
-							ginkgo.It("Both networks are isolated", func() {
-								ginkgo.By("Running two pods on the other network namespace on different nodes")
-								var otherPodSameNode, otherPodDiffNode *corev1.Pod
-								wg := sync.WaitGroup{}
-								wg.Add(2)
-								go func() {
-									ginkgo.GinkgoHelper()
-									defer ginkgo.GinkgoRecover()
-									defer wg.Done()
-									otherPodSameNode = e2epod.CreateExecPodOrFail(
-										context.Background(),
-										f.ClientSet,
-										otherNamespace.Name,
-										otherNamespace.Name+"-netexec-samenode-pod",
-										func(p *corev1.Pod) {
-											p.Spec.Containers[0].Args = []string{"netexec"}
-											p.Spec.NodeName = getSameNode()
-											p.Labels = map[string]string{"app": "netexec-samenode-pod"}
-										},
-									)
-								}()
-								go func() {
-									ginkgo.GinkgoHelper()
-									defer ginkgo.GinkgoRecover()
-									defer wg.Done()
-									otherPodDiffNode = e2epod.CreateExecPodOrFail(
-										context.Background(),
-										f.ClientSet,
-										otherNamespace.Name,
-										otherNamespace.Name+"-netexec-diffnode-pod",
-										func(p *corev1.Pod) {
-											p.Spec.Containers[0].Args = []string{"netexec"}
-											p.Spec.NodeName = getDifferentNode()
-											p.Labels = map[string]string{"app": "netexec-diffnode-pod"}
-										},
-									)
-								}()
-								wg.Wait()
-
-								ginkgo.By("Ensuring the pods from the other network can talk to each other")
-								testForIPFamilies(
-									ipFamilySet,
-									func(family utilnet.IPFamily) {
-										ginkgo.GinkgoHelper()
-										otherPodSameNodeIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										if peering.externalASN != peering.clusterASN {
+											e2eskipper.Skipf("Isolation tests only run in iBGP mode")
+										}
+										if !ipFamilySet.Has(family) {
+											e2eskipper.Skipf("IP family %v not supported", family)
+										}
+										ginkgo.By("Ensuring a request from the node cannot reach the tested network pod")
+										podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 											f.ClientSet,
-											otherPodSameNode.Namespace,
-											otherPodSameNode.Name,
-											otherNetworkName,
+											testPod.Namespace,
+											testPod.Name,
+											testNetworkName,
 											family,
 										)
 										gomega.Expect(err).NotTo(gomega.HaveOccurred())
-										gomega.Expect(otherPodSameNodeIP).ToNot(gomega.BeEmpty())
-										testPodToClientIP(otherPodDiffNode, otherPodSameNodeIP)
+										gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+										testNodeToClientIPNOK(getNode(), podIP)
 									},
+									ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+									ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+								)
+							},
+							ginkgo.Entry("When it is the same node", getSameNode),
+							ginkgo.Entry("When it is a different node", getDifferentNode),
+						)
+
+						ginkgo.DescribeTableSubtree("When other pod runs on the tested network",
+							func(getNode func() string) {
+								var otherPod *corev1.Pod
+
+								ginkgo.BeforeEach(func() {
+									ginkgo.By("Running other pod on the tested network namespace")
+									otherPod = e2epod.CreateExecPodOrFail(
+										context.Background(),
+										f.ClientSet,
+										testNamespace.Name,
+										testNamespace.Name+"-netexec-pod",
+										func(p *corev1.Pod) {
+											p.Spec.Containers[0].Args = []string{"netexec"}
+											p.Spec.NodeName = getNode()
+											p.Labels = map[string]string{"app": "netexec-pod"}
+										},
+									)
+								})
+
+								ginkgo.DescribeTable("The pods on the tested network can reach each other",
+									func(family utilnet.IPFamily) {
+										if !ipFamilySet.Has(family) {
+											e2eskipper.Skipf("IP family %v not supported", family)
+										}
+										ginkgo.By("Ensuring a request from the first pod can reach the second pod")
+										otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+											f.ClientSet,
+											otherPod.Namespace,
+											otherPod.Name,
+											testNetworkName,
+											family,
+										)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
+										testPodToClientIP(testPod, otherPodIP)
+									},
+									ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
+									ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
 								)
 
-								ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network pods")
-								for _, target := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the tested network pod cannot reach the other network pod %s on IPv%v", target.Name, family)
-											otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-												f.ClientSet,
-												target.Namespace,
-												target.Name,
-												otherNetworkName,
-												family,
-											)
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(testPod, otherPodIP)
-										},
-									)
-								}
+								ginkgo.Describe("Backing a ClusterIP service", func() {
+									var service *corev1.Service
 
-								ginkgo.By("Ensuring a request from the other network pods on the same node cannot reach the tested network pod")
-								for _, source := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the other network pod %s on the same node cannot reach the tested network pod on IPv%v", source.Name, family)
-											testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-												f.ClientSet,
-												testPod.Namespace,
-												testPod.Name,
-												testNetworkName,
-												family,
-											)
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(source, testPodIP)
-										},
-									)
-								}
+									ginkgo.BeforeEach(func() {
+										ginkgo.By("Creating a service backed by the other network pod")
+										service = e2eservice.CreateServiceSpec(
+											"service-for-netexec",
+											"",
+											false,
+											otherPod.Labels,
+										)
+										service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
+										familyPolicy := corev1.IPFamilyPolicyPreferDualStack
+										service.Spec.IPFamilyPolicy = &familyPolicy
+										var err error
+										service, err = f.ClientSet.CoreV1().Services(otherPod.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									})
 
-								ginkgo.By("Creating services backed by the other network pods")
-								var services []*corev1.Service
-								for _, backend := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-									service := e2eservice.CreateServiceSpec(
-										"service-"+backend.Name,
-										"",
-										false,
-										backend.Labels,
-									)
-									service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
-									familyPolicy := corev1.IPFamilyPolicyPreferDualStack
-									service.Spec.IPFamilyPolicy = &familyPolicy
-									var err error
-									service, err = f.ClientSet.CoreV1().Services(backend.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									services = append(services, service)
-								}
-
-								ginkgo.By("Ensuring the pods from the other network can reach their services")
-								for source, target := range map[*corev1.Pod]*corev1.Service{otherPodSameNode: services[1], otherPodDiffNode: services[0]} {
-									testForIPFamilies(
-										ipFamilySet,
+									ginkgo.DescribeTable("The first pod can reach the ClusterIP service on the same network",
 										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the other network pod %s can reach the its network service %s on IPv%v", source.Name, target.Name, family)
-											clusterIP := getFirstIPStringOfFamily(family, target.Spec.ClusterIPs)
-											gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-											testPodToClientIP(source, clusterIP)
-										},
-									)
-								}
-
-								ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network services")
-								for _, service := range services {
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the tested network pod cannot reach the other network service %s on IPv%v", service.Name, family)
+											if !ipFamilySet.Has(family) {
+												e2eskipper.Skipf("IP family %v not supported", family)
+											}
+											ginkgo.By("Ensuring a request from the first pod can reach the ClusterIP service")
 											clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
 											gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(testPod, clusterIP)
+											testPodToClientIP(testPod, clusterIP)
 										},
+										ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
+										ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
 									)
+								})
+							},
+							ginkgo.Entry("On the same node", getSameNode),
+							ginkgo.Entry("On a different node", getDifferentNode),
+						)
+
+						ginkgo.Describe("When there is other network", func() {
+							ginkgo.BeforeEach(func() {
+								if peering.externalASN != peering.clusterASN {
+									e2eskipper.Skipf("Isolation tests only run in iBGP mode")
 								}
 							})
-						},
-						otherNetworksToTest,
-					)
-				})
-			})
+
+						nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
+							return nil
+						}
+
+							otherNetworksToTest := []ginkgo.TableEntry{
+								ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
+								ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
+								ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+								ginkgo.Entry("Layer 3 UDN", udn, layer3NetworkSpecGen),
+								ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
+								ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
+								ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
+							ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
+							ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
+							ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+							}
+
+						ginkgo.DescribeTableSubtree("Of type",
+							func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+								var otherNamespace *corev1.Namespace
+								var otherNetworkName string
+
+								ginkgo.BeforeEach(func() {
+									otherNetworkName = testBaseName + "o"
+									otherNamespaceName := otherNetworkName
+
+									otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
+
+									otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
+									switch {
+									case otherNetworkSpec == nil:
+										otherNetworkName = "default"
+									case otherNetworkSpec.Layer3 != nil:
+										otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
+									case otherNetworkSpec.Layer2 != nil:
+										otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
+									}
+
+									otherNamespace, _, _ = configureNetworkWithInfra(
+										f,
+										ictx,
+										testBaseName,
+										ipFamilySet,
+										otherNamespaceName,
+										networkType,
+										otherNetworkSpec,
+										otherBGPAlloc,
+										peering.externalASN,
+										peering.clusterASN,
+										peering.routerContainer,
+									)
+								})
+
+									ginkgo.It("Both networks are isolated", func() {
+										ginkgo.By("Running two pods on the other network namespace on different nodes")
+										var otherPodSameNode, otherPodDiffNode *corev1.Pod
+										wg := sync.WaitGroup{}
+										wg.Add(2)
+										go func() {
+											ginkgo.GinkgoHelper()
+											defer ginkgo.GinkgoRecover()
+											defer wg.Done()
+											otherPodSameNode = e2epod.CreateExecPodOrFail(
+												context.Background(),
+												f.ClientSet,
+												otherNamespace.Name,
+												otherNamespace.Name+"-netexec-samenode-pod",
+												func(p *corev1.Pod) {
+													p.Spec.Containers[0].Args = []string{"netexec"}
+													p.Spec.NodeName = getSameNode()
+													p.Labels = map[string]string{"app": "netexec-samenode-pod"}
+												},
+											)
+										}()
+										go func() {
+											ginkgo.GinkgoHelper()
+											defer ginkgo.GinkgoRecover()
+											defer wg.Done()
+											otherPodDiffNode = e2epod.CreateExecPodOrFail(
+												context.Background(),
+												f.ClientSet,
+												otherNamespace.Name,
+												otherNamespace.Name+"-netexec-diffnode-pod",
+												func(p *corev1.Pod) {
+													p.Spec.Containers[0].Args = []string{"netexec"}
+													p.Spec.NodeName = getDifferentNode()
+													p.Labels = map[string]string{"app": "netexec-diffnode-pod"}
+												},
+											)
+										}()
+										wg.Wait()
+
+										ginkgo.By("Ensuring the pods from the other network can talk to each other")
+										testForIPFamilies(
+											ipFamilySet,
+											func(family utilnet.IPFamily) {
+												ginkgo.GinkgoHelper()
+												otherPodSameNodeIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+													f.ClientSet,
+													otherPodSameNode.Namespace,
+													otherPodSameNode.Name,
+													otherNetworkName,
+													family,
+												)
+												gomega.Expect(err).NotTo(gomega.HaveOccurred())
+												gomega.Expect(otherPodSameNodeIP).ToNot(gomega.BeEmpty())
+												testPodToClientIP(otherPodDiffNode, otherPodSameNodeIP)
+											},
+										)
+
+										ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network pods")
+										for _, target := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+											testForIPFamilies(
+												ipFamilySet,
+												func(family utilnet.IPFamily) {
+													ginkgo.GinkgoHelper()
+													framework.Logf("Ensuring a request from the tested network pod cannot reach the other network pod %s on IPv%v", target.Name, family)
+													otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+														f.ClientSet,
+														target.Namespace,
+														target.Name,
+														otherNetworkName,
+														family,
+													)
+													gomega.Expect(err).NotTo(gomega.HaveOccurred())
+													gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
+													testPodToClientIPNOK(testPod, otherPodIP)
+												},
+											)
+										}
+
+										ginkgo.By("Ensuring a request from the other network pods on the same node cannot reach the tested network pod")
+										for _, source := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+											testForIPFamilies(
+												ipFamilySet,
+												func(family utilnet.IPFamily) {
+													ginkgo.GinkgoHelper()
+													framework.Logf("Ensuring a request from the other network pod %s on the same node cannot reach the tested network pod on IPv%v", source.Name, family)
+													testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+														f.ClientSet,
+														testPod.Namespace,
+														testPod.Name,
+														testNetworkName,
+														family,
+													)
+													gomega.Expect(err).NotTo(gomega.HaveOccurred())
+													gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+													testPodToClientIPNOK(source, testPodIP)
+												},
+											)
+										}
+
+										ginkgo.By("Creating services backed by the other network pods")
+										var services []*corev1.Service
+										for _, backend := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+											service := e2eservice.CreateServiceSpec(
+												"service-"+backend.Name,
+												"",
+												false,
+												backend.Labels,
+											)
+											service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
+											familyPolicy := corev1.IPFamilyPolicyPreferDualStack
+											service.Spec.IPFamilyPolicy = &familyPolicy
+											var err error
+											service, err = f.ClientSet.CoreV1().Services(backend.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											services = append(services, service)
+										}
+
+										ginkgo.By("Ensuring the pods from the other network can reach their services")
+										for source, target := range map[*corev1.Pod]*corev1.Service{otherPodSameNode: services[1], otherPodDiffNode: services[0]} {
+											testForIPFamilies(
+												ipFamilySet,
+												func(family utilnet.IPFamily) {
+													ginkgo.GinkgoHelper()
+													framework.Logf("Ensuring a request from the other network pod %s can reach the its network service %s on IPv%v", source.Name, target.Name, family)
+													clusterIP := getFirstIPStringOfFamily(family, target.Spec.ClusterIPs)
+													gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
+													testPodToClientIP(source, clusterIP)
+												},
+											)
+										}
+
+										ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network services")
+										for _, service := range services {
+											testForIPFamilies(
+												ipFamilySet,
+												func(family utilnet.IPFamily) {
+													ginkgo.GinkgoHelper()
+													framework.Logf("Ensuring a request from the tested network pod cannot reach the other network service %s on IPv%v", service.Name, family)
+													clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
+													gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
+													testPodToClientIPNOK(testPod, clusterIP)
+												},
+											)
+										}
+									})
+								},
+								otherNetworksToTest,
+							)
+						})
+					})
+				},
+				networksToTest,
+			)
+
 		},
-		networksToTest,
+		bgpPeeringModes,
 	)
 })
 
@@ -3206,6 +3257,8 @@ func routeAdvertisementsReadyFunc(c raclientset.Clientset, name string) func() e
 // templateInputRouter data
 type templateInputRouter struct {
 	VRF           string
+	LocalASN      int
+	NeighborASN   int
 	NeighborsIPv4 []string
 	NeighborsIPv6 []string
 	NetworksIPv4  []string
@@ -3228,8 +3281,11 @@ var tmplDir = filepath.Join("testdata", "routeadvertisements")
 
 // generateFRRConfiguration to establish a BGP session towards the provided
 // neighbors in the network's VRF configured to advertised the provided
-// networks. Returns a temporary directory where the configuration is generated.
-func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (directory string, err error) {
+// networks. localASN is the ASN for this external FRR, neighborASN is the
+// ASN of the peers (cluster nodes). For iBGP, both are the same; for eBGP,
+// they differ and route-reflector-client is omitted.
+// Returns a temporary directory where the configuration is generated.
+func generateFRRConfiguration(neighborIPs, advertiseNetworks []string, localASN, neighborASN int) (directory string, err error) {
 	// parse configuration templates
 	var templates *template.Template
 	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr", "*.tmpl"))
@@ -3254,6 +3310,8 @@ func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (director
 	conf := templateInputFRR{
 		Routers: []templateInputRouter{
 			{
+				LocalASN:      localASN,
+				NeighborASN:   neighborASN,
 				NeighborsIPv4: neighborsIPv4,
 				NetworksIPv4:  networksIPv4,
 				NeighborsIPv6: neighborsIPv6,
@@ -3278,8 +3336,10 @@ func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (director
 // FRRConfiguration instance name, VRF name and used as value of `network`
 // label) to establish a BGP session towards the provided neighbors in the
 // network's VRF, configured to receive advertisements for the provided
-// networks. Returns a temporary directory where the configuration is generated.
-func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetworks []string) (directory string, err error) {
+// networks. localASN is the cluster's ASN, neighborASN is the ASN of the
+// external FRR peer.
+// Returns a temporary directory where the configuration is generated.
+func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetworks []string, localASN, neighborASN int) (directory string, err error) {
 	// parse configuration templates
 	var templates *template.Template
 	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr-k8s", "*.tmpl"))
@@ -3306,6 +3366,8 @@ func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetwork
 		Routers: []templateInputRouter{
 			{
 				VRF:           networkName,
+				LocalASN:      localASN,
+				NeighborASN:   neighborASN,
 				NeighborsIPv4: neighborsIPv4,
 				NeighborsIPv6: neighborsIPv6,
 				NetworksIPv4:  receivesIPv4,
@@ -3324,6 +3386,9 @@ func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetwork
 // runBGPNetworkAndServer configures a topology appropriate to be used with
 // route advertisement test cases. For VRF-Lite test cases, the caller is
 // resposible to attach the peer network interface to the CUDN VRF on the nodes.
+// externalASN is the ASN for the external FRR container, clusterASN is the ASN
+// for the cluster nodes (frr-k8s). For iBGP, both are the same; for eBGP, they
+// differ.
 //
 // -----------------                 ------------------                            ---------------
 // |               |  serverNetwork  |                |       peerNetwork          |             |
@@ -3339,6 +3404,8 @@ func runBGPNetworkAndServer(
 	serverNetworkName string,
 	peerNetworks []string,
 	serverNetworks []string,
+	externalASN int,
+	clusterASN int,
 ) error {
 	// filter networks by supported IP families
 	peerNetworks = matchCIDRStringsByIPFamilySet(peerNetworks, ipFamilySet)
@@ -3372,7 +3439,7 @@ func runBGPNetworkAndServer(
 
 	// run frr container
 	advertiseNetworks := serverNetworks
-	frrConfig, err := generateFRRConfiguration(nodeIPs, advertiseNetworks)
+	frrConfig, err := generateFRRConfiguration(nodeIPs, advertiseNetworks, externalASN, clusterASN)
 	if err != nil {
 		return fmt.Errorf("failed to generate FRR configuration: %w", err)
 	}
@@ -3430,7 +3497,7 @@ func runBGPNetworkAndServer(
 
 	// apply FRR-K8s Configuration
 	receiveNetworks := serverNetworks
-	frrK8sConfig, err := generateFRRk8sConfiguration(networkName, []string{frr.IPv4, frr.IPv6}, receiveNetworks)
+	frrK8sConfig, err := generateFRRk8sConfiguration(networkName, []string{frr.IPv4, frr.IPv6}, receiveNetworks, clusterASN, externalASN)
 	if err != nil {
 		return fmt.Errorf("failed to generate FRR-k8s configuration: %w", err)
 	}
@@ -3692,13 +3759,13 @@ func createRouteAdvertisements(
 	return nil
 }
 
-// getBGPServerContainerIPs retrieves the IP addresses of the BGP server container.
-func getBGPServerContainerIPs(f *framework.Framework) (serverContainerIPs []string) {
-	bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName) // pre-created network
-	framework.ExpectNoError(err, "must get bgpnet network")
-	bgpServer := infraapi.ExternalContainer{Name: serverContainerName}
+// getBGPServerContainerIPsFor retrieves the IP addresses of a BGP server container on a given network.
+func getBGPServerContainerIPsFor(f *framework.Framework, serverName, networkName string) (serverContainerIPs []string) {
+	bgpNetwork, err := infraprovider.Get().GetNetwork(networkName)
+	framework.ExpectNoError(err, "must get %s network", networkName)
+	bgpServer := infraapi.ExternalContainer{Name: serverName}
 	networkInterface, err := infraprovider.Get().GetExternalContainerNetworkInterface(bgpServer, bgpNetwork)
-	framework.ExpectNoError(err, "container %s attached to network %s must contain network info", serverContainerName, bgpExternalNetworkName)
+	framework.ExpectNoError(err, "container %s attached to network %s must contain network info", serverName, networkName)
 	if isIPv4Supported(f.ClientSet) && len(networkInterface.IPv4) > 0 {
 		serverContainerIPs = append(serverContainerIPs, networkInterface.IPv4)
 	}
@@ -3706,6 +3773,11 @@ func getBGPServerContainerIPs(f *framework.Framework) (serverContainerIPs []stri
 		serverContainerIPs = append(serverContainerIPs, networkInterface.IPv6)
 	}
 	return
+}
+
+// getBGPServerContainerIPs retrieves the IP addresses of the default iBGP server container.
+func getBGPServerContainerIPs(f *framework.Framework) (serverContainerIPs []string) {
+	return getBGPServerContainerIPsFor(f, serverContainerName, bgpExternalNetworkName)
 }
 
 // isNoOverlayOutboundSNATEnabled reads the ovnkube-config configmap to determine

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -863,315 +863,315 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 								ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
 							}
 						}
-				}
+					}
 
-				layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
-				if layer2LocalGateway {
-					ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
-				} else {
-					ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
-				}
-				for _, node := range nodes.Items {
-					nodeName := node.Name
-					for _, tc := range []struct {
-						cidr, nextHop string
-					}{
-						{externalServerV4CIDR, frrContainerIPv4},
-						{externalServerV6CIDR, nodeIPv6LLA},
-					} {
-						if tc.cidr == "" || tc.nextHop == "" {
-							continue
-						}
-						isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
-						if isV6 && !isIPv6Supported(f.ClientSet) {
-							continue
-						}
-						if !isV6 && !isIPv4Supported(f.ClientSet) {
-							continue
-						}
-						if layer2LocalGateway {
-							framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+					layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
+					if layer2LocalGateway {
+						ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
+					} else {
+						ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
+					}
+					for _, node := range nodes.Items {
+						nodeName := node.Name
+						for _, tc := range []struct {
+							cidr, nextHop string
+						}{
+							{externalServerV4CIDR, frrContainerIPv4},
+							{externalServerV6CIDR, nodeIPv6LLA},
+						} {
+							if tc.cidr == "" || tc.nextHop == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
+							if isV6 && !isIPv6Supported(f.ClientSet) {
+								continue
+							}
+							if !isV6 && !isIPv4Supported(f.ClientSet) {
+								continue
+							}
+							if layer2LocalGateway {
+								framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+								gomega.Eventually(func() bool {
+									found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+									if err != nil {
+										framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+										return false
+									}
+									return found
+								}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+									"route for %s via %s not found in CUDN VRF %s on node %s",
+									tc.cidr, tc.nextHop, cUDN.Name, nodeName)
+								continue
+							}
 							gomega.Eventually(func() bool {
-								found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+								routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
 								if err != nil {
-									framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+									framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
 									return false
 								}
-								return found
-							}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-								"route for %s via %s not found in CUDN VRF %s on node %s",
-								tc.cidr, tc.nextHop, cUDN.Name, nodeName)
-							continue
-						}
-						gomega.Eventually(func() bool {
-							routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
-							if err != nil {
-								framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
-								return false
-							}
-							framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
-							for _, line := range strings.Split(routes, "\n") {
-								if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
-									return true
+								framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
+								for _, line := range strings.Split(routes, "\n") {
+									if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
+										return true
+									}
 								}
-							}
-							return false
-						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-							"CUDN %q GR on node %s is missing a route %s -> %s",
-							cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+								return false
+							}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+								"CUDN %q GR on node %s is missing a route %s -> %s",
+								cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+						}
 					}
-				}
 
-				expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
-					cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+					expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+						cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 
-				if expectSNAT {
-					ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
-				} else {
-					ginkgo.By("queries to the external server are not SNATed (uses podIP)")
-				}
-				var expectedSNATSourceIPs []string
-				if expectSNAT {
-					clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
-					framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
-					expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
-					gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
-					framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
-				}
-				for _, serverContainerIP := range serverContainerIPs {
-					podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
-						f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-					framework.Logf("Client pod IP address=%s", podIP)
-
-					ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
-						"and expecting to receive the same payload", serverContainerIP))
-					cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
-						net.JoinHostPort(serverContainerIP, "8080"),
-					)
-					framework.Logf("Testing pod to external traffic with command %q", cmd)
-					stdout, err := e2epodoutput.RunHostCmdWithRetries(
-						clientPod.Namespace,
-						clientPod.Name,
-						cmd,
-						framework.Poll,
-						60*time.Second)
-					framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-
-					sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
-					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-						fmt.Sprintf("Failed to parse client address from output %q", stdout))
 					if expectSNAT {
-						expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
-						gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
-							"Expected node %s to have an InternalIP for the external server IP family %s",
-							clientPod.Spec.NodeName, serverContainerIP)
-						gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-							fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+						ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
 					} else {
-						gomega.Expect(sourceIP).To(gomega.Equal(podIP),
-							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+						ginkgo.By("queries to the external server are not SNATed (uses podIP)")
 					}
-				}
-			},
-			ginkgo.Entry("layer3",
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					// Keep generated CUDN names under the Linux 15-byte interface
-					// limit so the VRF name is unique instead of network ID based.
-					GenerateName: "bgp-l3-",
-					Labels:       map[string]string{"bgp-l3": ""},
+					var expectedSNATSourceIPs []string
+					if expectSNAT {
+						clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+						framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
+						expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
+						gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
+						framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
+					}
+					for _, serverContainerIP := range serverContainerIPs {
+						podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+							f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+						framework.Logf("Client pod IP address=%s", podIP)
+
+						ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
+							"and expecting to receive the same payload", serverContainerIP))
+						cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
+							net.JoinHostPort(serverContainerIP, "8080"),
+						)
+						framework.Logf("Testing pod to external traffic with command %q", cmd)
+						stdout, err := e2epodoutput.RunHostCmdWithRetries(
+							clientPod.Namespace,
+							clientPod.Name,
+							cmd,
+							framework.Poll,
+							60*time.Second)
+						framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
+
+						sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+							fmt.Sprintf("Failed to parse client address from output %q", stdout))
+						if expectSNAT {
+							expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
+							gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
+								"Expected node %s to have an InternalIP for the external server IP family %s",
+								clientPod.Spec.NodeName, serverContainerIP)
+							gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+								fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+						} else {
+							gomega.Expect(sourceIP).To(gomega.Equal(podIP),
+								fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+						}
+					}
 				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/23",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "103.104.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/63",
-								HostSubnet: 64,
-							}, {
-								CIDR:       "2014:100:201::0/48",
-								HostSubnet: 64,
-							}},
+				ginkgo.Entry("layer3",
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							// Keep generated CUDN names under the Linux 15-byte interface
+							// limit so the VRF name is unique instead of network ID based.
+							GenerateName: "bgp-l3-",
+							Labels:       map[string]string{"bgp-l3": ""},
 						},
-					},
-				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l3-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l3": ""},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer3,
+								Layer3: &udnv1.Layer3Config{
+									Role: "Primary",
+									Subnets: []udnv1.Layer3Subnet{{
+										CIDR:       "103.103.0.0/23",
+										HostSubnet: 24,
+									}, {
+										CIDR:       "103.104.0.0/16",
+										HostSubnet: 24,
+									}, {
+										CIDR:       "2014:100:200::0/63",
+										HostSubnet: 64,
+									}, {
+										CIDR:       "2014:100:201::0/48",
+										HostSubnet: 64,
+									}},
 								},
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
-					},
-				},
-			},
-		),
-			ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "bgp-l3a-",
-						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer3,
-							Layer3: &udnv1.Layer3Config{
-								Role: "Primary",
-								Subnets: []udnv1.Layer3Subnet{{
-									CIDR:       "103.103.0.0/16",
-									HostSubnet: 24,
-								}, {
-									CIDR:       "2014:100:200::0/60",
-									HostSubnet: 64,
-								}},
-							},
-							Transport: udnv1.TransportOptionNoOverlay,
-							NoOverlay: &udnv1.NoOverlayConfig{
-								OutboundSNAT: udnv1.SNATEnabled,
-								Routing:      udnv1.RoutingUnmanaged,
-							},
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-l3-ra",
 						},
-					},
-				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
-					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-l3": ""},
+										},
 									},
 								},
 							},
-						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
-					},
-				},
-			),
-			ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "bgp-l3b-",
-						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer3,
-							Layer3: &udnv1.Layer3Config{
-								Role: "Primary",
-								Subnets: []udnv1.Layer3Subnet{{
-									CIDR:       "103.103.0.0/16",
-									HostSubnet: 24,
-								}, {
-									CIDR:       "2014:100:200::0/60",
-									HostSubnet: 64,
-								}},
-							},
-							Transport: udnv1.TransportOptionNoOverlay,
-							NoOverlay: &udnv1.NoOverlayConfig{
-								OutboundSNAT: udnv1.SNATDisabled,
-								Routing:      udnv1.RoutingUnmanaged,
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
 							},
 						},
 					},
-				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+				),
+				ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "bgp-l3a-",
+							Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+						},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer3,
+								Layer3: &udnv1.Layer3Config{
+									Role: "Primary",
+									Subnets: []udnv1.Layer3Subnet{{
+										CIDR:       "103.103.0.0/16",
+										HostSubnet: 24,
+									}, {
+										CIDR:       "2014:100:200::0/60",
+										HostSubnet: 64,
+									}},
+								},
+								Transport: udnv1.TransportOptionNoOverlay,
+								NoOverlay: &udnv1.NoOverlayConfig{
+									OutboundSNAT: udnv1.SNATEnabled,
+									Routing:      udnv1.RoutingUnmanaged,
+								},
+							},
+						},
 					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
+						},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+										},
 									},
 								},
 							},
-						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
-					},
-				},
-			),
-			ginkgo.Entry("layer2",
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						// Keep generated CUDN names under the Linux 15-byte interface
-						// limit so the VRF name is unique instead of network ID based.
-						GenerateName: "bgp-l2-",
-						Labels:       map[string]string{"bgp-l2": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer2,
-							Layer2: &udnv1.Layer2Config{
-								Role:    "Primary",
-								Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
 							},
 						},
 					},
-				},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l2-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l2": ""},
+				),
+				ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "bgp-l3b-",
+							Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+						},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer3,
+								Layer3: &udnv1.Layer3Config{
+									Role: "Primary",
+									Subnets: []udnv1.Layer3Subnet{{
+										CIDR:       "103.103.0.0/16",
+										HostSubnet: 24,
+									}, {
+										CIDR:       "2014:100:200::0/60",
+										HostSubnet: 64,
+									}},
+								},
+								Transport: udnv1.TransportOptionNoOverlay,
+								NoOverlay: &udnv1.NoOverlayConfig{
+									OutboundSNAT: udnv1.SNATDisabled,
+									Routing:      udnv1.RoutingUnmanaged,
 								},
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+						},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+										},
+									},
+								},
+							},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
+							},
+						},
 					},
-				},
-			},
-		),
-	)
-},
-bgpPeeringModes,
+				),
+				ginkgo.Entry("layer2",
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							// Keep generated CUDN names under the Linux 15-byte interface
+							// limit so the VRF name is unique instead of network ID based.
+							GenerateName: "bgp-l2-",
+							Labels:       map[string]string{"bgp-l2": ""},
+						},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer2,
+								Layer2: &udnv1.Layer2Config{
+									Role:    "Primary",
+									Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
+								},
+							},
+						},
+					},
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-l2-ra",
+						},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-l2": ""},
+										},
+									},
+								},
+							},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
+							},
+						},
+					},
+				),
+			)
+		},
+		bgpPeeringModes,
 	)
 })
 
@@ -2221,11 +2221,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		networkName string,
 		networkType networkType,
 		networkSpec *udnv1.NetworkSpec,
-	bgpAlloc allocators.BGPAllocation,
-	externalASN int,
-	clusterASN int,
-	frrContainerName string,
-) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
+		bgpAlloc allocators.BGPAllocation,
+		externalASN int,
+		clusterASN int,
+		frrContainerName string,
+	) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
 		ginkgo.GinkgoHelper()
 
 		framework.Logf("Configuring the infra for network %s of type %s with allocations %#v", networkName, networkType, bgpAlloc)
@@ -2545,6 +2545,15 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		testSuffix = framework.RandomSuffix()
 		testBaseName = baseName + testSuffix
 		testNetworkName = testBaseName
+		// Skip single-IP-family specs for unsupported families before any expensive
+		// infra setup. Entry descriptions contain "IPv4" or "IPv6" explicitly.
+		specText := ginkgo.CurrentSpecReport().FullText()
+		if !ipFamilySet.Has(utilnet.IPv6) && strings.Contains(specText, "IPv6") {
+			e2eskipper.Skipf("IPv6 not supported in this cluster")
+		}
+		if !ipFamilySet.Has(utilnet.IPv4) && strings.Contains(specText, "IPv4") {
+			e2eskipper.Skipf("IPv4 not supported in this cluster")
+		}
 	})
 
 	// define networks to test with
@@ -2659,35 +2668,35 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 	ginkgo.DescribeTableSubtree("With underlay BGP in mode",
 		func(peering bgpPeeringConfig) {
 
-		ginkgo.DescribeTableSubtree("When the tested network is of type",
-			func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-				var testNamespace *corev1.Namespace
-				var testPod *corev1.Pod
-				var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
-				var networkSpec *udnv1.NetworkSpec
+			ginkgo.DescribeTableSubtree("When the tested network is of type",
+				func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+					var testNamespace *corev1.Namespace
+					var testPod *corev1.Pod
+					var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
+					var networkSpec *udnv1.NetworkSpec
 
-				expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
-					ginkgo.GinkgoHelper()
-					// In LGW VRF-Lite, host nftables masquerade picks the source IP
-					// from the node's egress interface in the target VRF when no-overlay
-					// outbound SNAT is enabled.
-					if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
-						testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
-						iface, ok := vrfLiteNodeInterfaces[node.Name]
-						gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
-						expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-						gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
-						return expectedIP
+					expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
+						ginkgo.GinkgoHelper()
+						// In LGW VRF-Lite, host nftables masquerade picks the source IP
+						// from the node's egress interface in the target VRF when no-overlay
+						// outbound SNAT is enabled.
+						if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
+							testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
+							iface, ok := vrfLiteNodeInterfaces[node.Name]
+							gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
+							expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+							gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
+							return expectedIP
+						}
+						expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						if family == utilnet.IPv6 {
+							expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						}
+						gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
+						return expectedNodeIPs[0]
 					}
-					expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
-					if family == utilnet.IPv6 {
-						expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
-					}
-					gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
-					return expectedNodeIPs[0]
-				}
 
-				getSameNode := func() string {
+					getSameNode := func() string {
 						return testPod.Spec.NodeName
 					}
 					getDifferentNode := func() string {
@@ -2704,23 +2713,23 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					}
 
 					ginkgo.BeforeEach(func() {
-						if peering.externalASN != peering.clusterASN && testedNetworkType == cudnAdvertisedEVPNUnmanagedRandomVTEP {
-							e2eskipper.Skipf("Random VTEP tests are skipped in eBGP mode")
+						if peering.externalASN != peering.clusterASN && testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
+							e2eskipper.Skipf("Shared node-IP VTEP tests are skipped in eBGP mode")
 						}
 
 						bgpAlloc, err := allocators.AllocateBGP(f, ictx)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
 
-					networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
-					switch {
-					case networkSpec.Layer3 != nil:
-						networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
-					case networkSpec.Layer2 != nil:
-						networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
-					}
+						networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
+						switch {
+						case networkSpec.Layer3 != nil:
+							networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
+						case networkSpec.Layer2 != nil:
+							networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
+						}
 
-					testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
+						testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
 							f,
 							ictx,
 							testBaseName,
@@ -2747,69 +2756,75 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 									p.Spec.Containers[0].Args = []string{"netexec"}
 								},
 							)
+
+							// testPod was created without Spec.NodeName, re-fetch the pod so Spec.NodeName is populated
+							var err error
+							testPod, err = f.ClientSet.CoreV1().Pods(testPod.Namespace).Get(
+								context.TODO(), testPod.Name, metav1.GetOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						})
 
-					ginkgo.DescribeTable("It can reach external servers on the same network",
-						func(family utilnet.IPFamily) {
-							if !ipFamilySet.Has(family) {
-								e2eskipper.Skipf("IP family %v not supported", family)
-							}
-							expectSNAT := networkSpec.NoOverlay != nil &&
-								networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
-
-							if expectSNAT {
-								ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
-							} else {
-								ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
-							}
-							for _, externalServer := range externalServers {
-								bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-									infraapi.ExternalContainer{Name: externalServer},
-									bgpServerNetwork,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-								gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-								framework.Logf("Checking request from pod reaches server %q", externalServer)
-								testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+						ginkgo.DescribeTable("It can reach external servers on the same network",
+							func(family utilnet.IPFamily) {
+								if !ipFamilySet.Has(family) {
+									e2eskipper.Skipf("IP family %v not supported", family)
+								}
+								expectSNAT := networkSpec.NoOverlay != nil &&
+									networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 
 								if expectSNAT {
-									framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
-									ip, err := e2epodoutput.RunHostCmdWithRetries(
-										testPod.Namespace,
-										testPod.Name,
-										fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
-										polling,
-										timeout,
-									)
-									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									sourceIP, _, err := net.SplitHostPort(ip)
-									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
-									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
-									gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-										fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
+									ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
 								} else {
-									testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-										f.ClientSet,
-										testPod.Namespace,
-										testPod.Name,
-										testNetworkName,
-										family,
+									ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+								}
+								for _, externalServer := range externalServers {
+									bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+										infraapi.ExternalContainer{Name: externalServer},
+										bgpServerNetwork,
 									)
 									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-									framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
-									testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+									serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+									gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+									framework.Logf("Checking request from pod reaches server %q", externalServer)
+									testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+
+									if expectSNAT {
+										framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
+										ip, err := e2epodoutput.RunHostCmdWithRetries(
+											testPod.Namespace,
+											testPod.Name,
+											fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
+											polling,
+											timeout,
+										)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										sourceIP, _, err := net.SplitHostPort(ip)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
+										gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+											fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
+									} else {
+										testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+											f.ClientSet,
+											testPod.Namespace,
+											testPod.Name,
+											testNetworkName,
+											family,
+										)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+										framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
+										testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+									}
 								}
-							}
-						},
-						ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-						ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-					)
+							},
+							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+						)
 
 						ginkgo.DescribeTable("It can be reached by an external server on the same network",
 							func(family utilnet.IPFamily) {
@@ -2857,85 +2872,78 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							gomega.Expect(output).To(gomega.Equal("ok"))
 						})
 
-						ginkgo.DescribeTable("It cannot reach an external server on a different network",
-							func(family utilnet.IPFamily) {
-								if peering.externalASN != peering.clusterASN {
-									e2eskipper.Skipf("Isolation tests only run in iBGP mode")
-								}
-								if !ipFamilySet.Has(family) {
-									e2eskipper.Skipf("IP family %v not supported", family)
-								}
-								ginkgo.By("Ensuring a request from the pod cannot reach the external server")
-								// using the external server setup for the default network
-								bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-									infraapi.ExternalContainer{Name: serverContainerName},
-									bgpServerNetwork,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-								gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-								testPodToClientIPNOK(testPod, serverIP)
-							},
-							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-						)
+						if peering.externalASN == peering.clusterASN {
+							ginkgo.DescribeTable("It cannot reach an external server on a different network",
+								func(family utilnet.IPFamily) {
+									if !ipFamilySet.Has(family) {
+										e2eskipper.Skipf("IP family %v not supported", family)
+									}
+									ginkgo.By("Ensuring a request from the pod cannot reach the external server")
+									// using the external server setup for the default network
+									bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+										infraapi.ExternalContainer{Name: serverContainerName},
+										bgpServerNetwork,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+									gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+									testPodToClientIPNOK(testPod, serverIP)
+								},
+								ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+								ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+							)
 
-						ginkgo.DescribeTable("It cannot be reached by an external server on a different network",
-							func(family utilnet.IPFamily) {
-								if peering.externalASN != peering.clusterASN {
-									e2eskipper.Skipf("Isolation tests only run in iBGP mode")
-								}
-								if !ipFamilySet.Has(family) {
-									e2eskipper.Skipf("IP family %v not supported", family)
-								}
-								ginkgo.By("Ensuring a request from the external server cannot reach the pod")
-								podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-									f.ClientSet,
-									testPod.Namespace,
-									testPod.Name,
-									testNetworkName,
-									family,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-								// using the external server setup for the default network
-								testContainerToClientIPNOK(serverContainerName, podIP)
-							},
-							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-						)
+							ginkgo.DescribeTable("It cannot be reached by an external server on a different network",
+								func(family utilnet.IPFamily) {
+									if !ipFamilySet.Has(family) {
+										e2eskipper.Skipf("IP family %v not supported", family)
+									}
+									ginkgo.By("Ensuring a request from the external server cannot reach the pod")
+									podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										f.ClientSet,
+										testPod.Namespace,
+										testPod.Name,
+										testNetworkName,
+										family,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+									// using the external server setup for the default network
+									testContainerToClientIPNOK(serverContainerName, podIP)
+								},
+								ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+								ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+							)
 
-						ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
-							func(getNode func() string) {
-								ginkgo.DescribeTable("",
-									func(family utilnet.IPFamily) {
-										if peering.externalASN != peering.clusterASN {
-											e2eskipper.Skipf("Isolation tests only run in iBGP mode")
-										}
-										if !ipFamilySet.Has(family) {
-											e2eskipper.Skipf("IP family %v not supported", family)
-										}
-										ginkgo.By("Ensuring a request from the node cannot reach the tested network pod")
-										podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-											f.ClientSet,
-											testPod.Namespace,
-											testPod.Name,
-											testNetworkName,
-											family,
-										)
-										gomega.Expect(err).NotTo(gomega.HaveOccurred())
-										gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-										testNodeToClientIPNOK(getNode(), podIP)
-									},
-									ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-									ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-								)
-							},
-							ginkgo.Entry("When it is the same node", getSameNode),
-							ginkgo.Entry("When it is a different node", getDifferentNode),
-						)
+							ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
+								func(getNode func() string) {
+									ginkgo.DescribeTable("",
+										func(family utilnet.IPFamily) {
+											if !ipFamilySet.Has(family) {
+												e2eskipper.Skipf("IP family %v not supported", family)
+											}
+											ginkgo.By("Ensuring a request from the node cannot reach the tested network pod")
+											podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												f.ClientSet,
+												testPod.Namespace,
+												testPod.Name,
+												testNetworkName,
+												family,
+											)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+											testNodeToClientIPNOK(getNode(), podIP)
+										},
+										ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+										ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+									)
+								},
+								ginkgo.Entry("When it is the same node", getSameNode),
+								ginkgo.Entry("When it is a different node", getDifferentNode),
+							)
+						}
 
 						ginkgo.DescribeTableSubtree("When other pod runs on the tested network",
 							func(getNode func() string) {
@@ -3015,217 +3023,214 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							ginkgo.Entry("On a different node", getDifferentNode),
 						)
 
-						ginkgo.Describe("When there is other network", func() {
-							ginkgo.BeforeEach(func() {
-								if peering.externalASN != peering.clusterASN {
-									e2eskipper.Skipf("Isolation tests only run in iBGP mode")
+						if peering.externalASN == peering.clusterASN {
+							ginkgo.Describe("When there is other network", func() {
+
+								nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
+									return nil
 								}
-							})
 
-							nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
-								return nil
-							}
+								otherNetworksToTest := []ginkgo.TableEntry{
+									ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+									ginkgo.Entry("Layer 3 UDN", udn, layer3NetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
+									ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+								}
 
-							otherNetworksToTest := []ginkgo.TableEntry{
-								ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
-								ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
-								ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
-								ginkgo.Entry("Layer 3 UDN", udn, layer3NetworkSpecGen),
-								ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
-								ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
-								ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
-								ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
-								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
-								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-							}
+								ginkgo.DescribeTableSubtree("Of type",
+									func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+										var otherNamespace *corev1.Namespace
+										var otherNetworkName string
 
-							ginkgo.DescribeTableSubtree("Of type",
-								func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-									var otherNamespace *corev1.Namespace
-									var otherNetworkName string
+										ginkgo.BeforeEach(func() {
+											otherNetworkName = testBaseName + "o"
+											otherNamespaceName := otherNetworkName
 
-									ginkgo.BeforeEach(func() {
-										otherNetworkName = testBaseName + "o"
-										otherNamespaceName := otherNetworkName
+											otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
 
-										otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
-										gomega.Expect(err).NotTo(gomega.HaveOccurred())
-										otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
+											otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
+											switch {
+											case otherNetworkSpec == nil:
+												otherNetworkName = "default"
+											case otherNetworkSpec.Layer3 != nil:
+												otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
+											case otherNetworkSpec.Layer2 != nil:
+												otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
+											}
 
-										otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
-										switch {
-										case otherNetworkSpec == nil:
-											otherNetworkName = "default"
-										case otherNetworkSpec.Layer3 != nil:
-											otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
-										case otherNetworkSpec.Layer2 != nil:
-											otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
-										}
-
-									otherNamespace, _, _ = configureNetworkWithInfra(
-										f,
-										ictx,
-										testBaseName,
-										ipFamilySet,
-										otherNamespaceName,
-										networkType,
-										otherNetworkSpec,
-										otherBGPAlloc,
-										peering.externalASN,
-										peering.clusterASN,
-										peering.routerContainer,
-									)
-								})
-
-									ginkgo.It("Both networks are isolated", func() {
-										ginkgo.By("Running two pods on the other network namespace on different nodes")
-										var otherPodSameNode, otherPodDiffNode *corev1.Pod
-										wg := sync.WaitGroup{}
-										wg.Add(2)
-										go func() {
-											ginkgo.GinkgoHelper()
-											defer ginkgo.GinkgoRecover()
-											defer wg.Done()
-											otherPodSameNode = e2epod.CreateExecPodOrFail(
-												context.Background(),
-												f.ClientSet,
-												otherNamespace.Name,
-												otherNamespace.Name+"-netexec-samenode-pod",
-												func(p *corev1.Pod) {
-													p.Spec.Containers[0].Args = []string{"netexec"}
-													p.Spec.NodeName = getSameNode()
-													p.Labels = map[string]string{"app": "netexec-samenode-pod"}
-												},
+											otherNamespace, _, _ = configureNetworkWithInfra(
+												f,
+												ictx,
+												testBaseName,
+												ipFamilySet,
+												otherNamespaceName,
+												networkType,
+												otherNetworkSpec,
+												otherBGPAlloc,
+												peering.externalASN,
+												peering.clusterASN,
+												peering.routerContainer,
 											)
-										}()
-										go func() {
-											ginkgo.GinkgoHelper()
-											defer ginkgo.GinkgoRecover()
-											defer wg.Done()
-											otherPodDiffNode = e2epod.CreateExecPodOrFail(
-												context.Background(),
-												f.ClientSet,
-												otherNamespace.Name,
-												otherNamespace.Name+"-netexec-diffnode-pod",
-												func(p *corev1.Pod) {
-													p.Spec.Containers[0].Args = []string{"netexec"}
-													p.Spec.NodeName = getDifferentNode()
-													p.Labels = map[string]string{"app": "netexec-diffnode-pod"}
-												},
-											)
-										}()
-										wg.Wait()
+										})
 
-										ginkgo.By("Ensuring the pods from the other network can talk to each other")
-										testForIPFamilies(
-											ipFamilySet,
-											func(family utilnet.IPFamily) {
+										ginkgo.It("Both networks are isolated", func() {
+											ginkgo.By("Running two pods on the other network namespace on different nodes")
+											var otherPodSameNode, otherPodDiffNode *corev1.Pod
+											wg := sync.WaitGroup{}
+											wg.Add(2)
+											go func() {
 												ginkgo.GinkgoHelper()
-												otherPodSameNodeIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												defer ginkgo.GinkgoRecover()
+												defer wg.Done()
+												otherPodSameNode = e2epod.CreateExecPodOrFail(
+													context.Background(),
 													f.ClientSet,
-													otherPodSameNode.Namespace,
-													otherPodSameNode.Name,
-													otherNetworkName,
-													family,
+													otherNamespace.Name,
+													otherNamespace.Name+"-netexec-samenode-pod",
+													func(p *corev1.Pod) {
+														p.Spec.Containers[0].Args = []string{"netexec"}
+														p.Spec.NodeName = getSameNode()
+														p.Labels = map[string]string{"app": "netexec-samenode-pod"}
+													},
 												)
-												gomega.Expect(err).NotTo(gomega.HaveOccurred())
-												gomega.Expect(otherPodSameNodeIP).ToNot(gomega.BeEmpty())
-												testPodToClientIP(otherPodDiffNode, otherPodSameNodeIP)
-											},
-										)
+											}()
+											go func() {
+												ginkgo.GinkgoHelper()
+												defer ginkgo.GinkgoRecover()
+												defer wg.Done()
+												otherPodDiffNode = e2epod.CreateExecPodOrFail(
+													context.Background(),
+													f.ClientSet,
+													otherNamespace.Name,
+													otherNamespace.Name+"-netexec-diffnode-pod",
+													func(p *corev1.Pod) {
+														p.Spec.Containers[0].Args = []string{"netexec"}
+														p.Spec.NodeName = getDifferentNode()
+														p.Labels = map[string]string{"app": "netexec-diffnode-pod"}
+													},
+												)
+											}()
+											wg.Wait()
 
-										ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network pods")
-										for _, target := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+											ginkgo.By("Ensuring the pods from the other network can talk to each other")
 											testForIPFamilies(
 												ipFamilySet,
 												func(family utilnet.IPFamily) {
 													ginkgo.GinkgoHelper()
-													framework.Logf("Ensuring a request from the tested network pod cannot reach the other network pod %s on IPv%v", target.Name, family)
-													otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+													otherPodSameNodeIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 														f.ClientSet,
-														target.Namespace,
-														target.Name,
+														otherPodSameNode.Namespace,
+														otherPodSameNode.Name,
 														otherNetworkName,
 														family,
 													)
 													gomega.Expect(err).NotTo(gomega.HaveOccurred())
-													gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-													testPodToClientIPNOK(testPod, otherPodIP)
+													gomega.Expect(otherPodSameNodeIP).ToNot(gomega.BeEmpty())
+													testPodToClientIP(otherPodDiffNode, otherPodSameNodeIP)
 												},
 											)
-										}
 
-										ginkgo.By("Ensuring a request from the other network pods on the same node cannot reach the tested network pod")
-										for _, source := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-											testForIPFamilies(
-												ipFamilySet,
-												func(family utilnet.IPFamily) {
-													ginkgo.GinkgoHelper()
-													framework.Logf("Ensuring a request from the other network pod %s on the same node cannot reach the tested network pod on IPv%v", source.Name, family)
-													testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-														f.ClientSet,
-														testPod.Namespace,
-														testPod.Name,
-														testNetworkName,
-														family,
-													)
-													gomega.Expect(err).NotTo(gomega.HaveOccurred())
-													gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-													testPodToClientIPNOK(source, testPodIP)
-												},
-											)
-										}
+											ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network pods")
+											for _, target := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the tested network pod cannot reach the other network pod %s on IPv%v", target.Name, family)
+														otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+															f.ClientSet,
+															target.Namespace,
+															target.Name,
+															otherNetworkName,
+															family,
+														)
+														gomega.Expect(err).NotTo(gomega.HaveOccurred())
+														gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
+														testPodToClientIPNOK(testPod, otherPodIP)
+													},
+												)
+											}
 
-										ginkgo.By("Creating services backed by the other network pods")
-										var services []*corev1.Service
-										for _, backend := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-											service := e2eservice.CreateServiceSpec(
-												"service-"+backend.Name,
-												"",
-												false,
-												backend.Labels,
-											)
-											service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
-											familyPolicy := corev1.IPFamilyPolicyPreferDualStack
-											service.Spec.IPFamilyPolicy = &familyPolicy
-											var err error
-											service, err = f.ClientSet.CoreV1().Services(backend.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											services = append(services, service)
-										}
+											ginkgo.By("Ensuring a request from the other network pods on the same node cannot reach the tested network pod")
+											for _, source := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the other network pod %s on the same node cannot reach the tested network pod on IPv%v", source.Name, family)
+														testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+															f.ClientSet,
+															testPod.Namespace,
+															testPod.Name,
+															testNetworkName,
+															family,
+														)
+														gomega.Expect(err).NotTo(gomega.HaveOccurred())
+														gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+														testPodToClientIPNOK(source, testPodIP)
+													},
+												)
+											}
 
-										ginkgo.By("Ensuring the pods from the other network can reach their services")
-										for source, target := range map[*corev1.Pod]*corev1.Service{otherPodSameNode: services[1], otherPodDiffNode: services[0]} {
-											testForIPFamilies(
-												ipFamilySet,
-												func(family utilnet.IPFamily) {
-													ginkgo.GinkgoHelper()
-													framework.Logf("Ensuring a request from the other network pod %s can reach the its network service %s on IPv%v", source.Name, target.Name, family)
-													clusterIP := getFirstIPStringOfFamily(family, target.Spec.ClusterIPs)
-													gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-													testPodToClientIP(source, clusterIP)
-												},
-											)
-										}
+											ginkgo.By("Creating services backed by the other network pods")
+											var services []*corev1.Service
+											for _, backend := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+												service := e2eservice.CreateServiceSpec(
+													"service-"+backend.Name,
+													"",
+													false,
+													backend.Labels,
+												)
+												service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
+												familyPolicy := corev1.IPFamilyPolicyPreferDualStack
+												service.Spec.IPFamilyPolicy = &familyPolicy
+												var err error
+												service, err = f.ClientSet.CoreV1().Services(backend.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+												gomega.Expect(err).NotTo(gomega.HaveOccurred())
+												services = append(services, service)
+											}
 
-										ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network services")
-										for _, service := range services {
-											testForIPFamilies(
-												ipFamilySet,
-												func(family utilnet.IPFamily) {
-													ginkgo.GinkgoHelper()
-													framework.Logf("Ensuring a request from the tested network pod cannot reach the other network service %s on IPv%v", service.Name, family)
-													clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
-													gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-													testPodToClientIPNOK(testPod, clusterIP)
-												},
-											)
-										}
-									})
-								},
-								otherNetworksToTest,
-							)
-						})
+											ginkgo.By("Ensuring the pods from the other network can reach their services")
+											for source, target := range map[*corev1.Pod]*corev1.Service{otherPodSameNode: services[1], otherPodDiffNode: services[0]} {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the other network pod %s can reach the its network service %s on IPv%v", source.Name, target.Name, family)
+														clusterIP := getFirstIPStringOfFamily(family, target.Spec.ClusterIPs)
+														gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
+														testPodToClientIP(source, clusterIP)
+													},
+												)
+											}
+
+											ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network services")
+											for _, service := range services {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the tested network pod cannot reach the other network service %s on IPv%v", service.Name, family)
+														clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
+														gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
+														testPodToClientIPNOK(testPod, clusterIP)
+													},
+												)
+											}
+										})
+									},
+									otherNetworksToTest,
+								)
+							})
+						}
 					})
 				},
 				networksToTest,

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -5,8 +5,8 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -976,58 +976,58 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				}
 			},
 			ginkgo.Entry("layer3",
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						// Keep generated CUDN names under the Linux 15-byte interface
-						// limit so the VRF name is unique instead of network ID based.
-						GenerateName: "bgp-l3-",
-						Labels:       map[string]string{"bgp-l3": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer3,
-							Layer3: &udnv1.Layer3Config{
-								Role: "Primary",
-								Subnets: []udnv1.Layer3Subnet{{
-									CIDR:       "103.103.0.0/23",
-									HostSubnet: 24,
-								}, {
-									CIDR:       "103.104.0.0/16",
-									HostSubnet: 24,
-								}, {
-									CIDR:       "2014:100:200::0/63",
-									HostSubnet: 64,
-								}, {
-									CIDR:       "2014:100:201::0/48",
-									HostSubnet: 64,
-								}},
-							},
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					// Keep generated CUDN names under the Linux 15-byte interface
+					// limit so the VRF name is unique instead of network ID based.
+					GenerateName: "bgp-l3-",
+					Labels:       map[string]string{"bgp-l3": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/23",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "103.104.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/63",
+								HostSubnet: 64,
+							}, {
+								CIDR:       "2014:100:201::0/48",
+								HostSubnet: 64,
+							}},
 						},
 					},
 				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-l3-ra",
-					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-l3": ""},
-									},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-l3-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-l3": ""},
 								},
 							},
 						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
 					},
 				},
-			),
+			},
+		),
 			ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
 				&udnv1.ClusterUserDefinedNetwork{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1146,32 +1146,32 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						},
 					},
 				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-l2-ra",
-					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-l2": ""},
-									},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-l2-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-l2": ""},
 								},
 							},
 						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
 					},
 				},
-			),
-		)
-	},
-	bgpPeeringModes,
+			},
+		),
+	)
+},
+bgpPeeringModes,
 	)
 })
 
@@ -1470,9 +1470,9 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				serverContainerIPs := getBGPServerContainerIPs(f)
 				for _, serverContainerIP := range serverContainerIPs {
 					for _, node := range nodes.Items {
-					if cudnA.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
-						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnA.Name)
-						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
+						if cudnA.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
+							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnA.Name)
+							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
 						} else {
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnATemplate.Spec.Network.Layer2.Subnets)
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnBTemplate.Spec.Network.Layer2.Subnets)
@@ -2212,7 +2212,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 
 var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdvertisements, func() {
 
-
 	// configuration helper to setup infra
 	configureNetworkWithInfra := func(
 		f *framework.Framework,
@@ -2273,7 +2272,6 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				bgpAlloc.VTEPSubnet = kindV4Subnet
 				vtepName = sharedNodeIPsVTEPName
 			}
-
 
 			macVRFContainer := infraapi.ExternalContainer{
 				Name:    networkName + "-" + frrContainerName + "-macvrf-agnhost",
@@ -2690,48 +2688,48 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				}
 
 				getSameNode := func() string {
-					return testPod.Spec.NodeName
-				}
-				getDifferentNode := func() string {
-					ginkgo.GinkgoHelper()
-					nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get ready schedulable nodes")
-				for _, node := range nodes.Items {
-					if node.Name != testPod.Spec.NodeName {
-						return node.Name
+						return testPod.Spec.NodeName
 					}
-				}
-				ginkgo.Fail(fmt.Sprintf("Failed to find a different ready schedulable node than %s", testPod.Spec.NodeName))
-				return ""
-			}
+					getDifferentNode := func() string {
+						ginkgo.GinkgoHelper()
+						nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get ready schedulable nodes")
+						for _, node := range nodes.Items {
+							if node.Name != testPod.Spec.NodeName {
+								return node.Name
+							}
+						}
+						ginkgo.Fail(fmt.Sprintf("Failed to find a different ready schedulable node than %s", testPod.Spec.NodeName))
+						return ""
+					}
 
-			ginkgo.BeforeEach(func() {
-				bgpAlloc, err := allocators.AllocateBGP(f, ictx)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
+					ginkgo.BeforeEach(func() {
+						bgpAlloc, err := allocators.AllocateBGP(f, ictx)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
 
-				networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
-				switch {
-				case networkSpec.Layer3 != nil:
-					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
-				case networkSpec.Layer2 != nil:
-					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
-				}
+					networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
+					switch {
+					case networkSpec.Layer3 != nil:
+						networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
+					case networkSpec.Layer2 != nil:
+						networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
+					}
 
-				testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
-					f,
-					ictx,
-					testBaseName,
-					ipFamilySet,
-					testNetworkName,
-					testedNetworkType,
-					networkSpec,
-					bgpAlloc,
-					peering.externalASN,
-					peering.clusterASN,
-					peering.routerContainer,
-				)
-				})
+					testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
+							f,
+							ictx,
+							testBaseName,
+							ipFamilySet,
+							testNetworkName,
+							testedNetworkType,
+							networkSpec,
+							bgpAlloc,
+							peering.externalASN,
+							peering.clusterASN,
+							peering.routerContainer,
+						)
+					})
 
 					ginkgo.Describe("When a pod runs on the tested network", func() {
 						ginkgo.BeforeEach(func() {
@@ -2905,10 +2903,10 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
 						)
 
-			ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
-				func(getNode func() string) {
-				ginkgo.DescribeTable("",
-							func(family utilnet.IPFamily) {
+						ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
+							func(getNode func() string) {
+								ginkgo.DescribeTable("",
+									func(family utilnet.IPFamily) {
 										if peering.externalASN != peering.clusterASN {
 											e2eskipper.Skipf("Isolation tests only run in iBGP mode")
 										}
@@ -3020,9 +3018,9 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 								}
 							})
 
-						nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
-							return nil
-						}
+							nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
+								return nil
+							}
 
 							otherNetworksToTest := []ginkgo.TableEntry{
 								ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
@@ -3032,33 +3030,33 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 								ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
 								ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
 								ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
-							ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
-							ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
-							ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+								ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
+								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
+								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
 							}
 
-						ginkgo.DescribeTableSubtree("Of type",
-							func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-								var otherNamespace *corev1.Namespace
-								var otherNetworkName string
+							ginkgo.DescribeTableSubtree("Of type",
+								func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+									var otherNamespace *corev1.Namespace
+									var otherNetworkName string
 
-								ginkgo.BeforeEach(func() {
-									otherNetworkName = testBaseName + "o"
-									otherNamespaceName := otherNetworkName
+									ginkgo.BeforeEach(func() {
+										otherNetworkName = testBaseName + "o"
+										otherNamespaceName := otherNetworkName
 
-									otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
-									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
+										otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
 
-									otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
-									switch {
-									case otherNetworkSpec == nil:
-										otherNetworkName = "default"
-									case otherNetworkSpec.Layer3 != nil:
-										otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
-									case otherNetworkSpec.Layer2 != nil:
-										otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
-									}
+										otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
+										switch {
+										case otherNetworkSpec == nil:
+											otherNetworkName = "default"
+										case otherNetworkSpec.Layer3 != nil:
+											otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
+										case otherNetworkSpec.Layer2 != nil:
+											otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
+										}
 
 									otherNamespace, _, _ = configureNetworkWithInfra(
 										f,

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -2704,6 +2704,10 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					}
 
 					ginkgo.BeforeEach(func() {
+						if peering.externalASN != peering.clusterASN && testedNetworkType == cudnAdvertisedEVPNUnmanagedRandomVTEP {
+							e2eskipper.Skipf("Random VTEP tests are skipped in eBGP mode")
+						}
+
 						bgpAlloc, err := allocators.AllocateBGP(f, ictx)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -5,8 +5,8 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -1141,29 +1141,29 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						},
 					},
 				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-l3-ra",
-					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-l3": ""},
-									},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-l3-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-l3": ""},
 								},
 							},
 						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
 					},
 				},
-			),
+			},
+		),
 			ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
 				&udnv1.ClusterUserDefinedNetwork{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1282,32 +1282,32 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						},
 					},
 				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-l2-ra",
-					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-l2": ""},
-									},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-l2-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-l2": ""},
 								},
 							},
 						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
 					},
 				},
-			),
-		)
-	},
-	bgpPeeringModes,
+			},
+		),
+	)
+},
+bgpPeeringModes,
 	)
 })
 
@@ -2614,7 +2614,6 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 
 var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdvertisements, func() {
 
-
 	// configuration helper to setup infra
 	configureNetworkWithInfra := func(
 		f *framework.Framework,
@@ -2680,7 +2679,6 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				bridgeName = "br" + testName
 				vxlanName = "vx" + testName
 			}
-
 
 			macVRFContainer := infraapi.ExternalContainer{
 				Name:    networkName + "-" + frrContainerName + "-macvrf-agnhost",
@@ -3440,7 +3438,6 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 
 						if peering.externalASN == peering.clusterASN {
 							ginkgo.Describe("When there is other network", func() {
-
 
 								overlappingSpecGen := func(_ string, _ string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
 									spec := testNetworkSpec.DeepCopy()

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -5,8 +5,8 @@ package e2e
 
 import (
 	"context"
-	"embed"
 	"encoding/json"
+	"embed"
 	"fmt"
 	"math/rand"
 	"net"
@@ -65,6 +65,46 @@ const (
 	echoClientPodName      = "echo-client-pod"
 	bgpExternalNetworkName = "bgpnet"
 	netexecPort            = 8080
+
+	serverContainerNameEBGP    = "bgpserver-ebgp"
+	routerContainerNameEBGP    = "frr-ebgp"
+	bgpExternalNetworkNameEBGP = "bgpnet-ebgp"
+
+	bgpClusterASN = 64512
+	bgpEBGPASN    = 64513
+)
+
+// bgpPeeringConfig holds the BGP peering parameters that differ between iBGP
+// and eBGP modes. For iBGP, externalASN equals clusterASN. For eBGP, they
+// differ and route-reflector-client is not used.
+type bgpPeeringConfig struct {
+	externalASN     int
+	clusterASN      int
+	routerContainer string
+	serverContainer string
+	externalNetwork string
+}
+
+var (
+	ibgpPeering = bgpPeeringConfig{
+		externalASN:     bgpClusterASN,
+		clusterASN:      bgpClusterASN,
+		routerContainer: routerContainerName,
+		serverContainer: serverContainerName,
+		externalNetwork: bgpExternalNetworkName,
+	}
+	ebgpPeering = bgpPeeringConfig{
+		externalASN:     bgpEBGPASN,
+		clusterASN:      bgpClusterASN,
+		routerContainer: routerContainerNameEBGP,
+		serverContainer: serverContainerNameEBGP,
+		externalNetwork: bgpExternalNetworkNameEBGP,
+	}
+
+	bgpPeeringModes = []ginkgo.TableEntry{
+		ginkgo.Entry("iBGP", ibgpPeering),
+		ginkgo.Entry("eBGP", ebgpPeering),
+	}
 )
 
 func init() {
@@ -74,573 +114,579 @@ func init() {
 }
 
 var _ = ginkgo.Describe("BGP: When default podNetwork is advertised", feature.RouteAdvertisements, func() {
-	var serverContainerIPs []string
-	var frrContainerIPv4, frrContainerIPv6 string
-	var nodes *corev1.NodeList
 	f := wrappedTestFramework("pod2external-route-advertisements")
 
-	ginkgo.BeforeEach(func() {
-		serverContainerIPs = getBGPServerContainerIPs(f)
-		framework.Logf("The external server IPs are: %+v", serverContainerIPs)
-		providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
-		framework.ExpectNoError(err, "provider primary network must be available")
-		externalContainerNetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: routerContainerName}, providerPrimaryNetwork)
-		framework.ExpectNoError(err, "external container %s network %s information must be available", routerContainerName, providerPrimaryNetwork.Name())
-		frrContainerIPv4, frrContainerIPv6 = externalContainerNetInf.IPv4, externalContainerNetInf.IPv6
-		framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
-	})
+	ginkgo.DescribeTableSubtree("with underlay BGP in mode",
+		func(peering bgpPeeringConfig) {
+			var serverContainerIPs []string
+			var frrContainerIPv4, frrContainerIPv6 string
+			var nodes *corev1.NodeList
 
-	ginkgo.When("a client ovnk pod is created", func() {
+			ginkgo.BeforeEach(func() {
+				serverContainerIPs = getBGPServerContainerIPsFor(f, peering.serverContainer, peering.externalNetwork)
+				framework.Logf("The external server IPs are: %+v", serverContainerIPs)
+				providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
+				framework.ExpectNoError(err, "provider primary network must be available")
+				externalContainerNetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(infraapi.ExternalContainer{Name: peering.routerContainer}, providerPrimaryNetwork)
+				framework.ExpectNoError(err, "external container %s network %s information must be available", peering.routerContainer, providerPrimaryNetwork.Name())
+				frrContainerIPv4, frrContainerIPv6 = externalContainerNetInf.IPv4, externalContainerNetInf.IPv6
+				framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
+			})
 
-		var clientPod, hostNetworkedPod *corev1.Pod
-		var clientPodNodeName string
-		var err error
+			ginkgo.When("a client ovnk pod is created", func() {
 
-		ginkgo.BeforeEach(func() {
-			if !isDefaultNetworkAdvertised() {
-				e2eskipper.Skipf(
-					"skipping pod to external server tests when podNetwork is not advertised",
-				)
-			}
-			ginkgo.By("Selecting 3 schedulable nodes")
-			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
+				var clientPod, hostNetworkedPod *corev1.Pod
+				var clientPodNodeName string
+				var err error
 
-			ginkgo.By("Selecting node for client pod")
-			clientPodNodeName = nodes.Items[1].Name
-
-			ginkgo.By("Creating client pod")
-			clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
-			clientPod.Spec.NodeName = clientPodNodeName
-			for k := range clientPod.Spec.Containers {
-				if clientPod.Spec.Containers[k].Name == "agnhost-container" {
-					clientPod.Spec.Containers[k].Command = []string{
-						"sleep",
-						"infinity",
+				ginkgo.BeforeEach(func() {
+					if !isDefaultNetworkAdvertised() {
+						e2eskipper.Skipf(
+							"skipping pod to external server tests when podNetwork is not advertised",
+						)
 					}
-				}
-			}
-			e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
-
-			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
-		})
-		// -----------------               ------------------                         ---------------------
-		// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
-		// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
-		// |    server     |               |                |                         |    ovn-worker     |   (client pod advertised
-		// -----------------               ------------------                         ---------------------    using RouteAdvertisements
-		//                                                                            |    ovn-worker2    |    from default pod network)
-		//                                                                            ---------------------
-		// The client pod inside the KIND cluster on the default network exposed using default network Router
-		// Advertisement will curl the external server container sitting outside the cluster via a FRR router
-		// This test ensures the north-south connectivity is happening through podIP
-		ginkgo.It("tests are run towards the external agnhost echo server", func() {
-			ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
-			bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-			framework.ExpectNoError(err, "network %s must be available and precreated before test run", bgpExternalNetworkName)
-			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
-			framework.ExpectNoError(err, "must get bgpnet subnets")
-			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			for _, node := range nodes.Items {
-				if isIPv4Supported(f.ClientSet) {
-					ipVer := ""
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrContainerIPv4)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-				if isIPv6Supported(f.ClientSet) {
-					ipVer := " -6"
-					nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
+					ginkgo.By("Selecting 3 schedulable nodes")
+					nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, nodeIPv6LLA)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-			}
+					gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
 
-			ginkgo.By("routes to the default pod network are advertised to external frr router")
-			// Get the first element in the advertisements array (assuming you want to check the first one)
-			gomega.Eventually(func() string {
-				podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
-				if err != nil {
-					return ""
-				}
-				return podNetworkValue
-			}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
+					ginkgo.By("Selecting node for client pod")
+					clientPodNodeName = nodes.Items[1].Name
 
-			gomega.Eventually(func() string {
-				reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
-				if err != nil {
-					return ""
-				}
-				return reason
-			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
-
-			ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
-			// sample
-			//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
-			//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
-			//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
-			for _, serverContainerIP := range serverContainerIPs {
-				for _, node := range nodes.Items {
-					checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.DefaultNetworkName)
-				}
-			}
-
-			var expectedV4IP, expectedV6IP string
-			snatEnabled := isNoOverlayOutboundSNATEnabled(f)
-
-			if snatEnabled {
-				ginkgo.By("queries to the external server are SNATed (uses node IP)")
-				// Get the node where the client pod is running
-				clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPodNodeName, metav1.GetOptions{})
-				framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPodNodeName, err))
-
-				// Get node IPs
-				nodeV4Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				nodeV6Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				if len(nodeV4Addrs) > 0 {
-					expectedV4IP = nodeV4Addrs[0]
-				}
-				if len(nodeV6Addrs) > 0 {
-					expectedV6IP = nodeV6Addrs[0]
-				}
-				framework.Logf("Client pod node IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
-			} else {
-				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
-				podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
-				framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-				expectedV4IP = podv4IP
-				expectedV6IP = podv6IP
-				framework.Logf("Client pod IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
-			}
-			for _, serverContainerIP := range serverContainerIPs {
-				ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
-					"and expecting to receive the same payload", serverContainerIP))
-				cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
-					net.JoinHostPort(serverContainerIP, "8080"),
-				)
-				framework.Logf("Testing pod to external traffic with command %q", cmd)
-				stdout, err := e2epodoutput.RunHostCmdWithRetries(
-					clientPod.Namespace,
-					clientPod.Name,
-					cmd,
-					framework.Poll,
-					60*time.Second)
-				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-				expectedIP := expectedV4IP
-				if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-					expectedIP = expectedV6IP
-					// For IPv6 addresses, need to handle the brackets in the output
-					outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-					gomega.Expect(outputIP).To(gomega.Equal(expectedIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
-				} else {
-					// Original IPv4 handling
-					gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(expectedIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
-				}
-			}
-		})
-
-		ginkgo.It("can connect to an external server and another cluster node after toggling default network advertisement off and back on", ginkgo.Serial, func() {
-			ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
-			bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-			framework.ExpectNoError(err, "network %s must be available and precreated before test run", bgpExternalNetworkName)
-			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
-			framework.ExpectNoError(err, "must get bgpnet subnets")
-			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			for _, node := range nodes.Items {
-				if isIPv4Supported(f.ClientSet) {
-					ipVer := ""
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrContainerIPv4)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-				if isIPv6Supported(f.ClientSet) {
-					ipVer := " -6"
-					nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, nodeIPv6LLA)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-			}
-
-			ginkgo.By("routes to the default pod network are advertised to external frr router")
-			// Get the first element in the advertisements array (assuming you want to check the first one)
-			gomega.Eventually(func() string {
-				podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
-				if err != nil {
-					return ""
-				}
-				return podNetworkValue
-			}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
-
-			gomega.Eventually(func() string {
-				reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
-				if err != nil {
-					return ""
-				}
-				return reason
-			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
-
-			ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
-			// sample
-			//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
-			//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
-			//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
-			for _, serverContainerIP := range serverContainerIPs {
-				for _, node := range nodes.Items {
-					checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.DefaultNetworkName)
-				}
-			}
-
-			// Get client pod IPs and its host's nodeIPs, get the nodeIPs for the node where the host networked pod is running
-			var clientPodIPs, clientPodNodeIPs, hostNetworkedPodNodeIPs []string
-
-			podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
-			framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-			framework.Logf("Client pod IP address v4=%s, v6=%s", podv4IP, podv6IP)
-			if podv4IP != "" {
-				clientPodIPs = append(clientPodIPs, podv4IP)
-			}
-			if podv6IP != "" {
-				clientPodIPs = append(clientPodIPs, podv6IP)
-			}
-
-			clientNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-
-			// Get the nodeIPs for the node where the client pod is running
-			var nodeIPv4, nodeIPv6 string
-			if isIPv4Supported(f.ClientSet) {
-				v4Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				if len(v4Addrs) > 0 {
-					nodeIPv4 = v4Addrs[0]
-				}
-			}
-			if isIPv6Supported(f.ClientSet) {
-				v6Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				if len(v6Addrs) > 0 {
-					nodeIPv6 = v6Addrs[0]
-				}
-			}
-			if nodeIPv4 != "" {
-				clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv4)
-			}
-			if nodeIPv6 != "" {
-				clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv6)
-			}
-			framework.Logf("clientPodNodeIPs: %v", clientPodNodeIPs)
-
-			ginkgo.By("Creating a host networked pod on a second node")
-			// Add labels so the service can select this pod
-			podLabels := map[string]string{
-				"app": "internal-server-pod",
-			}
-
-			// Create host networked pod on another cluster node using createPod function
-			// Use a random high port to avoid collisions on the host
-			min, max := 25000, 25999
-			hostNetPort := rand.Intn(max-min+1) + min
-			framework.Logf("host-networked netexec port: %d", hostNetPort)
-			hostNetworkedPod, err = createPod(f, "internal-server-pod", nodes.Items[2].Name, f.Namespace.Name,
-				[]string{}, podLabels, func(p *corev1.Pod) {
-					// Set host networking
-					p.Spec.HostNetwork = true
-					// Run netexec on the chosen port
-					p.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", hostNetPort)}
-
-					// Add required security context to comply with PodSecurity "restricted" policy
-					for i := range p.Spec.Containers {
-						if p.Spec.Containers[i].SecurityContext == nil {
-							p.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{}
+					ginkgo.By("Creating client pod")
+					clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
+					clientPod.Spec.NodeName = clientPodNodeName
+					for k := range clientPod.Spec.Containers {
+						if clientPod.Spec.Containers[k].Name == "agnhost-container" {
+							clientPod.Spec.Containers[k].Command = []string{
+								"sleep",
+								"infinity",
+							}
 						}
+					}
+					e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
 
-						// Set required security context fields
-						p.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
-						p.Spec.Containers[i].SecurityContext.RunAsNonRoot = ptr.To(true)
-						p.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To(int64(1000))
-						p.Spec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
+					gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
+				})
+				// -----------------               ------------------                         ---------------------
+				// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
+				// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
+				// |    server     |               |                |                         |    ovn-worker     |   (client pod advertised
+				// -----------------               ------------------                         ---------------------    using RouteAdvertisements
+				//                                                                            |    ovn-worker2    |    from default pod network)
+				//                                                                            ---------------------
+				// The client pod inside the KIND cluster on the default network exposed using default network Router
+				// Advertisement will curl the external server container sitting outside the cluster via a FRR router
+				// This test ensures the north-south connectivity is happening through podIP
+				ginkgo.It("tests are run towards the external agnhost echo server", func() {
+					ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
+					bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork)
+					framework.ExpectNoError(err, "network %s must be available and precreated before test run", peering.externalNetwork)
+					externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
+					framework.ExpectNoError(err, "must get bgpnet subnets")
+					framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
+					for _, node := range nodes.Items {
+						if isIPv4Supported(f.ClientSet) {
+							ipVer := ""
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, frrContainerIPv4)
+							}, 30*time.Second).Should(gomega.BeTrue())
 						}
-						p.Spec.Containers[i].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						if isIPv6Supported(f.ClientSet) {
+							ipVer := " -6"
+							nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(peering.routerContainer)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, nodeIPv6LLA)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+					}
+
+					ginkgo.By("routes to the default pod network are advertised to external frr router")
+					// Get the first element in the advertisements array (assuming you want to check the first one)
+					gomega.Eventually(func() string {
+						podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
+						if err != nil {
+							return ""
+						}
+						return podNetworkValue
+					}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
+
+					gomega.Eventually(func() string {
+						reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
+						if err != nil {
+							return ""
+						}
+						return reason
+					}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+					ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
+					// sample
+					//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
+					//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
+					//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
+					for _, serverContainerIP := range serverContainerIPs {
+						for _, node := range nodes.Items {
+							checkL3NodePodRoute(node, serverContainerIP, peering.routerContainer, types.DefaultNetworkName)
+						}
+					}
+
+					var expectedV4IP, expectedV6IP string
+					snatEnabled := isNoOverlayOutboundSNATEnabled(f)
+
+					if snatEnabled {
+						ginkgo.By("queries to the external server are SNATed (uses node IP)")
+						// Get the node where the client pod is running
+						clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPodNodeName, metav1.GetOptions{})
+						framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPodNodeName, err))
+
+						// Get node IPs
+						nodeV4Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						nodeV6Addrs := e2enode.GetAddressesByTypeAndFamily(clientPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						if len(nodeV4Addrs) > 0 {
+							expectedV4IP = nodeV4Addrs[0]
+						}
+						if len(nodeV6Addrs) > 0 {
+							expectedV6IP = nodeV6Addrs[0]
+						}
+						framework.Logf("Client pod node IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
+					} else {
+						ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+						podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
+						framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+						expectedV4IP = podv4IP
+						expectedV6IP = podv6IP
+						framework.Logf("Client pod IP address v4=%s, v6=%s", expectedV4IP, expectedV6IP)
+					}
+					for _, serverContainerIP := range serverContainerIPs {
+						ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
+							"and expecting to receive the same payload", serverContainerIP))
+						cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
+							net.JoinHostPort(serverContainerIP, "8080"),
+						)
+						framework.Logf("Testing pod to external traffic with command %q", cmd)
+						stdout, err := e2epodoutput.RunHostCmdWithRetries(
+							clientPod.Namespace,
+							clientPod.Name,
+							cmd,
+							framework.Poll,
+							60*time.Second)
+						framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
+						expectedIP := expectedV4IP
+						if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+							expectedIP = expectedV6IP
+							// For IPv6 addresses, need to handle the brackets in the output
+							outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
+							gomega.Expect(outputIP).To(gomega.Equal(expectedIP),
+								fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+						} else {
+							// Original IPv4 handling
+							gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(expectedIP),
+								fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
 						}
 					}
 				})
-			framework.ExpectNoError(err)
 
-			hostNetworkedPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), hostNetworkedPod.Spec.NodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-
-			// reset before collecting for a different node
-			nodeIPv4, nodeIPv6 = "", ""
-
-			if isIPv4Supported(f.ClientSet) {
-				v4Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				if len(v4Addrs) > 0 {
-					nodeIPv4 = v4Addrs[0]
-				}
-			}
-			if isIPv6Supported(f.ClientSet) {
-				v6Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				if len(v6Addrs) > 0 {
-					nodeIPv6 = v6Addrs[0]
-				}
-			}
-			if nodeIPv4 != "" {
-				hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv4)
-			}
-			if nodeIPv6 != "" {
-				hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv6)
-			}
-			framework.Logf("hostNetworkedPodNodeIPs: %v", hostNetworkedPodNodeIPs)
-
-			// When SNAT is enabled, external traffic uses node IPs even when advertised
-			snatEnabled := isNoOverlayOutboundSNATEnabled(f)
-			expectedExternalSourceIPs := clientPodIPs
-			if snatEnabled {
-				expectedExternalSourceIPs = clientPodNodeIPs
-			}
-
-			if snatEnabled {
-				ginkgo.By("With default network being advertised, queries to the external server are SNATed (uses nodeIP)")
-			} else {
-				ginkgo.By("With default network being advertised, queries to the external server are not SNATed (uses podIP)")
-			}
-			gomega.Eventually(func() error {
-				for _, serverIP := range serverContainerIPs {
-					if serverIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(serverIP)
-					var expectedIP string
-					for _, srcIP := range expectedExternalSourceIPs {
-						if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
-							expectedIP = srcIP
-							break
+				ginkgo.It("can connect to an external server and another cluster node after toggling default network advertisement off and back on", ginkgo.Serial, func() {
+					ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
+					bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork)
+					framework.ExpectNoError(err, "network %s must be available and precreated before test run", peering.externalNetwork)
+					externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
+					framework.ExpectNoError(err, "must get bgpnet subnets")
+					framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
+					for _, node := range nodes.Items {
+						if isIPv4Supported(f.ClientSet) {
+							ipVer := ""
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, frrContainerIPv4)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+						if isIPv6Supported(f.ClientSet) {
+							ipVer := " -6"
+							nodeIPv6LLA, err := GetNodeIPv6LinkLocalAddressForEth0(peering.routerContainer)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, nodeIPv6LLA)
+							}, 30*time.Second).Should(gomega.BeTrue())
 						}
 					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to external server test failed")
 
-			ginkgo.By("With default network being advertised, queries to the second node are SNATed (uses nodeIP)")
-			gomega.Eventually(func() error {
-				for _, nodeIP := range hostNetworkedPodNodeIPs {
-					if nodeIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(nodeIP)
-					var expectedIP string
-					for _, clientNodeIP := range clientPodNodeIPs {
-						if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-							expectedIP = clientNodeIP
-							break
+					ginkgo.By("routes to the default pod network are advertised to external frr router")
+					// Get the first element in the advertisements array (assuming you want to check the first one)
+					gomega.Eventually(func() string {
+						podNetworkValue, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "--template={{index .spec.advertisements 0}}")
+						if err != nil {
+							return ""
+						}
+						return podNetworkValue
+					}, 5*time.Second, time.Second).Should(gomega.Equal("PodNetwork"))
+
+					gomega.Eventually(func() string {
+						reason, err := e2ekubectl.RunKubectl("", "get", "ra", "default", "-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].reason}")
+						if err != nil {
+							return ""
+						}
+						return reason
+					}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+					ginkgo.By("all 3 node's podSubnet routes are exported correctly to external FRR router by frr-k8s speakers")
+					// sample
+					//10.244.0.0/24 nhid 27 via 172.18.0.3 dev eth0 proto bgp metric 20
+					//10.244.1.0/24 nhid 30 via 172.18.0.2 dev eth0 proto bgp metric 20
+					//10.244.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
+					for _, serverContainerIP := range serverContainerIPs {
+						for _, node := range nodes.Items {
+							checkL3NodePodRoute(node, serverContainerIP, peering.routerContainer, types.DefaultNetworkName)
 						}
 					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to second node test failed")
 
-			// defer add default network RA back to restore to the original test setup
-			ra := &rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.DefaultNetwork,
+					// Get client pod IPs and its host's nodeIPs, get the nodeIPs for the node where the host networked pod is running
+					var clientPodIPs, clientPodNodeIPs, hostNetworkedPodNodeIPs []string
+
+					podv4IP, podv6IP, err := podIPsForDefaultNetwork(f.ClientSet, f.Namespace.Name, clientPod.Name)
+					framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+					framework.Logf("Client pod IP address v4=%s, v6=%s", podv4IP, podv6IP)
+					if podv4IP != "" {
+						clientPodIPs = append(clientPodIPs, podv4IP)
+					}
+					if podv6IP != "" {
+						clientPodIPs = append(clientPodIPs, podv6IP)
+					}
+
+					clientNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+
+					// Get the nodeIPs for the node where the client pod is running
+					var nodeIPv4, nodeIPv6 string
+					if isIPv4Supported(f.ClientSet) {
+						v4Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						if len(v4Addrs) > 0 {
+							nodeIPv4 = v4Addrs[0]
+						}
+					}
+					if isIPv6Supported(f.ClientSet) {
+						v6Addrs := e2enode.GetAddressesByTypeAndFamily(clientNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						if len(v6Addrs) > 0 {
+							nodeIPv6 = v6Addrs[0]
+						}
+					}
+					if nodeIPv4 != "" {
+						clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv4)
+					}
+					if nodeIPv6 != "" {
+						clientPodNodeIPs = append(clientPodNodeIPs, nodeIPv6)
+					}
+					framework.Logf("clientPodNodeIPs: %v", clientPodNodeIPs)
+
+					ginkgo.By("Creating a host networked pod on a second node")
+					// Add labels so the service can select this pod
+					podLabels := map[string]string{
+						"app": "internal-server-pod",
+					}
+
+					// Create host networked pod on another cluster node using createPod function
+					// Use a random high port to avoid collisions on the host
+					min, max := 25000, 25999
+					hostNetPort := rand.Intn(max-min+1) + min
+					framework.Logf("host-networked netexec port: %d", hostNetPort)
+					hostNetworkedPod, err = createPod(f, "internal-server-pod", nodes.Items[2].Name, f.Namespace.Name,
+						[]string{}, podLabels, func(p *corev1.Pod) {
+							// Set host networking
+							p.Spec.HostNetwork = true
+							// Run netexec on the chosen port
+							p.Spec.Containers[0].Args = []string{"netexec", fmt.Sprintf("--http-port=%d", hostNetPort)}
+
+							// Add required security context to comply with PodSecurity "restricted" policy
+							for i := range p.Spec.Containers {
+								if p.Spec.Containers[i].SecurityContext == nil {
+									p.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{}
+								}
+
+								// Set required security context fields
+								p.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+								p.Spec.Containers[i].SecurityContext.RunAsNonRoot = ptr.To(true)
+								p.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To(int64(1000))
+								p.Spec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								}
+								p.Spec.Containers[i].SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								}
+							}
+						})
+					framework.ExpectNoError(err)
+
+					hostNetworkedPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), hostNetworkedPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+
+					// reset before collecting for a different node
+					nodeIPv4, nodeIPv6 = "", ""
+
+					if isIPv4Supported(f.ClientSet) {
+						v4Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						if len(v4Addrs) > 0 {
+							nodeIPv4 = v4Addrs[0]
+						}
+					}
+					if isIPv6Supported(f.ClientSet) {
+						v6Addrs := e2enode.GetAddressesByTypeAndFamily(hostNetworkedPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						if len(v6Addrs) > 0 {
+							nodeIPv6 = v6Addrs[0]
+						}
+					}
+					if nodeIPv4 != "" {
+						hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv4)
+					}
+					if nodeIPv6 != "" {
+						hostNetworkedPodNodeIPs = append(hostNetworkedPodNodeIPs, nodeIPv6)
+					}
+					framework.Logf("hostNetworkedPodNodeIPs: %v", hostNetworkedPodNodeIPs)
+
+					// When SNAT is enabled, external traffic uses node IPs even when advertised
+					snatEnabled := isNoOverlayOutboundSNATEnabled(f)
+					expectedExternalSourceIPs := clientPodIPs
+					if snatEnabled {
+						expectedExternalSourceIPs = clientPodNodeIPs
+					}
+
+					if snatEnabled {
+						ginkgo.By("With default network being advertised, queries to the external server are SNATed (uses nodeIP)")
+					} else {
+						ginkgo.By("With default network being advertised, queries to the external server are not SNATed (uses podIP)")
+					}
+					gomega.Eventually(func() error {
+						for _, serverIP := range serverContainerIPs {
+							if serverIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(serverIP)
+							var expectedIP string
+							for _, srcIP := range expectedExternalSourceIPs {
+								if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
+									expectedIP = srcIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to external server test failed")
+
+					ginkgo.By("With default network being advertised, queries to the second node are SNATed (uses nodeIP)")
+					gomega.Eventually(func() error {
+						for _, nodeIP := range hostNetworkedPodNodeIPs {
+							if nodeIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(nodeIP)
+							var expectedIP string
+							for _, clientNodeIP := range clientPodNodeIPs {
+								if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+									expectedIP = clientNodeIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised initially, pod to second node test failed")
+
+					// defer add default network RA back to restore to the original test setup
+					ra := &rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
 						},
-					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
-					},
-				},
-			}
-			raClient, err := raclientset.NewForConfig(f.ClientConfig())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.DefaultNetwork,
+								},
+							},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
+							},
+						},
+					}
+					raClient, err := raclientset.NewForConfig(f.ClientConfig())
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			defer func() {
-				ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					defer func() {
+						ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Wait for RouteAdvertisement to be accepted, but don't fail the test if it times out
-				// We'll handle the failure with AbortSuite instead
-				accepted := false
-				err = wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-					ra, err := raClient.K8sV1().RouteAdvertisements().Get(ctx, ra.Name, metav1.GetOptions{})
-					if err != nil {
-						return false, nil // Continue polling on error
-					}
-					condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
-					if condition == nil {
-						return false, nil // Continue polling if condition not found
-					}
-					if condition.Reason == "Accepted" {
-						accepted = true
-						return true, nil // Success - stop polling
-					}
-					return false, nil // Continue polling if not accepted yet
+						// Wait for RouteAdvertisement to be accepted, but don't fail the test if it times out
+						// We'll handle the failure with AbortSuite instead
+						accepted := false
+						err = wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+							ra, err := raClient.K8sV1().RouteAdvertisements().Get(ctx, ra.Name, metav1.GetOptions{})
+							if err != nil {
+								return false, nil // Continue polling on error
+							}
+							condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+							if condition == nil {
+								return false, nil // Continue polling if condition not found
+							}
+							if condition.Reason == "Accepted" {
+								accepted = true
+								return true, nil // Success - stop polling
+							}
+							return false, nil // Continue polling if not accepted yet
+						})
+						// Note: we ignore the error from PollImmediate since we handle timeout via the accepted variable
+
+						// Abort suite if default RA failed to reach Accepted state in defer restore
+						if !accepted {
+							ginkgo.AbortSuite("CRITICAL: Default route advertisement failed to reach Accepted state in defer cleanup - test environment is corrupted")
+						}
+
+						// repeat pod to external and pod to second node tests
+						if snatEnabled {
+							ginkgo.By("With default network being advertised again, queries to the external server are SNATed (uses nodeIP)")
+						} else {
+							ginkgo.By("With default network being advertised again, queries to the external server are not SNATed (uses podIP)")
+						}
+						gomega.Eventually(func() error {
+							for _, serverIP := range serverContainerIPs {
+								if serverIP == "" {
+									continue
+								}
+								isV6 := utilnet.IsIPv6String(serverIP)
+								var expectedIP string
+								for _, srcIP := range expectedExternalSourceIPs {
+									if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
+										expectedIP = srcIP
+										break
+									}
+								}
+								if expectedIP == "" {
+									continue
+								}
+								if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
+									return err
+								}
+							}
+							return nil
+						}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to external server test failed, test environment may be corrupted")
+
+						ginkgo.By("With default network being advertised again, queries to the second node are SNATed (uses nodeIP)")
+						gomega.Eventually(func() error {
+							for _, nodeIP := range hostNetworkedPodNodeIPs {
+								if nodeIP == "" {
+									continue
+								}
+								isV6 := utilnet.IsIPv6String(nodeIP)
+								var expectedIP string
+								for _, clientNodeIP := range clientPodNodeIPs {
+									if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+										expectedIP = clientNodeIP
+										break
+									}
+								}
+								if expectedIP == "" {
+									continue
+								}
+								if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
+									return err
+								}
+							}
+							return nil
+						}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to second node test failed, test environment may be corrupted")
+
+					}()
+
+					ginkgo.By("Delete route advertisement")
+					_, err = e2ekubectl.RunKubectl("", "delete", "ra", "default", "--ignore-not-found=true")
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					// Make sure default RA is deleted
+					_, err = e2ekubectl.RunKubectl("", "get", "ra", "default")
+					gomega.Expect(err).To(gomega.HaveOccurred())
+
+					ginkgo.By("After default network is toggled to unadvertised, run test towards the external agnhost echo server from client pod again, egressing packets should be SNATed to pod's host nodeIP")
+					gomega.Eventually(func() error {
+						for _, serverIP := range serverContainerIPs {
+							if serverIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(serverIP)
+							var expectedIP string
+							for _, clientNodeIP := range clientPodNodeIPs {
+								if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+									expectedIP = clientNodeIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to external server test failed")
+
+					ginkgo.By("After default network is toggled to unadvertised, run test towards the second node from client pod, egressing packets should be SNATed to pod's host nodeIP")
+					gomega.Eventually(func() error {
+						for _, nodeIP := range hostNetworkedPodNodeIPs {
+							if nodeIP == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6String(nodeIP)
+							var expectedIP string
+							for _, clientNodeIP := range clientPodNodeIPs {
+								if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
+									expectedIP = clientNodeIP
+									break
+								}
+							}
+							if expectedIP == "" {
+								continue
+							}
+							if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
+								return err
+							}
+						}
+						return nil
+					}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to second node test failed")
+
 				})
-				// Note: we ignore the error from PollImmediate since we handle timeout via the accepted variable
-
-				// Abort suite if default RA failed to reach Accepted state in defer restore
-				if !accepted {
-					ginkgo.AbortSuite("CRITICAL: Default route advertisement failed to reach Accepted state in defer cleanup - test environment is corrupted")
-				}
-
-				// repeat pod to external and pod to second node tests
-				if snatEnabled {
-					ginkgo.By("With default network being advertised again, queries to the external server are SNATed (uses nodeIP)")
-				} else {
-					ginkgo.By("With default network being advertised again, queries to the external server are not SNATed (uses podIP)")
-				}
-				gomega.Eventually(func() error {
-					for _, serverIP := range serverContainerIPs {
-						if serverIP == "" {
-							continue
-						}
-						isV6 := utilnet.IsIPv6String(serverIP)
-						var expectedIP string
-						for _, srcIP := range expectedExternalSourceIPs {
-							if srcIP != "" && utilnet.IsIPv6String(srcIP) == isV6 {
-								expectedIP = srcIP
-								break
-							}
-						}
-						if expectedIP == "" {
-							continue
-						}
-						if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
-							return err
-						}
-					}
-					return nil
-				}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to external server test failed, test environment may be corrupted")
-
-				ginkgo.By("With default network being advertised again, queries to the second node are SNATed (uses nodeIP)")
-				gomega.Eventually(func() error {
-					for _, nodeIP := range hostNetworkedPodNodeIPs {
-						if nodeIP == "" {
-							continue
-						}
-						isV6 := utilnet.IsIPv6String(nodeIP)
-						var expectedIP string
-						for _, clientNodeIP := range clientPodNodeIPs {
-							if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-								expectedIP = clientNodeIP
-								break
-							}
-						}
-						if expectedIP == "" {
-							continue
-						}
-						if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
-							return err
-						}
-					}
-					return nil
-				}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "With default network being advertised again, pod to second node test failed, test environment may be corrupted")
-
-			}()
-
-			ginkgo.By("Delete route advertisement")
-			_, err = e2ekubectl.RunKubectl("", "delete", "ra", "default", "--ignore-not-found=true")
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Make sure default RA is deleted
-			_, err = e2ekubectl.RunKubectl("", "get", "ra", "default")
-			gomega.Expect(err).To(gomega.HaveOccurred())
-
-			ginkgo.By("After default network is toggled to unadvertised, run test towards the external agnhost echo server from client pod again, egressing packets should be SNATed to pod's host nodeIP")
-			gomega.Eventually(func() error {
-				for _, serverIP := range serverContainerIPs {
-					if serverIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(serverIP)
-					var expectedIP string
-					for _, clientNodeIP := range clientPodNodeIPs {
-						if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-							expectedIP = clientNodeIP
-							break
-						}
-					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, serverIP, strconv.Itoa(netexecPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to external server test failed")
-
-			ginkgo.By("After default network is toggled to unadvertised, run test towards the second node from client pod, egressing packets should be SNATed to pod's host nodeIP")
-			gomega.Eventually(func() error {
-				for _, nodeIP := range hostNetworkedPodNodeIPs {
-					if nodeIP == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6String(nodeIP)
-					var expectedIP string
-					for _, clientNodeIP := range clientPodNodeIPs {
-						if clientNodeIP != "" && utilnet.IsIPv6String(clientNodeIP) == isV6 {
-							expectedIP = clientNodeIP
-							break
-						}
-					}
-					if expectedIP == "" {
-						continue
-					}
-					if err := curlAgnHostClientIPFromPod(clientPod.Namespace, clientPod.Name, expectedIP, nodeIP, strconv.Itoa(hostNetPort)); err != nil {
-						return err
-					}
-				}
-				return nil
-			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed(), "After default network is toggled to unadvertised, pod to second node test failed")
-
-		})
-	})
+			})
+		},
+		bgpPeeringModes,
+	)
 })
 
 // Helper functions for Layer3 subnet configurations
@@ -767,500 +813,501 @@ func expectNodesNotAdvertisedInFRR(nodes []corev1.Node, activeNodeName, v4CIDR, 
 }
 
 var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advertised", feature.RouteAdvertisements, func() {
-	var serverContainerIPs []string
-	var frrContainerIPv4, frrContainerIPv6 string
-	var nodes *corev1.NodeList
-	var clientPod *corev1.Pod
-
 	f := wrappedTestFramework("pod2external-route-advertisements")
 	f.SkipNamespaceCreation = true
 
-	ginkgo.BeforeEach(func() {
-		var err error
-		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
-			"e2e-framework":           f.BaseName,
-			RequiredUDNNamespaceLabel: "",
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		f.Namespace = namespace
+	ginkgo.DescribeTableSubtree("with underlay BGP in mode",
+		func(peering bgpPeeringConfig) {
+			var serverContainerIPs []string
+			var frrContainerIPv4, frrContainerIPv6 string
+			var nodes *corev1.NodeList
+			var clientPod *corev1.Pod
 
-		serverContainerIPs = []string{}
+			ginkgo.BeforeEach(func() {
+				var err error
+				namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+					"e2e-framework":           f.BaseName,
+					RequiredUDNNamespaceLabel: "",
+				})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				f.Namespace = namespace
 
-		bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName) // pre-created network
-		framework.ExpectNoError(err, "must get bgpnet network")
-		bgpServer := infraapi.ExternalContainer{Name: serverContainerName}
-		networkInterface, err := infraprovider.Get().GetExternalContainerNetworkInterface(bgpServer, bgpNetwork)
-		framework.ExpectNoError(err, "container %s attached to network %s must contain network info", serverContainerName, bgpExternalNetworkName)
-		if isIPv4Supported(f.ClientSet) && len(networkInterface.IPv4) > 0 {
-			serverContainerIPs = append(serverContainerIPs, networkInterface.IPv4)
-		}
-		if isIPv6Supported(f.ClientSet) && len(networkInterface.IPv6) > 0 {
-			serverContainerIPs = append(serverContainerIPs, networkInterface.IPv6)
-		}
-		gomega.Expect(len(serverContainerIPs)).Should(gomega.BeNumerically(">", 0), "failed to find external container IPs")
-		framework.Logf("The external server IPs are: %+v", serverContainerIPs)
-		providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
-		framework.ExpectNoError(err, "provider primary network must be available")
-		frrContainer := infraapi.ExternalContainer{Name: routerContainerName}
-		networkInterface, err = infraprovider.Get().GetExternalContainerNetworkInterface(frrContainer, providerPrimaryNetwork)
-		framework.ExpectNoError(err, "container %s attached to network %s must contain network info", routerContainerName, providerPrimaryNetwork.Name())
-		frrContainerIPv4, frrContainerIPv6 = networkInterface.IPv4, networkInterface.IPv6
-		framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
+				serverContainerIPs = []string{}
 
-		// Select nodes here so they're available for all tests
-		ginkgo.By("Selecting 3 schedulable nodes")
-		nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
-	})
+				bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork) // pre-created network
+				framework.ExpectNoError(err, "must get bgpnet network")
+				bgpServer := infraapi.ExternalContainer{Name: peering.serverContainer}
+				networkInterface, err := infraprovider.Get().GetExternalContainerNetworkInterface(bgpServer, bgpNetwork)
+				framework.ExpectNoError(err, "container %s attached to network %s must contain network info", peering.serverContainer, peering.externalNetwork)
+				if isIPv4Supported(f.ClientSet) && len(networkInterface.IPv4) > 0 {
+					serverContainerIPs = append(serverContainerIPs, networkInterface.IPv4)
+				}
+				if isIPv6Supported(f.ClientSet) && len(networkInterface.IPv6) > 0 {
+					serverContainerIPs = append(serverContainerIPs, networkInterface.IPv6)
+				}
+				gomega.Expect(len(serverContainerIPs)).Should(gomega.BeNumerically(">", 0), "failed to find external container IPs")
+				framework.Logf("The external server IPs are: %+v", serverContainerIPs)
+				providerPrimaryNetwork, err := infraprovider.Get().PrimaryNetwork()
+				framework.ExpectNoError(err, "provider primary network must be available")
+				frrContainer := infraapi.ExternalContainer{Name: peering.routerContainer}
+				networkInterface, err = infraprovider.Get().GetExternalContainerNetworkInterface(frrContainer, providerPrimaryNetwork)
+				framework.ExpectNoError(err, "container %s attached to network %s must contain network info", peering.routerContainer, providerPrimaryNetwork.Name())
+				frrContainerIPv4, frrContainerIPv6 = networkInterface.IPv4, networkInterface.IPv6
+				framework.Logf("The frr router container IPs are: %s/%s", frrContainerIPv4, frrContainerIPv6)
 
-	ginkgo.DescribeTable("Route Advertisements",
-		func(cudnTemplate *udnv1.ClusterUserDefinedNetwork, ra *rav1.RouteAdvertisements) {
-			// set the exact selector
-			cudnTemplate.Spec.NamespaceSelector = metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "kubernetes.io/metadata.name",
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{f.Namespace.Name},
-			}}}
-
-			// Create CUDN
-			ginkgo.By("create ClusterUserDefinedNetwork")
-			udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			if cudnTemplate.Spec.Network.Layer3 != nil {
-				cudnTemplate.Spec.Network.Layer3.Subnets = filterL3Subnets(f.ClientSet, cudnTemplate.Spec.Network.Layer3.Subnets)
-			}
-			if cudnTemplate.Spec.Network.Layer2 != nil {
-				cudnTemplate.Spec.Network.Layer2.Subnets = filterDualStackCIDRs(f.ClientSet, cudnTemplate.Spec.Network.Layer2.Subnets)
-			}
-			cUDN, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudnTemplate, metav1.CreateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.DeferCleanup(func() {
-				udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), cUDN.Name, metav1.DeleteOptions{})
-			})
-			gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cUDN.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
-
-			ginkgo.DeferCleanup(func() {
-				ginkgo.By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", f.Namespace.Name))
-				gomega.Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
+				// Select nodes here so they're available for all tests
+				ginkgo.By("Selecting 3 schedulable nodes")
+				nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
 			})
 
-			// Create client pod
-			ginkgo.By("Creating client pod")
-			clientPod, err = createPod(f, echoClientPodName, nodes.Items[1].Name, f.Namespace.Name, []string{"bash", "-c", "sleep infinity"}, nil)
-			framework.ExpectNoError(err)
+			ginkgo.DescribeTable("Route Advertisements",
+				func(cudnTemplate *udnv1.ClusterUserDefinedNetwork, ra *rav1.RouteAdvertisements) {
+					// set the exact selector
+					cudnTemplate.Spec.NamespaceSelector = metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{f.Namespace.Name},
+					}}}
 
-			// With dynamic UDN allocation, the network only exists on nodes
-			// that run workloads attached to it, which here is just the
-			// client pod's node: only expect it to be advertised.
-			advertisedNodes := nodes.Items
-			if isDynamicUDNEnabled() {
-				advertisedNodes = []corev1.Node{nodes.Items[1]}
-			}
+					// Create CUDN
+					ginkgo.By("create ClusterUserDefinedNetwork")
+					udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if cudnTemplate.Spec.Network.Layer3 != nil {
+						cudnTemplate.Spec.Network.Layer3.Subnets = filterL3Subnets(f.ClientSet, cudnTemplate.Spec.Network.Layer3.Subnets)
+					}
+					if cudnTemplate.Spec.Network.Layer2 != nil {
+						cudnTemplate.Spec.Network.Layer2.Subnets = filterDualStackCIDRs(f.ClientSet, cudnTemplate.Spec.Network.Layer2.Subnets)
+					}
+					cUDN, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudnTemplate, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.DeferCleanup(func() {
+						udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), cUDN.Name, metav1.DeleteOptions{})
+					})
+					gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cUDN.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
 
-			// Create route advertisement
-			ginkgo.By("create router advertisement")
-			raClient, err := raclientset.NewForConfig(f.ClientConfig())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.DeferCleanup(func() {
+						ginkgo.By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", f.Namespace.Name))
+						gomega.Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
+					})
 
-			ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.DeferCleanup(func() { raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), ra.Name, metav1.DeleteOptions{}) })
-			ginkgo.By("ensure route advertisement matching CUDN was created successfully")
-			gomega.Eventually(func() string {
-				ra, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ra.Name, metav1.GetOptions{})
-				if err != nil {
-					return ""
-				}
-				condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
-				if condition == nil {
-					return ""
-				}
-				return condition.Reason
-			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+					// Create client pod
+					ginkgo.By("Creating client pod")
+					clientPod, err = createPod(f, echoClientPodName, nodes.Items[1].Name, f.Namespace.Name, []string{"bash", "-c", "sleep infinity"}, nil)
+					framework.ExpectNoError(err)
 
-			// Check CUDN TransportAccepted condition is True after RA is created
-			if cudnTemplate.Spec.Network.Transport != "" && cudnTemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
-				ginkgo.By("ensure CUDN TransportAccepted condition is True")
-				gomega.Eventually(func(g gomega.Gomega) {
-					cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cUDN.Name, metav1.GetOptions{}, "status")
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					conditions, err := getConditions(cudnObj)
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					for _, condition := range conditions {
-						if condition.Type == "TransportAccepted" {
-							g.Expect(string(condition.Status)).To(gomega.Equal("True"))
-							g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
-							return
+					// With dynamic UDN allocation, the network only exists on nodes
+					// that run workloads attached to it, which here is just the
+					// client pod's node: only expect it to be advertised.
+					advertisedNodes := nodes.Items
+					if isDynamicUDNEnabled() {
+						advertisedNodes = []corev1.Node{nodes.Items[1]}
+					}
+
+					// Create route advertisement
+					ginkgo.By("create router advertisement")
+					raClient, err := raclientset.NewForConfig(f.ClientConfig())
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.DeferCleanup(func() { raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), ra.Name, metav1.DeleteOptions{}) })
+					ginkgo.By("ensure route advertisement matching CUDN was created successfully")
+					gomega.Eventually(func() string {
+						ra, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ra.Name, metav1.GetOptions{})
+						if err != nil {
+							return ""
+						}
+						condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+						if condition == nil {
+							return ""
+						}
+						return condition.Reason
+					}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+					// Check CUDN TransportAccepted condition is True after RA is created
+					if cudnTemplate.Spec.Network.Transport != "" && cudnTemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+						ginkgo.By("ensure CUDN TransportAccepted condition is True")
+						gomega.Eventually(func(g gomega.Gomega) {
+							cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cUDN.Name, metav1.GetOptions{}, "status")
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+							conditions, err := getConditions(cudnObj)
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+							for _, condition := range conditions {
+								if condition.Type == "TransportAccepted" {
+									g.Expect(string(condition.Status)).To(gomega.Equal("True"))
+									g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+									return
+								}
+							}
+							g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cUDN.Name)
+						}, 30*time.Second, time.Second).Should(gomega.Succeed())
+					}
+
+					gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
+
+					// -----------------               ------------------                         ---------------------
+					// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
+					// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
+					// |    server     |               |                |                         |    ovn-worker     |   (client UDN pod advertised
+					// -----------------               ------------------                         ---------------------    using RouteAdvertisements
+					//                                                                            |    ovn-worker2    |    from default pod network)
+					//                                                                            ---------------------
+					// The client pod inside the KIND cluster on the default network exposed using default network Router
+					// Advertisement will curl the external server container sitting outside the cluster via a FRR router
+					// This test ensures the north-south connectivity is happening through podIP
+					ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
+					bgpNetwork, err := infraprovider.Get().GetNetwork(peering.externalNetwork)
+					framework.ExpectNoError(err, "network %s must be available", peering.externalNetwork)
+					externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
+					framework.ExpectNoError(err, "must get BGP network subnets")
+					framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
+					var nodeIPv6LLA string
+					if isDualStackCluster(nodes) {
+						var err error
+						nodeIPv6LLA, err = GetNodeIPv6LinkLocalAddressForEth0(peering.routerContainer)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					for _, node := range nodes.Items {
+						if isIPv4Supported(f.ClientSet) {
+							ipVer := ""
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, frrContainerIPv4)
+							}, 30*time.Second).Should(gomega.BeTrue())
+						}
+						if isIPv6Supported(f.ClientSet) {
+							ipVer := " -6"
+							bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
+							framework.Logf("Checking for server's route in node %s", node.Name)
+							gomega.Eventually(func() bool {
+								routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
+								framework.ExpectNoError(err, "failed to get BGP routes from node")
+								framework.Logf("Routes in node %s", routes)
+								return strings.Contains(routes, nodeIPv6LLA)
+							}, 30*time.Second).Should(gomega.BeTrue())
 						}
 					}
-					g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cUDN.Name)
-				}, 30*time.Second, time.Second).Should(gomega.Succeed())
-			}
 
-			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
-
-			// -----------------               ------------------                         ---------------------
-			// |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
-			// |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
-			// |    server     |               |                |                         |    ovn-worker     |   (client UDN pod advertised
-			// -----------------               ------------------                         ---------------------    using RouteAdvertisements
-			//                                                                            |    ovn-worker2    |    from default pod network)
-			//                                                                            ---------------------
-			// The client pod inside the KIND cluster on the default network exposed using default network Router
-			// Advertisement will curl the external server container sitting outside the cluster via a FRR router
-			// This test ensures the north-south connectivity is happening through podIP
-			ginkgo.By("routes from external bgp server are imported by nodes in the cluster")
-			bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
-			framework.ExpectNoError(err, "network %s must be available", bgpExternalNetworkName)
-			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
-			framework.ExpectNoError(err, "must get BGP network subnets")
-			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			var frrIPv6LLA string
-			if isIPv6Supported(f.ClientSet) {
-				var err error
-				frrIPv6LLA, err = GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			}
-			for _, node := range nodes.Items {
-				if isIPv4Supported(f.ClientSet) {
-					ipVer := ""
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV4CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrContainerIPv4)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-				if isIPv6Supported(f.ClientSet) {
-					ipVer := " -6"
-					bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, externalServerV6CIDR), " ")
-					framework.Logf("Checking for server's route in node %s", node.Name)
-					gomega.Eventually(func() bool {
-						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
-						framework.ExpectNoError(err, "failed to get BGP routes from node")
-						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, frrIPv6LLA)
-					}, 30*time.Second).Should(gomega.BeTrue())
-				}
-			}
-
-			ginkgo.By("ensure CUDN pod subnet is advertised to the external FRR router")
-			for _, serverContainerIP := range serverContainerIPs {
-				for _, node := range advertisedNodes {
-					if cudnTemplate.Spec.Network.Layer3 != nil {
-						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cUDN.Name)
-					} else if cudnTemplate.Spec.Network.Layer2 != nil {
-						checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnTemplate.Spec.Network.Layer2.Subnets)
-					} else {
-						ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
+					ginkgo.By("ensure CUDN pod subnet is advertised to the external FRR router")
+					for _, serverContainerIP := range serverContainerIPs {
+						for _, node := range advertisedNodes {
+							if cudnTemplate.Spec.Network.Layer3 != nil {
+								checkL3NodePodRoute(node, serverContainerIP, peering.routerContainer, types.CUDNPrefix+cUDN.Name)
+							} else if cudnTemplate.Spec.Network.Layer2 != nil {
+								checkL2NodePodRoute(node, serverContainerIP, peering.routerContainer, cudnTemplate.Spec.Network.Layer2.Subnets)
+							} else {
+								ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
+							}
+						}
 					}
-				}
-			}
 
-			if isDynamicUDNEnabled() && cudnTemplate.Spec.Network.Layer3 != nil {
-				ginkgo.By("ensure nodes without workloads attached to the network get no subnet allocated for it")
-				expectNoUDNSubnetOnNodesExcept(nodes.Items, clientPod.Spec.NodeName, types.CUDNPrefix+cUDN.Name)
-			}
+					if isDynamicUDNEnabled() && cudnTemplate.Spec.Network.Layer3 != nil {
+						ginkgo.By("ensure nodes without workloads attached to the network get no subnet allocated for it")
+						expectNoUDNSubnetOnNodesExcept(nodes.Items, clientPod.Spec.NodeName, types.CUDNPrefix+cUDN.Name)
+					}
 
-			layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
-			if layer2LocalGateway {
-				ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
-			} else {
-				ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
-			}
-			// the network topology only exists on the nodes it is allocated on
-			for _, node := range advertisedNodes {
-				nodeName := node.Name
-				for _, tc := range []struct {
-					cidr, nextHop string
-				}{
-					{externalServerV4CIDR, frrContainerIPv4},
-					{externalServerV6CIDR, frrIPv6LLA},
-				} {
-					if tc.cidr == "" || tc.nextHop == "" {
-						continue
-					}
-					isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
-					if isV6 && !isIPv6Supported(f.ClientSet) {
-						continue
-					}
-					if !isV6 && !isIPv4Supported(f.ClientSet) {
-						continue
-					}
+					layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
 					if layer2LocalGateway {
-						framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+						ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
+					} else {
+						ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
+					}
+					// the network topology only exists on the nodes it is allocated on
+					for _, node := range advertisedNodes {
+						nodeName := node.Name
+						for _, tc := range []struct {
+							cidr, nextHop string
+						}{
+							{externalServerV4CIDR, frrContainerIPv4},
+							{externalServerV6CIDR, nodeIPv6LLA},
+						} {
+							if tc.cidr == "" || tc.nextHop == "" {
+								continue
+							}
+							isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
+							if isV6 && !isIPv6Supported(f.ClientSet) {
+								continue
+							}
+							if !isV6 && !isIPv4Supported(f.ClientSet) {
+								continue
+							}
+							if layer2LocalGateway {
+								framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+								gomega.Eventually(func() bool {
+									found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+									if err != nil {
+										framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+										return false
+									}
+									return found
+								}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+									"route for %s via %s not found in CUDN VRF %s on node %s",
+									tc.cidr, tc.nextHop, cUDN.Name, nodeName)
+								continue
+							}
 						gomega.Eventually(func() bool {
-							found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+							routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
 							if err != nil {
-								framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+								framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
 								return false
 							}
-							return found
-						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-							"route for %s via %s not found in CUDN VRF %s on node %s",
-							tc.cidr, tc.nextHop, cUDN.Name, nodeName)
-						continue
-					}
-					// Assert the GR has a static-route line matching
-					// the CIDR and the expected next hop, that is the external FRR
-					// container IP.
-					gomega.Eventually(func() bool {
-						routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
-						if err != nil {
-							framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
-							return false
-						}
-						framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
-						for _, line := range strings.Split(routes, "\n") {
-							if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
-								return true
+							framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
+							for _, line := range strings.Split(routes, "\n") {
+								if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
+									return true
+								}
 							}
-						}
-						return false
-					}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-						"CUDN %q GR on node %s is missing a route %s -> %s",
-						cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+							return false
+						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+							"CUDN %q GR on node %s is missing a route %s -> %s",
+							cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+					}
 				}
-			}
 
-			expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
-				cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+				expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+					cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 
-			if expectSNAT {
-				ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
-			} else {
-				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
-			}
-			var expectedSNATSourceIPs []string
-			if expectSNAT {
-				clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
-				framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
-				expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
-				gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
-				framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
-			}
-			for _, serverContainerIP := range serverContainerIPs {
-				podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
-					f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-				framework.Logf("Client pod IP address=%s", podIP)
-
-				ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
-					"and expecting to receive the same payload", serverContainerIP))
-				cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
-					net.JoinHostPort(serverContainerIP, "8080"),
-				)
-				framework.Logf("Testing pod to external traffic with command %q", cmd)
-				stdout, err := e2epodoutput.RunHostCmdWithRetries(
-					clientPod.Namespace,
-					clientPod.Name,
-					cmd,
-					framework.Poll,
-					60*time.Second)
-				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-
-				sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-					fmt.Sprintf("Failed to parse client address from output %q", stdout))
 				if expectSNAT {
-					// When OutboundSNAT is enabled, traffic to external destinations
-					// is masqueraded to the node IP. Verify the source is NOT the pod IP.
-					expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
-					gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
-						"Expected node %s to have an InternalIP for the external server IP family %s",
-						clientPod.Spec.NodeName, serverContainerIP)
-					gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-						fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+					ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
 				} else {
-					gomega.Expect(sourceIP).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					ginkgo.By("queries to the external server are not SNATed (uses podIP)")
 				}
-			}
-		},
-		ginkgo.Entry("layer3",
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					// Keep generated CUDN names under the Linux 15-byte interface
-					// limit so the VRF name is unique instead of network ID based.
-					GenerateName: "bgp-l3-",
-					Labels:       map[string]string{"bgp-l3": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role:    "Primary",
-							Subnets: cudnLayer3SubnetsB(),
-						},
-					},
-				},
+				var expectedSNATSourceIPs []string
+				if expectSNAT {
+					clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
+					expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
+					gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
+					framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
+				}
+				for _, serverContainerIP := range serverContainerIPs {
+					podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+						f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+					framework.Logf("Client pod IP address=%s", podIP)
+
+					ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
+						"and expecting to receive the same payload", serverContainerIP))
+					cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
+						net.JoinHostPort(serverContainerIP, "8080"),
+					)
+					framework.Logf("Testing pod to external traffic with command %q", cmd)
+					stdout, err := e2epodoutput.RunHostCmdWithRetries(
+						clientPod.Namespace,
+						clientPod.Name,
+						cmd,
+						framework.Poll,
+						60*time.Second)
+					framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
+
+					sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+						fmt.Sprintf("Failed to parse client address from output %q", stdout))
+					if expectSNAT {
+						expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
+						gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
+							"Expected node %s to have an InternalIP for the external server IP family %s",
+							clientPod.Spec.NodeName, serverContainerIP)
+						gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+							fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+					} else {
+						gomega.Expect(sourceIP).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					}
+				}
 			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l3-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l3": ""},
-								},
+			ginkgo.Entry("layer3",
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						// Keep generated CUDN names under the Linux 15-byte interface
+						// limit so the VRF name is unique instead of network ID based.
+						GenerateName: "bgp-l3-",
+						Labels:       map[string]string{"bgp-l3": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer3,
+							Layer3: &udnv1.Layer3Config{
+								Role:    "Primary",
+								Subnets: cudnLayer3SubnetsB(),
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-l3-ra",
 					},
-				},
-			},
-		),
-		ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-l3a-",
-					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/60",
-								HostSubnet: 64,
-							}},
-						},
-						Transport: udnv1.TransportOptionNoOverlay,
-						NoOverlay: &udnv1.NoOverlayConfig{
-							OutboundSNAT: udnv1.SNATEnabled,
-							Routing:      udnv1.RoutingUnmanaged,
-						},
-					},
-				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-l3": ""},
+									},
 								},
 							},
 						},
-					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
-					},
-				},
-			},
-		),
-		ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-l3b-",
-					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/60",
-								HostSubnet: 64,
-							}},
-						},
-						Transport: udnv1.TransportOptionNoOverlay,
-						NoOverlay: &udnv1.NoOverlayConfig{
-							OutboundSNAT: udnv1.SNATDisabled,
-							Routing:      udnv1.RoutingUnmanaged,
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
 						},
 					},
 				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
-								},
+			),
+			ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "bgp-l3a-",
+						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer3,
+							Layer3: &udnv1.Layer3Config{
+								Role: "Primary",
+								Subnets: []udnv1.Layer3Subnet{{
+									CIDR:       "103.103.0.0/16",
+									HostSubnet: 24,
+								}, {
+									CIDR:       "2014:100:200::0/60",
+									HostSubnet: 64,
+								}},
+							},
+							Transport: udnv1.TransportOptionNoOverlay,
+							NoOverlay: &udnv1.NoOverlayConfig{
+								OutboundSNAT: udnv1.SNATEnabled,
+								Routing:      udnv1.RoutingUnmanaged,
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
 					},
-				},
-			},
-		),
-		ginkgo.Entry("layer2",
-			&udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-l2-",
-					Labels:       map[string]string{"bgp-l2": ""},
-				},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer2,
-						Layer2: &udnv1.Layer2Config{
-							Role:    "Primary",
-							Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
-						},
-					},
-				},
-			},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l2-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l2": ""},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+									},
 								},
 							},
 						},
-					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
+						},
 					},
 				},
-			},
-		),
+			),
+			ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "bgp-l3b-",
+						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer3,
+							Layer3: &udnv1.Layer3Config{
+								Role: "Primary",
+								Subnets: []udnv1.Layer3Subnet{{
+									CIDR:       "103.103.0.0/16",
+									HostSubnet: 24,
+								}, {
+									CIDR:       "2014:100:200::0/60",
+									HostSubnet: 64,
+								}},
+							},
+							Transport: udnv1.TransportOptionNoOverlay,
+							NoOverlay: &udnv1.NoOverlayConfig{
+								OutboundSNAT: udnv1.SNATDisabled,
+								Routing:      udnv1.RoutingUnmanaged,
+							},
+						},
+					},
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+					},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+									},
+								},
+							},
+						},
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
+						},
+					},
+				},
+			),
+			ginkgo.Entry("layer2",
+				&udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						// Keep generated CUDN names under the Linux 15-byte interface
+						// limit so the VRF name is unique instead of network ID based.
+						GenerateName: "bgp-l2-",
+						Labels:       map[string]string{"bgp-l2": ""},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						Network: udnv1.NetworkSpec{
+							Topology: udnv1.NetworkTopologyLayer2,
+							Layer2: &udnv1.Layer2Config{
+								Role:    "Primary",
+								Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
+							},
+						},
+					},
+				},
+				&rav1.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-l2-ra",
+					},
+					Spec: rav1.RouteAdvertisementsSpec{
+						NetworkSelectors: apitypes.NetworkSelectors{
+							apitypes.NetworkSelector{
+								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+									NetworkSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"bgp-l2": ""},
+									},
+								},
+							},
+						},
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						Advertisements: []rav1.AdvertisementType{
+							rav1.PodNetwork,
+						},
+					},
+				},
+			),
+		)
+	},
+	bgpPeeringModes,
 	)
 })
 
@@ -2567,10 +2614,6 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 
 var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdvertisements, func() {
 
-	// infra constants
-	const (
-		bgpASN = 64512
-	)
 
 	// configuration helper to setup infra
 	configureNetworkWithInfra := func(
@@ -2581,8 +2624,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		networkName string,
 		networkType networkType,
 		networkSpec *udnv1.NetworkSpec,
-		bgpAlloc allocators.BGPAllocation,
-	) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
+	bgpAlloc allocators.BGPAllocation,
+	externalASN int,
+	clusterASN int,
+	frrContainerName string,
+) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
 		ginkgo.GinkgoHelper()
 
 		framework.Logf("Configuring the infra for network %s of type %s with allocations %#v", networkName, networkType, bgpAlloc)
@@ -2597,7 +2643,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			bgpPeerCIDRs := []string{bgpAlloc.BGPPeerSubnet, bgpAlloc.BGPPeerSubnet6}
 			bgpServerCIDRs := []string{bgpAlloc.IPVRFSubnet, bgpAlloc.IPVRFSubnet6}
 			gomega.Expect(
-				runBGPNetworkAndServer(
+				runBGPNetworkAndServerWithASN(
 					f,
 					ictx,
 					ipFamilySet,
@@ -2606,6 +2652,8 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					agnhostNetworkName,
 					bgpPeerCIDRs,
 					bgpServerCIDRs,
+					externalASN,
+					clusterASN,
 				),
 			).To(gomega.Succeed())
 			servers = append(servers, agnhostName)
@@ -2633,14 +2681,15 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				vxlanName = "vx" + testName
 			}
 
+
 			macVRFContainer := infraapi.ExternalContainer{
-				Name:    networkName + "-macvrf-agnhost",
+				Name:    networkName + "-" + frrContainerName + "-macvrf-agnhost",
 				Image:   images.AgnHost(),
 				CmdArgs: []string{"netexec", fmt.Sprintf("--http-port=%d", agnhostHTTPPort)},
 			}
 			macVRFNetworkName := macVRFContainer.Name
 			ipVRFContainer := infraapi.ExternalContainer{
-				Name:    networkName + "-ipvrf-agnhost",
+				Name:    networkName + "-" + frrContainerName + "-ipvrf-agnhost",
 				Image:   images.AgnHost(),
 				CmdArgs: []string{"netexec", fmt.Sprintf("--http-port=%d", agnhostHTTPPort)},
 			}
@@ -2653,7 +2702,9 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					ipFamilySet,
 					networkSpec,
 					bgpAlloc,
-					bgpASN,
+					externalASN,
+					clusterASN,
+					frrContainerName,
 					bridgeName,
 					vxlanName,
 					vtepName,
@@ -3015,672 +3066,704 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
 	}
 
-	ginkgo.DescribeTableSubtree("When the tested network is of type",
-		func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-			var testNamespace *corev1.Namespace
-			var testPod *corev1.Pod
-			var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
-			var networkSpec *udnv1.NetworkSpec
-			var testNetworkSpec *udnv1.NetworkSpec
 
-			expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
-				ginkgo.GinkgoHelper()
-				// In LGW VRF-Lite, host nftables masquerade picks the source IP
-				// from the node's egress interface in the target VRF when no-overlay
-				// outbound SNAT is enabled.
-				if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
-					testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
-					iface, ok := vrfLiteNodeInterfaces[node.Name]
-					gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
-					expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-					gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
-					return expectedIP
-				}
-				expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
-				if family == utilnet.IPv6 {
-					expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
-				}
-				gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
-				return expectedNodeIPs[0]
-			}
+	networksToTest := []ginkgo.TableEntry{
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT enabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATEnabledUnmanagedSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT disabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATDisabledUnmanagedSpecGen),
+		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+	}
 
-			getExternalServerIPForFamily := func(server string, family utilnet.IPFamily) string {
-				ginkgo.GinkgoHelper()
-				bgpServerNetwork, err := infraprovider.Get().GetNetwork(server)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-					infraapi.ExternalContainer{Name: server},
-					bgpServerNetwork,
-				)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				return getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-			}
+	ginkgo.DescribeTableSubtree("With underlay BGP in mode",
+		func(peering bgpPeeringConfig) {
 
-			getSameNode := func() string {
-				return testPod.Spec.NodeName
-			}
-			getDifferentNode := func() string {
-				ginkgo.GinkgoHelper()
-				nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get ready schedulable nodes")
-				for _, node := range nodes.Items {
-					if node.Name != testPod.Spec.NodeName {
-						return node.Name
+			ginkgo.DescribeTableSubtree("When the tested network is of type",
+				func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+					var testNamespace *corev1.Namespace
+					var testPod *corev1.Pod
+					var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
+					var networkSpec *udnv1.NetworkSpec
+				var testNetworkSpec *udnv1.NetworkSpec
+
+					expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
+						ginkgo.GinkgoHelper()
+						// In LGW VRF-Lite, host nftables masquerade picks the source IP
+						// from the node's egress interface in the target VRF when no-overlay
+						// outbound SNAT is enabled.
+						if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
+							testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
+							iface, ok := vrfLiteNodeInterfaces[node.Name]
+							gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
+							expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+							gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
+							return expectedIP
+						}
+						expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
+						if family == utilnet.IPv6 {
+							expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
+						}
+						gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
+						return expectedNodeIPs[0]
 					}
-				}
-				ginkgo.Fail(fmt.Sprintf("Failed to find a different ready schedulable node than %s", testPod.Spec.NodeName))
-				return ""
-			}
 
-			ginkgo.BeforeEach(func() {
-				bgpAlloc, err := allocators.AllocateBGP(f, ictx)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
-
-				networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
-				switch {
-				case networkSpec.Layer3 != nil:
-					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
-				case networkSpec.Layer2 != nil:
-					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
-				}
-				testNetworkSpec = networkSpec
-
-				testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
-					f,
-					ictx,
-					testBaseName,
-					ipFamilySet,
-					testNetworkName,
-					testedNetworkType,
-					networkSpec,
-					bgpAlloc,
-				)
-			})
-
-			ginkgo.Describe("When a pod runs on the tested network", func() {
-				ginkgo.BeforeEach(func() {
-					ginkgo.By("Running a pod on the tested network namespace")
-					testPod = e2epod.CreateExecPodOrFail(
-						context.Background(),
-						f.ClientSet,
-						testNamespace.Name,
-						testNamespace.Name+"-netexec-pod",
-						func(p *corev1.Pod) {
-							p.Spec.Containers[0].Args = []string{"netexec"}
-						},
-					)
-					var err error
-					testPod, err = f.ClientSet.CoreV1().Pods(testPod.Namespace).Get(context.Background(), testPod.Name, metav1.GetOptions{})
+					getExternalServerIPForFamily := func(server string, family utilnet.IPFamily) string {
+					ginkgo.GinkgoHelper()
+					bgpServerNetwork, err := infraprovider.Get().GetNetwork(server)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(testPod.Spec.NodeName).NotTo(gomega.BeEmpty())
-				})
+					iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+						infraapi.ExternalContainer{Name: server},
+						bgpServerNetwork,
+					)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					return getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+				}
 
-				ginkgo.DescribeTable("It can reach external servers on the same network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
-						}
-						expectSNAT := networkSpec.NoOverlay != nil &&
-							networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
-
-						if expectSNAT {
-							ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
-						} else {
-							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
-						}
-						for _, externalServer := range externalServers {
-							serverIP := getExternalServerIPForFamily(externalServer, family)
-							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-							framework.Logf("Checking request from pod reaches server %q", externalServer)
-							testPodToHostnameAndExpect(testPod, serverIP, externalServer)
-
-							if expectSNAT {
-								framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
-								// When OutboundSNAT is enabled, pod-to-external traffic is masqueraded
-								// to the node IP.
-								ip, err := e2epodoutput.RunHostCmdWithRetries(
-									testPod.Namespace,
-									testPod.Name,
-									fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
-									polling,
-									timeout,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								sourceIP, _, err := net.SplitHostPort(ip)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
-								gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-									fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
-							} else {
-								testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-									f.ClientSet,
-									testPod.Namespace,
-									testPod.Name,
-									testNetworkName,
-									family,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-								framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
-								testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+				getSameNode := func() string {
+						return testPod.Spec.NodeName
+					}
+					getDifferentNode := func() string {
+						ginkgo.GinkgoHelper()
+						nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get ready schedulable nodes")
+						for _, node := range nodes.Items {
+							if node.Name != testPod.Spec.NodeName {
+								return node.Name
 							}
 						}
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
+						ginkgo.Fail(fmt.Sprintf("Failed to find a different ready schedulable node than %s", testPod.Spec.NodeName))
+						return ""
+					}
 
-				ginkgo.DescribeTable("It can be reached by an external server on the same network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
+					ginkgo.BeforeEach(func() {
+						if peering.externalASN != peering.clusterASN && testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
+							e2eskipper.Skipf("Shared node-IP VTEP tests are skipped in eBGP mode")
 						}
-						ginkgo.By("Ensuring a request from the external servers can reach the pod")
-						for _, externalServer := range externalServers {
-							serverIP := getExternalServerIPForFamily(externalServer, family)
-							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-							podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-								f.ClientSet,
-								testPod.Namespace,
-								testPod.Name,
-								testNetworkName,
-								family,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-							framework.Logf("Checking request from server %q reaches pod", externalServer)
-							testContainerToClientIPAndExpect(externalServer, podIP, serverIP)
-						}
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
 
-				ginkgo.It("Can reach KAPI service", func() {
-					ginkgo.By("Ensuring a request from the pod can reach KAPI service")
-					output, err := e2epodoutput.RunHostCmdWithRetries(
-						testPod.Namespace,
-						testPod.Name,
-						fmt.Sprintf("curl --max-time %d -g -q -s -k https://kubernetes.default/healthz", curlMaxTime),
-						polling,
-						timeout,
-					)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(output).To(gomega.Equal("ok"))
-				})
-
-				ginkgo.DescribeTable("It cannot reach an external server on a different network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
-						}
-						ginkgo.By("Ensuring a request from the pod cannot reach the external server")
-						// using the external server setup for the default network
-						bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
+						bgpAlloc, err := allocators.AllocateBGP(f, ictx)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-							infraapi.ExternalContainer{Name: serverContainerName},
-							bgpServerNetwork,
-						)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-						gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-						testPodToClientIPNOK(testPod, serverIP)
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
+						udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
 
-				ginkgo.DescribeTable("It cannot be reached by an external server on a different network",
-					func(family utilnet.IPFamily) {
-						if !ipFamilySet.Has(family) {
-							e2eskipper.Skipf("IP family %v not supported", family)
+						networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
+						switch {
+						case networkSpec.Layer3 != nil:
+							networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
+						case networkSpec.Layer2 != nil:
+							networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
 						}
-						ginkgo.By("Ensuring a request from the external server cannot reach the pod")
-						podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-							f.ClientSet,
-							testPod.Namespace,
-							testPod.Name,
+						testNetworkSpec = networkSpec
+
+						testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
+							f,
+							ictx,
+							testBaseName,
+							ipFamilySet,
 							testNetworkName,
-							family,
+							testedNetworkType,
+							networkSpec,
+							bgpAlloc,
+							peering.externalASN,
+							peering.clusterASN,
+							peering.routerContainer,
 						)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-						// using the external server setup for the default network
-						testContainerToClientIPNOK(serverContainerName, podIP)
-					},
-					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-					ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-				)
+					})
 
-				ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
-					func(getNode func() string) {
-						ginkgo.DescribeTable("",
-							func(family utilnet.IPFamily) {
-								if !ipFamilySet.Has(family) {
-									e2eskipper.Skipf("IP family %v not supported", family)
-								}
-								ginkgo.By("Ensuring a request from the node cannot reach the tested network pod")
-								podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-									f.ClientSet,
-									testPod.Namespace,
-									testPod.Name,
-									testNetworkName,
-									family,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								gomega.Expect(podIP).ToNot(gomega.BeEmpty())
-								testNodeToClientIPNOK(getNode(), podIP)
-							},
-							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
-							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
-						)
-					},
-					ginkgo.Entry("When it is the same node", getSameNode),
-					ginkgo.Entry("When it is a different node", getDifferentNode),
-				)
-
-				ginkgo.DescribeTableSubtree("When other pod runs on the tested network",
-					func(getNode func() string) {
-						var otherPod *corev1.Pod
-
+					ginkgo.Describe("When a pod runs on the tested network", func() {
 						ginkgo.BeforeEach(func() {
-							ginkgo.By("Running other pod on the tested network namespace")
-							otherPod = e2epod.CreateExecPodOrFail(
+							ginkgo.By("Running a pod on the tested network namespace")
+							testPod = e2epod.CreateExecPodOrFail(
 								context.Background(),
 								f.ClientSet,
 								testNamespace.Name,
 								testNamespace.Name+"-netexec-pod",
 								func(p *corev1.Pod) {
 									p.Spec.Containers[0].Args = []string{"netexec"}
-									p.Spec.NodeName = getNode()
-									p.Labels = map[string]string{"app": "netexec-pod"}
 								},
 							)
+
+							// testPod was created without Spec.NodeName, re-fetch the pod so Spec.NodeName is populated
+							var err error
+							testPod, err = f.ClientSet.CoreV1().Pods(testPod.Namespace).Get(
+								context.TODO(), testPod.Name, metav1.GetOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						})
 
-						ginkgo.DescribeTable("The pods on the tested network can reach each other",
+						ginkgo.DescribeTable("It can reach external servers on the same network",
 							func(family utilnet.IPFamily) {
 								if !ipFamilySet.Has(family) {
 									e2eskipper.Skipf("IP family %v not supported", family)
 								}
-								ginkgo.By("Ensuring a request from the first pod can reach the second pod")
-								otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-									f.ClientSet,
-									otherPod.Namespace,
-									otherPod.Name,
-									testNetworkName,
-									family,
-								)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-								testPodToClientIP(testPod, otherPodIP)
+								expectSNAT := networkSpec.NoOverlay != nil &&
+									networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+								if expectSNAT {
+									ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
+								} else {
+									ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+								}
+								for _, externalServer := range externalServers {
+									serverIP := getExternalServerIPForFamily(externalServer, family)
+									gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+									framework.Logf("Checking request from pod reaches server %q", externalServer)
+									testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+
+									if expectSNAT {
+										framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
+										ip, err := e2epodoutput.RunHostCmdWithRetries(
+											testPod.Namespace,
+											testPod.Name,
+											fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
+											polling,
+											timeout,
+										)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										sourceIP, _, err := net.SplitHostPort(ip)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
+										gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+											fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
+									} else {
+										testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+											f.ClientSet,
+											testPod.Namespace,
+											testPod.Name,
+											testNetworkName,
+											family,
+										)
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+										gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+										framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
+										testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+									}
+								}
 							},
-							ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
-							ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
+							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
 						)
 
-						ginkgo.Describe("Backing a ClusterIP service", func() {
-							var service *corev1.Service
+						ginkgo.DescribeTable("It can be reached by an external server on the same network",
+							func(family utilnet.IPFamily) {
+								if !ipFamilySet.Has(family) {
+									e2eskipper.Skipf("IP family %v not supported", family)
+								}
+								ginkgo.By("Ensuring a request from the external servers can reach the pod")
+								for _, externalServer := range externalServers {
+									serverIP := getExternalServerIPForFamily(externalServer, family)
+									gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+									podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										f.ClientSet,
+										testPod.Namespace,
+										testPod.Name,
+										testNetworkName,
+										family,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+									framework.Logf("Checking request from server %q reaches pod", externalServer)
+									testContainerToClientIPAndExpect(externalServer, podIP, serverIP)
+								}
+							},
+							ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+							ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+						)
 
-							ginkgo.BeforeEach(func() {
-								ginkgo.By("Creating a service backed by the other network pod")
-								service = e2eservice.CreateServiceSpec(
-									"service-for-netexec",
-									"",
-									false,
-									otherPod.Labels,
-								)
-								service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
-								familyPolicy := corev1.IPFamilyPolicyPreferDualStack
-								service.Spec.IPFamilyPolicy = &familyPolicy
-								var err error
-								service, err = f.ClientSet.CoreV1().Services(otherPod.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							})
+						ginkgo.It("Can reach KAPI service", func() {
+							ginkgo.By("Ensuring a request from the pod can reach KAPI service")
+							output, err := e2epodoutput.RunHostCmdWithRetries(
+								testPod.Namespace,
+								testPod.Name,
+								fmt.Sprintf("curl --max-time %d -g -q -s -k https://kubernetes.default/healthz", curlMaxTime),
+								polling,
+								timeout,
+							)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(output).To(gomega.Equal("ok"))
+						})
 
-							ginkgo.DescribeTable("The first pod can reach the ClusterIP service on the same network",
+						if peering.externalASN == peering.clusterASN {
+							ginkgo.DescribeTable("It cannot reach an external server on a different network",
 								func(family utilnet.IPFamily) {
 									if !ipFamilySet.Has(family) {
 										e2eskipper.Skipf("IP family %v not supported", family)
 									}
-									ginkgo.By("Ensuring a request from the first pod can reach the ClusterIP service")
-									clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
-									gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-									testPodToClientIP(testPod, clusterIP)
+									ginkgo.By("Ensuring a request from the pod cannot reach the external server")
+									// using the external server setup for the default network
+									bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+										infraapi.ExternalContainer{Name: serverContainerName},
+										bgpServerNetwork,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+									gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+									testPodToClientIPNOK(testPod, serverIP)
 								},
-								ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
-								ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
+								ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+								ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
 							)
-						})
-					},
-					ginkgo.Entry("On the same node", getSameNode),
-					ginkgo.Entry("On a different node", getDifferentNode),
-				)
 
-				ginkgo.Describe("When there is other network", func() {
+							ginkgo.DescribeTable("It cannot be reached by an external server on a different network",
+								func(family utilnet.IPFamily) {
+									if !ipFamilySet.Has(family) {
+										e2eskipper.Skipf("IP family %v not supported", family)
+									}
+									ginkgo.By("Ensuring a request from the external server cannot reach the pod")
+									podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										f.ClientSet,
+										testPod.Namespace,
+										testPod.Name,
+										testNetworkName,
+										family,
+									)
+									gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+									// using the external server setup for the default network
+									testContainerToClientIPNOK(serverContainerName, podIP)
+								},
+								ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+								ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+							)
 
-					nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
-						return nil
-					}
-
-					// overlappingSpecGen reuses the tested network's topology and subnets
-					// with fresh VNIs to prove VPN-level isolation with overlapping IP
-					// address space. Only appended to otherNetworksToTest when the outer
-					// tested network is cudnAdvertisedEVPNUnmanagedSharedVTEP, so
-					// testNetworkSpec is guaranteed to have an EVPN config here.
-					overlappingSpecGen := func(_ string, _ string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
-						spec := testNetworkSpec.DeepCopy()
-						if spec.EVPN.MACVRF != nil {
-							spec.EVPN.MACVRF.VNI = int32(bgpAlloc.MACVRFVNI)
+							ginkgo.DescribeTableSubtree("It cannot be reached by a cluster node",
+								func(getNode func() string) {
+									ginkgo.DescribeTable("",
+										func(family utilnet.IPFamily) {
+											if !ipFamilySet.Has(family) {
+												e2eskipper.Skipf("IP family %v not supported", family)
+											}
+											ginkgo.By("Ensuring a request from the node cannot reach the tested network pod")
+											podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												f.ClientSet,
+												testPod.Namespace,
+												testPod.Name,
+												testNetworkName,
+												family,
+											)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											gomega.Expect(podIP).ToNot(gomega.BeEmpty())
+											testNodeToClientIPNOK(getNode(), podIP)
+										},
+										ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
+										ginkgo.Entry("When the network is IPv6", utilnet.IPv6),
+									)
+								},
+								ginkgo.Entry("When it is the same node", getSameNode),
+								ginkgo.Entry("When it is a different node", getDifferentNode),
+							)
 						}
-						if spec.EVPN.IPVRF != nil {
-							spec.EVPN.IPVRF.VNI = int32(bgpAlloc.IPVRFVNI)
-						}
-						spec.EVPN.VTEP = ""
-						return spec
-					}
 
-					otherNetworksToTest := []ginkgo.TableEntry{
-						ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
-						ginkgo.Entry("Layer 3 UDN", udn, layer3NetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
-						ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
-						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-					}
-					if testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
-						otherNetworksToTest = append(otherNetworksToTest,
-							ginkgo.Entry("CUDN EVPN overlapping subnet shared VTEP", feature.EVPN, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP, overlappingSpecGen),
-						)
-					}
+						ginkgo.DescribeTableSubtree("When other pod runs on the tested network",
+							func(getNode func() string) {
+								var otherPod *corev1.Pod
 
-					ginkgo.DescribeTableSubtree("Of type",
-						func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
-							var otherNamespace *corev1.Namespace
-							var otherNetworkName string
-
-							ginkgo.BeforeEach(func() {
-								otherNetworkName = testBaseName + "o"
-								otherNamespaceName := otherNetworkName
-
-								otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
-								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
-
-								otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
-								switch {
-								case otherNetworkSpec == nil && networkType == defaultNetwork:
-									otherNetworkName = "default"
-								case otherNetworkSpec.Layer3 != nil:
-									otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
-								case otherNetworkSpec.Layer2 != nil:
-									otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
-								}
-
-								otherNamespace, _, _ = configureNetworkWithInfra(
-									f,
-									ictx,
-									testBaseName,
-									ipFamilySet,
-									otherNamespaceName,
-									networkType,
-									otherNetworkSpec,
-									otherBGPAlloc,
-								)
-							})
-
-							ginkgo.It("Both networks are isolated", func() {
-								ginkgo.By("Running two pods on the other network namespace on different nodes")
-								var otherPodSameNode, otherPodDiffNode *corev1.Pod
-								wg := sync.WaitGroup{}
-								wg.Add(2)
-								go func() {
-									ginkgo.GinkgoHelper()
-									defer ginkgo.GinkgoRecover()
-									defer wg.Done()
-									otherPodSameNode = e2epod.CreateExecPodOrFail(
+								ginkgo.BeforeEach(func() {
+									ginkgo.By("Running other pod on the tested network namespace")
+									otherPod = e2epod.CreateExecPodOrFail(
 										context.Background(),
 										f.ClientSet,
-										otherNamespace.Name,
-										otherNamespace.Name+"-netexec-samenode-pod",
+										testNamespace.Name,
+										testNamespace.Name+"-netexec-pod",
 										func(p *corev1.Pod) {
 											p.Spec.Containers[0].Args = []string{"netexec"}
-											p.Spec.NodeName = getSameNode()
-											p.Labels = map[string]string{"app": "netexec-samenode-pod"}
+											p.Spec.NodeName = getNode()
+											p.Labels = map[string]string{"app": "netexec-pod"}
 										},
 									)
-								}()
-								go func() {
-									ginkgo.GinkgoHelper()
-									defer ginkgo.GinkgoRecover()
-									defer wg.Done()
-									otherPodDiffNode = e2epod.CreateExecPodOrFail(
-										context.Background(),
-										f.ClientSet,
-										otherNamespace.Name,
-										otherNamespace.Name+"-netexec-diffnode-pod",
-										func(p *corev1.Pod) {
-											p.Spec.Containers[0].Args = []string{"netexec"}
-											p.Spec.NodeName = getDifferentNode()
-											p.Labels = map[string]string{"app": "netexec-diffnode-pod"}
-										},
-									)
-								}()
-								wg.Wait()
+								})
 
-								ginkgo.By("Ensuring the pods from the other network can talk to each other")
-								testForIPFamilies(
-									ipFamilySet,
+								ginkgo.DescribeTable("The pods on the tested network can reach each other",
 									func(family utilnet.IPFamily) {
-										ginkgo.GinkgoHelper()
-										otherPodSameNodeIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+										if !ipFamilySet.Has(family) {
+											e2eskipper.Skipf("IP family %v not supported", family)
+										}
+										ginkgo.By("Ensuring a request from the first pod can reach the second pod")
+										otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 											f.ClientSet,
-											otherPodSameNode.Namespace,
-											otherPodSameNode.Name,
-											otherNetworkName,
+											otherPod.Namespace,
+											otherPod.Name,
+											testNetworkName,
 											family,
 										)
 										gomega.Expect(err).NotTo(gomega.HaveOccurred())
-										gomega.Expect(otherPodSameNodeIP).ToNot(gomega.BeEmpty())
-										testPodToClientIP(otherPodDiffNode, otherPodSameNodeIP)
+										gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
+										testPodToClientIP(testPod, otherPodIP)
 									},
+									ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
+									ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
 								)
 
-								ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network pods")
-								for _, target := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-									testForIPFamilies(
-										ipFamilySet,
+								ginkgo.Describe("Backing a ClusterIP service", func() {
+									var service *corev1.Service
+
+									ginkgo.BeforeEach(func() {
+										ginkgo.By("Creating a service backed by the other network pod")
+										service = e2eservice.CreateServiceSpec(
+											"service-for-netexec",
+											"",
+											false,
+											otherPod.Labels,
+										)
+										service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
+										familyPolicy := corev1.IPFamilyPolicyPreferDualStack
+										service.Spec.IPFamilyPolicy = &familyPolicy
+										var err error
+										service, err = f.ClientSet.CoreV1().Services(otherPod.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+										gomega.Expect(err).NotTo(gomega.HaveOccurred())
+									})
+
+									ginkgo.DescribeTable("The first pod can reach the ClusterIP service on the same network",
 										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the tested network pod cannot reach the other network pod %s on IPv%v", target.Name, family)
-											otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-												f.ClientSet,
-												target.Namespace,
-												target.Name,
-												otherNetworkName,
-												family,
-											)
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-											testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-												f.ClientSet,
-												testPod.Namespace,
-												testPod.Name,
-												testNetworkName,
-												family,
-											)
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-											if testPodIP == otherPodIP {
-												// Overlapping CUDNs assigned the same IP; verify the tested pod
-												// reaches itself (its own hostname), proving traffic stays within
-												// its own CUDN.
-												framework.Logf("Tested pod and other pod share IP %s; verifying hostname to confirm per-CUDN isolation", otherPodIP)
-												testPodToHostnameAndExpect(testPod, otherPodIP, testPod.Name)
-											} else {
-												testPodToClientIPNOK(testPod, otherPodIP)
+											if !ipFamilySet.Has(family) {
+												e2eskipper.Skipf("IP family %v not supported", family)
 											}
-										},
-									)
-								}
-
-								ginkgo.By("Ensuring a request from the other network pods on the same node cannot reach the tested network pod")
-								for _, source := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the other network pod %s on the same node cannot reach the tested network pod on IPv%v", source.Name, family)
-											testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-												f.ClientSet,
-												testPod.Namespace,
-												testPod.Name,
-												testNetworkName,
-												family,
-											)
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-											sourcePodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-												f.ClientSet,
-												source.Namespace,
-												source.Name,
-												otherNetworkName,
-												family,
-											)
-											gomega.Expect(err).NotTo(gomega.HaveOccurred())
-											gomega.Expect(sourcePodIP).ToNot(gomega.BeEmpty())
-											if sourcePodIP == testPodIP {
-												// Overlapping CUDNs assigned the same IP; verify the other pod
-												// reaches itself (its own hostname) to confirm per-CUDN isolation.
-												framework.Logf("Other pod %s and tested pod share IP %s; verifying hostname to confirm per-CUDN isolation", source.Name, testPodIP)
-												testPodToHostnameAndExpect(source, testPodIP, source.Name)
-											} else {
-												// Source pod has a different IP from the tested pod. In the
-												// overlapping CIDR case, the source's same-network peer may
-												// share the tested pod's IP. If so, when the source curls
-												// testPodIP, routing within the other network delivers the
-												// packet to that peer — not to the tested pod. Determine
-												// which pod is the peer and check its IP.
-												var peerPod *corev1.Pod
-												if source == otherPodSameNode {
-													peerPod = otherPodDiffNode
-												} else {
-													peerPod = otherPodSameNode
-												}
-												peerPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-													f.ClientSet,
-													peerPod.Namespace,
-													peerPod.Name,
-													otherNetworkName,
-													family,
-												)
-												gomega.Expect(err).NotTo(gomega.HaveOccurred())
-												gomega.Expect(peerPodIP).ToNot(gomega.BeEmpty())
-												if peerPodIP == testPodIP {
-													framework.Logf("Other network peer pod %s and tested pod share IP %s; verifying pod %s reaches its same-network peer, not the tested pod", peerPod.Name, testPodIP, source.Name)
-													testPodToHostnameAndExpect(source, testPodIP, peerPod.Name)
-												} else {
-													testPodToClientIPNOK(source, testPodIP)
-												}
-											}
-										},
-									)
-								}
-
-								ginkgo.By("Creating services backed by the other network pods")
-								var services []*corev1.Service
-								for _, backend := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
-									service := e2eservice.CreateServiceSpec(
-										"service-"+backend.Name,
-										"",
-										false,
-										backend.Labels,
-									)
-									service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
-									familyPolicy := corev1.IPFamilyPolicyPreferDualStack
-									service.Spec.IPFamilyPolicy = &familyPolicy
-									var err error
-									service, err = f.ClientSet.CoreV1().Services(backend.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-									gomega.Expect(err).NotTo(gomega.HaveOccurred())
-									services = append(services, service)
-								}
-
-								ginkgo.By("Ensuring the pods from the other network can reach their services")
-								for source, target := range map[*corev1.Pod]*corev1.Service{otherPodSameNode: services[1], otherPodDiffNode: services[0]} {
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the other network pod %s can reach the its network service %s on IPv%v", source.Name, target.Name, family)
-											clusterIP := getFirstIPStringOfFamily(family, target.Spec.ClusterIPs)
-											gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-											testPodToClientIP(source, clusterIP)
-										},
-									)
-								}
-
-								ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network services")
-								for _, service := range services {
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											framework.Logf("Ensuring a request from the tested network pod cannot reach the other network service %s on IPv%v", service.Name, family)
+											ginkgo.By("Ensuring a request from the first pod can reach the ClusterIP service")
 											clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
 											gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(testPod, clusterIP)
+											testPodToClientIP(testPod, clusterIP)
 										},
+										ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
+										ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
+									)
+								})
+							},
+							ginkgo.Entry("On the same node", getSameNode),
+							ginkgo.Entry("On a different node", getDifferentNode),
+						)
+
+						if peering.externalASN == peering.clusterASN {
+							ginkgo.Describe("When there is other network", func() {
+
+
+								overlappingSpecGen := func(_ string, _ string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
+									spec := testNetworkSpec.DeepCopy()
+									if spec.EVPN.MACVRF != nil {
+										spec.EVPN.MACVRF.VNI = int32(bgpAlloc.MACVRFVNI)
+									}
+									if spec.EVPN.IPVRF != nil {
+										spec.EVPN.IPVRF.VNI = int32(bgpAlloc.IPVRFVNI)
+									}
+									spec.EVPN.VTEP = ""
+									return spec
+								}
+
+								nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
+									return nil
+								}
+
+								otherNetworksToTest := []ginkgo.TableEntry{
+									ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+									ginkgo.Entry("Layer 3 UDN", udn, layer3NetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN advertised", cudnAdvertised, layer3NetworkSpecGen),
+									ginkgo.Entry("Layer 2 UDN", udn, layer2NetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN advertised", cudnAdvertised, layer2NetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+								ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
+								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
+								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+								}
+								if testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
+									otherNetworksToTest = append(otherNetworksToTest,
+										ginkgo.Entry("CUDN EVPN overlapping subnet shared VTEP", feature.EVPN, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP, overlappingSpecGen),
 									)
 								}
 
-								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP &&
-									testNetworkSpec.EVPN != nil && testNetworkSpec.EVPN.MACVRF != nil {
-									// The outer "It can reach external servers on the same network" block already
-									// tests north-south connectivity for the tested network in isolation.
-									// This additional check runs within the "other network is set up" context,
-									// verifying that VNI isolation holds for north-south traffic: even when
-									// the other network shares the same VTEP IP and its MAC-VRF external server
-									// is reachable at the same IP (both networks derive container IPs from the
-									// shared CUDN subnet), the tested pod still reaches only its own external
-									// server (identified by hostname) rather than the other network's.
-									// Only the MAC-VRF server is checked here: it is the only one whose IP is
-									// shared between both networks (secondToLastIP of the CUDN subnet).
-									// IP-VRF containers are allocated from a separate per-network subnet
-									// (bgpAlloc.IPVRFSubnet6), so they have distinct IPs and there is no
-									// shared-IP VNI ambiguity to verify.
-									ginkgo.By("Ensuring the tested network pod reaches its own MAC-VRF external server at the shared IP (north-south VNI isolation)")
-									macVRFServerName := testNetworkName + "-macvrf-agnhost"
-									testForIPFamilies(
-										ipFamilySet,
-										func(family utilnet.IPFamily) {
-											ginkgo.GinkgoHelper()
-											serverIP := getExternalServerIPForFamily(macVRFServerName, family)
-											gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-											framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", macVRFServerName, serverIP, family)
-											testPodToHostnameAndExpect(testPod, serverIP, macVRFServerName)
-										},
-									)
-								}
+								ginkgo.DescribeTableSubtree("Of type",
+									func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+										var otherNamespace *corev1.Namespace
+										var otherNetworkName string
+
+										ginkgo.BeforeEach(func() {
+											otherNetworkName = testBaseName + "o"
+											otherNamespaceName := otherNetworkName
+
+											otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
+
+											otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
+											switch {
+											case otherNetworkSpec == nil && networkType == defaultNetwork:
+												otherNetworkName = "default"
+											case otherNetworkSpec.Layer3 != nil:
+												otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
+											case otherNetworkSpec.Layer2 != nil:
+												otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
+											}
+
+											otherNamespace, _, _ = configureNetworkWithInfra(
+												f,
+												ictx,
+												testBaseName,
+												ipFamilySet,
+												otherNamespaceName,
+												networkType,
+												otherNetworkSpec,
+												otherBGPAlloc,
+												peering.externalASN,
+												peering.clusterASN,
+												peering.routerContainer,
+											)
+										})
+
+										ginkgo.It("Both networks are isolated", func() {
+											ginkgo.By("Running two pods on the other network namespace on different nodes")
+											var otherPodSameNode, otherPodDiffNode *corev1.Pod
+											wg := sync.WaitGroup{}
+											wg.Add(2)
+											go func() {
+												ginkgo.GinkgoHelper()
+												defer ginkgo.GinkgoRecover()
+												defer wg.Done()
+												otherPodSameNode = e2epod.CreateExecPodOrFail(
+													context.Background(),
+													f.ClientSet,
+													otherNamespace.Name,
+													otherNamespace.Name+"-netexec-samenode-pod",
+													func(p *corev1.Pod) {
+														p.Spec.Containers[0].Args = []string{"netexec"}
+														p.Spec.NodeName = getSameNode()
+														p.Labels = map[string]string{"app": "netexec-samenode-pod"}
+													},
+												)
+											}()
+											go func() {
+												ginkgo.GinkgoHelper()
+												defer ginkgo.GinkgoRecover()
+												defer wg.Done()
+												otherPodDiffNode = e2epod.CreateExecPodOrFail(
+													context.Background(),
+													f.ClientSet,
+													otherNamespace.Name,
+													otherNamespace.Name+"-netexec-diffnode-pod",
+													func(p *corev1.Pod) {
+														p.Spec.Containers[0].Args = []string{"netexec"}
+														p.Spec.NodeName = getDifferentNode()
+														p.Labels = map[string]string{"app": "netexec-diffnode-pod"}
+													},
+												)
+											}()
+											wg.Wait()
+
+											ginkgo.By("Ensuring the pods from the other network can talk to each other")
+											testForIPFamilies(
+												ipFamilySet,
+												func(family utilnet.IPFamily) {
+													ginkgo.GinkgoHelper()
+													otherPodSameNodeIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+														f.ClientSet,
+														otherPodSameNode.Namespace,
+														otherPodSameNode.Name,
+														otherNetworkName,
+														family,
+													)
+													gomega.Expect(err).NotTo(gomega.HaveOccurred())
+													gomega.Expect(otherPodSameNodeIP).ToNot(gomega.BeEmpty())
+													testPodToClientIP(otherPodDiffNode, otherPodSameNodeIP)
+												},
+											)
+
+											ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network pods")
+											for _, target := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the tested network pod cannot reach the other network pod %s on IPv%v", target.Name, family)
+														otherPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+															f.ClientSet,
+															target.Namespace,
+															target.Name,
+															otherNetworkName,
+															family,
+														)
+														gomega.Expect(err).NotTo(gomega.HaveOccurred())
+														gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
+														testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+															f.ClientSet,
+															testPod.Namespace,
+															testPod.Name,
+															testNetworkName,
+															family,
+														)
+														gomega.Expect(err).NotTo(gomega.HaveOccurred())
+														gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+														if testPodIP == otherPodIP {
+															// Overlapping CUDNs assigned the same IP; verify the tested pod
+															// reaches itself (its own hostname), proving traffic stays within
+															// its own CUDN.
+															framework.Logf("Tested pod and other pod share IP %s; verifying hostname to confirm per-CUDN isolation", otherPodIP)
+															testPodToHostnameAndExpect(testPod, otherPodIP, testPod.Name)
+														} else {
+															testPodToClientIPNOK(testPod, otherPodIP)
+														}
+													},
+												)
+											}
+
+											ginkgo.By("Ensuring a request from the other network pods on the same node cannot reach the tested network pod")
+											for _, source := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the other network pod %s on the same node cannot reach the tested network pod on IPv%v", source.Name, family)
+														testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+															f.ClientSet,
+															testPod.Namespace,
+															testPod.Name,
+															testNetworkName,
+															family,
+														)
+														gomega.Expect(err).NotTo(gomega.HaveOccurred())
+														gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+														sourcePodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+															f.ClientSet,
+															source.Namespace,
+															source.Name,
+															otherNetworkName,
+															family,
+														)
+														gomega.Expect(err).NotTo(gomega.HaveOccurred())
+														gomega.Expect(sourcePodIP).ToNot(gomega.BeEmpty())
+														if sourcePodIP == testPodIP {
+															// Overlapping CUDNs assigned the same IP; verify the other pod
+															// reaches itself (its own hostname) to confirm per-CUDN isolation.
+															framework.Logf("Other pod %s and tested pod share IP %s; verifying hostname to confirm per-CUDN isolation", source.Name, testPodIP)
+															testPodToHostnameAndExpect(source, testPodIP, source.Name)
+														} else {
+															// Source pod has a different IP from the tested pod. In the
+															// overlapping CIDR case, the source's same-network peer may
+															// share the tested pod's IP. If so, when the source curls
+															// testPodIP, routing within the other network delivers the
+															// packet to that peer — not to the tested pod. Determine
+															// which pod is the peer and check its IP.
+															var peerPod *corev1.Pod
+															if source == otherPodSameNode {
+																peerPod = otherPodDiffNode
+															} else {
+																peerPod = otherPodSameNode
+															}
+															peerPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+																f.ClientSet,
+																peerPod.Namespace,
+																peerPod.Name,
+																otherNetworkName,
+																family,
+															)
+															gomega.Expect(err).NotTo(gomega.HaveOccurred())
+															gomega.Expect(peerPodIP).ToNot(gomega.BeEmpty())
+															if peerPodIP == testPodIP {
+																framework.Logf("Other network peer pod %s and tested pod share IP %s; verifying pod %s reaches its same-network peer, not the tested pod", peerPod.Name, testPodIP, source.Name)
+																testPodToHostnameAndExpect(source, testPodIP, peerPod.Name)
+															} else {
+																testPodToClientIPNOK(source, testPodIP)
+															}
+														}
+													},
+												)
+											}
+
+											ginkgo.By("Creating services backed by the other network pods")
+											var services []*corev1.Service
+											for _, backend := range []*corev1.Pod{otherPodSameNode, otherPodDiffNode} {
+												service := e2eservice.CreateServiceSpec(
+													"service-"+backend.Name,
+													"",
+													false,
+													backend.Labels,
+												)
+												service.Spec.Ports = []corev1.ServicePort{{Port: netexecPort}}
+												familyPolicy := corev1.IPFamilyPolicyPreferDualStack
+												service.Spec.IPFamilyPolicy = &familyPolicy
+												var err error
+												service, err = f.ClientSet.CoreV1().Services(backend.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+												gomega.Expect(err).NotTo(gomega.HaveOccurred())
+												services = append(services, service)
+											}
+
+											ginkgo.By("Ensuring the pods from the other network can reach their services")
+											for source, target := range map[*corev1.Pod]*corev1.Service{otherPodSameNode: services[1], otherPodDiffNode: services[0]} {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the other network pod %s can reach the its network service %s on IPv%v", source.Name, target.Name, family)
+														clusterIP := getFirstIPStringOfFamily(family, target.Spec.ClusterIPs)
+														gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
+														testPodToClientIP(source, clusterIP)
+													},
+												)
+											}
+
+											ginkgo.By("Ensuring a request from the tested network pod cannot reach the other network services")
+											for _, service := range services {
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														framework.Logf("Ensuring a request from the tested network pod cannot reach the other network service %s on IPv%v", service.Name, family)
+														clusterIP := getFirstIPStringOfFamily(family, service.Spec.ClusterIPs)
+														gomega.Expect(clusterIP).ToNot(gomega.BeEmpty())
+														testPodToClientIPNOK(testPod, clusterIP)
+													},
+												)
+											}
+
+											if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP &&
+												testNetworkSpec.EVPN != nil && testNetworkSpec.EVPN.MACVRF != nil {
+												// The outer "It can reach external servers on the same network" block already
+												// tests north-south connectivity for the tested network in isolation.
+												// This additional check runs within the "other network is set up" context,
+												// verifying that VNI isolation holds for north-south traffic: even when
+												// the other network shares the same VTEP IP and its MAC-VRF external server
+												// is reachable at the same IP (both networks derive container IPs from the
+												// shared CUDN subnet), the tested pod still reaches only its own external
+												// server (identified by hostname) rather than the other network's.
+												// Only the MAC-VRF server is checked here: it is the only one whose IP is
+												// shared between both networks (secondToLastIP of the CUDN subnet).
+												// IP-VRF containers are allocated from a separate per-network subnet
+												// (bgpAlloc.IPVRFSubnet6), so they have distinct IPs and there is no
+												// shared-IP VNI ambiguity to verify.
+												ginkgo.By("Ensuring the tested network pod reaches its own MAC-VRF external server at the shared IP (north-south VNI isolation)")
+												macVRFServerName := testNetworkName + "-macvrf-agnhost"
+												testForIPFamilies(
+													ipFamilySet,
+													func(family utilnet.IPFamily) {
+														ginkgo.GinkgoHelper()
+														serverIP := getExternalServerIPForFamily(macVRFServerName, family)
+														gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+														framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", macVRFServerName, serverIP, family)
+														testPodToHostnameAndExpect(testPod, serverIP, macVRFServerName)
+													},
+												)
+											}
+										})
+									},
+									otherNetworksToTest,
+								)
 							})
-						},
-						otherNetworksToTest,
-					)
-				})
-			})
+						}
+					})
+				},
+				networksToTest,
+			)
+
 		},
-		networksToTest,
+		bgpPeeringModes,
 	)
+
 
 	ginkgo.DescribeTable("Validates BUM suppression is in effect for L2 EVPN networks",
 		func(bumTestBaseName string, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
@@ -3707,6 +3790,9 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				cudnAdvertisedEVPNUnmanagedRandomVTEP,
 				bumNetworkSpec,
 				bgpAlloc,
+				bgpClusterASN,
+				bgpClusterASN,
+				routerContainerName,
 			)
 			gomega.Expect(externalServers).NotTo(gomega.BeEmpty(), "MAC-VRF external agnhost container must exist for EVPN L2 test")
 			macVRFAgnhostContainer := externalServers[0]
@@ -3733,7 +3819,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 
 			ginkgo.By("Validation 1: Type-3 (BUM flood list) routes for each VTEP")
 			macVRFVNI := fmt.Sprintf("%d", bumNetworkSpec.EVPN.MACVRF.VNI)
-			externalFRRIP, err := getExternalFRRIP(ipFamilySet)
+			externalFRRIP, err := getExternalFRRIP(routerContainerName, ipFamilySet)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "external FRR VTEP IP")
 			// Collect VTEP IPs from the k8s.ovn.org/vteps node annotation written by the EVPN controller.
 			var nodes *corev1.NodeList
@@ -4051,6 +4137,8 @@ func routeAdvertisementsReadyFunc(c raclientset.Clientset, name string) func() e
 // templateInputRouter data
 type templateInputRouter struct {
 	VRF           string
+	LocalASN      int
+	NeighborASN   int
 	NeighborsIPv4 []string
 	NeighborsIPv6 []string
 	NetworksIPv4  []string
@@ -4073,8 +4161,11 @@ var tmplDir = filepath.Join("testdata", "routeadvertisements")
 
 // generateFRRConfiguration to establish a BGP session towards the provided
 // neighbors in the network's VRF configured to advertised the provided
-// networks. Returns a temporary directory where the configuration is generated.
-func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (directory string, err error) {
+// networks. localASN is the ASN for this external FRR, neighborASN is the
+// ASN of the peers (cluster nodes). For iBGP, both are the same; for eBGP,
+// they differ and route-reflector-client is omitted.
+// Returns a temporary directory where the configuration is generated.
+func generateFRRConfiguration(neighborIPs, advertiseNetworks []string, localASN, neighborASN int) (directory string, err error) {
 	// parse configuration templates
 	var templates *template.Template
 	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr", "*.tmpl"))
@@ -4099,6 +4190,8 @@ func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (director
 	conf := templateInputFRR{
 		Routers: []templateInputRouter{
 			{
+				LocalASN:      localASN,
+				NeighborASN:   neighborASN,
 				NeighborsIPv4: neighborsIPv4,
 				NetworksIPv4:  networksIPv4,
 				NeighborsIPv6: neighborsIPv6,
@@ -4125,10 +4218,10 @@ func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (director
 // network's VRF, configured to receive advertisements for the provided
 // networks. Returns a temporary directory where the configuration is generated.
 func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetworks []string) (directory string, err error) {
-	return generateFRRk8sConfigurationForVRF(networkName, networkName, neighborIPs, receiveNetworks)
+	return generateFRRk8sConfigurationForVRF(networkName, networkName, neighborIPs, receiveNetworks, bgpClusterASN, bgpClusterASN)
 }
 
-func generateFRRk8sConfigurationForVRF(networkName, vrf string, neighborIPs, receiveNetworks []string) (directory string, err error) {
+func generateFRRk8sConfigurationForVRF(networkName, vrf string, neighborIPs, receiveNetworks []string, localASN, neighborASN int) (directory string, err error) {
 	// parse configuration templates
 	var templates *template.Template
 	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr-k8s", "*.tmpl"))
@@ -4155,6 +4248,8 @@ func generateFRRk8sConfigurationForVRF(networkName, vrf string, neighborIPs, rec
 		Routers: []templateInputRouter{
 			{
 				VRF:           vrf,
+				LocalASN:      localASN,
+				NeighborASN:   neighborASN,
 				NeighborsIPv4: neighborsIPv4,
 				NeighborsIPv6: neighborsIPv6,
 				NetworksIPv4:  receivesIPv4,
@@ -4173,6 +4268,9 @@ func generateFRRk8sConfigurationForVRF(networkName, vrf string, neighborIPs, rec
 // runBGPNetworkAndServer configures a topology appropriate to be used with
 // route advertisement test cases. For VRF-Lite test cases, the caller is
 // resposible to attach the peer network interface to the CUDN VRF on the nodes.
+// externalASN is the ASN for the external FRR container, clusterASN is the ASN
+// for the cluster nodes (frr-k8s). For iBGP, both are the same; for eBGP, they
+// differ.
 //
 // -----------------                 ------------------                            ---------------
 // |               |  serverNetwork  |                |       peerNetwork          |             |
@@ -4189,17 +4287,22 @@ func runBGPNetworkAndServer(
 	peerNetworks []string,
 	serverNetworks []string,
 ) error {
-	return runBGPNetworkAndServerWithFRRVRF(
-		f,
-		ictx,
-		ipFamilySet,
-		networkName,
-		serverName,
-		serverNetworkName,
-		peerNetworks,
-		serverNetworks,
-		networkName,
-	)
+	return runBGPNetworkAndServerWithASN(f, ictx, ipFamilySet, networkName, serverName, serverNetworkName, peerNetworks, serverNetworks, bgpClusterASN, bgpClusterASN)
+}
+
+func runBGPNetworkAndServerWithASN(
+	f *framework.Framework,
+	ictx infraapi.Context,
+	ipFamilySet sets.Set[utilnet.IPFamily],
+	networkName string,
+	serverName string,
+	serverNetworkName string,
+	peerNetworks []string,
+	serverNetworks []string,
+	externalASN int,
+	clusterASN int,
+) error {
+	return runBGPNetworkAndServerWithFRRVRFAndASN(f, ictx, ipFamilySet, networkName, serverName, serverNetworkName, peerNetworks, serverNetworks, networkName, externalASN, clusterASN)
 }
 
 func runBGPNetworkAndServerWithFRRVRF(
@@ -4212,6 +4315,22 @@ func runBGPNetworkAndServerWithFRRVRF(
 	peerNetworks []string,
 	serverNetworks []string,
 	frrVRF string,
+) error {
+	return runBGPNetworkAndServerWithFRRVRFAndASN(f, ictx, ipFamilySet, networkName, serverName, serverNetworkName, peerNetworks, serverNetworks, frrVRF, bgpClusterASN, bgpClusterASN)
+}
+
+func runBGPNetworkAndServerWithFRRVRFAndASN(
+	f *framework.Framework,
+	ictx infraapi.Context,
+	ipFamilySet sets.Set[utilnet.IPFamily],
+	networkName string,
+	serverName string,
+	serverNetworkName string,
+	peerNetworks []string,
+	serverNetworks []string,
+	frrVRF string,
+	externalASN int,
+	clusterASN int,
 ) error {
 	// filter networks by supported IP families
 	peerNetworks = matchCIDRStringsByIPFamilySet(peerNetworks, ipFamilySet)
@@ -4245,7 +4364,7 @@ func runBGPNetworkAndServerWithFRRVRF(
 
 	// run frr container
 	advertiseNetworks := serverNetworks
-	frrConfig, err := generateFRRConfiguration(nodeIPs, advertiseNetworks)
+	frrConfig, err := generateFRRConfiguration(nodeIPs, advertiseNetworks, externalASN, clusterASN)
 	if err != nil {
 		return fmt.Errorf("failed to generate FRR configuration: %w", err)
 	}
@@ -4303,7 +4422,7 @@ func runBGPNetworkAndServerWithFRRVRF(
 
 	// apply FRR-K8s Configuration
 	receiveNetworks := serverNetworks
-	frrK8sConfig, err := generateFRRk8sConfigurationForVRF(networkName, frrVRF, []string{frr.IPv4, frr.IPv6}, receiveNetworks)
+	frrK8sConfig, err := generateFRRk8sConfigurationForVRF(networkName, frrVRF, []string{frr.IPv4, frr.IPv6}, receiveNetworks, clusterASN, externalASN)
 	if err != nil {
 		return fmt.Errorf("failed to generate FRR-k8s configuration: %w", err)
 	}
@@ -4326,14 +4445,13 @@ func runBGPNetworkAndServerWithFRRVRF(
 type networkType string
 
 const (
-	defaultNetwork                              networkType = "DEFAULT"
-	udn                                         networkType = "UDN"
-	cudn                                        networkType = "CUDN"
-	cudnAdvertised                              networkType = "CUDN_ADVERTISED"
-	cudnAdvertisedVRFLite                       networkType = "CUDN_ADVERTISED_VRFLITE"
-	cudnAdvertisedEVPNUnmanagedSharedVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
-	cudnAdvertisedEVPNUnmanagedRandomVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
-	cudnAdvertisedEVPNOverlappingCIDRSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_OVERLAPPING_CIDR_SHARED_VTEP"
+	defaultNetwork                        networkType = "DEFAULT"
+	udn                                   networkType = "UDN"
+	cudn                                  networkType = "CUDN"
+	cudnAdvertised                        networkType = "CUDN_ADVERTISED"
+	cudnAdvertisedVRFLite                 networkType = "CUDN_ADVERTISED_VRFLITE"
+	cudnAdvertisedEVPNUnmanagedSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
+	cudnAdvertisedEVPNUnmanagedRandomVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
 )
 
 // createNamespaceWithPrimaryNetworkOfType helper function configures a
@@ -4356,7 +4474,7 @@ func createNamespaceWithPrimaryNetworkOfType(
 	case cudnAdvertised:
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"name": "receive-all"}
-	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP:
+	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
 		targetVRF = networkName
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"network": networkName}
@@ -4577,13 +4695,13 @@ func createRouteAdvertisements(
 	return nil
 }
 
-// getBGPServerContainerIPs retrieves the IP addresses of the BGP server container.
-func getBGPServerContainerIPs(f *framework.Framework) (serverContainerIPs []string) {
-	bgpNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName) // pre-created network
-	framework.ExpectNoError(err, "must get bgpnet network")
-	bgpServer := infraapi.ExternalContainer{Name: serverContainerName}
+// getBGPServerContainerIPsFor retrieves the IP addresses of a BGP server container on a given network.
+func getBGPServerContainerIPsFor(f *framework.Framework, serverName, networkName string) (serverContainerIPs []string) {
+	bgpNetwork, err := infraprovider.Get().GetNetwork(networkName)
+	framework.ExpectNoError(err, "must get %s network", networkName)
+	bgpServer := infraapi.ExternalContainer{Name: serverName}
 	networkInterface, err := infraprovider.Get().GetExternalContainerNetworkInterface(bgpServer, bgpNetwork)
-	framework.ExpectNoError(err, "container %s attached to network %s must contain network info", serverContainerName, bgpExternalNetworkName)
+	framework.ExpectNoError(err, "container %s attached to network %s must contain network info", serverName, networkName)
 	if isIPv4Supported(f.ClientSet) && len(networkInterface.IPv4) > 0 {
 		serverContainerIPs = append(serverContainerIPs, networkInterface.IPv4)
 	}
@@ -4591,6 +4709,11 @@ func getBGPServerContainerIPs(f *framework.Framework) (serverContainerIPs []stri
 		serverContainerIPs = append(serverContainerIPs, networkInterface.IPv6)
 	}
 	return
+}
+
+// getBGPServerContainerIPs retrieves the IP addresses of the default iBGP server container.
+func getBGPServerContainerIPs(f *framework.Framework) (serverContainerIPs []string) {
+	return getBGPServerContainerIPsFor(f, serverContainerName, bgpExternalNetworkName)
 }
 
 // isNoOverlayOutboundSNATEnabled reads the ovnkube-config configmap to determine

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1051,263 +1051,263 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 									tc.cidr, tc.nextHop, cUDN.Name, nodeName)
 								continue
 							}
-						gomega.Eventually(func() bool {
-							routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
-							if err != nil {
-								framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
-								return false
-							}
-							framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
-							for _, line := range strings.Split(routes, "\n") {
-								if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
-									return true
+							gomega.Eventually(func() bool {
+								routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
+								if err != nil {
+									framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
+									return false
 								}
-							}
-							return false
-						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
-							"CUDN %q GR on node %s is missing a route %s -> %s",
-							cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+								framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
+								for _, line := range strings.Split(routes, "\n") {
+									if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
+										return true
+									}
+								}
+								return false
+							}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+								"CUDN %q GR on node %s is missing a route %s -> %s",
+								cUDN.Name, nodeName, tc.cidr, tc.nextHop)
+						}
 					}
-				}
 
-				expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
-					cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+					expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+						cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 
-				if expectSNAT {
-					ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
-				} else {
-					ginkgo.By("queries to the external server are not SNATed (uses podIP)")
-				}
-				var expectedSNATSourceIPs []string
-				if expectSNAT {
-					clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
-					framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
-					expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
-					gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
-					framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
-				}
-				for _, serverContainerIP := range serverContainerIPs {
-					podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
-						f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
-					framework.Logf("Client pod IP address=%s", podIP)
-
-					ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
-						"and expecting to receive the same payload", serverContainerIP))
-					cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
-						net.JoinHostPort(serverContainerIP, "8080"),
-					)
-					framework.Logf("Testing pod to external traffic with command %q", cmd)
-					stdout, err := e2epodoutput.RunHostCmdWithRetries(
-						clientPod.Namespace,
-						clientPod.Name,
-						cmd,
-						framework.Poll,
-						60*time.Second)
-					framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-
-					sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
-					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-						fmt.Sprintf("Failed to parse client address from output %q", stdout))
 					if expectSNAT {
-						expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
-						gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
-							"Expected node %s to have an InternalIP for the external server IP family %s",
-							clientPod.Spec.NodeName, serverContainerIP)
-						gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
-							fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+						ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
 					} else {
-						gomega.Expect(sourceIP).To(gomega.Equal(podIP),
-							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+						ginkgo.By("queries to the external server are not SNATed (uses podIP)")
 					}
-				}
-			},
-			ginkgo.Entry("layer3",
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						// Keep generated CUDN names under the Linux 15-byte interface
-						// limit so the VRF name is unique instead of network ID based.
-						GenerateName: "bgp-l3-",
-						Labels:       map[string]string{"bgp-l3": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer3,
-							Layer3: &udnv1.Layer3Config{
-								Role:    "Primary",
-								Subnets: cudnLayer3SubnetsB(),
-							},
+					var expectedSNATSourceIPs []string
+					if expectSNAT {
+						clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+						framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
+						expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
+						gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
+						framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
+					}
+					for _, serverContainerIP := range serverContainerIPs {
+						podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+							f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+						framework.Logf("Client pod IP address=%s", podIP)
+
+						ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
+							"and expecting to receive the same payload", serverContainerIP))
+						cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip",
+							net.JoinHostPort(serverContainerIP, "8080"),
+						)
+						framework.Logf("Testing pod to external traffic with command %q", cmd)
+						stdout, err := e2epodoutput.RunHostCmdWithRetries(
+							clientPod.Namespace,
+							clientPod.Name,
+							cmd,
+							framework.Poll,
+							60*time.Second)
+						framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
+
+						sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+							fmt.Sprintf("Failed to parse client address from output %q", stdout))
+						if expectSNAT {
+							expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
+							gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
+								"Expected node %s to have an InternalIP for the external server IP family %s",
+								clientPod.Spec.NodeName, serverContainerIP)
+							gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+								fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
+						} else {
+							gomega.Expect(sourceIP).To(gomega.Equal(podIP),
+								fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+						}
+					}
+				},
+				ginkgo.Entry("layer3",
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							// Keep generated CUDN names under the Linux 15-byte interface
+							// limit so the VRF name is unique instead of network ID based.
+							GenerateName: "bgp-l3-",
+							Labels:       map[string]string{"bgp-l3": ""},
 						},
-					},
-				},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l3-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l3": ""},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer3,
+								Layer3: &udnv1.Layer3Config{
+									Role:    "Primary",
+									Subnets: cudnLayer3SubnetsB(),
 								},
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
-					},
-				},
-			},
-		),
-			ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "bgp-l3a-",
-						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer3,
-							Layer3: &udnv1.Layer3Config{
-								Role: "Primary",
-								Subnets: []udnv1.Layer3Subnet{{
-									CIDR:       "103.103.0.0/16",
-									HostSubnet: 24,
-								}, {
-									CIDR:       "2014:100:200::0/60",
-									HostSubnet: 64,
-								}},
-							},
-							Transport: udnv1.TransportOptionNoOverlay,
-							NoOverlay: &udnv1.NoOverlayConfig{
-								OutboundSNAT: udnv1.SNATEnabled,
-								Routing:      udnv1.RoutingUnmanaged,
-							},
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-l3-ra",
 						},
-					},
-				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
-					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-l3": ""},
+										},
 									},
 								},
 							},
-						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
-					},
-				},
-			),
-			ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "bgp-l3b-",
-						Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer3,
-							Layer3: &udnv1.Layer3Config{
-								Role: "Primary",
-								Subnets: []udnv1.Layer3Subnet{{
-									CIDR:       "103.103.0.0/16",
-									HostSubnet: 24,
-								}, {
-									CIDR:       "2014:100:200::0/60",
-									HostSubnet: 64,
-								}},
-							},
-							Transport: udnv1.TransportOptionNoOverlay,
-							NoOverlay: &udnv1.NoOverlayConfig{
-								OutboundSNAT: udnv1.SNATDisabled,
-								Routing:      udnv1.RoutingUnmanaged,
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
 							},
 						},
 					},
-				},
-				&rav1.RouteAdvertisements{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+				),
+				ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "bgp-l3a-",
+							Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+						},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer3,
+								Layer3: &udnv1.Layer3Config{
+									Role: "Primary",
+									Subnets: []udnv1.Layer3Subnet{{
+										CIDR:       "103.103.0.0/16",
+										HostSubnet: 24,
+									}, {
+										CIDR:       "2014:100:200::0/60",
+										HostSubnet: 64,
+									}},
+								},
+								Transport: udnv1.TransportOptionNoOverlay,
+								NoOverlay: &udnv1.NoOverlayConfig{
+									OutboundSNAT: udnv1.SNATEnabled,
+									Routing:      udnv1.RoutingUnmanaged,
+								},
+							},
+						},
 					},
-					Spec: rav1.RouteAdvertisementsSpec{
-						NetworkSelectors: apitypes.NetworkSelectors{
-							apitypes.NetworkSelector{
-								NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-								ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-									NetworkSelector: metav1.LabelSelector{
-										MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
+						},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+										},
 									},
 								},
 							},
-						},
-						NodeSelector:             metav1.LabelSelector{},
-						FRRConfigurationSelector: metav1.LabelSelector{},
-						Advertisements: []rav1.AdvertisementType{
-							rav1.PodNetwork,
-						},
-					},
-				},
-			),
-			ginkgo.Entry("layer2",
-				&udnv1.ClusterUserDefinedNetwork{
-					ObjectMeta: metav1.ObjectMeta{
-						// Keep generated CUDN names under the Linux 15-byte interface
-						// limit so the VRF name is unique instead of network ID based.
-						GenerateName: "bgp-l2-",
-						Labels:       map[string]string{"bgp-l2": ""},
-					},
-					Spec: udnv1.ClusterUserDefinedNetworkSpec{
-						Network: udnv1.NetworkSpec{
-							Topology: udnv1.NetworkTopologyLayer2,
-							Layer2: &udnv1.Layer2Config{
-								Role:    "Primary",
-								Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
 							},
 						},
 					},
-				},
-			&rav1.RouteAdvertisements{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-l2-ra",
-				},
-				Spec: rav1.RouteAdvertisementsSpec{
-					NetworkSelectors: apitypes.NetworkSelectors{
-						apitypes.NetworkSelector{
-							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
-								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-l2": ""},
+				),
+				ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "bgp-l3b-",
+							Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+						},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer3,
+								Layer3: &udnv1.Layer3Config{
+									Role: "Primary",
+									Subnets: []udnv1.Layer3Subnet{{
+										CIDR:       "103.103.0.0/16",
+										HostSubnet: 24,
+									}, {
+										CIDR:       "2014:100:200::0/60",
+										HostSubnet: 64,
+									}},
+								},
+								Transport: udnv1.TransportOptionNoOverlay,
+								NoOverlay: &udnv1.NoOverlayConfig{
+									OutboundSNAT: udnv1.SNATDisabled,
+									Routing:      udnv1.RoutingUnmanaged,
 								},
 							},
 						},
 					},
-					NodeSelector:             metav1.LabelSelector{},
-					FRRConfigurationSelector: metav1.LabelSelector{},
-					Advertisements: []rav1.AdvertisementType{
-						rav1.PodNetwork,
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+						},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+										},
+									},
+								},
+							},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
+							},
+						},
 					},
-				},
-			},
-		),
-	)
-},
-bgpPeeringModes,
+				),
+				ginkgo.Entry("layer2",
+					&udnv1.ClusterUserDefinedNetwork{
+						ObjectMeta: metav1.ObjectMeta{
+							// Keep generated CUDN names under the Linux 15-byte interface
+							// limit so the VRF name is unique instead of network ID based.
+							GenerateName: "bgp-l2-",
+							Labels:       map[string]string{"bgp-l2": ""},
+						},
+						Spec: udnv1.ClusterUserDefinedNetworkSpec{
+							Network: udnv1.NetworkSpec{
+								Topology: udnv1.NetworkTopologyLayer2,
+								Layer2: &udnv1.Layer2Config{
+									Role:    "Primary",
+									Subnets: udnv1.DualStackCIDRs{"103.0.0.0/16", "2014:100::0/60"},
+								},
+							},
+						},
+					},
+					&rav1.RouteAdvertisements{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bgp-l2-ra",
+						},
+						Spec: rav1.RouteAdvertisementsSpec{
+							NetworkSelectors: apitypes.NetworkSelectors{
+								apitypes.NetworkSelector{
+									NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+									ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+										NetworkSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"bgp-l2": ""},
+										},
+									},
+								},
+							},
+							NodeSelector:             metav1.LabelSelector{},
+							FRRConfigurationSelector: metav1.LabelSelector{},
+							Advertisements: []rav1.AdvertisementType{
+								rav1.PodNetwork,
+							},
+						},
+					},
+				),
+			)
+		},
+		bgpPeeringModes,
 	)
 })
 
@@ -2623,11 +2623,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		networkName string,
 		networkType networkType,
 		networkSpec *udnv1.NetworkSpec,
-	bgpAlloc allocators.BGPAllocation,
-	externalASN int,
-	clusterASN int,
-	frrContainerName string,
-) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
+		bgpAlloc allocators.BGPAllocation,
+		externalASN int,
+		clusterASN int,
+		frrContainerName string,
+	) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
 		ginkgo.GinkgoHelper()
 
 		framework.Logf("Configuring the infra for network %s of type %s with allocations %#v", networkName, networkType, bgpAlloc)
@@ -2953,6 +2953,15 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		testSuffix = framework.RandomSuffix()
 		testBaseName = baseName + testSuffix
 		testNetworkName = testBaseName
+		// Skip single-IP-family specs for unsupported families before any expensive
+		// infra setup. Entry descriptions contain "IPv4" or "IPv6" explicitly.
+		specText := ginkgo.CurrentSpecReport().FullText()
+		if !ipFamilySet.Has(utilnet.IPv6) && strings.Contains(specText, "IPv6") {
+			e2eskipper.Skipf("IPv6 not supported in this cluster")
+		}
+		if !ipFamilySet.Has(utilnet.IPv4) && strings.Contains(specText, "IPv4") {
+			e2eskipper.Skipf("IPv4 not supported in this cluster")
+		}
 	})
 
 	// define networks to test with
@@ -3064,20 +3073,6 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
 	}
 
-
-	networksToTest := []ginkgo.TableEntry{
-		ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
-		ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
-		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT enabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATEnabledUnmanagedSpecGen),
-		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT disabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATDisabledUnmanagedSpecGen),
-		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
-		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
-		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
-		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
-		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-	}
-
 	ginkgo.DescribeTableSubtree("With underlay BGP in mode",
 		func(peering bgpPeeringConfig) {
 
@@ -3087,7 +3082,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					var testPod *corev1.Pod
 					var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
 					var networkSpec *udnv1.NetworkSpec
-				var testNetworkSpec *udnv1.NetworkSpec
+					var testNetworkSpec *udnv1.NetworkSpec
 
 					expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
 						ginkgo.GinkgoHelper()
@@ -3111,18 +3106,18 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					}
 
 					getExternalServerIPForFamily := func(server string, family utilnet.IPFamily) string {
-					ginkgo.GinkgoHelper()
-					bgpServerNetwork, err := infraprovider.Get().GetNetwork(server)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-						infraapi.ExternalContainer{Name: server},
-						bgpServerNetwork,
-					)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					return getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
-				}
+						ginkgo.GinkgoHelper()
+						bgpServerNetwork, err := infraprovider.Get().GetNetwork(server)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+							infraapi.ExternalContainer{Name: server},
+							bgpServerNetwork,
+						)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+					}
 
-				getSameNode := func() string {
+					getSameNode := func() string {
 						return testPod.Spec.NodeName
 					}
 					getDifferentNode := func() string {
@@ -3466,9 +3461,9 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 									ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
 									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
 									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
-								ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
-								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
-								ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
+									ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
 								}
 								if testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
 									otherNetworksToTest = append(otherNetworksToTest,
@@ -3734,7 +3729,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 												// (bgpAlloc.IPVRFSubnet6), so they have distinct IPs and there is no
 												// shared-IP VNI ambiguity to verify.
 												ginkgo.By("Ensuring the tested network pod reaches its own MAC-VRF external server at the shared IP (north-south VNI isolation)")
-												macVRFServerName := testNetworkName + "-macvrf-agnhost"
+												macVRFServerName := testNetworkName + "-" + routerContainerName + "-macvrf-agnhost"
 												testForIPFamilies(
 													ipFamilySet,
 													func(family utilnet.IPFamily) {
@@ -3760,7 +3755,6 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		},
 		bgpPeeringModes,
 	)
-
 
 	ginkgo.DescribeTable("Validates BUM suppression is in effect for L2 EVPN networks",
 		func(bumTestBaseName string, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
@@ -4447,8 +4441,9 @@ const (
 	cudn                                  networkType = "CUDN"
 	cudnAdvertised                        networkType = "CUDN_ADVERTISED"
 	cudnAdvertisedVRFLite                 networkType = "CUDN_ADVERTISED_VRFLITE"
-	cudnAdvertisedEVPNUnmanagedSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
-	cudnAdvertisedEVPNUnmanagedRandomVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
+	cudnAdvertisedEVPNUnmanagedSharedVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
+	cudnAdvertisedEVPNUnmanagedRandomVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
+	cudnAdvertisedEVPNOverlappingCIDRSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_OVERLAPPING_CIDR_SHARED_VTEP"
 )
 
 // createNamespaceWithPrimaryNetworkOfType helper function configures a
@@ -4471,7 +4466,7 @@ func createNamespaceWithPrimaryNetworkOfType(
 	case cudnAdvertised:
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"name": "receive-all"}
-	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
+	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP:
 		targetVRF = networkName
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"network": networkName}

--- a/test/e2e/testdata/routeadvertisements/frr-k8s/frrconf.yaml.tmpl
+++ b/test/e2e/testdata/routeadvertisements/frr-k8s/frrconf.yaml.tmpl
@@ -13,14 +13,14 @@ spec:
   bgp:
     routers:
 {{- range $v := .Routers }}
-    - asn: 64512
+    - asn: {{ .LocalASN }}
 {{- if .VRF }}
       vrf: {{ .VRF }}
 {{- end }}
       neighbors:
 {{- range .NeighborsIPv4 }}
       - address: {{ . }}
-        asn: 64512
+        asn: {{ $v.NeighborASN }}
         disableMP: true
         toReceive:
           allowed:
@@ -32,7 +32,7 @@ spec:
 {{- end }}
 {{- range .NeighborsIPv6 }}
       - address: {{ . }}
-        asn: 64512
+        asn: {{ $v.NeighborASN }}
         disableMP: true
         toReceive:
           allowed:

--- a/test/e2e/testdata/routeadvertisements/frr-k8s/frrconf.yaml.tmpl
+++ b/test/e2e/testdata/routeadvertisements/frr-k8s/frrconf.yaml.tmpl
@@ -21,7 +21,6 @@ spec:
 {{- range .NeighborsIPv4 }}
       - address: {{ . }}
         asn: {{ $v.NeighborASN }}
-        disableMP: true
         toReceive:
           allowed:
             mode: filtered
@@ -33,7 +32,6 @@ spec:
 {{- range .NeighborsIPv6 }}
       - address: {{ . }}
         asn: {{ $v.NeighborASN }}
-        disableMP: true
         toReceive:
           allowed:
             mode: filtered

--- a/test/e2e/testdata/routeadvertisements/frr/frr.conf.tmpl
+++ b/test/e2e/testdata/routeadvertisements/frr/frr.conf.tmpl
@@ -13,26 +13,30 @@ log stdout debugging
 log syslog debugging
 log file /etc/frr/frr.log debugging
 {{ range .Routers -}}
-router bgp 64512 {{ if .VRF }}vrf {{ .VRF }}{{ end }}
+{{- $router := . -}}
+router bgp {{ .LocalASN }} {{ if .VRF }}vrf {{ .VRF }}{{ end }}
  no bgp default ipv4-unicast
  no bgp default ipv6-unicast
  no bgp network import-check
+ no bgp ebgp-requires-policy
 {{- range .NeighborsIPv4 }}
- neighbor {{ . }} remote-as 64512
+ neighbor {{ . }} remote-as {{ $router.NeighborASN }}
  # zebra has been observed to fail to start for unknown reasons,
  # reduce timers to try to minimize delay impact on tests
  neighbor {{ . }} timers connect 10
  neighbor {{ . }} timers 15 5
 {{- end }}
 {{- range .NeighborsIPv6 }}
- neighbor {{ . }} remote-as 64512
+ neighbor {{ . }} remote-as {{ $router.NeighborASN }}
  neighbor {{ . }} timers connect 10
  neighbor {{ . }} timers 15 5
 {{- end }}
 {{- if .NeighborsIPv4 }}
  address-family ipv4 unicast
 {{- range .NeighborsIPv4 }}
+{{- if eq $router.LocalASN $router.NeighborASN }}
   neighbor {{ . }} route-reflector-client
+{{- end }}
   neighbor {{ . }} activate
   neighbor {{ . }} next-hop-self 
 {{- end }}
@@ -44,7 +48,9 @@ router bgp 64512 {{ if .VRF }}vrf {{ .VRF }}{{ end }}
 {{- if .NeighborsIPv6 }}
  address-family ipv6 unicast
 {{- range .NeighborsIPv6 }}
+{{- if eq $router.LocalASN $router.NeighborASN }}
   neighbor {{ . }} route-reflector-client
+{{- end }}
   neighbor {{ . }} activate
   neighbor {{ . }} next-hop-self
 {{- end }}


### PR DESCRIPTION
Add eBGP peering support to the KIND cluster test infrastructure and enable all non-isolation BGP/EVPN e2e tests to run under both iBGP and eBGP modes.

**eBGP KIND Infrastructure**
The existing KIND BGP setup deploys a single FRR container (frr) that peers with cluster nodes using iBGP (same ASN 64512). This PR adds a parallel eBGP topology:

frr-ebgp: A second FRR container with ASN 64513 that peers with cluster nodes (ASN 64512) via eBGP
bgpnet-ebgp: A separate Docker network for the eBGP external server
bgpserver-ebgp: An agnhost server on bgpnet-ebgp, routed through frr-ebgp
A shared _deploy_bgp_server_for() helper removes duplication between the iBGP and eBGP deploy paths
destroy_bgp() and install_frr_k8s() are extended to manage eBGP-specific resources
Both iBGP and eBGP containers are deployed when ENABLE_ROUTE_ADVERTISEMENTS=true. When ENABLE_EVPN=true, EVPN BGP (l2vpn evpn address-family, advertise-all-vni) is configured on the eBGP FRR container as well.

**Test Parameterization**
All BGP-related test helpers and templates are refactored to accept ASN and FRR container name as parameters instead of relying on hardcoded constants:

FRR config templates (frr.conf.tmpl, frrconf.yaml.tmpl): Use LocalASN/NeighborASN variables; conditionally configure route-reflector-client only for iBGP; add no bgp ebgp-requires-policy for FRR 10.x compatibility
EVPN helpers (evpn.go): Accept frrContainerName, externalASN, and clusterASN parameters throughout the setup chain
Route advertisement tests (route_advertisements.go): Introduce bgpPeeringConfig struct and run non-isolation test suites via DescribeTableSubtree over both iBGP and eBGP peering configurations; isolation tests are gated in BeforeEach to skip early and avoid heavy cluster setup under eBGP

**eBGP EVPN Fixes**
Route-target alignment: For eBGP EVPN, the external FRR auto-derives RTs as externalASN:VNI while cluster nodes use clusterASN:VNI. Both IP-VRF (via rtASN parameter) and MAC-VRF (via explicit RT override) are fixed to use clusterASN:VNI on both sides.
AS_PATH loop prevention (allowas-in): When Node A (AS 64512) sends an EVPN route through the external FRR (AS 64513) to Node B (AS 64512), Node B sees its own AS in the AS_PATH and rejects the route. allowas-in is configured via the FRRConfiguration CR's rawConfig field to survive frr-k8s reconciliation.
FRR readiness race: vtysh -c "show daemons" exits 0 while bgpd is still loading frr.conf (EAGAIN), causing write memory to fail and abort EVPN cluster setup under set -eo pipefail. Fixed by also checking the output for "processing failure" before treating FRR as ready.

**Scope**
Isolation tests are skipped under eBGP mode (identical behavior, saves CI time)
All non-isolation BGP and EVPN tests run in both iBGP and eBGP modes


How to verify
Deploy a KIND cluster with eBGP + EVPN:

./contrib/kind.sh -gm local -ic -mne -nse -rae -evpn -adv
Run EVPN e2e tests:

make -C test control-plane WHAT="EVPN"

## Checks

* My code requires tests
* I have added and/or updated the tests as required
* All the tests have passed in the CI