### PR TITLE
EVPN E2E: overlapping L3/L2 CUDNs isolation tests over L3/L2 VPNs

### DIFF
--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -737,6 +737,7 @@ func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.Exte
 			[]string{"sh", "-c", strings.Join(shellCmds, " && ")}); err != nil {
 			return nil, fmt.Errorf("failed to reassign IPs on container %s (network %s): %w", container.Name, networkName, err)
 		}
+		info.containerIPs = containerIPs
 		framework.Logf("Reassigned container %s (network %s) IPs to CUDN IPs: %v", container.Name, networkName, containerIPs)
 	}
 

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -676,24 +676,68 @@ func getMACVRFAgnhostIPsFromSubnets(subnets []string) ([]string, error) {
 //   - vid: VLAN ID for the access port on the bridge (e.g., 100)
 //   - ipFamilies: Cluster IP family support (e.g., sets.New(utilnet.IPv4, utilnet.IPv6))
 //   - subnets: Subnets for the Docker network matching the CUDN (e.g., "10.100.0.0/16")
-func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName, bridgeName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string) (*evpnContainerInfo, error) {
+//   - useProxyDockerNetwork: When true, the Docker network is created without explicit subnets
+//     (Docker picks a random unused range) and the container's IPs are reassigned
+//     afterward to match the CUDN subnets. This is needed when two MAC-VRF agnhosts
+//     share the same CUDN subnet because Docker rejects overlapping subnets. The Docker
+//     bridge still forwards L2 frames regardless of IP addressing.
+func setupMACVRFExternalContainer(ictx infraapi.Context, container infraapi.ExternalContainer, networkName, bridgeName string, vid int, ipFamilies sets.Set[utilnet.IPFamily], subnets []string, useProxyDockerNetwork bool) (*evpnContainerInfo, error) {
 	// Derive container IPs from CUDN subnets
 	containerIPs, err := getMACVRFAgnhostIPsFromSubnets(subnets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive MAC-VRF container IPs from subnets: %w", err)
 	}
 
-	ips4, ips6 := splitIPStringsByIPFamily(containerIPs)
-	if len(ips4) > 0 {
-		container.IPv4 = ips4[0]
-	}
-	if len(ips6) > 0 {
-		container.IPv6 = ips6[0]
+	if !useProxyDockerNetwork {
+		ips4, ips6 := splitIPStringsByIPFamily(containerIPs)
+		if len(ips4) > 0 {
+			container.IPv4 = ips4[0]
+		}
+		if len(ips6) > 0 {
+			container.IPv6 = ips6[0]
+		}
 	}
 
-	info, err := createEVPNExternalContainer(ictx, container, networkName, ipFamilies, subnets)
+	var info *evpnContainerInfo
+	dockerSubnets := subnets
+	if useProxyDockerNetwork {
+		dockerSubnets = nil
+	}
+	info, err = createEVPNExternalContainer(ictx, container, networkName, ipFamilies, dockerSubnets)
 	if err != nil {
 		return nil, err
+	}
+
+	// When useProxyDockerNetwork is set, the network was created without explicit
+	// subnets, this lets Docker pick a random unused range, avoiding Docker rejecting a
+	// second network with the same CUDN CIDR. Then reassign the container's IPs
+	// to match the actual CUDN subnets.
+	if useProxyDockerNetwork {
+		shellCmds := []string{
+			fmt.Sprintf("ip addr flush dev %s", info.containerInterface),
+		}
+		// CreateNetwork infers IP family from the subnets passed to it; with nil
+		// subnets it creates an IPv4-only network, which disables IPv6 on the
+		// interface. Enable it so we can add IPv6 CUDN addresses.
+		if ipFamilies.Has(utilnet.IPv6) {
+			shellCmds = append(shellCmds,
+				fmt.Sprintf("sysctl -w net.ipv6.conf.%s.disable_ipv6=0", info.containerInterface))
+		}
+		for i, subnet := range subnets {
+			_, ipNet, parseErr := net.ParseCIDR(subnet)
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse CUDN subnet %s: %w", subnet, parseErr)
+			}
+			prefixLen, _ := ipNet.Mask.Size()
+			addr := fmt.Sprintf("%s/%d", containerIPs[i], prefixLen)
+			shellCmds = append(shellCmds,
+				fmt.Sprintf("ip addr add %s dev %s", addr, info.containerInterface))
+		}
+		if _, err := infraprovider.Get().ExecExternalContainerCommand(container,
+			[]string{"sh", "-c", strings.Join(shellCmds, " && ")}); err != nil {
+			return nil, fmt.Errorf("failed to reassign IPs on container %s (network %s): %w", container.Name, networkName, err)
+		}
+		framework.Logf("Reassigned container %s (network %s) IPs to CUDN IPs: %v", container.Name, networkName, containerIPs)
 	}
 
 	// Move FRR's interface to bridgeName and configure as access port
@@ -1160,6 +1204,12 @@ func populateExternalContainerIPs(c *infraapi.ExternalContainer, info *evpnConta
 //
 // The macVRFContainer and ipVRFContainer pointers are mutated: after creation
 // their IPv4/IPv6 fields are populated with the discovered container IPs.
+//
+// When macVRFUseProxyDockerNetwork is true, the MAC-VRF Docker network is created
+// without explicit subnets (Docker picks a random range) and the container's
+// IPs are reassigned afterward to match the CUDN subnets. This is needed when
+// two MAC-VRF containers share the same CUDN subnet because Docker rejects
+// overlapping subnets.
 func runEVPNNetworkAndServers(
 	f *framework.Framework,
 	ictx infraapi.Context,
@@ -1175,6 +1225,7 @@ func runEVPNNetworkAndServers(
 	macVRFNetworkName string,
 	ipVRFContainer *infraapi.ExternalContainer,
 	ipVRFNetworkName string,
+	macVRFUseProxyDockerNetwork bool,
 ) error {
 	// Derive what to setup from networkSpec
 	hasMACVRF := networkSpec.EVPN != nil && networkSpec.EVPN.MACVRF != nil
@@ -1215,7 +1266,7 @@ func runEVPNNetworkAndServers(
 		}
 
 		framework.Logf("Creating MAC-VRF external container")
-		macVRFInfo, err := setupMACVRFExternalContainer(ictx, *macVRFContainer, macVRFNetworkName, bridgeName, macVRFVID, ipFamilySet, cudnSubnetsFromSpec)
+		macVRFInfo, err := setupMACVRFExternalContainer(ictx, *macVRFContainer, macVRFNetworkName, bridgeName, macVRFVID, ipFamilySet, cudnSubnetsFromSpec, macVRFUseProxyDockerNetwork)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1766,6 +1766,7 @@ write_files:
 					externalMACVRFContainer.Name,
 					&externalContainer,
 					externalContainer.Name,
+					false,
 				)).To(Succeed())
 				// Register namespace deletion on the infra context so it runs
 				// before VTEP poll in LIFO cleanup order. VTEP has a finalizer

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1919,6 +1919,7 @@ write_files:
 					externalMACVRFContainer.Name,
 					&externalContainer,
 					externalContainer.Name,
+					false,
 				)).To(Succeed())
 				// Register namespace deletion on the infra context so it runs
 				// before VTEP poll in LIFO cleanup order. VTEP has a finalizer

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -3261,27 +3261,33 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 									)
 								}
 
-								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP {
+								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP &&
+									testNetworkSpec.EVPN != nil && testNetworkSpec.EVPN.MACVRF != nil {
 									// The outer "It can reach external servers on the same network" block already
 									// tests north-south connectivity for the tested network in isolation.
 									// This additional check runs within the "other network is set up" context,
 									// verifying that VNI isolation holds for north-south traffic: even when
-									// the other network shares the same VTEP IP and its external server is
-									// reachable at the same IP, the tested pod still reaches only its own
-									// external server (identified by hostname) rather than the other network's.
-									ginkgo.By("Ensuring the tested network pod reaches its own external servers at the shared IP (north-south VNI isolation)")
-									for _, externalServer := range externalServers {
-										testForIPFamilies(
-											ipFamilySet,
-											func(family utilnet.IPFamily) {
-												ginkgo.GinkgoHelper()
-												serverIP := getExternalServerIPForFamily(externalServer, family)
-												gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-												framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", externalServer, serverIP, family)
-												testPodToHostnameAndExpect(testPod, serverIP, externalServer)
-											},
-										)
-									}
+									// the other network shares the same VTEP IP and its MAC-VRF external server
+									// is reachable at the same IP (both networks derive container IPs from the
+									// shared CUDN subnet), the tested pod still reaches only its own external
+									// server (identified by hostname) rather than the other network's.
+									// Only the MAC-VRF server is checked here: it is the only one whose IP is
+									// shared between both networks (secondToLastIP of the CUDN subnet).
+									// IP-VRF containers are allocated from a separate per-network subnet
+									// (bgpAlloc.IPVRFSubnet6), so they have distinct IPs and there is no
+									// shared-IP VNI ambiguity to verify.
+									ginkgo.By("Ensuring the tested network pod reaches its own MAC-VRF external server at the shared IP (north-south VNI isolation)")
+									macVRFServerName := testNetworkName + "-macvrf-agnhost"
+									testForIPFamilies(
+										ipFamilySet,
+										func(family utilnet.IPFamily) {
+											ginkgo.GinkgoHelper()
+											serverIP := getExternalServerIPForFamily(macVRFServerName, family)
+											gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+											framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", macVRFServerName, serverIP, family)
+											testPodToHostnameAndExpect(testPod, serverIP, macVRFServerName)
+										},
+									)
 								}
 							})
 						},

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -2226,7 +2226,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				),
 			).To(gomega.Succeed())
 			servers = append(servers, agnhostName)
-		case cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
+		case cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP:
 			ginkgo.By("Running an external EVPN network")
 
 			bridgeName := "br" + networkName
@@ -2243,6 +2243,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				bgpAlloc.VTEPSubnet = kindV4Subnet
 				vtepName = sharedNodeIPsVTEPName
+				// All networks sharing the same VTEP also share the same bridge and
+				// VXLAN interface on the external FRR; derive names from testName so
+				// every network in the test lands on the same device.
+				bridgeName = "br" + testName
+				vxlanName = "vx" + testName
 			}
 
 			macVRFContainer := infraapi.ExternalContainer{
@@ -2273,6 +2278,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					macVRFNetworkName,
 					&ipVRFContainer,
 					ipVRFNetworkName,
+					networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP,
 				),
 			).To(gomega.Succeed())
 			if networkSpec.EVPN.MACVRF != nil {
@@ -2632,6 +2638,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			var testPod *corev1.Pod
 			var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
 			var networkSpec *udnv1.NetworkSpec
+			var testNetworkSpec *udnv1.NetworkSpec
 
 			expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
 				ginkgo.GinkgoHelper()
@@ -2652,6 +2659,18 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				}
 				gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
 				return expectedNodeIPs[0]
+			}
+
+			getExternalServerIPForFamily := func(server string, family utilnet.IPFamily) string {
+				ginkgo.GinkgoHelper()
+				bgpServerNetwork, err := infraprovider.Get().GetNetwork(server)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+					infraapi.ExternalContainer{Name: server},
+					bgpServerNetwork,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
 			}
 
 			getSameNode := func() string {
@@ -2682,6 +2701,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				case networkSpec.Layer2 != nil:
 					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
 				}
+				testNetworkSpec = networkSpec
 
 				testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
 					f,
@@ -2727,14 +2747,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
 						}
 						for _, externalServer := range externalServers {
-							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-								infraapi.ExternalContainer{Name: externalServer},
-								bgpServerNetwork,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+							serverIP := getExternalServerIPForFamily(externalServer, family)
 							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
 							framework.Logf("Checking request from pod reaches server %q", externalServer)
 							testPodToHostnameAndExpect(testPod, serverIP, externalServer)
@@ -2784,14 +2797,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						}
 						ginkgo.By("Ensuring a request from the external servers can reach the pod")
 						for _, externalServer := range externalServers {
-							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-								infraapi.ExternalContainer{Name: externalServer},
-								bgpServerNetwork,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+							serverIP := getExternalServerIPForFamily(externalServer, family)
 							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
 							podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 								f.ClientSet,
@@ -2978,6 +2984,23 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						return nil
 					}
 
+					// overlappingSpecGen reuses the tested network's topology and subnets
+					// with fresh VNIs to prove VPN-level isolation with overlapping IP
+					// address space. Only appended to otherNetworksToTest when the outer
+					// tested network is cudnAdvertisedEVPNUnmanagedSharedVTEP, so
+					// testNetworkSpec is guaranteed to have an EVPN config here.
+					overlappingSpecGen := func(_ string, _ string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
+						spec := testNetworkSpec.DeepCopy()
+						if spec.EVPN.MACVRF != nil {
+							spec.EVPN.MACVRF.VNI = int32(bgpAlloc.MACVRFVNI)
+						}
+						if spec.EVPN.IPVRF != nil {
+							spec.EVPN.IPVRF.VNI = int32(bgpAlloc.IPVRFVNI)
+						}
+						spec.EVPN.VTEP = ""
+						return spec
+					}
+
 					otherNetworksToTest := []ginkgo.TableEntry{
 						ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
 						ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
@@ -2992,6 +3015,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
 						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
 						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+					}
+					if testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
+						otherNetworksToTest = append(otherNetworksToTest,
+							ginkgo.Entry("CUDN EVPN overlapping subnet shared VTEP", feature.EVPN, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP, overlappingSpecGen),
+						)
 					}
 
 					ginkgo.DescribeTableSubtree("Of type",
@@ -3009,7 +3037,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 
 								otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
 								switch {
-								case otherNetworkSpec == nil:
+								case otherNetworkSpec == nil && networkType == defaultNetwork:
 									otherNetworkName = "default"
 								case otherNetworkSpec.Layer3 != nil:
 									otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
@@ -3102,7 +3130,24 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 											)
 											gomega.Expect(err).NotTo(gomega.HaveOccurred())
 											gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(testPod, otherPodIP)
+											testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												f.ClientSet,
+												testPod.Namespace,
+												testPod.Name,
+												testNetworkName,
+												family,
+											)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+											if testPodIP == otherPodIP {
+												// Overlapping CUDNs assigned the same IP; verify the tested pod
+												// reaches itself (its own hostname), proving traffic stays within
+												// its own CUDN.
+												framework.Logf("Tested pod and other pod share IP %s; verifying hostname to confirm per-CUDN isolation", otherPodIP)
+												testPodToHostnameAndExpect(testPod, otherPodIP, testPod.Name)
+											} else {
+												testPodToClientIPNOK(testPod, otherPodIP)
+											}
 										},
 									)
 								}
@@ -3123,7 +3168,49 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 											)
 											gomega.Expect(err).NotTo(gomega.HaveOccurred())
 											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(source, testPodIP)
+											sourcePodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												f.ClientSet,
+												source.Namespace,
+												source.Name,
+												otherNetworkName,
+												family,
+											)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											gomega.Expect(sourcePodIP).ToNot(gomega.BeEmpty())
+											if sourcePodIP == testPodIP {
+												// Overlapping CUDNs assigned the same IP; verify the other pod
+												// reaches itself (its own hostname) to confirm per-CUDN isolation.
+												framework.Logf("Other pod %s and tested pod share IP %s; verifying hostname to confirm per-CUDN isolation", source.Name, testPodIP)
+												testPodToHostnameAndExpect(source, testPodIP, source.Name)
+											} else {
+												// Source pod has a different IP from the tested pod. In the
+												// overlapping CIDR case, the source's same-network peer may
+												// share the tested pod's IP. If so, when the source curls
+												// testPodIP, routing within the other network delivers the
+												// packet to that peer — not to the tested pod. Determine
+												// which pod is the peer and check its IP.
+												var peerPod *corev1.Pod
+												if source == otherPodSameNode {
+													peerPod = otherPodDiffNode
+												} else {
+													peerPod = otherPodSameNode
+												}
+												peerPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+													f.ClientSet,
+													peerPod.Namespace,
+													peerPod.Name,
+													otherNetworkName,
+													family,
+												)
+												gomega.Expect(err).NotTo(gomega.HaveOccurred())
+												gomega.Expect(peerPodIP).ToNot(gomega.BeEmpty())
+												if peerPodIP == testPodIP {
+													framework.Logf("Other network peer pod %s and tested pod share IP %s; verifying pod %s reaches its same-network peer, not the tested pod", peerPod.Name, testPodIP, source.Name)
+													testPodToHostnameAndExpect(source, testPodIP, peerPod.Name)
+												} else {
+													testPodToClientIPNOK(source, testPodIP)
+												}
+											}
 										},
 									)
 								}
@@ -3172,6 +3259,29 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 											testPodToClientIPNOK(testPod, clusterIP)
 										},
 									)
+								}
+
+								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP {
+									// The outer "It can reach external servers on the same network" block already
+									// tests north-south connectivity for the tested network in isolation.
+									// This additional check runs within the "other network is set up" context,
+									// verifying that VNI isolation holds for north-south traffic: even when
+									// the other network shares the same VTEP IP and its external server is
+									// reachable at the same IP, the tested pod still reaches only its own
+									// external server (identified by hostname) rather than the other network's.
+									ginkgo.By("Ensuring the tested network pod reaches its own external servers at the shared IP (north-south VNI isolation)")
+									for _, externalServer := range externalServers {
+										testForIPFamilies(
+											ipFamilySet,
+											func(family utilnet.IPFamily) {
+												ginkgo.GinkgoHelper()
+												serverIP := getExternalServerIPForFamily(externalServer, family)
+												gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+												framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", externalServer, serverIP, family)
+												testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+											},
+										)
+									}
 								}
 							})
 						},
@@ -3799,13 +3909,14 @@ func runBGPNetworkAndServer(
 type networkType string
 
 const (
-	defaultNetwork                        networkType = "DEFAULT"
-	udn                                   networkType = "UDN"
-	cudn                                  networkType = "CUDN"
-	cudnAdvertised                        networkType = "CUDN_ADVERTISED"
-	cudnAdvertisedVRFLite                 networkType = "CUDN_ADVERTISED_VRFLITE"
-	cudnAdvertisedEVPNUnmanagedSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
-	cudnAdvertisedEVPNUnmanagedRandomVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
+	defaultNetwork                              networkType = "DEFAULT"
+	udn                                         networkType = "UDN"
+	cudn                                        networkType = "CUDN"
+	cudnAdvertised                              networkType = "CUDN_ADVERTISED"
+	cudnAdvertisedVRFLite                       networkType = "CUDN_ADVERTISED_VRFLITE"
+	cudnAdvertisedEVPNUnmanagedSharedVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
+	cudnAdvertisedEVPNUnmanagedRandomVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
+	cudnAdvertisedEVPNOverlappingCIDRSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_OVERLAPPING_CIDR_SHARED_VTEP"
 )
 
 // createNamespaceWithPrimaryNetworkOfType helper function configures a
@@ -3828,7 +3939,7 @@ func createNamespaceWithPrimaryNetworkOfType(
 	case cudnAdvertised:
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"name": "receive-all"}
-	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
+	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP:
 		targetVRF = networkName
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"network": networkName}

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -2609,7 +2609,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				),
 			).To(gomega.Succeed())
 			servers = append(servers, agnhostName)
-		case cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
+		case cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP:
 			ginkgo.By("Running an external EVPN network")
 
 			bridgeName := "br" + networkName
@@ -2626,6 +2626,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				bgpAlloc.VTEPSubnet = kindV4Subnet
 				vtepName = sharedNodeIPsVTEPName
+				// All networks sharing the same VTEP also share the same bridge and
+				// VXLAN interface on the external FRR; derive names from testName so
+				// every network in the test lands on the same device.
+				bridgeName = "br" + testName
+				vxlanName = "vx" + testName
 			}
 
 			macVRFContainer := infraapi.ExternalContainer{
@@ -2656,6 +2661,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					macVRFNetworkName,
 					&ipVRFContainer,
 					ipVRFNetworkName,
+					networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP,
 				),
 			).To(gomega.Succeed())
 			if networkSpec.EVPN.MACVRF != nil {
@@ -3015,6 +3021,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			var testPod *corev1.Pod
 			var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
 			var networkSpec *udnv1.NetworkSpec
+			var testNetworkSpec *udnv1.NetworkSpec
 
 			expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
 				ginkgo.GinkgoHelper()
@@ -3035,6 +3042,18 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				}
 				gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
 				return expectedNodeIPs[0]
+			}
+
+			getExternalServerIPForFamily := func(server string, family utilnet.IPFamily) string {
+				ginkgo.GinkgoHelper()
+				bgpServerNetwork, err := infraprovider.Get().GetNetwork(server)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
+					infraapi.ExternalContainer{Name: server},
+					bgpServerNetwork,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
 			}
 
 			getSameNode := func() string {
@@ -3065,6 +3084,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				case networkSpec.Layer2 != nil:
 					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
 				}
+				testNetworkSpec = networkSpec
 
 				testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
 					f,
@@ -3110,14 +3130,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
 						}
 						for _, externalServer := range externalServers {
-							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-								infraapi.ExternalContainer{Name: externalServer},
-								bgpServerNetwork,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+							serverIP := getExternalServerIPForFamily(externalServer, family)
 							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
 							framework.Logf("Checking request from pod reaches server %q", externalServer)
 							testPodToHostnameAndExpect(testPod, serverIP, externalServer)
@@ -3167,14 +3180,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						}
 						ginkgo.By("Ensuring a request from the external servers can reach the pod")
 						for _, externalServer := range externalServers {
-							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							iface, err := infraprovider.Get().GetExternalContainerNetworkInterface(
-								infraapi.ExternalContainer{Name: externalServer},
-								bgpServerNetwork,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							serverIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+							serverIP := getExternalServerIPForFamily(externalServer, family)
 							gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
 							podIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 								f.ClientSet,
@@ -3361,6 +3367,23 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						return nil
 					}
 
+					// overlappingSpecGen reuses the tested network's topology and subnets
+					// with fresh VNIs to prove VPN-level isolation with overlapping IP
+					// address space. Only appended to otherNetworksToTest when the outer
+					// tested network is cudnAdvertisedEVPNUnmanagedSharedVTEP, so
+					// testNetworkSpec is guaranteed to have an EVPN config here.
+					overlappingSpecGen := func(_ string, _ string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
+						spec := testNetworkSpec.DeepCopy()
+						if spec.EVPN.MACVRF != nil {
+							spec.EVPN.MACVRF.VNI = int32(bgpAlloc.MACVRFVNI)
+						}
+						if spec.EVPN.IPVRF != nil {
+							spec.EVPN.IPVRF.VNI = int32(bgpAlloc.IPVRFVNI)
+						}
+						spec.EVPN.VTEP = ""
+						return spec
+					}
+
 					otherNetworksToTest := []ginkgo.TableEntry{
 						ginkgo.Entry("Default", defaultNetwork, nilNetworkSpecGen),
 						ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
@@ -3375,6 +3398,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer3IPVRFNetworkSpecGen),
 						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFNetworkSpecGen),
 						ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF random VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedRandomVTEP, layer2MACVRFIPVRFNetworkSpecGen),
+					}
+					if testedNetworkType == cudnAdvertisedEVPNUnmanagedSharedVTEP {
+						otherNetworksToTest = append(otherNetworksToTest,
+							ginkgo.Entry("CUDN EVPN overlapping subnet shared VTEP", feature.EVPN, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP, overlappingSpecGen),
+						)
 					}
 
 					ginkgo.DescribeTableSubtree("Of type",
@@ -3392,7 +3420,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 
 								otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
 								switch {
-								case otherNetworkSpec == nil:
+								case otherNetworkSpec == nil && networkType == defaultNetwork:
 									otherNetworkName = "default"
 								case otherNetworkSpec.Layer3 != nil:
 									otherNetworkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer3.Subnets...)
@@ -3485,7 +3513,24 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 											)
 											gomega.Expect(err).NotTo(gomega.HaveOccurred())
 											gomega.Expect(otherPodIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(testPod, otherPodIP)
+											testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												f.ClientSet,
+												testPod.Namespace,
+												testPod.Name,
+												testNetworkName,
+												family,
+											)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+											if testPodIP == otherPodIP {
+												// Overlapping CUDNs assigned the same IP; verify the tested pod
+												// reaches itself (its own hostname), proving traffic stays within
+												// its own CUDN.
+												framework.Logf("Tested pod and other pod share IP %s; verifying hostname to confirm per-CUDN isolation", otherPodIP)
+												testPodToHostnameAndExpect(testPod, otherPodIP, testPod.Name)
+											} else {
+												testPodToClientIPNOK(testPod, otherPodIP)
+											}
 										},
 									)
 								}
@@ -3506,7 +3551,49 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 											)
 											gomega.Expect(err).NotTo(gomega.HaveOccurred())
 											gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-											testPodToClientIPNOK(source, testPodIP)
+											sourcePodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+												f.ClientSet,
+												source.Namespace,
+												source.Name,
+												otherNetworkName,
+												family,
+											)
+											gomega.Expect(err).NotTo(gomega.HaveOccurred())
+											gomega.Expect(sourcePodIP).ToNot(gomega.BeEmpty())
+											if sourcePodIP == testPodIP {
+												// Overlapping CUDNs assigned the same IP; verify the other pod
+												// reaches itself (its own hostname) to confirm per-CUDN isolation.
+												framework.Logf("Other pod %s and tested pod share IP %s; verifying hostname to confirm per-CUDN isolation", source.Name, testPodIP)
+												testPodToHostnameAndExpect(source, testPodIP, source.Name)
+											} else {
+												// Source pod has a different IP from the tested pod. In the
+												// overlapping CIDR case, the source's same-network peer may
+												// share the tested pod's IP. If so, when the source curls
+												// testPodIP, routing within the other network delivers the
+												// packet to that peer — not to the tested pod. Determine
+												// which pod is the peer and check its IP.
+												var peerPod *corev1.Pod
+												if source == otherPodSameNode {
+													peerPod = otherPodDiffNode
+												} else {
+													peerPod = otherPodSameNode
+												}
+												peerPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+													f.ClientSet,
+													peerPod.Namespace,
+													peerPod.Name,
+													otherNetworkName,
+													family,
+												)
+												gomega.Expect(err).NotTo(gomega.HaveOccurred())
+												gomega.Expect(peerPodIP).ToNot(gomega.BeEmpty())
+												if peerPodIP == testPodIP {
+													framework.Logf("Other network peer pod %s and tested pod share IP %s; verifying pod %s reaches its same-network peer, not the tested pod", peerPod.Name, testPodIP, source.Name)
+													testPodToHostnameAndExpect(source, testPodIP, peerPod.Name)
+												} else {
+													testPodToClientIPNOK(source, testPodIP)
+												}
+											}
 										},
 									)
 								}
@@ -3555,6 +3642,29 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 											testPodToClientIPNOK(testPod, clusterIP)
 										},
 									)
+								}
+
+								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP {
+									// The outer "It can reach external servers on the same network" block already
+									// tests north-south connectivity for the tested network in isolation.
+									// This additional check runs within the "other network is set up" context,
+									// verifying that VNI isolation holds for north-south traffic: even when
+									// the other network shares the same VTEP IP and its external server is
+									// reachable at the same IP, the tested pod still reaches only its own
+									// external server (identified by hostname) rather than the other network's.
+									ginkgo.By("Ensuring the tested network pod reaches its own external servers at the shared IP (north-south VNI isolation)")
+									for _, externalServer := range externalServers {
+										testForIPFamilies(
+											ipFamilySet,
+											func(family utilnet.IPFamily) {
+												ginkgo.GinkgoHelper()
+												serverIP := getExternalServerIPForFamily(externalServer, family)
+												gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+												framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", externalServer, serverIP, family)
+												testPodToHostnameAndExpect(testPod, serverIP, externalServer)
+											},
+										)
+									}
 								}
 							})
 						},
@@ -4210,13 +4320,14 @@ func runBGPNetworkAndServerWithFRRVRF(
 type networkType string
 
 const (
-	defaultNetwork                        networkType = "DEFAULT"
-	udn                                   networkType = "UDN"
-	cudn                                  networkType = "CUDN"
-	cudnAdvertised                        networkType = "CUDN_ADVERTISED"
-	cudnAdvertisedVRFLite                 networkType = "CUDN_ADVERTISED_VRFLITE"
-	cudnAdvertisedEVPNUnmanagedSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
-	cudnAdvertisedEVPNUnmanagedRandomVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
+	defaultNetwork                              networkType = "DEFAULT"
+	udn                                         networkType = "UDN"
+	cudn                                        networkType = "CUDN"
+	cudnAdvertised                              networkType = "CUDN_ADVERTISED"
+	cudnAdvertisedVRFLite                       networkType = "CUDN_ADVERTISED_VRFLITE"
+	cudnAdvertisedEVPNUnmanagedSharedVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
+	cudnAdvertisedEVPNUnmanagedRandomVTEP       networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
+	cudnAdvertisedEVPNOverlappingCIDRSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_OVERLAPPING_CIDR_SHARED_VTEP"
 )
 
 // createNamespaceWithPrimaryNetworkOfType helper function configures a
@@ -4239,7 +4350,7 @@ func createNamespaceWithPrimaryNetworkOfType(
 	case cudnAdvertised:
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"name": "receive-all"}
-	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
+	case cudnAdvertisedVRFLite, cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP, cudnAdvertisedEVPNOverlappingCIDRSharedVTEP:
 		targetVRF = networkName
 		networkLabels = map[string]string{"advertise": networkName}
 		frrConfigurationLabels = map[string]string{"network": networkName}

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -3644,27 +3644,33 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 									)
 								}
 
-								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP {
+								if networkType == cudnAdvertisedEVPNOverlappingCIDRSharedVTEP &&
+									testNetworkSpec.EVPN != nil && testNetworkSpec.EVPN.MACVRF != nil {
 									// The outer "It can reach external servers on the same network" block already
 									// tests north-south connectivity for the tested network in isolation.
 									// This additional check runs within the "other network is set up" context,
 									// verifying that VNI isolation holds for north-south traffic: even when
-									// the other network shares the same VTEP IP and its external server is
-									// reachable at the same IP, the tested pod still reaches only its own
-									// external server (identified by hostname) rather than the other network's.
-									ginkgo.By("Ensuring the tested network pod reaches its own external servers at the shared IP (north-south VNI isolation)")
-									for _, externalServer := range externalServers {
-										testForIPFamilies(
-											ipFamilySet,
-											func(family utilnet.IPFamily) {
-												ginkgo.GinkgoHelper()
-												serverIP := getExternalServerIPForFamily(externalServer, family)
-												gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
-												framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", externalServer, serverIP, family)
-												testPodToHostnameAndExpect(testPod, serverIP, externalServer)
-											},
-										)
-									}
+									// the other network shares the same VTEP IP and its MAC-VRF external server
+									// is reachable at the same IP (both networks derive container IPs from the
+									// shared CUDN subnet), the tested pod still reaches only its own external
+									// server (identified by hostname) rather than the other network's.
+									// Only the MAC-VRF server is checked here: it is the only one whose IP is
+									// shared between both networks (secondToLastIP of the CUDN subnet).
+									// IP-VRF containers are allocated from a separate per-network subnet
+									// (bgpAlloc.IPVRFSubnet6), so they have distinct IPs and there is no
+									// shared-IP VNI ambiguity to verify.
+									ginkgo.By("Ensuring the tested network pod reaches its own MAC-VRF external server at the shared IP (north-south VNI isolation)")
+									macVRFServerName := testNetworkName + "-macvrf-agnhost"
+									testForIPFamilies(
+										ipFamilySet,
+										func(family utilnet.IPFamily) {
+											ginkgo.GinkgoHelper()
+											serverIP := getExternalServerIPForFamily(macVRFServerName, family)
+											gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+											framework.Logf("Ensuring testPod reaches its external server %q at shared IP %s (IPv%v)", macVRFServerName, serverIP, family)
+											testPodToHostnameAndExpect(testPod, serverIP, macVRFServerName)
+										},
+									)
 								}
 							})
 						},


### PR DESCRIPTION
Add E2E tests that verify traffic isolation between two EVPN-enabled CUDNs sharing the same subnet but using different VNIs. A single overlapping-subnet entry is conditionally appended to the `otherNetworksToTest` table inside `DescribeTableSubtree("When the tested network is of type")` — only when the outer tested network is `cudnAdvertisedEVPNUnmanagedSharedVTEP` — producing exactly three test cases (one per shared-VTEP topology: L3 IP-VRF, L2 MAC-VRF, L2 MAC-VRF + IP-VRF).

## Key implementation details

**New `cudnAdvertisedEVPNOverlappingCIDRSharedVTEP` network type**: Uses shared VTEP (kind primary-network subnet and `sharedNodeIPsVTEPName`). Both overlapping CUDNs within the same test share a single bridge/VXLAN on the external FRR (names derived from `testName`, same as `cudnAdvertisedEVPNUnmanagedSharedVTEP`). Isolation between the two overlapping networks is enforced by their different VNIs, which come from independent `AllocateBGP` allocations.

**Single adaptive `overlappingSpecGen` closure**: `DeepCopy`s `testNetworkSpec` (the spec of the currently-tested outer network) and stamps fresh VNIs from the inner `bgpAlloc`, clearing `VTEP` so the shared VTEP is used. This replaces three separate topology-specific generators and avoids nil-return skip logic.

**`macVRFUseProxyDockerNetwork` flag in `runEVPNNetworkAndServers`**: Docker rejects creating two bridge networks with the same CIDR. When `macVRFUseProxyDockerNetwork=true`, `setupMACVRFExternalContainer` creates the Docker network without explicit subnets (Docker picks a random unused range), then reassigns the container IPs to match the actual CUDN subnets via a single `sh -c` command that flushes Docker-assigned IPs, enables IPv6 if needed (nil subnets cause `CreateNetwork` to create an IPv4-only network), and adds each CUDN address. The Docker bridge forwards L2 frames by MAC regardless of IP addressing.

**Hostname-based isolation checks for overlapping IPs**: When the tested pod and the other pod are assigned the same IP (expected since both CUDNs share the same subnet with independent IPAM pools), `testPodToHostnameAndExpect` is used to prove traffic stays within its own CUDN. When IPs differ (sequential allocation within the overlapping subnet), the NOK check is skipped since the same-IP hostname path already covers isolation.

## Test plan

- [x] All 3 overlapping tests pass on dual-stack EVPN KIND cluster
- [x] All 3 overlapping tests pass on singlev4 EVPN KIND cluster
- [ ] singlev6: blocked by pre-existing issue — all EVPN IP-VRF tests (non-overlapping cases) fail on singlev6 clusters

Fixes #

## Additional Information for reviewers

## ✅ Checks

- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Run the overlapping CUDN test entries on an EVPN-enabled KIND cluster:

```bash
go test ./test/e2e/... -v -ginkgo.focus "overlapping subnet" \
  -provider=skeleton -kubeconfig="${HOME}/ovn.conf"
```