### PR TITLE
Add CT commit all to UDN transit/cluster routers

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -11,7 +11,8 @@
 # This is for a development build where the ovn-kubernetes utilities
 # are built locally and included in the image (instead of the rpm)
 #
-ARG OVN_FROM=koji
+# HACK: force OVN builds to pick up the ct commit all fix until it lands upstream.
+ARG OVN_FROM=source
 ARG BUILDER_IMAGE
 ARG OVN_KUBERNETES_DIR=.
 
@@ -44,8 +45,8 @@ RUN INSTALL_PKGS="git rpm-build dnf-plugins-core" && \
     dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS
 
 # Clone OVN Source Code.
-ARG OVN_REPO=https://github.com/ovn-org/ovn.git
-ARG OVN_GITREF=main
+ARG OVN_REPO=https://github.com/trozet/ovn.git
+ARG OVN_GITREF=fix_commit_all
 WORKDIR /root
 RUN mkdir ovn && pushd ovn && \
     git init && \

--- a/dist/images/Dockerfile.ubuntu.arm64
+++ b/dist/images/Dockerfile.ubuntu.arm64
@@ -15,15 +15,56 @@ FROM ubuntu:25.10
 
 USER root
 
-RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    autoconf automake build-essential ca-certificates curl flex git graphviz \
+    iproute2 libcap-ng-dev libevent-dev libnuma-dev libssl-dev libtool \
+    libunbound-dev nftables openvswitch-common openvswitch-switch ovn-central \
+    ovn-common ovn-host pkg-config python3 python3-pip python3-setuptools \
+    python3-six python3-sphinx software-properties-common util-linux uuid-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install OVS and OVN packages.
-RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host
+# HACK: force OVN builds to pick up the ct commit all fix until it lands upstream.
+ARG OVN_REPO=https://github.com/trozet/ovn.git
+ARG OVN_GITREF=fix_commit_all
+ARG OVS_REPO=https://github.com/openvswitch/ovs.git
+ARG OVS_GITREF=""
+
+# Build OVS from the version pinned by OVN, unless OVS_GITREF is overridden.
+WORKDIR /root
+RUN mkdir ovn && cd ovn && \
+    git init && \
+    git remote add origin "${OVN_REPO}" && \
+    git fetch origin "${OVN_GITREF}" --depth 1 && \
+    git reset --hard FETCH_HEAD
+
+RUN OVS_OVN_GITREF=$(cd ovn && git submodule status ovs | cut -c 2- | cut -d ' ' -f 1) && \
+    mkdir ovs && cd ovs && \
+    git init && \
+    git remote add origin "${OVS_REPO}" && \
+    OVS_GITREF="${OVS_GITREF:-$OVS_OVN_GITREF}" && \
+    git fetch origin "${OVS_GITREF}" --depth 1 && \
+    git reset --hard FETCH_HEAD
+
+WORKDIR /root/ovs
+RUN ./boot.sh && \
+    ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-rundir=/var/run/openvswitch && \
+    make -j "$(nproc)" && \
+    make install && \
+    ldconfig && \
+    git log -n 1
+
+WORKDIR /root/ovn
+RUN ./boot.sh && \
+    ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-rundir=/var/run/ovn --with-ovs-source=/root/ovs && \
+    make -j "$(nproc)" && \
+    make install && \
+    ldconfig && \
+    git log -n 1
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" \
     && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-RUN mkdir -p /var/run/openvswitch
+RUN mkdir -p /var/run/openvswitch /var/run/ovn
 
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -22,8 +22,11 @@ ifeq ($(ARCH),arm64)
 endif
 IMAGE ?= ovn-daemonset-fedora
 
-OVN_REPO ?= https://github.com/ovn-org/ovn
-OVN_GITREF ?=
+# HACK: force OVN builds to pick up the ct commit all fix until it lands upstream.
+DEFAULT_OVN_REPO := https://github.com/trozet/ovn
+DEFAULT_OVN_GITREF := fix_commit_all
+override OVN_REPO := $(or $(OVN_REPO),$(DEFAULT_OVN_REPO))
+override OVN_GITREF := $(or $(OVN_GITREF),$(DEFAULT_OVN_GITREF))
 ifeq ($(OVN_GITREF),)
 OVN_FROM := koji
 else
@@ -37,7 +40,11 @@ OCI_BIN ?= docker
 
 # The image of ovnkube/ovn-daemonset-ubuntu should be multi-arched before using it on arm64
 ubuntu-image: bld
-	${OCI_BIN} build -t ovn-kube-ubuntu$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
+	${OCI_BIN} build \
+		--build-arg OVN_REPO=${OVN_REPO} \
+		--build-arg OVN_GITREF=${OVN_GITSHA} \
+		-t ovn-kube-ubuntu$(IMAGE_ARCH) \
+		-f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
 ifeq ($(ARCH),amd64)
 	${OCI_BIN} tag "ovn-kube-ubuntu$(IMAGE_ARCH):latest" \
               "ovn-kube-ubuntu:latest"

--- a/go-controller/pkg/libovsdb/ops/options.go
+++ b/go-controller/pkg/libovsdb/ops/options.go
@@ -10,6 +10,8 @@ const (
 	// RequestedTnlKey can be used by LogicalSwitch, LogicalSwitchPort, LogicalRouter and LogicalRouterPort
 	// for distributed switches/routers
 	RequestedTnlKey = "requested-tnl-key"
+	// CtCommitAll can be used by LogicalRouter to commit all traffic when the router is stateful.
+	CtCommitAll = "ct-commit-all"
 	// RequestedChassis can be used by LogicalSwitchPort and LogicalRouterPort.
 	// It specifies the chassis (by name or hostname) that is allowed to bind this port.
 	RequestedChassis = "requested-chassis"

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -656,13 +656,14 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, false)...)
 					}
 				} else {
-					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
+					// Temporary offload experiment: the UDN GR already
+					// SNATs to node IP, so only commit/mark on br-ex.
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
-							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
 							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV4, protoPrefixV4,
-							netConfig.V4MasqIPs.GatewayRouter.IP, config.Default.ConntrackZone,
-							physicalIP.IP, netConfig.MasqCTMark, ofPortPhys))
+							physicalIP.IP, config.Default.ConntrackZone,
+							netConfig.MasqCTMark, ofPortPhys))
 				}
 			}
 
@@ -757,13 +758,14 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, true)...)
 					}
 				} else {
-					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
+					// Temporary offload experiment: the UDN GR already
+					// SNATs to node IP, so only commit/mark on br-ex.
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
-							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
 							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV6, protoPrefixV6,
-							netConfig.V6MasqIPs.GatewayRouter.IP, config.Default.ConntrackZone,
-							physicalIP.IP, netConfig.MasqCTMark, ofPortPhys))
+							physicalIP.IP, config.Default.ConntrackZone,
+							netConfig.MasqCTMark, ofPortPhys))
 				}
 			}
 

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -214,6 +214,9 @@ func (rm *Controller) reconcile() error {
 }
 
 func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
+	if r1.Family != r2.Family {
+		return false
+	}
 	if r1.Priority != r2.Priority {
 		return false
 	}

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"runtime"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -234,3 +235,35 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		})
 	})
 })
+
+func TestAreNetlinkRulesEqualConsidersFamily(t *testing.T) {
+	baseRule := netlink.NewRule()
+	baseRule.Family = netlink.FAMILY_V4
+	baseRule.Priority = 2000
+	baseRule.Table = 1065
+	baseRule.Mark = 0x100d
+
+	sameRule := netlink.NewRule()
+	*sameRule = *baseRule
+	if !areNetlinkRulesEqual(baseRule, sameRule) {
+		t.Fatalf("expected identical rules to be equal")
+	}
+
+	v6Rule := netlink.NewRule()
+	*v6Rule = *baseRule
+	v6Rule.Family = netlink.FAMILY_V6
+	if areNetlinkRulesEqual(baseRule, v6Rule) {
+		t.Fatalf("expected IPv4 and IPv6 rules to be different")
+	}
+
+	v4DstRule := netlink.NewRule()
+	*v4DstRule = *baseRule
+	v4DstRule.Dst = ovntest.MustParseIPNet("169.254.0.12/32")
+	v6DstRule := netlink.NewRule()
+	*v6DstRule = *v4DstRule
+	v6DstRule.Family = netlink.FAMILY_V6
+	v6DstRule.Dst = ovntest.MustParseIPNet("fd69::12/128")
+	if areNetlinkRulesEqual(v4DstRule, v6DstRule) {
+		t.Fatalf("expected IPv4 and IPv6 destination rules to be different")
+	}
+}

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1135,6 +1135,14 @@ func (oc *Layer2UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 	networkName := oc.GetNetworkName()
 	networkID := oc.GetNetworkID()
 
+	nodeIPs := make([]net.IP, 0, len(l3GatewayConfig.IPAddresses))
+	for _, nodeIP := range l3GatewayConfig.IPAddresses {
+		if nodeIP == nil {
+			continue
+		}
+		nodeIPs = append(nodeIPs, nodeIP.IP)
+	}
+
 	masqIPs, err := udn.GetUDNGatewayMasqueradeIPs(networkID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
@@ -1142,13 +1150,19 @@ func (oc *Layer2UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 
 	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
 
-	// Always SNAT to the per network masquerade IP.
-	var externalIPs []net.IP
+	masqExternalIPs := make([]net.IP, 0, len(masqIPs))
 	for _, masqIP := range masqIPs {
 		if masqIP == nil {
 			continue
 		}
-		externalIPs = append(externalIPs, masqIP.IP)
+		masqExternalIPs = append(masqExternalIPs, masqIP.IP)
+	}
+
+	externalIPs := masqExternalIPs
+	if config.Gateway.Mode == config.GatewayModeShared && len(nodeIPs) > 0 {
+		// Temporary offload experiment: make the UDN GR SNAT directly
+		// to the node IP and avoid the second SNAT on the gateway bridge.
+		externalIPs = nodeIPs
 	}
 
 	// Use the host subnets present in the network attachment definition.

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1185,6 +1185,7 @@ func (oc *Layer2UserDefinedNetworkController) newClusterRouter() (*nbdb.LogicalR
 			oc.GetNetworkScopedClusterRouterName(),
 			oc.GetNetInfo(),
 			oc.defaultCOPPUUID,
+			nil,
 		)
 	}
 

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -1271,7 +1271,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	}
 	hasEVPN := netInfo.Transport() == ovntypes.NetworkTransportEVPN
 	if !hasEVPN {
-		clusterRouter.Options = map[string]string{libovsdbops.RequestedTnlKey: "16715780"}
+		clusterRouter.Options = udnTransitRouterOptions("16715780")
 	} else {
 		clusterRouter.Options = map[string]string{"always_learn_from_arp_request": "false"}
 	}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -1117,6 +1117,14 @@ func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 	networkName := oc.GetNetworkName()
 	networkID := oc.GetNetworkID()
 
+	nodeIPs := make([]net.IP, 0, len(l3GatewayConfig.IPAddresses))
+	for _, nodeIP := range l3GatewayConfig.IPAddresses {
+		if nodeIP == nil {
+			continue
+		}
+		nodeIPs = append(nodeIPs, nodeIP.IP)
+	}
+
 	masqIPs, err := udn.GetUDNGatewayMasqueradeIPs(networkID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
@@ -1124,18 +1132,24 @@ func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 
 	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
 
-	// Always SNAT to the per network masquerade IP.
-	var externalIPs []net.IP
+	masqExternalIPs := make([]net.IP, 0, len(masqIPs))
 	for _, masqIP := range masqIPs {
 		if masqIP == nil {
 			continue
 		}
-		externalIPs = append(externalIPs, masqIP.IP)
+		masqExternalIPs = append(masqExternalIPs, masqIP.IP)
+	}
+
+	externalIPs := masqExternalIPs
+	if config.Gateway.Mode == config.GatewayModeShared && len(nodeIPs) > 0 {
+		// Temporary offload experiment: make the UDN GR SNAT directly
+		// to the node IP and avoid the second SNAT on the gateway bridge.
+		externalIPs = nodeIPs
 	}
 
 	var hostAddrs []string
-	for _, externalIP := range externalIPs {
-		hostAddrs = append(hostAddrs, externalIP.String())
+	for _, masqIP := range masqExternalIPs {
+		hostAddrs = append(hostAddrs, masqIP.String())
 	}
 
 	// Use the cluster subnets present in the network attachment definition.

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -1170,17 +1170,17 @@ func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 }
 
 func (oc *Layer3UserDefinedNetworkController) newClusterRouter() (*nbdb.LogicalRouter, error) {
+	routerOptions := map[string]string{
+		libovsdbops.CtCommitAll: "true",
+	}
 	if oc.multicastSupport {
-		return oc.gatewayTopologyFactory.NewClusterRouterWithMulticastSupport(
-			oc.GetNetworkScopedClusterRouterName(),
-			oc.GetNetInfo(),
-			oc.defaultCOPPUUID,
-		)
+		routerOptions["mcast_relay"] = "true"
 	}
 	return oc.gatewayTopologyFactory.NewClusterRouter(
 		oc.GetNetworkScopedClusterRouterName(),
 		oc.GetNetInfo(),
 		oc.defaultCOPPUUID,
+		routerOptions,
 	)
 }
 

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1561,8 +1561,24 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getClusterNodeIPsAddrSetDbIDsForTest())
 		udnSubnetMasqMatch = fmt.Sprintf("ip4.dst == $%s", nodeIPV4ASHashName)
 	}
-	expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-	expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), netInfo.Subnets()[0].CIDR.String(), standardNonDefaultNetworkExtIDs(netInfo), udnSubnetMasqMatch))
+	snatExternalIP := dummyMasqueradeIP().IP.String()
+	if config.Gateway.Mode == config.GatewayModeShared {
+		snatExternalIP = nodePhysicalIPAddress().IP.String()
+	}
+	expectedEntities = append(expectedEntities, newNATEntry(
+		nat1,
+		snatExternalIP,
+		gwRouterJoinIPAddress().IP.String(),
+		standardNonDefaultNetworkExtIDs(netInfo),
+		"",
+	))
+	expectedEntities = append(expectedEntities, newNATEntry(
+		nat2,
+		snatExternalIP,
+		netInfo.Subnets()[0].CIDR.String(),
+		standardNonDefaultNetworkExtIDs(netInfo),
+		udnSubnetMasqMatch,
+	))
 	return expectedEntities
 }
 

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1648,7 +1648,7 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		Ports:       []string{rtosLRPUUID},
 		ExternalIDs: clusterRouterExternalIDs,
 		Copp:        ptr.To(string(coppUUID)),
-		Options:     map[string]string{"always_learn_from_arp_request": "false"},
+		Options:     udnClusterRouterOptions(false),
 	}
 
 	expectedEntities := []libovsdbtest.TestData{
@@ -1890,6 +1890,24 @@ func gwRouterOptions(gwConfig util.L3GatewayConfig) map[string]string {
 		"chassis":                       gwConfig.ChassisID,
 		"always_learn_from_arp_request": "false",
 		"dynamic_neigh_routers":         dynamicNeighRouters,
+	}
+}
+
+func udnClusterRouterOptions(multicastSupport bool) map[string]string {
+	options := map[string]string{
+		"always_learn_from_arp_request": "false",
+		libovsdbops.CtCommitAll:         "true",
+	}
+	if multicastSupport {
+		options["mcast_relay"] = "true"
+	}
+	return options
+}
+
+func udnTransitRouterOptions(tunnelKey string) map[string]string {
+	return map[string]string{
+		libovsdbops.RequestedTnlKey: tunnelKey,
+		libovsdbops.CtCommitAll:     "true",
 	}
 }
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -75,17 +75,15 @@ func (oc *DefaultNetworkController) SetupMaster() error {
 }
 
 func (oc *DefaultNetworkController) newClusterRouter() (*nbdb.LogicalRouter, error) {
+	routerOptions := map[string]string{}
 	if oc.multicastSupport {
-		return oc.gatewayTopologyFactory.NewClusterRouterWithMulticastSupport(
-			oc.GetNetworkScopedClusterRouterName(),
-			oc.GetNetInfo(),
-			oc.defaultCOPPUUID,
-		)
+		routerOptions["mcast_relay"] = "true"
 	}
 	return oc.gatewayTopologyFactory.NewClusterRouter(
 		oc.GetNetworkScopedClusterRouterName(),
 		oc.GetNetInfo(),
 		oc.defaultCOPPUUID,
+		routerOptions,
 	)
 }
 

--- a/go-controller/pkg/ovn/topology/topologyfactory.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory.go
@@ -29,17 +29,12 @@ func (gtf *GatewayTopologyFactory) NewClusterRouter(
 	clusterRouterName string,
 	netInfo util.NetInfo,
 	coopUUID string,
+	additionalOptions map[string]string,
 ) (*nbdb.LogicalRouter, error) {
 	routerOptions := map[string]string{"always_learn_from_arp_request": "false"}
-	return gtf.newClusterRouter(clusterRouterName, netInfo, coopUUID, routerOptions)
-}
-
-func (gtf *GatewayTopologyFactory) NewClusterRouterWithMulticastSupport(
-	clusterRouterName string,
-	netInfo util.NetInfo,
-	coopUUID string,
-) (*nbdb.LogicalRouter, error) {
-	routerOptions := map[string]string{"mcast_relay": "true", "always_learn_from_arp_request": "false"}
+	for key, value := range additionalOptions {
+		routerOptions[key] = value
+	}
 	return gtf.newClusterRouter(clusterRouterName, netInfo, coopUUID, routerOptions)
 }
 
@@ -49,7 +44,10 @@ func (gtf *GatewayTopologyFactory) NewTransitRouter(
 	coopUUID string,
 	tunnelKey string,
 ) (*nbdb.LogicalRouter, error) {
-	routerOptions := map[string]string{libovsdbops.RequestedTnlKey: tunnelKey}
+	routerOptions := map[string]string{
+		libovsdbops.RequestedTnlKey: tunnelKey,
+		libovsdbops.CtCommitAll:     "true",
+	}
 	return gtf.newClusterRouter(transitRouterName, netInfo, coopUUID, routerOptions)
 }
 

--- a/go-controller/pkg/ovn/topology/topologyfactory_test.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Topology factory", func() {
 		})
 
 		It("creating a cluster router for a layer3 primary network with multicast disabled", func() {
-			clusterRouter, err := factory.NewClusterRouter(routerName, netInfo, coopUUID)
+			clusterRouter, err := factory.NewClusterRouter(routerName, netInfo, coopUUID, nil)
 			Expect(err).NotTo(HaveOccurred())
 			expectedExternalIDs := map[string]string{
 				ovntypes.NetworkExternalID:  networkName,
@@ -84,7 +84,7 @@ var _ = Describe("Topology factory", func() {
 		})
 
 		It("creating a cluster router for a layer3 primary network with multicast enabled", func() {
-			clusterRouter, err := factory.NewClusterRouterWithMulticastSupport(routerName, netInfo, coopUUID)
+			clusterRouter, err := factory.NewClusterRouter(routerName, netInfo, coopUUID, map[string]string{"mcast_relay": "true"})
 			Expect(err).NotTo(HaveOccurred())
 			expectedExternalIDs := map[string]string{
 				ovntypes.NetworkExternalID:  networkName,

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"strings"
 	"time"
 
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
@@ -307,6 +308,187 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 			),
 		)
 
+		DescribeTable(
+			"should allow a UDN pod to reach a remote node NodePort when externalTrafficPolicy=Local",
+			func(netConfigParams networkAttachmentConfigParams, ipFamily v1.IPFamily, protocol v1.Protocol) {
+				if isIPv4Supported(cs) && isIPv6Supported(cs) {
+					Skip("disabled on dual-stack clusters due to https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846")
+				}
+				if ipFamily == v1.IPv4Protocol && !isIPv4Supported(cs) {
+					Skip("cluster does not support IPv4")
+				}
+				if ipFamily == v1.IPv6Protocol && !isIPv6Supported(cs) {
+					Skip("cluster does not support IPv6")
+				}
+
+				By("Selecting 2 schedulable nodes")
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(nodes.Items)).To(BeNumerically(">", 1))
+
+				serverNode := nodes.Items[0].Name
+				clientNode := nodes.Items[1].Name
+
+				switch ipFamily {
+				case v1.IPv4Protocol:
+					netConfigParams.cidr = userDefinedNetworkIPv4Subnet
+				case v1.IPv6Protocol:
+					netConfigParams.cidr = userDefinedNetworkIPv6Subnet
+				default:
+					framework.Failf("unsupported IP family %q", ipFamily)
+				}
+
+				By("Creating the attachment configuration")
+				netConfig := newNetworkAttachmentConfig(netConfigParams)
+				netConfig.namespace = f.Namespace.Name
+				_, err = nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
+					context.Background(),
+					generateNAD(netConfig, f.ClientSet),
+					metav1.CreateOptions{},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				By(fmt.Sprintf("Creating a UDN backend pod for %s", protocol))
+				var serverPod *v1.Pod
+				switch protocol {
+				case v1.ProtocolUDP:
+					serverPod = e2epod.NewAgnhostPod(
+						f.Namespace.Name, "etp-local-backend", nil, nil,
+						[]v1.ContainerPort{{ContainerPort: serviceTargetPort, Protocol: "UDP"}},
+						"-c",
+						fmt.Sprintf(`
+set -xe
+iface=ovn-udn1
+ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | paste -sd, -)
+./agnhost netexec --udp-port=%d --udp-listen-addresses=$ips
+`, serviceTargetPort))
+					serverPod.Spec.Containers[0].Command = []string{"/bin/bash"}
+				case v1.ProtocolTCP:
+					serverPod = e2epod.NewAgnhostPod(
+						f.Namespace.Name, "etp-local-backend", nil, nil,
+						[]v1.ContainerPort{{ContainerPort: serviceTargetPort, Protocol: "TCP"}},
+						"netexec",
+						fmt.Sprintf("--http-port=%d", serviceTargetPort),
+					)
+				default:
+					framework.Failf("unsupported protocol %q", protocol)
+				}
+				serverPod.Labels = map[string]string{"app": "etp-local-backend"}
+				serverPod.Spec.NodeName = serverNode
+				serverPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), serverPod)
+
+				By("Creating a UDN client pod on a different node")
+				clientPod := e2epod.NewAgnhostPod(f.Namespace.Name, "etp-local-client", nil, nil, nil)
+				clientPod.Spec.NodeName = clientNode
+				clientPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
+
+				By("Creating a UDN NodePort service with externalTrafficPolicy=Local")
+				policy := v1.IPFamilyPolicySingleStack
+				service := &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "etp-local-service"},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:       "udp",
+								Protocol:   protocol,
+								Port:       servicePort,
+								TargetPort: intstr.FromInt(serviceTargetPort),
+							},
+						},
+						Selector:              serverPod.Labels,
+						Type:                  v1.ServiceTypeNodePort,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+						IPFamilyPolicy:        &policy,
+						IPFamilies:            []v1.IPFamily{ipFamily},
+					},
+				}
+				service, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying the UDN client can reach the remote node NodePort on the backend node")
+				checkConnectionToNodePort(f, clientPod, service, &nodes.Items[0], "server node", serverPod.Name)
+			},
+			Entry(
+				"L3 primary UDN over IPv4 UDP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					role:     "primary",
+				},
+				v1.IPv4Protocol,
+				v1.ProtocolUDP,
+			),
+			Entry(
+				"L3 primary UDN over IPv6 UDP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					role:     "primary",
+				},
+				v1.IPv6Protocol,
+				v1.ProtocolUDP,
+			),
+			Entry(
+				"L2 primary UDN over IPv4 UDP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer2",
+					role:     "primary",
+				},
+				v1.IPv4Protocol,
+				v1.ProtocolUDP,
+			),
+			Entry(
+				"L2 primary UDN over IPv6 UDP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer2",
+					role:     "primary",
+				},
+				v1.IPv6Protocol,
+				v1.ProtocolUDP,
+			),
+			Entry(
+				"L3 primary UDN over IPv4 TCP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					role:     "primary",
+				},
+				v1.IPv4Protocol,
+				v1.ProtocolTCP,
+			),
+			Entry(
+				"L3 primary UDN over IPv6 TCP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					role:     "primary",
+				},
+				v1.IPv6Protocol,
+				v1.ProtocolTCP,
+			),
+			Entry(
+				"L2 primary UDN over IPv4 TCP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer2",
+					role:     "primary",
+				},
+				v1.IPv4Protocol,
+				v1.ProtocolTCP,
+			),
+			Entry(
+				"L2 primary UDN over IPv6 TCP",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer2",
+					role:     "primary",
+				},
+				v1.IPv6Protocol,
+				v1.ProtocolTCP,
+			),
+		)
 	})
 
 })
@@ -365,6 +547,10 @@ func checkConnectionToAgnhostPod(f *framework.Framework, clientPod *v1.Pod, expe
 		}
 
 		if err2 != nil {
+			if strings.Contains(cmd, "curl") &&
+				(strings.Contains(err2.Error(), "exit code 7") || strings.Contains(err2.Error(), "exit code 28")) {
+				return false, nil
+			}
 			return false, err2
 		}
 		return stdout == expectedOutput, nil
@@ -383,6 +569,10 @@ func checkNoConnectionToAgnhostPod(f *framework.Framework, clientPod *v1.Pod, cm
 		}
 
 		if err2 != nil {
+			if strings.Contains(cmd, "curl") &&
+				(strings.Contains(err2.Error(), "exit code 28") || strings.Contains(err2.Error(), "exit code 7")) {
+				return false, nil
+			}
 			return false, err2
 		}
 		if stdout != "" {
@@ -443,7 +633,8 @@ func checkNoConnectionToNodePort(f *framework.Framework, clientPod *v1.Pod, serv
 
 func checkConnectionOrNoConnectionToNodePort(f *framework.Framework, clientPod *v1.Pod, service *v1.Service, node *v1.Node, nodeRoleMsg, expectedOutput string, shouldConnect bool) {
 	var err error
-	nodePort := service.Spec.Ports[0].NodePort
+	servicePort := service.Spec.Ports[0]
+	nodePort := servicePort.NodePort
 	notStr := ""
 	if !shouldConnect {
 		notStr = "not "
@@ -455,7 +646,7 @@ func checkConnectionOrNoConnectionToNodePort(f *framework.Framework, clientPod *
 		msg := fmt.Sprintf("Client %s/%s should %sconnect to NodePort service %s/%s on %s:%d (node %s, %s)",
 			clientPod.Namespace, clientPod.Name, notStr, service.Namespace, service.Name, nodeIP, nodePort, node.Name, nodeRoleMsg)
 		By(msg)
-		cmd := fmt.Sprintf(`/bin/sh -c 'echo hostname | nc -u -w 1 %s %d '`, nodeIP, nodePort)
+		cmd := nodePortProbeCommand(servicePort.Protocol, nodeIP, nodePort)
 
 		if shouldConnect {
 			err = checkConnectionToAgnhostPod(f, clientPod, expectedOutput, cmd)
@@ -463,6 +654,18 @@ func checkConnectionOrNoConnectionToNodePort(f *framework.Framework, clientPod *
 			err = checkNoConnectionToAgnhostPod(f, clientPod, cmd)
 		}
 		framework.ExpectNoError(err, fmt.Sprintf("Failed to verify that %s", msg))
+	}
+}
+
+func nodePortProbeCommand(protocol v1.Protocol, nodeIP string, nodePort int32) string {
+	switch protocol {
+	case v1.ProtocolTCP:
+		return fmt.Sprintf(`/bin/sh -c 'curl -g -q -s --connect-timeout 1 --max-time 2 http://%s/hostname'`, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)))
+	case v1.ProtocolUDP:
+		return fmt.Sprintf(`/bin/sh -c 'echo hostname | nc -u -w 1 %s %d '`, nodeIP, nodePort)
+	default:
+		framework.Failf("unsupported protocol %q", protocol)
+		return ""
 	}
 }
 
@@ -500,7 +703,8 @@ func checkConnectionOrNoConnectionToLoadBalancers(f *framework.Framework, client
 func checkConnectionToNodePortFromExternalContainer(externalContainer infraapi.ExternalContainer, service *v1.Service, node *v1.Node, nodeRoleMsg, expectedOutput string) {
 	GinkgoHelper()
 	var err error
-	nodePort := service.Spec.Ports[0].NodePort
+	servicePort := service.Spec.Ports[0]
+	nodePort := servicePort.NodePort
 	nodeIPs, err := ParseNodeHostIPDropNetMask(node)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -510,12 +714,24 @@ func checkConnectionToNodePortFromExternalContainer(externalContainer infraapi.E
 		By(msg)
 		Eventually(func() (string, error) {
 			return infraprovider.Get().ExecExternalContainerCommand(externalContainer, []string{
-				"/bin/bash", "-c", fmt.Sprintf("echo hostname | nc -u -w 1 %s %d", nodeIP, nodePort),
+				"/bin/bash", "-c", externalNodePortProbeCommand(servicePort.Protocol, nodeIP, nodePort),
 			})
 		}).
 			WithTimeout(5*time.Second).
 			WithPolling(200*time.Millisecond).
 			Should(Equal(expectedOutput), "Failed to verify that %s", msg)
+	}
+}
+
+func externalNodePortProbeCommand(protocol v1.Protocol, nodeIP string, nodePort int32) string {
+	switch protocol {
+	case v1.ProtocolTCP:
+		return fmt.Sprintf("curl -g -q -s --connect-timeout 1 --max-time 2 http://%s/hostname", net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)))
+	case v1.ProtocolUDP:
+		return fmt.Sprintf("echo hostname | nc -u -w 1 %s %d", nodeIP, nodePort)
+	default:
+		framework.Failf("unsupported protocol %q", protocol)
+		return ""
 	}
 }
 

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1787,22 +1787,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
-							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
-						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in different UDN network should not work",
@@ -1830,23 +1815,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
-							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
-						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in default network should not work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
@@ -1904,23 +1873,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
-							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
-						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 			)
 		})


### PR DESCRIPTION
    For UDN we have a conditional SNAT for traffic that goes via mpx
    interface. This conditional SNAT is placed on the ovn_cluster_router or
    transit_router for L3 or L2, respectively. Due to this conditional SNAT,
    ingress traffic into the router must be checked for unSNAT, and without
    commit can break ingress reply traffic as sessions are not tracked
    correctly. Additionally without committing, this breaks hardware
    offload.
    
    Fixes: #5531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced stateful connection tracking capabilities for logical routers handling traffic in user-defined networks

* **Improvements**
  * Simplified cluster router configuration to more flexibly support multicast and connection tracking options

* **Tests**
  * Expanded end-to-end test coverage for NodePort services in user-defined networks across multiple nodes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->