### PR TITLE
EVPN BFD failover with dual-spine u/s usecase with utils

### DIFF
--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1757,6 +1758,33 @@ func verifyBFDState(containerName string, peerIPs []string, expectUp bool) error
 		}
 	}
 	return nil
+}
+
+// getNeighborPfxRcd returns the PfxRcd (received prefix count) for a BGP
+// neighbor from "show bgp l2vpn evpn summary" output on an FRR-K8s pod.
+// Returns 0 if the neighbor is present but not established (e.g. "Idle").
+// Returns an error if the neighbor IP is not found in the summary at all.
+func getNeighborPfxRcd(namespace, podName, containerName, neighborIP string) (int, error) {
+	cmd := vtyshCommand("show bgp l2vpn evpn summary")
+	out, err := e2ekubectl.RunKubectl(namespace,
+		append([]string{"exec", podName, "-c", containerName, "--"}, cmd...)...)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get EVPN summary on pod %s: %w", podName, err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] != neighborIP {
+			continue
+		}
+		lastField := fields[len(fields)-1]
+		count, parseErr := strconv.Atoi(lastField)
+		if parseErr != nil {
+			// Non-numeric last field means not established (e.g. "Idle", "Active")
+			return 0, nil
+		}
+		return count, nil
+	}
+	return 0, fmt.Errorf("neighbor %s not found in EVPN summary on pod %s", neighborIP, podName)
 }
 
 // setK8NodeLinkDown sets a node's interface down, simulating a link failure.

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -1759,9 +1759,8 @@ func verifyBFDState(containerName string, peerIPs []string, expectUp bool) error
 	return nil
 }
 
-// bringDownSpineLink sets a node's interface to the given spine network down,
-// simulating a link failure that triggers BFD fast detection.
-func bringDownSpineLink(nodeName, ifaceName string) error {
+// setK8NodeLinkDown sets a node's interface down, simulating a link failure.
+func setK8NodeLinkDown(nodeName, ifaceName string) error {
 	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName,
 		[]string{"ip", "link", "set", ifaceName, "down"})
 	if err != nil {
@@ -1771,8 +1770,8 @@ func bringDownSpineLink(nodeName, ifaceName string) error {
 	return nil
 }
 
-// bringUpSpineLink restores a node's interface to the given spine network.
-func bringUpSpineLink(nodeName, ifaceName string) error {
+// setK8NodeLinkUp restores a node's interface.
+func setK8NodeLinkUp(nodeName, ifaceName string) error {
 	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName,
 		[]string{"ip", "link", "set", ifaceName, "up"})
 	if err != nil {

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -331,6 +332,15 @@ func setupMACVRFOnExternalFRR(ictx infraapi.Context, vni, vid int, bridgeName, v
 func setupIPVRFOnExternalFRR(ictx infraapi.Context, vrfName string, vni, vid int, bridgeName, vxlanName string) error {
 	frr := infraapi.ExternalContainer{Name: externalFRRContainerName}
 	vniStr := fmt.Sprintf("%d", vni)
+
+	// Enable IPv6 forwarding before VRF creation so all interfaces
+	// (including those later moved into the VRF) inherit the setting.
+	// Without this, the kernel drops IPv6 packets transiting the VRF
+	// (e.g. VXLAN/SVI → eth1), breaking EVPN Type-5 IPv6 routes.
+	if _, err := infraprovider.Get().ExecExternalContainerCommand(frr,
+		[]string{"sysctl", "-w", "net.ipv6.conf.all.forwarding=1"}); err != nil {
+		return fmt.Errorf("failed to enable IPv6 forwarding on %s: %w", externalFRRContainerName, err)
+	}
 
 	// Create Linux VRF with routing table = VNI
 	_, err := infraprovider.Get().ExecExternalContainerCommand(frr,
@@ -1314,3 +1324,461 @@ func runEVPNNetworkAndServers(
 
 	return nil
 }
+
+// =============================================================================
+// Dual-Spine BFD Infrastructure
+// =============================================================================
+//
+// These utilities set up a second FRR spine container on a dedicated Docker
+// network, configure BGP + EVPN + BFD on both spines, and inject BFD peers
+// into the FRR-K8s pods running on each cluster node.
+//
+// Topology:
+//
+//   Spine1 (frr)          Spine2 (frr-spine2)
+//   172.18.0.5            172.31.0.2
+//   kind network          spine2-net
+//   BGP+EVPN+BFD          BGP+EVPN+BFD
+//       │                     │
+//       ├── node1 ─────────── ┤
+//       ├── node2 ─────────── ┤
+//       └── node3 ─────────── ┘
+//
+// Link failure is simulated by setting a node's spine2-net interface down,
+// which triggers BFD fast detection (~1s) and BGP route withdrawal.
+
+const (
+	spine2ContainerName = "frr-spine2"
+	spine2NetworkName   = "evpn-spine2-net"
+	spine2SubnetIPv4    = "172.31.0.0/16"
+	spine2SubnetIPv6    = "fd10:abcd::/64"
+	frrK8sDaemonLabel   = "control-plane=frr-k8s"
+	frrK8sContainerName = "frr"
+)
+
+// dualSpineInfo holds the network and addressing information for the dual-spine
+// topology, used by the BFD failover test to bring links down and verify state.
+type dualSpineInfo struct {
+	// spine1IPs are the IPs of the existing FRR container on the kind network
+	// (IPv4 and/or IPv6, filtered by cluster IP family support).
+	spine1IPs []string
+	// spine2IPs are the IPs of the second FRR container on spine2-net
+	// (IPv4 and/or IPv6, filtered by cluster IP family support).
+	spine2IPs []string
+	// spine2Network is the infra network object for spine2-net.
+	spine2Network infraapi.Network
+	// nodeSpine2IPs maps node name -> list of node's IPs on spine2-net (IPv4 and/or IPv6).
+	nodeSpine2IPs map[string][]string
+	// nodeSpine2Ifaces maps node name -> node's interface name on spine2-net.
+	nodeSpine2Ifaces map[string]string
+}
+
+// setupDualSpineEVPN creates a second FRR spine with BGP + EVPN + BFD and
+// connects all cluster nodes to it. It also configures BFD on the existing
+// spine1 (the "frr" container) and injects BFD peers into all FRR-K8s pods.
+//
+// The returned dualSpineInfo contains addressing data needed to simulate
+// link failures and verify BFD state.
+//
+// Cleanup is automatically registered via ictx.
+func setupDualSpineEVPN(
+	f *framework.Framework,
+	ictx infraapi.Context,
+	ipFamilySet sets.Set[utilnet.IPFamily],
+	asn int,
+	frrConfigLabels map[string]string,
+) (*dualSpineInfo, error) {
+	info := &dualSpineInfo{
+		nodeSpine2IPs:    make(map[string][]string),
+		nodeSpine2Ifaces: make(map[string]string),
+	}
+
+	// Remove stale spine2 resources left over from a prior test run whose
+	// cleanup may have failed or timed out.
+	_ = ictx.DeleteExternalContainer(infraapi.ExternalContainer{Name: spine2ContainerName})
+	if staleNet, err := infraprovider.Get().GetNetwork(spine2NetworkName); err == nil {
+		_ = ictx.DeleteNetwork(staleNet)
+	}
+
+	// Get spine1 IPs (existing FRR on kind network) for all supported families
+	kindNetwork, err := infraprovider.Get().GetNetwork("kind")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kind network: %w", err)
+	}
+	spine1NetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+		infraapi.ExternalContainer{Name: externalFRRContainerName}, kindNetwork)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get spine1 network interface: %w", err)
+	}
+	info.spine1IPs = matchIPStringsByIPFamilySet([]string{spine1NetInf.IPv4, spine1NetInf.IPv6}, ipFamilySet)
+
+	// Build spine2 subnet list based on cluster IP family support
+	var spine2Subnets []string
+	if ipFamilySet.Has(utilnet.IPv4) {
+		spine2Subnets = append(spine2Subnets, spine2SubnetIPv4)
+	}
+	if ipFamilySet.Has(utilnet.IPv6) {
+		spine2Subnets = append(spine2Subnets, spine2SubnetIPv6)
+	}
+
+	// Create spine2 Docker network (dual-stack if cluster supports it)
+	info.spine2Network, err = ictx.CreateNetwork(spine2NetworkName, spine2Subnets...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create spine2 network: %w", err)
+	}
+
+	// Create spine2 FRR container
+	spine2 := infraapi.ExternalContainer{
+		Name:    spine2ContainerName,
+		Image:   "quay.io/frrouting/frr:10.4.3",
+		Network: info.spine2Network,
+		RuntimeArgs: []string{
+			"--privileged",
+			"--cap-add=NET_ADMIN",
+			"--cap-add=SYS_ADMIN",
+		},
+	}
+	_, err = ictx.CreateExternalContainer(spine2)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create spine2 container: %w", err)
+	}
+
+	// Start bgpd and bfdd on spine2 (they're disabled by default).
+	// We enable them in the daemons file and then start each daemon
+	// directly rather than using frrinit.sh restart, because restart
+	// kills watchfrr (PID 1) which stops the container.
+	spine2Ref := infraapi.ExternalContainer{Name: spine2ContainerName}
+	for _, daemon := range []string{"bgpd", "bfdd"} {
+		_, err := infraprovider.Get().ExecExternalContainerCommand(spine2Ref,
+			[]string{"sed", "-i", fmt.Sprintf("s/%s=no/%s=yes/g", daemon, daemon), "/etc/frr/daemons"})
+		if err != nil {
+			return nil, fmt.Errorf("failed to enable %s on spine2: %w", daemon, err)
+		}
+	}
+	// Start bgpd and bfdd directly, then add them to watchfrr
+	for _, daemon := range []string{"bgpd", "bfdd"} {
+		_, err := infraprovider.Get().ExecExternalContainerCommand(spine2Ref,
+			[]string{"/usr/lib/frr/" + daemon, "-d", "-A", "127.0.0.1"})
+		if err != nil {
+			return nil, fmt.Errorf("failed to start %s on spine2: %w", daemon, err)
+		}
+	}
+	framework.Logf("bgpd and bfdd started on spine2")
+
+	// Enable IPv6 forwarding on spine2 for dual-stack VRF support
+	if ipFamilySet.Has(utilnet.IPv6) {
+		if _, err := infraprovider.Get().ExecExternalContainerCommand(spine2Ref,
+			[]string{"sysctl", "-w", "net.ipv6.conf.all.forwarding=1"}); err != nil {
+			return nil, fmt.Errorf("failed to enable IPv6 forwarding on spine2: %w", err)
+		}
+	}
+
+	// Connect all cluster nodes to spine2-net
+	nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var allSpine2NodeIPs []string
+	for _, node := range nodeList.Items {
+		_, err := ictx.AttachNetwork(info.spine2Network, node.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to attach node %s to spine2-net: %w", node.Name, err)
+		}
+		iface, err := infraprovider.Get().GetK8NodeNetworkInterface(node.Name, info.spine2Network)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get spine2 interface for node %s: %w", node.Name, err)
+		}
+		nodeIPs := matchIPStringsByIPFamilySet([]string{iface.IPv4, iface.IPv6}, ipFamilySet)
+		info.nodeSpine2IPs[node.Name] = nodeIPs
+		info.nodeSpine2Ifaces[node.Name] = iface.InfName
+		allSpine2NodeIPs = append(allSpine2NodeIPs, nodeIPs...)
+
+		if ipFamilySet.Has(utilnet.IPv6) {
+			if _, err := infraprovider.Get().ExecK8NodeCommand(node.Name,
+				[]string{"sysctl", "-w", "net.ipv6.conf." + iface.InfName + ".keep_addr_on_down=1"}); err != nil {
+				return nil, fmt.Errorf("failed to set keep_addr_on_down on node %s iface %s: %w", node.Name, iface.InfName, err)
+			}
+		}
+	}
+
+	// Get spine2 IPs
+	spine2NetInf, err := infraprovider.Get().GetExternalContainerNetworkInterface(spine2Ref, info.spine2Network)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get spine2 IP: %w", err)
+	}
+	info.spine2IPs = matchIPStringsByIPFamilySet([]string{spine2NetInf.IPv4, spine2NetInf.IPv6}, ipFamilySet)
+
+	// Configure BGP + EVPN on spine2 (handles IPv4/IPv6 neighbor split internally)
+	err = configureSpineBGPEVPN(spine2ContainerName, asn, allSpine2NodeIPs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure BGP on spine2: %w", err)
+	}
+
+	// Configure BFD on both spines (BFD is IP-version agnostic in FRR)
+	err = configureBFDOnExternalFRR(spine2ContainerName, allSpine2NodeIPs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure BFD on spine2: %w", err)
+	}
+	nodeKindIPs := e2enode.CollectAddresses(nodeList, corev1.NodeInternalIP)
+	err = configureBFDOnExternalFRR(externalFRRContainerName, nodeKindIPs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure BFD on spine1: %w", err)
+	}
+
+	// Create FRRConfiguration CR for spine2 so FRR-K8s peers with it.
+	// FRRConfiguration takes a single neighbor address; for dual-stack we use
+	// the IPv4 address (FRR-K8s creates separate sessions per address family
+	// via disableMP). If IPv4 is not available, fall back to IPv6.
+	if len(info.spine2IPs) == 0 {
+		return nil, fmt.Errorf("no spine2 IPs discovered on network %q", spine2NetworkName)
+	}
+	spine2NeighborIP := info.spine2IPs[0]
+	spine2FRRConfigName := frrConfigLabels["network"] + "-spine2"
+	err = createFRRConfiguration(ictx, spine2FRRConfigName,
+		deploymentconfig.Get().FRRK8sNamespace(),
+		asn, spine2NeighborIP, frrConfigLabels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create FRRConfiguration for spine2: %w", err)
+	}
+
+	// Wait for FRR-K8s to reconcile the new neighbor on all pods before
+	// injecting BFD peers via vtysh.
+	framework.Logf("Waiting for FRR-K8s to reconcile spine2 neighbor before injecting BFD...")
+	err = waitForFRRK8sNeighbor(f.ClientSet, spine2NeighborIP)
+	if err != nil {
+		return nil, fmt.Errorf("FRR-K8s did not reconcile spine2 neighbor: %w", err)
+	}
+
+	// Inject BFD peers for all spine IPs (both families) into FRR-K8s pods.
+	// We use vtysh injection rather than the FRRConfiguration bfdProfile
+	// field because the frr-k8s webhook requires all CRs referencing the
+	// same neighbor to agree on bfdProfile. The ovnk-generated CRs and
+	// the "receive-all" CR also peer with spine1's IP, and we cannot
+	// atomically patch all of them — nor should we, since the ovnk-generated
+	// CRs are operator-managed and would be overwritten on reconciliation.
+	// The vtysh-injected BFD config lives in a separate "bfd" block that
+	// the operator does not render or reconcile, so it persists.
+	var allSpineIPs []string
+	allSpineIPs = append(allSpineIPs, info.spine1IPs...)
+	allSpineIPs = append(allSpineIPs, info.spine2IPs...)
+	err = configureBFDOnFRRK8sPods(f.ClientSet, allSpineIPs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure BFD on FRR-K8s pods: %w", err)
+	}
+
+	framework.Logf("Dual-spine EVPN setup complete: spine1=%v, spine2=%v, node spine2 IPs=%v",
+		info.spine1IPs, info.spine2IPs, info.nodeSpine2IPs)
+	return info, nil
+}
+
+// configureSpineBGPEVPN sets up BGP + EVPN (route-reflector) on an external
+// FRR container. IPv4 neighbors are activated in the ipv4 unicast AF, IPv6
+// neighbors in the ipv6 unicast AF, and all neighbors in l2vpn evpn.
+func configureSpineBGPEVPN(containerName string, asn int, neighborIPs []string) error {
+	frr := infraapi.ExternalContainer{Name: containerName}
+	args := []string{
+		"configure terminal",
+		fmt.Sprintf("router bgp %d", asn),
+		"no bgp default ipv4-unicast",
+		"no bgp network import-check",
+	}
+	for _, ip := range neighborIPs {
+		args = append(args,
+			fmt.Sprintf("neighbor %s remote-as %d", ip, asn),
+			fmt.Sprintf("neighbor %s bfd", ip),
+		)
+	}
+
+	// Split neighbors by IP family
+	var ipv4Neighbors, ipv6Neighbors []string
+	for _, ip := range neighborIPs {
+		if utilnet.IsIPv4String(ip) {
+			ipv4Neighbors = append(ipv4Neighbors, ip)
+		} else {
+			ipv6Neighbors = append(ipv6Neighbors, ip)
+		}
+	}
+
+	// IPv4 unicast — only IPv4 neighbors
+	if len(ipv4Neighbors) > 0 {
+		args = append(args, "address-family ipv4 unicast")
+		for _, ip := range ipv4Neighbors {
+			args = append(args,
+				fmt.Sprintf("neighbor %s activate", ip),
+				fmt.Sprintf("neighbor %s route-reflector-client", ip),
+				fmt.Sprintf("neighbor %s next-hop-self", ip))
+		}
+		args = append(args, "exit-address-family")
+	}
+
+	// IPv6 unicast — only IPv6 neighbors
+	if len(ipv6Neighbors) > 0 {
+		args = append(args, "address-family ipv6 unicast")
+		for _, ip := range ipv6Neighbors {
+			args = append(args,
+				fmt.Sprintf("neighbor %s activate", ip),
+				fmt.Sprintf("neighbor %s route-reflector-client", ip),
+				fmt.Sprintf("neighbor %s next-hop-self", ip))
+		}
+		args = append(args, "exit-address-family")
+	}
+
+	// l2vpn evpn — all neighbors regardless of IP family
+	args = append(args, "address-family l2vpn evpn")
+	for _, ip := range neighborIPs {
+		args = append(args,
+			fmt.Sprintf("neighbor %s activate", ip),
+			fmt.Sprintf("neighbor %s route-reflector-client", ip))
+	}
+	args = append(args, "advertise-all-vni", "exit-address-family", "exit", "end")
+
+	_, err := infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(args...))
+	if err != nil {
+		return fmt.Errorf("failed to configure BGP+EVPN on %s: %w", containerName, err)
+	}
+	framework.Logf("BGP+EVPN configured on %s (ASN %d, neighbors: %v)", containerName, asn, neighborIPs)
+	return nil
+}
+
+// configureBFDOnExternalFRR adds BFD peers on an external FRR container via
+// vtysh. Unlike setupBFDOnExternalContainer in external_gateways.go which
+// appends to frr.conf and restarts FRR (killing the container), this uses
+// vtysh for live configuration that doesn't require a restart.
+func configureBFDOnExternalFRR(containerName string, peerIPs []string) error {
+	frr := infraapi.ExternalContainer{Name: containerName}
+	args := []string{"configure terminal", "bfd"}
+	for _, ip := range peerIPs {
+		args = append(args, fmt.Sprintf("peer %s", ip), "no shutdown", "exit")
+	}
+	args = append(args, "exit", "end")
+
+	_, err := infraprovider.Get().ExecExternalContainerCommand(frr, vtyshCommand(args...))
+	if err != nil {
+		return fmt.Errorf("failed to configure BFD on %s: %w", containerName, err)
+	}
+	framework.Logf("BFD configured on %s (peers: %v)", containerName, peerIPs)
+	return nil
+}
+
+// configureBFDOnFRRK8sPods injects BFD peer configuration into the FRR daemon
+// running inside each FRR-K8s pod via vtysh exec. The injected config lives in
+// FRR's "bfd" block, which the frr-k8s operator does not render or reconcile
+// (it only generates the "bfd" block when bfdProfiles is set in a CRD), so
+// the injected config persists across operator reconciliation cycles.
+//
+// We use vtysh injection rather than the FRRConfiguration bfdProfile field
+// because the frr-k8s webhook requires all CRs referencing the same neighbor
+// to agree on bfdProfile. The ovnk-generated CRs and the "receive-all" CR
+// also peer with spine1's IP, and we cannot atomically patch all of them.
+func configureBFDOnFRRK8sPods(cs clientset.Interface, spineIPs []string) error {
+	namespace := deploymentconfig.Get().FRRK8sNamespace()
+	pods, err := cs.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: frrK8sDaemonLabel,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list FRR-K8s pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no FRR-K8s pods matched %q in namespace %q", frrK8sDaemonLabel, namespace)
+	}
+
+	var vtyshArgs []string
+	vtyshArgs = append(vtyshArgs, "configure terminal", "bfd")
+	for _, ip := range spineIPs {
+		vtyshArgs = append(vtyshArgs, fmt.Sprintf("peer %s", ip), "no shutdown", "exit")
+	}
+	vtyshArgs = append(vtyshArgs, "exit", "end")
+	cmd := vtyshCommand(vtyshArgs...)
+
+	for _, pod := range pods.Items {
+		_, err := e2ekubectl.RunKubectl(namespace,
+			append([]string{"exec", pod.Name, "-c", frrK8sContainerName, "--"}, cmd...)...)
+		if err != nil {
+			return fmt.Errorf("failed to configure BFD on pod %s: %w", pod.Name, err)
+		}
+		framework.Logf("BFD peers %v configured on FRR-K8s pod %s", spineIPs, pod.Name)
+	}
+	return nil
+}
+
+// waitForFRRK8sNeighbor polls all FRR-K8s pods until each one shows the given
+// neighbor IP in its BGP running config (via "show bgp summary"). This replaces
+// a static sleep and ensures the FRR-K8s operator has reconciled the
+// FRRConfiguration CR before we inject BFD peers.
+func waitForFRRK8sNeighbor(cs clientset.Interface, neighborIP string) error {
+	namespace := deploymentconfig.Get().FRRK8sNamespace()
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			pods, err := cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: frrK8sDaemonLabel,
+			})
+			if err != nil {
+				return false, nil // transient error, retry
+			}
+			if len(pods.Items) == 0 {
+				framework.Logf("No FRR-K8s pods matched %q yet", frrK8sDaemonLabel)
+				return false, nil
+			}
+			for _, pod := range pods.Items {
+				cmd := vtyshCommand("show bgp summary")
+				out, err := e2ekubectl.RunKubectl(namespace,
+					append([]string{"exec", pod.Name, "-c", frrK8sContainerName, "--"}, cmd...)...)
+				if err != nil {
+					framework.Logf("Pod %s: vtysh not ready yet: %v", pod.Name, err)
+					return false, nil
+				}
+				if !strings.Contains(out, neighborIP) {
+					framework.Logf("Pod %s: spine2 neighbor %s not yet in BGP summary", pod.Name, neighborIP)
+					return false, nil
+				}
+			}
+			framework.Logf("All FRR-K8s pods have spine2 neighbor %s in BGP summary", neighborIP)
+			return true, nil
+		})
+}
+
+// verifyBFDState checks that BFD peers on an external FRR container match the
+// expected state (up or down) for the given peer IPs.
+func verifyBFDState(containerName string, peerIPs []string, expectUp bool) error {
+	frr := infraapi.ExternalContainer{Name: containerName}
+	for _, ip := range peerIPs {
+		res, err := infraprovider.Get().ExecExternalContainerCommand(frr,
+			vtyshCommand(fmt.Sprintf("show bfd peer %s", ip)))
+		if err != nil {
+			return fmt.Errorf("failed to check BFD peer %s on %s: %w", ip, containerName, err)
+		}
+		isUp := strings.Contains(res, "Status: up")
+		if expectUp && !isUp {
+			return fmt.Errorf("BFD peer %s on %s: expected up, got down", ip, containerName)
+		}
+		if !expectUp && isUp {
+			return fmt.Errorf("BFD peer %s on %s: expected down, got up", ip, containerName)
+		}
+	}
+	return nil
+}
+
+// bringDownSpineLink sets a node's interface to the given spine network down,
+// simulating a link failure that triggers BFD fast detection.
+func bringDownSpineLink(nodeName, ifaceName string) error {
+	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName,
+		[]string{"ip", "link", "set", ifaceName, "down"})
+	if err != nil {
+		return fmt.Errorf("failed to bring down %s on %s: %w", ifaceName, nodeName, err)
+	}
+	framework.Logf("Link %s on %s set DOWN", ifaceName, nodeName)
+	return nil
+}
+
+// bringUpSpineLink restores a node's interface to the given spine network.
+func bringUpSpineLink(nodeName, ifaceName string) error {
+	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName,
+		[]string{"ip", "link", "set", ifaceName, "up"})
+	if err != nil {
+		return fmt.Errorf("failed to bring up %s on %s: %w", ifaceName, nodeName, err)
+	}
+	framework.Logf("Link %s on %s set UP", ifaceName, nodeName)
+	return nil
+}
+

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -3181,6 +3181,285 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		},
 		networksToTest,
 	)
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// EVPN BFD Failover Tests
+	// ─────────────────────────────────────────────────────────────────────────
+	//
+	// These tests verify that EVPN connectivity survives a single spine failure
+	// when BFD is enabled for fast link detection. A second FRR spine is created
+	// on a dedicated Docker network, and all nodes peer with both spines via
+	// BGP + EVPN + BFD. One spine's links are then brought down, and the test
+	// verifies:
+	//   - BFD detects the failure within ~1 second
+	//   - Intra-VPN connectivity continues without long outage
+	//   - Inter-VPN isolation remains enforced after failover
+
+	evpnBFDNetworks := []ginkgo.TableEntry{
+		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF", feature.EVPN, layer3IPVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF", feature.EVPN, layer2MACVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF", feature.EVPN, layer2MACVRFIPVRFNetworkSpecGen),
+	}
+
+	ginkgo.DescribeTableSubtree("EVPN BFD failover with dual-spine", ginkgo.Serial,
+		func(networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
+			var (
+				testNamespace   *corev1.Namespace
+				externalServers []string
+				testPod         = make([]*corev1.Pod, 2)
+				dualSpine       *dualSpineInfo
+			)
+
+			ginkgo.BeforeEach(func() {
+				bgpAlloc, err := allocators.AllocateBGP(f, ictx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
+
+				networkSpec := networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
+				// Match subnets by IP families
+				switch {
+				case networkSpec.Layer3 != nil:
+					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
+				case networkSpec.Layer2 != nil:
+					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
+				}
+
+				// Set up EVPN network + CUDN + external servers via standard infra
+				testNamespace, externalServers, _ = configureNetworkWithInfra(
+					f,
+					ictx,
+					testBaseName,
+					ipFamilySet,
+					testNetworkName,
+					cudnAdvertisedEVPNUnmanagedSharedVTEP,
+					networkSpec,
+					bgpAlloc,
+				)
+				gomega.Expect(testNamespace).NotTo(gomega.BeNil(), "testNamespace must not be nil")
+
+				// Set up dual-spine with BFD
+				ginkgo.By("Setting up dual-spine EVPN with BFD")
+				frrConfigLabels := map[string]string{"network": testNetworkName}
+				dualSpine, err = setupDualSpineEVPN(f, ictx, ipFamilySet, bgpASN, frrConfigLabels)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create two test pods on different nodes
+				ginkgo.By("Creating test pods on different nodes")
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.Background(), f.ClientSet, 2)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">=", 2), "need at least 2 nodes")
+				for i := range 2 {
+					testPod[i] = e2epod.CreateExecPodOrFail(
+						context.Background(),
+						f.ClientSet,
+						testNamespace.Name,
+						fmt.Sprintf("%s-bfd-pod-%d", testNamespace.Name, i),
+						func(p *corev1.Pod) {
+							p.Spec.Containers[0].Args = []string{"netexec"}
+							p.Spec.NodeName = nodes.Items[i].Name
+							p.Labels = map[string]string{"app": "bfd-test-pod"}
+						},
+					)
+				}
+
+				// Verify BFD sessions are up on both spines for all nodes (not just pod nodes)
+				ginkgo.By("Verifying BFD sessions are up on both spines")
+				allNodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				var spine1Peers, spine2Peers []string
+				for _, node := range allNodes.Items {
+					if ipFamilySet.Has(utilnet.IPv4) {
+						spine1Peers = append(spine1Peers,
+							e2enode.GetAddressesByTypeAndFamily(&node, corev1.NodeInternalIP, corev1.IPv4Protocol)...)
+					}
+					if ipFamilySet.Has(utilnet.IPv6) {
+						spine1Peers = append(spine1Peers,
+							e2enode.GetAddressesByTypeAndFamily(&node, corev1.NodeInternalIP, corev1.IPv6Protocol)...)
+					}
+					spine2Peers = append(spine2Peers, dualSpine.nodeSpine2IPs[node.Name]...)
+				}
+				gomega.Eventually(func() error {
+					if err := verifyBFDState(externalFRRContainerName, spine1Peers, true); err != nil {
+						return fmt.Errorf("BFD link to spine1 was not up: %w", err)
+					}
+					if err := verifyBFDState(spine2ContainerName, spine2Peers, true); err != nil {
+						return fmt.Errorf("BFD link to spine2 was not up: %w", err)
+					}
+					return nil
+				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+			})
+
+			ginkgo.DescribeTable("Connectivity survives single spine failure",
+				func(family utilnet.IPFamily) {
+					if !ipFamilySet.Has(family) {
+						e2eskipper.Skipf("IP family %v not supported", family)
+					}
+
+					// ── Step 1: Verify connectivity BEFORE failure ──
+					ginkgo.By("Verifying intra-VPN connectivity before failure")
+					pod1IP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+						f.ClientSet, testPod[0].Namespace, testPod[0].Name, testNetworkName, family)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(pod1IP).NotTo(gomega.BeEmpty())
+
+					pod2IP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+						f.ClientSet, testPod[1].Namespace, testPod[1].Name, testNetworkName, family)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(pod2IP).NotTo(gomega.BeEmpty())
+
+					// Intra-VPN: pod can reach another pod on another node
+					testPodToClientIP(testPod[0], pod2IP)
+					testPodToClientIP(testPod[1], pod1IP)
+
+					// Intra-VPN: pod can reach external server on same network
+					reachedExternal := false
+					for _, externalServer := range externalServers {
+						sameNetwork, networkErr := infraprovider.Get().GetNetwork(externalServer)
+						gomega.Expect(networkErr).NotTo(gomega.HaveOccurred())
+						sameIface, ifaceErr := infraprovider.Get().GetExternalContainerNetworkInterface(
+							infraapi.ExternalContainer{Name: externalServer}, sameNetwork)
+						gomega.Expect(ifaceErr).NotTo(gomega.HaveOccurred())
+						sameServerIP := getFirstIPStringOfFamily(family, []string{sameIface.IPv4, sameIface.IPv6})
+						if sameServerIP != "" {
+							testPodToClientIP(testPod[0], sameServerIP)
+							reachedExternal = true
+						}
+					}
+					gomega.Expect(reachedExternal).To(gomega.BeTrue(),
+						"at least one external server should be reachable for the active IP family")
+
+					// Inter-VPN isolation: pods belong to different L3/L2 VPNs cannot reach each other
+					ginkgo.By("Verifying inter-VPN isolation before failure")
+					bgpServerNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+						infraapi.ExternalContainer{Name: serverContainerName}, bgpServerNetwork)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					externalServerIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+					gomega.Expect(externalServerIP).NotTo(gomega.BeEmpty(),
+						"external server should have an IP for the active IP family")
+					testPodToClientIPNOK(testPod[0], externalServerIP)
+
+					// Verify EVPN routes exist before injecting failure.
+					// We cannot check per-spine because both spines act as
+					// route reflectors and preserve the original next-hop
+					// (the originating node's IP), not the reflector's IP.
+					// BFD sessions with both spines are already verified in
+					// the BeforeEach, so we only need to confirm that the
+					// EVPN route table is populated.
+					ginkgo.By("Verifying EVPN routes are present before failure injection")
+					frrk8sNamespace := deploymentconfig.Get().FRRK8sNamespace()
+					frrk8sPods, err := f.ClientSet.CoreV1().Pods(frrk8sNamespace).List(context.Background(), metav1.ListOptions{
+						LabelSelector: frrK8sDaemonLabel,
+					})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					for _, pod := range frrk8sPods.Items {
+						gomega.Eventually(func() error {
+							cmd := vtyshCommand("show bgp l2vpn evpn")
+							out, execErr := e2ekubectl.RunKubectl(frrk8sNamespace,
+								append([]string{"exec", pod.Name, "-c", frrK8sContainerName, "--"}, cmd...)...)
+							if execErr != nil {
+								return fmt.Errorf("failed to check EVPN routes on pod %s: %w", pod.Name, execErr)
+							}
+							if !strings.Contains(out, "Route Distinguisher") {
+								return fmt.Errorf("no EVPN routes found on pod %s", pod.Name)
+							}
+							return nil
+						}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(gomega.Succeed(),
+							fmt.Sprintf("EVPN routes should be present on pod %s before failure injection", pod.Name))
+					}
+
+					// ── Step 2: Bring down spine2 ──
+					ginkgo.By("Bringing down spine2 links on all nodes")
+					nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					// Register cleanup before taking links down so partially-failed
+					// iterations don't leave interfaces stuck in the down state.
+					ictx.AddCleanUpFn(func() error {
+						for _, node := range nodeList.Items {
+							ifaceName := dualSpine.nodeSpine2Ifaces[node.Name]
+							if ifaceName == "" {
+								continue
+							}
+							_ = bringUpSpineLink(node.Name, ifaceName)
+						}
+						return nil
+					})
+					for _, node := range nodeList.Items {
+						ifaceName := dualSpine.nodeSpine2Ifaces[node.Name]
+						gomega.Expect(bringDownSpineLink(node.Name, ifaceName)).To(gomega.Succeed())
+					}
+
+					// Verify BFD detects the failure. The 5s timeout is well under
+					// the BGP hold-timer (default 180s), so if BFD reports peers
+					// down within this window it proves BFD-driven detection rather
+					// than BGP keepalive expiry.
+					ginkgo.By("Verifying BFD detects spine2 failure")
+					var spine2Peers []string
+					for _, node := range nodeList.Items {
+						spine2Peers = append(spine2Peers, dualSpine.nodeSpine2IPs[node.Name]...)
+					}
+					gomega.Eventually(func() error {
+						return verifyBFDState(spine2ContainerName, spine2Peers, false)
+					}).WithTimeout(5 * time.Second).WithPolling(1 * time.Second).Should(gomega.Succeed(),
+						"BFD should detect link failure on spine2 within 5s (well under BGP hold-timer)")
+
+					ginkgo.By("Verifying spine1 BFD remains up")
+					gomega.Consistently(func() error {
+						return verifyBFDState(
+							externalFRRContainerName,
+							e2enode.CollectAddresses(nodeList, corev1.NodeInternalIP),
+							true,
+						)
+					}).WithTimeout(10 * time.Second).WithPolling(2 * time.Second).Should(
+						gomega.Succeed(),
+						"spine1 BFD should remain up while spine2 fails",
+					)
+
+					// ── Step 3: Verify connectivity AFTER failover ──
+					ginkgo.By("Verifying intra-VPN connectivity continues after failover")
+					testPodToClientIP(testPod[0], pod2IP)
+					testPodToClientIP(testPod[1], pod1IP)
+
+					// Intra-VPN: pod can still reach external server on same network
+					reachedExternal = false
+					for _, externalServer := range externalServers {
+						sameNetwork, networkErr := infraprovider.Get().GetNetwork(externalServer)
+						gomega.Expect(networkErr).NotTo(gomega.HaveOccurred())
+						sameIface, ifaceErr := infraprovider.Get().GetExternalContainerNetworkInterface(
+							infraapi.ExternalContainer{Name: externalServer}, sameNetwork)
+						gomega.Expect(ifaceErr).NotTo(gomega.HaveOccurred())
+						sameServerIP := getFirstIPStringOfFamily(family, []string{sameIface.IPv4, sameIface.IPv6})
+						if sameServerIP != "" {
+							testPodToClientIP(testPod[0], sameServerIP)
+							reachedExternal = true
+						}
+					}
+					gomega.Expect(reachedExternal).To(gomega.BeTrue(),
+						"at least one external server should be reachable after failover for the active IP family")
+
+					ginkgo.By("Verifying inter-VPN isolation remains after failover")
+					testPodToClientIPNOK(testPod[0], externalServerIP)
+
+					// ── Step 4: Restore spine2 and verify BFD re-establishes ──
+					ginkgo.By("Restoring spine2 links on all nodes")
+					for _, node := range nodeList.Items {
+						ifaceName := dualSpine.nodeSpine2Ifaces[node.Name]
+						gomega.Expect(bringUpSpineLink(node.Name, ifaceName)).To(gomega.Succeed())
+					}
+
+					ginkgo.By("Verifying BFD re-establishes on spine2 after restore")
+					gomega.Eventually(func() error {
+						return verifyBFDState(spine2ContainerName, spine2Peers, true)
+					}).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Succeed(),
+						"BFD should re-establish on spine2 after links are restored")
+				},
+				ginkgo.Entry("When the networks are IPv4", utilnet.IPv4),
+				ginkgo.Entry("When the networks are IPv6", utilnet.IPv6),
+			)
+		},
+		evpnBFDNetworks,
+	)
 })
 
 // routeAdvertisementsReadyFunc returns a function that checks for the

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -3369,6 +3369,22 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							fmt.Sprintf("EVPN routes should be present on pod %s before failure injection", pod.Name))
 					}
 
+					ginkgo.By("Verifying spine2 is providing EVPN routes (PfxRcd > 0)")
+					spine2NeighborIP := dualSpine.spine2IPs[0]
+					for _, pod := range frrk8sPods.Items {
+						gomega.Eventually(func() error {
+							pfxRcd, err := getNeighborPfxRcd(frrk8sNamespace, pod.Name, frrK8sContainerName, spine2NeighborIP)
+							if err != nil {
+								return err
+							}
+							if pfxRcd == 0 {
+								return fmt.Errorf("spine2 neighbor %s has PfxRcd=0 on pod %s", spine2NeighborIP, pod.Name)
+							}
+							return nil
+						}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(gomega.Succeed(),
+							fmt.Sprintf("spine2 (%s) should have PfxRcd > 0 on pod %s before failure injection", spine2NeighborIP, pod.Name))
+					}
+
 					// ── Step 2: Bring down spine2 ──
 					ginkgo.By("Bringing down spine2 links on all nodes")
 					nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -3417,6 +3433,22 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						gomega.Succeed(),
 						"spine1 BFD should remain up while spine2 fails",
 					)
+
+					ginkgo.By("Verifying spine2 EVPN routes are withdrawn (PfxRcd = 0)")
+					for _, pod := range frrk8sPods.Items {
+						gomega.Eventually(func() error {
+							pfxRcd, err := getNeighborPfxRcd(frrk8sNamespace, pod.Name, frrK8sContainerName, spine2NeighborIP)
+							if err != nil {
+								// Neighbor gone from summary entirely is also acceptable
+								return nil
+							}
+							if pfxRcd > 0 {
+								return fmt.Errorf("spine2 neighbor %s still has PfxRcd=%d on pod %s", spine2NeighborIP, pfxRcd, pod.Name)
+							}
+							return nil
+						}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(gomega.Succeed(),
+							fmt.Sprintf("spine2 (%s) should have PfxRcd=0 on pod %s after failure", spine2NeighborIP, pod.Name))
+					}
 
 					// ── Step 3: Verify connectivity AFTER failover ──
 					ginkgo.By("Verifying intra-VPN connectivity continues after failover")

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -3381,13 +3381,15 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							if ifaceName == "" {
 								continue
 							}
-							_ = bringUpSpineLink(node.Name, ifaceName)
+							if err := setK8NodeLinkUp(node.Name, ifaceName); err != nil {
+								framework.Logf("cleanup: failed to restore link %s on %s: %v", ifaceName, node.Name, err)
+							}
 						}
 						return nil
 					})
 					for _, node := range nodeList.Items {
 						ifaceName := dualSpine.nodeSpine2Ifaces[node.Name]
-						gomega.Expect(bringDownSpineLink(node.Name, ifaceName)).To(gomega.Succeed())
+						gomega.Expect(setK8NodeLinkDown(node.Name, ifaceName)).To(gomega.Succeed())
 					}
 
 					// Verify BFD detects the failure. The 5s timeout is well under
@@ -3445,7 +3447,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					ginkgo.By("Restoring spine2 links on all nodes")
 					for _, node := range nodeList.Items {
 						ifaceName := dualSpine.nodeSpine2Ifaces[node.Name]
-						gomega.Expect(bringUpSpineLink(node.Name, ifaceName)).To(gomega.Succeed())
+						gomega.Expect(setK8NodeLinkUp(node.Name, ifaceName)).To(gomega.Succeed())
 					}
 
 					ginkgo.By("Verifying BFD re-establishes on spine2 after restore")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR automated EVPN BFD failover witj dual-spine scenario and corresponding evpn utils needed

Following is the test flow:

```
BeforeEach (per network type)                                                                                                                   
   
  1. Configure EVPN network — creates CUDN, external agnhost servers, VTEP, FRRConfiguration for spine1 via configureNetworkWithInfra()           
  2. Set up dual-spine with BFD — setupDualSpineEVPN():     
    - Create evpn-spine2-net Docker network                                                                                                       
    - Create frr-spine2 container, start bgpd + bfdd                                                                                              
    - Attach all cluster nodes to spine2 network                                                                                                  
    - Configure BGP + EVPN on spine2 (route-reflector for all node IPs)                                                                           
    - Configure BFD peers on spine2 (all node IPs) and spine1 (all node IPs)                                                                      
    - Create FRRConfiguration CR for spine2 so FRR-K8s peers with it                                                                              
    - Poll FRR-K8s pods until spine2 neighbor appears in BGP summary                                                                              
    - Inject BFD peers into all FRR-K8s pods via vtysh                                                                                            
  3. Create two test pods on different nodes                                                                                                      
  
  4. Verify BFD sessions are up on both spine1 and spine2 (poll with 30s timeout)                                                                 
 
Actual Test                                                                                                                                                                                                                                                                                                   
 
  5. Step 2 — Pre-failure verification:                                                                                                           
    - Verify intra-CUDN connectivity: pod1 → pod2 and pod2 → pod1
    - Verify inter-CUDN isolation: pod1 cannot reach external server on a different network                                                       
  6. Step 3 — Simulate spine2 failure:                                                                                                            
    - Bring down each node's spine2 interface (ip link set ethX down)                                                                             
    - Verify BFD detects spine2 failure (poll with 15s timeout, expect all peers down)                                                            
    - Verify spine1 BFD remains up                                                                                                                
  7. Step 4 — Post-failover verification:                                                                                                         
    - Verify intra-CUDN connectivity still works: pod1 → pod2 and pod2 → pod1                                                                     
    - Verify inter-CUDN isolation still holds: pod1 cannot reach external server                                                                  
                                                                                                                                                  
Cleanup (automatic via ictx)                                                                                                                    
                                                            
  8. Restore spine2 links (ip link set ethX up)                                                                                                   
  9. Delete FRRConfigurations (<name>-spine2, <name>)       
  10. Detach nodes from evpn-spine2-net                                                                                                           
  11. Delete frr-spine2 container and agnhost containers                                                                                          
  12. Delete evpn-spine2-net and agnhost Docker networks   

```

Has been validated successfully locally on IPv4 and Dual-stack on PR https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5988 cc @Meina-rh @jechen0648 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for EVPN BFD failover in a dual‑spine topology across IPv4/IPv6 and multiple EVPN variants (L2, L3, combined). Tests validate BFD session health on both spines, simulate spine link failure/recovery, and confirm pre/post-failure connectivity and external isolation.

* **New Features**
  * Added test infrastructure to provision and manage a secondary spine and automate BGP/BFD setup and verification for dual‑spine scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Anurag Saxena <anusaxen@redhat.com>