### PR TITLE
Batch UDN Node Annotation Updates to Reduce Contention and Kubeapi Throttling

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/managedbgp"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/networkconnect"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/node"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/nooverlay"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/routeadvertisements"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/status_manager"
@@ -28,6 +29,7 @@ import (
 	udntemplate "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
 	vtepcontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/vtep"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	nodecontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllers/node"
 	networkconnectclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/clientset/versioned"
 	rainformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/routeadvertisements/v1"
@@ -77,6 +79,9 @@ type ClusterManager struct {
 	noOverlayController  *nooverlay.Controller
 	managedBGPController *managedbgp.Controller
 	vtepController       *vtepcontroller.Controller
+
+	// nodeAnnotationBatcher batches node annotation updates across all networks
+	nodeAnnotationBatcher *node.NodeAnnotationBatcher
 }
 
 // NewClusterManager creates a new cluster manager to manage the cluster nodes.
@@ -88,6 +93,7 @@ func NewClusterManager(
 ) (*ClusterManager, error) {
 
 	wf = wf.ShallowClone()
+
 	cm := &ClusterManager{
 		client:         ovnClient.KubeClient,
 		wf:             wf,
@@ -118,17 +124,20 @@ func NewClusterManager(
 	cm.statusManager = status_manager.NewStatusManager(wf, ovnClient, cm.networkManager.Interface())
 
 	nodeController := nodecontroller.NewController(wf, "clustermanager-node", cm.networkManager.Interface())
-	defaultNetClusterController := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, ovnClient, wf, recorder, nodeController)
+
+	kubeInterface := &kube.Kube{KClient: ovnClient.KubeClient}
+	cm.nodeAnnotationBatcher = node.NewNodeAnnotationBatcher(kubeInterface)
+
+	cm.defaultNetClusterController = newDefaultNetworkClusterController(&util.DefaultNetInfo{}, ovnClient, wf, recorder, nodeController, cm.nodeAnnotationBatcher)
 	zoneClusterController, err := newZoneClusterController(ovnClient, wf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zone cluster controller, err : %w", err)
 	}
-	cm.defaultNetClusterController = defaultNetClusterController
 	cm.nodeController = nodeController
 	cm.zoneClusterController = zoneClusterController
 
 	if config.OVNKubernetesFeature.EnableMultiNetwork {
-		cm.udnClusterManager, err = newUserDefinedNetworkClusterManager(ovnClient, wf, cm.networkManager.Interface(), recorder, nodeController)
+		cm.udnClusterManager, err = newUserDefinedNetworkClusterManager(ovnClient, wf, cm.networkManager.Interface(), recorder, nodeController, cm.nodeAnnotationBatcher)
 		if err != nil {
 			return nil, err
 		}
@@ -245,6 +254,10 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 		return err
 	}
 
+	if err := controller.Start(cm.nodeAnnotationBatcher.Reconciler()); err != nil {
+		return err
+	}
+
 	if err := cm.defaultNetClusterController.Start(ctx); err != nil {
 		return err
 	}
@@ -326,6 +339,7 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 // Stop the cluster manager.
 func (cm *ClusterManager) Stop() {
 	klog.Info("Stopping the cluster manager")
+
 	cm.defaultNetClusterController.Stop()
 	cm.zoneClusterController.Stop()
 
@@ -364,6 +378,8 @@ func (cm *ClusterManager) Stop() {
 		cm.noOverlayController = nil
 	}
 	cm.nodeController.Stop()
+
+	controller.Stop(cm.nodeAnnotationBatcher.Reconciler())
 }
 
 func (cm *ClusterManager) NewNetworkController(netInfo util.NetInfo) (networkmanager.NetworkController, error) {

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -96,6 +96,9 @@ type networkClusterController struct {
 	nadKeysLock sync.Mutex
 	lastNADKeys sets.Set[string]
 
+	// nodeAnnotationBatcher batches node annotation updates across networks
+	nodeAnnotationBatcher *node.NodeAnnotationBatcher
+
 	util.ReconcilableNetInfo
 }
 
@@ -192,6 +195,7 @@ func newNetworkClusterController(
 	networkManager networkmanager.Interface,
 	errorReporter NetworkStatusReporter,
 	nodeReconciler *sharednode.NodeController,
+	batcher *node.NodeAnnotationBatcher,
 ) *networkClusterController {
 	kube := &kube.KubeOVN{
 		Kube: kube.Kube{
@@ -203,23 +207,24 @@ func newNetworkClusterController(
 	wg := &sync.WaitGroup{}
 
 	ncc := &networkClusterController{
-		ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo),
-		watchFactory:        wf,
-		kube:                kube,
-		stopChan:            make(chan struct{}),
-		wg:                  wg,
-		recorder:            recorder,
-		networkManager:      networkManager,
-		nodeReconciler:      nodeReconciler,
-		statusReporter:      errorReporter,
-		nodeErrors:          make(map[string]string),
-		nodeErrorsLock:      sync.Mutex{},
+		ReconcilableNetInfo:   util.NewReconcilableNetInfo(netInfo),
+		watchFactory:          wf,
+		kube:                  kube,
+		stopChan:              make(chan struct{}),
+		wg:                    wg,
+		recorder:              recorder,
+		networkManager:        networkManager,
+		nodeReconciler:        nodeReconciler,
+		statusReporter:        errorReporter,
+		nodeErrors:            make(map[string]string),
+		nodeErrorsLock:        sync.Mutex{},
+		nodeAnnotationBatcher: batcher,
 	}
 
 	return ncc
 }
 
-func newDefaultNetworkClusterController(netInfo util.NetInfo, ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory, recorder record.EventRecorder, nodeReconciler *sharednode.NodeController) *networkClusterController {
+func newDefaultNetworkClusterController(netInfo util.NetInfo, ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory, recorder record.EventRecorder, nodeReconciler *sharednode.NodeController, batcher *node.NodeAnnotationBatcher) *networkClusterController {
 	// use an allocator that can only allocate a single network ID for the
 	// defaiult network
 	networkIDAllocator := id.NewIDAllocator(types.DefaultNetworkName, 1)
@@ -229,7 +234,7 @@ func newDefaultNetworkClusterController(netInfo util.NetInfo, ovnClient *util.OV
 		panic(fmt.Errorf("could not reserve default network ID: %w", err))
 	}
 
-	return newNetworkClusterController(netInfo, ovnClient, wf, recorder, networkmanager.Default().Interface(), nil, nodeReconciler)
+	return newNetworkClusterController(netInfo, ovnClient, wf, recorder, networkmanager.Default().Interface(), nil, nodeReconciler, batcher)
 }
 
 func (ncc *networkClusterController) nodeIsActive(nodeName string) bool {
@@ -434,7 +439,7 @@ func (ncc *networkClusterController) init() error {
 	}
 
 	if ncc.hasNodeAllocation() {
-		ncc.nodeAllocator = node.NewNodeAllocator(networkID, ncc.GetNetInfo(), ncc.watchFactory.NodeCoreInformer().Lister(), ncc.kube, ncc.tunnelIDAllocator)
+		ncc.nodeAllocator = node.NewNodeAllocator(networkID, ncc.GetNetInfo(), ncc.watchFactory.NodeCoreInformer().Lister(), ncc.kube, ncc.tunnelIDAllocator, ncc.nodeAnnotationBatcher)
 		err := ncc.nodeAllocator.Init()
 		if err != nil {
 			return fmt.Errorf("failed to initialize host subnet ip allocator: %w", err)

--- a/go-controller/pkg/clustermanager/network_cluster_controller_node_test.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller_node_test.go
@@ -33,7 +33,7 @@ func TestShouldReconcileNodeIgnoresOtherNetworkTunnelIDChanges(t *testing.T) {
 		Subnets:  "10.1.0.0/16",
 	})
 	ncc := &networkClusterController{ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo)}
-	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil)
+	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil, nil)
 
 	oldNode := testNodeWithAnnotations("node1", map[string]string{
 		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"9"}`,
@@ -60,7 +60,7 @@ func TestShouldReconcileNodeIgnoresOtherNetworkSubnetChanges(t *testing.T) {
 		NetConf: cnitypes.NetConf{Name: types.DefaultNetworkName, Type: "ovn-k8s-cni-overlay"},
 	})
 	ncc := &networkClusterController{ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo)}
-	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil)
+	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil, nil)
 
 	oldNode := testNodeWithAnnotations("node1", map[string]string{
 		types.NodeSubnetsAnnotation: `{"default":"10.1.0.0/24","red":"10.2.0.0/24"}`,
@@ -92,7 +92,7 @@ func TestShouldReconcileNodeWhenNetworkSpecificTunnelIDChanges(t *testing.T) {
 		Subnets:  "10.1.0.0/16",
 	})
 	ncc := &networkClusterController{ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo)}
-	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil)
+	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil, nil)
 
 	oldNode := testNodeWithAnnotations("node1", map[string]string{
 		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"9"}`,
@@ -119,7 +119,7 @@ func TestShouldReconcileNodeWhenNetworkSpecificSubnetChanges(t *testing.T) {
 		NetConf: cnitypes.NetConf{Name: types.DefaultNetworkName, Type: "ovn-k8s-cni-overlay"},
 	})
 	ncc := &networkClusterController{ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo)}
-	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil)
+	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil, nil)
 
 	oldNode := testNodeWithAnnotations("node1", map[string]string{
 		types.NodeSubnetsAnnotation: `{"default":"10.1.0.0/24","red":"10.2.0.0/24"}`,

--- a/go-controller/pkg/clustermanager/network_cluster_controller_test.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller_test.go
@@ -18,16 +18,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	node "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/node"
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	nodecontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllers/node"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+func createTestBatcher(t *testing.T, fakeClient *util.OVNClusterManagerClientset) *node.NodeAnnotationBatcher {
+	t.Helper()
+	kubeInterface := &kube.Kube{KClient: fakeClient.KubeClient}
+	batcher := node.NewNodeAnnotationBatcher(kubeInterface)
+	if err := controller.Start(batcher.Reconciler()); err != nil {
+		t.Fatalf("Failed to start batcher: %v", err)
+	}
+	t.Cleanup(func() { controller.Stop(batcher.Reconciler()) })
+	return batcher
+}
 
 func TestHandleNetworkRefChangeUpdatesStatusAndMetrics(t *testing.T) {
 	g := gomega.NewWithT(t)
@@ -159,6 +173,8 @@ func TestHandleNetworkRefChangeCleanupWithZeroGraceOnStart(t *testing.T) {
 	g.Expect(nodeController.Start()).To(gomega.Succeed())
 	defer nodeController.Stop()
 
+	batcher := createTestBatcher(t, fakeClient)
+
 	ncc := newNetworkClusterController(
 		netInfo,
 		fakeClient,
@@ -167,6 +183,7 @@ func TestHandleNetworkRefChangeCleanupWithZeroGraceOnStart(t *testing.T) {
 		nm,
 		nil,
 		nodeController,
+		batcher,
 	)
 	g.Expect(ncc.init()).To(gomega.Succeed())
 	g.Expect(ncc.Start(context.Background())).To(gomega.Succeed())
@@ -234,6 +251,8 @@ func TestHandleNetworkRefChangeCleanupWithZeroGraceAfterStart(t *testing.T) {
 	g.Expect(nodeController.Start()).To(gomega.Succeed())
 	defer nodeController.Stop()
 
+	batcher := createTestBatcher(t, fakeClient)
+
 	ncc := newNetworkClusterController(
 		netInfo,
 		fakeClient,
@@ -242,6 +261,7 @@ func TestHandleNetworkRefChangeCleanupWithZeroGraceAfterStart(t *testing.T) {
 		nm,
 		nil,
 		nodeController,
+		batcher,
 	)
 	g.Expect(ncc.init()).To(gomega.Succeed())
 	g.Expect(ncc.Start(context.Background())).To(gomega.Succeed())
@@ -308,6 +328,8 @@ func TestHandleNetworkRefChangeAllocatesOnActivation(t *testing.T) {
 	g.Expect(nodeController.Start()).To(gomega.Succeed())
 	defer nodeController.Stop()
 
+	batcher := createTestBatcher(t, fakeClient)
+
 	ncc := newNetworkClusterController(
 		netInfo,
 		fakeClient,
@@ -316,6 +338,7 @@ func TestHandleNetworkRefChangeAllocatesOnActivation(t *testing.T) {
 		nm,
 		nil,
 		nodeController,
+		batcher,
 	)
 	g.Expect(ncc.init()).To(gomega.Succeed())
 	g.Expect(ncc.Start(context.Background())).To(gomega.Succeed())
@@ -401,6 +424,8 @@ func TestReconcileNodeCleansUpOnNoHostSubnetTransition(t *testing.T) {
 	g.Expect(nodeController.Start()).To(gomega.Succeed())
 	defer nodeController.Stop()
 
+	batcher := createTestBatcher(t, fakeClient)
+
 	ncc := newNetworkClusterController(
 		netInfo,
 		fakeClient,
@@ -409,16 +434,19 @@ func TestReconcileNodeCleansUpOnNoHostSubnetTransition(t *testing.T) {
 		nm,
 		nil,
 		nodeController,
+		batcher,
 	)
 	g.Expect(ncc.init()).To(gomega.Succeed())
 
 	g.Expect(ncc.ReconcileNode(oldNode, newNode, nil, nil)).To(gomega.Succeed())
 
-	updatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), newNode.Name, metav1.GetOptions{})
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(util.HasNodeHostSubnetAnnotation(updatedNode, networkName)).To(gomega.BeFalse())
-	_, err = util.ParseNetworkIDAnnotation(updatedNode, networkName)
-	g.Expect(util.IsAnnotationNotSetError(err)).To(gomega.BeTrue())
+	g.Eventually(func(innerG gomega.Gomega) {
+		updatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), newNode.Name, metav1.GetOptions{})
+		innerG.Expect(err).ToNot(gomega.HaveOccurred())
+		innerG.Expect(util.HasNodeHostSubnetAnnotation(updatedNode, networkName)).To(gomega.BeFalse())
+		_, err = util.ParseNetworkIDAnnotation(updatedNode, networkName)
+		innerG.Expect(util.IsAnnotationNotSetError(err)).To(gomega.BeTrue())
+	}, 5*time.Second, 100*time.Millisecond).Should(gomega.Succeed())
 }
 
 func TestReconcileNodeMarksNodeSyncFailedOnCleanupError(t *testing.T) {
@@ -472,6 +500,7 @@ func TestReconcileNodeMarksNodeSyncFailedOnCleanupError(t *testing.T) {
 		nm,
 		nil,
 		nodeController,
+		nil,
 	)
 	g.Expect(ncc.init()).To(gomega.Succeed())
 

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
@@ -47,9 +46,12 @@ type NodeAllocator struct {
 
 	// nodeSubnets is a list of node subnets that are managed by the cluster subnet allocator
 	nodeSubnets []*net.IPNet
+
+	// batcher batches annotation updates across all networks for better API server efficiency
+	batcher *NodeAnnotationBatcher
 }
 
-func NewNodeAllocator(networkID int, netInfo util.NetInfo, nodeLister listers.NodeLister, kube kube.Interface, tunnelIDAllocator id.Allocator) *NodeAllocator {
+func NewNodeAllocator(networkID int, netInfo util.NetInfo, nodeLister listers.NodeLister, kube kube.Interface, tunnelIDAllocator id.Allocator, batcher *NodeAnnotationBatcher) *NodeAllocator {
 	na := &NodeAllocator{
 		kube:                         kube,
 		nodeLister:                   nodeLister,
@@ -58,6 +60,7 @@ func NewNodeAllocator(networkID int, netInfo util.NetInfo, nodeLister listers.No
 		clusterSubnetAllocator:       NewSubnetAllocator(),
 		hybridOverlaySubnetAllocator: NewSubnetAllocator(),
 		idAllocator:                  tunnelIDAllocator,
+		batcher:                      batcher,
 	}
 
 	if na.hasNodeSubnetAllocation() {
@@ -523,49 +526,16 @@ func (na *NodeAllocator) Sync(nodes []interface{}) error {
 	return nil
 }
 
-// updateNodeNetworkAnnotationsWithRetry will update the node's subnet annotation and network id annotation
 func (na *NodeAllocator) updateNodeNetworkAnnotationsWithRetry(nodeName string, hostSubnetsMap map[string][]*net.IPNet, networkId, tunnelID int) error {
-	// Retry if it fails because of potential conflict which is transient. Return error in the
-	// case of other errors (say temporary API server down), and it will be taken care of by the
-	// retry mechanism.
-	resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		// Informer cache should not be mutated, so get a copy of the object
-		node, err := na.nodeLister.Get(nodeName)
-		if err != nil {
-			return err
-		}
+	if na.batcher == nil {
+		return fmt.Errorf("node annotation batcher is required but was not configured")
+	}
 
-		cnode := node.DeepCopy()
-		for netName, hostSubnets := range hostSubnetsMap {
-			cnode.Annotations, err = util.UpdateNodeHostSubnetAnnotation(cnode.Annotations, hostSubnets, netName)
-			if err != nil {
-				return fmt.Errorf("failed to update node %q annotation subnet %s: %w",
-					node.Name, util.JoinIPNets(hostSubnets, ","), err)
-			}
-		}
-
-		networkName := na.netInfo.GetNetworkName()
-
-		if networkId != types.NoNetworkID {
-			cnode.Annotations, err = util.UpdateNetworkIDAnnotation(cnode.Annotations, networkName, networkId)
-			if err != nil {
-				return fmt.Errorf("failed to update node %q network id annotation %d for network %s: %w",
-					node.Name, networkId, networkName, err)
-			}
-		}
-		if tunnelID != types.NoTunnelID {
-			cnode.Annotations, err = util.UpdateUDNLayer2NodeGRLRPTunnelIDs(cnode.Annotations, networkName, tunnelID)
-			if err != nil {
-				return fmt.Errorf("failed to update node %q tunnel id annotation %d for network %s: %w",
-					node.Name, tunnelID, networkName, err)
-			}
-		}
-		// It is possible to update the node annotations using status subresource
-		// because changes to metadata via status subresource are not restricted for nodes.
-		return na.kube.UpdateNodeStatus(cnode)
-	})
-	if resultErr != nil {
-		return fmt.Errorf("failed to update node %s annotation: %w", nodeName, resultErr)
+	networkName := na.netInfo.GetNetworkName()
+	hostSubnets, hasSubnetUpdate := hostSubnetsMap[networkName]
+	if hasSubnetUpdate || networkId != types.NoNetworkID || tunnelID != types.NoTunnelID {
+		na.batcher.EnqueueUpdate(nodeName, networkName, hostSubnets, networkId, tunnelID)
+		klog.V(5).Infof("Enqueued annotation update for node %s network %s to batcher", nodeName, networkName)
 	}
 	return nil
 }
@@ -588,7 +558,7 @@ func (na *NodeAllocator) Cleanup() error {
 			continue
 		}
 
-		hostSubnetsMap := map[string][]*net.IPNet{networkName: nil}
+		hostSubnetsMap := map[string][]*net.IPNet{networkName: {}}
 		// passing util.InvalidID deletes the network/tunnel id annotation for the network.
 		err = na.updateNodeNetworkAnnotationsWithRetry(node.Name, hostSubnetsMap, types.InvalidID, types.InvalidID)
 		if err != nil {

--- a/go-controller/pkg/clustermanager/node/node_allocator_test.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/id"
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	sharednode "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllers/node"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -690,11 +692,18 @@ func TestController_CleanupNodeRemovesUDNAnnotations(t *testing.T) {
 	fakeClient := fake.NewClientset(node)
 	kube := &kube.Kube{KClient: fakeClient}
 
+	batcher := NewNodeAnnotationBatcher(kube)
+	if err := controller.Start(batcher.Reconciler()); err != nil {
+		t.Fatal(err)
+	}
+	defer controller.Stop(batcher.Reconciler())
+
 	na := &NodeAllocator{
 		nodeLister:             newFakeNodeLister([]*corev1.Node{node}),
 		kube:                   kube,
 		netInfo:                netInfo,
 		clusterSubnetAllocator: NewSubnetAllocator(),
+		batcher:                batcher,
 	}
 	_, subnetCIDR, err := net.ParseCIDR("10.1.0.0/16")
 	if err != nil {
@@ -711,6 +720,9 @@ func TestController_CleanupNodeRemovesUDNAnnotations(t *testing.T) {
 		t.Fatalf("CleanupNode failed: %v", err)
 	}
 
+	if !testing.Short() {
+		time.Sleep(500 * time.Millisecond)
+	}
 	updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -762,12 +774,19 @@ func TestController_CleanupNodeReleasesTunnelIDs(t *testing.T) {
 	fakeClient := fake.NewClientset(node)
 	kube := &kube.Kube{KClient: fakeClient}
 
+	batcher := NewNodeAnnotationBatcher(kube)
+	if err := controller.Start(batcher.Reconciler()); err != nil {
+		t.Fatal(err)
+	}
+	defer controller.Stop(batcher.Reconciler())
+
 	na := &NodeAllocator{
 		nodeLister:             newFakeNodeLister([]*corev1.Node{node}),
 		kube:                   kube,
 		netInfo:                netInfo,
 		clusterSubnetAllocator: NewSubnetAllocator(),
 		idAllocator:            id.NewIDAllocator("tunnel-ids", 1024),
+		batcher:                batcher,
 	}
 	if err := na.idAllocator.ReserveID(networkName+"_"+node.Name, 42); err != nil {
 		t.Fatal(err)
@@ -777,6 +796,7 @@ func TestController_CleanupNodeReleasesTunnelIDs(t *testing.T) {
 		t.Fatalf("CleanupNode failed: %v", err)
 	}
 
+	time.Sleep(500 * time.Millisecond)
 	updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)

--- a/go-controller/pkg/clustermanager/node/node_annotation_batcher.go
+++ b/go-controller/pkg/clustermanager/node/node_annotation_batcher.go
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package node
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
+	nodecontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllers/node"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// NodeAnnotationBatcher batches node annotation updates from multiple networks
+// and applies them in a single API call. When multiple networks enqueue updates
+// for the same node before the worker processes it, the workqueue coalesces the
+// key and all pending updates are applied together, reducing API server load.
+type NodeAnnotationBatcher struct {
+	kube kube.Interface
+
+	pendingUpdates map[string]*pendingNodeUpdate
+	mutex          sync.Mutex
+
+	reconciler controller.Reconciler
+
+	cache *nodecontroller.NodeAnnotationCache
+}
+
+// pendingNodeUpdate accumulates annotation updates for a single node
+// from potentially multiple networks before batching them together
+type pendingNodeUpdate struct {
+	hostSubnets map[string][]*net.IPNet
+	networkIDs  map[string]int
+	tunnelIDs   map[string]int
+}
+
+func NewNodeAnnotationBatcher(kube kube.Interface) *NodeAnnotationBatcher {
+	b := &NodeAnnotationBatcher{
+		kube:           kube,
+		pendingUpdates: make(map[string]*pendingNodeUpdate),
+		cache:          nodecontroller.NewNodeAnnotationCache(),
+	}
+
+	b.reconciler = controller.NewReconciler("node-annotation-batcher", &controller.ReconcilerConfig{
+		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+		Reconcile:   b.reconcile,
+		Threadiness: 15,
+		MaxAttempts: controller.InfiniteAttempts,
+	})
+
+	return b
+}
+
+func (b *NodeAnnotationBatcher) Reconciler() controller.Reconciler {
+	return b.reconciler
+}
+
+// EnqueueUpdate queues an annotation update for a node from a specific network.
+// Multiple updates for the same node are merged and applied together.
+func (b *NodeAnnotationBatcher) EnqueueUpdate(nodeName, networkName string, hostSubnets []*net.IPNet, networkID, tunnelID int) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	pending, ok := b.pendingUpdates[nodeName]
+	if !ok {
+		pending = &pendingNodeUpdate{
+			hostSubnets: make(map[string][]*net.IPNet),
+			networkIDs:  make(map[string]int),
+			tunnelIDs:   make(map[string]int),
+		}
+		b.pendingUpdates[nodeName] = pending
+	}
+
+	pending.hostSubnets[networkName] = hostSubnets
+	if networkID != types.NoNetworkID {
+		pending.networkIDs[networkName] = networkID
+	}
+	if tunnelID != types.NoTunnelID {
+		pending.tunnelIDs[networkName] = tunnelID
+	}
+
+	klog.V(5).Infof("Enqueued annotation update for node %s network %s (subnets=%v, netID=%v, tunnelID=%v)",
+		nodeName, networkName, len(hostSubnets), networkID, tunnelID)
+
+	b.reconciler.Reconcile(nodeName)
+}
+
+func (b *NodeAnnotationBatcher) reconcile(nodeName string) error {
+	b.mutex.Lock()
+	pending, ok := b.pendingUpdates[nodeName]
+	if ok {
+		delete(b.pendingUpdates, nodeName)
+	}
+	b.mutex.Unlock()
+
+	if !ok || pending == nil {
+		return nil
+	}
+
+	klog.V(4).Infof("Processing batched annotation update for node %s (%d networks)",
+		nodeName, len(pending.hostSubnets)+len(pending.networkIDs)+len(pending.tunnelIDs))
+
+	return b.updateNodeAnnotations(nodeName, pending)
+}
+
+func pendingNodeUpdateToString(pending *pendingNodeUpdate) string {
+	allNetworks := make(map[string]bool)
+	for name := range pending.hostSubnets {
+		allNetworks[name] = true
+	}
+	for name := range pending.networkIDs {
+		allNetworks[name] = true
+	}
+	for name := range pending.tunnelIDs {
+		allNetworks[name] = true
+	}
+	var perNetwork []string
+	for name := range allNetworks {
+		var parts []string
+		if subnets, ok := pending.hostSubnets[name]; ok {
+			parts = append(parts, fmt.Sprintf("subnets=%v", subnets))
+		}
+		if netID, ok := pending.networkIDs[name]; ok {
+			parts = append(parts, fmt.Sprintf("netID=%d", netID))
+		}
+		if tunID, ok := pending.tunnelIDs[name]; ok {
+			parts = append(parts, fmt.Sprintf("tunnelID=%d", tunID))
+		}
+		perNetwork = append(perNetwork, fmt.Sprintf("%s{%s}", name, strings.Join(parts, ", ")))
+	}
+	return strings.Join(perNetwork, "; ")
+}
+
+func (b *NodeAnnotationBatcher) updateNodeAnnotations(nodeName string, pending *pendingNodeUpdate) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cnode, err := b.kube.GetNode(nodeName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("Node %s not found, dropping annotation update", nodeName)
+				return nil
+			}
+			return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		}
+
+		existingSubnets, err := b.cache.ParseNodeHostSubnetsAnnotationCached(cnode)
+		if err != nil && !util.IsAnnotationNotSetError(err) {
+			return fmt.Errorf("failed to parse existing node-subnets for node %s: %w", nodeName, err)
+		} else if existingSubnets == nil {
+			existingSubnets = make(map[string][]*net.IPNet)
+		}
+
+		existingNetworkIDs, err := b.cache.ParseNetworkIDsMapCached(cnode)
+		if err != nil && !util.IsAnnotationNotSetError(err) {
+			return fmt.Errorf("failed to parse existing network-ids for node %s: %w", nodeName, err)
+		} else if existingNetworkIDs == nil {
+			existingNetworkIDs = make(map[string]int)
+		}
+
+		existingTunnelIDs, err := b.cache.ParseUDNLayer2NodeGRLRPTunnelIDsMapCached(cnode)
+		if err != nil && !util.IsAnnotationNotSetError(err) {
+			return fmt.Errorf("failed to parse existing tunnel-ids for node %s: %w", nodeName, err)
+		} else if existingTunnelIDs == nil {
+			existingTunnelIDs = make(map[string]int)
+		}
+
+		subnetsUpdated := false
+		networkIDsUpdated := false
+		tunnelIDsUpdated := false
+
+		for networkName, subnets := range pending.hostSubnets {
+			existingSubnets[networkName] = subnets
+			subnetsUpdated = true
+		}
+		if subnetsUpdated {
+			cnode.Annotations, err = util.UpdateNodeHostSubnetAnnotationMap(cnode.Annotations, existingSubnets)
+			if err != nil {
+				return fmt.Errorf("failed to update node-subnets annotation for node %s: %w", nodeName, err)
+			}
+		}
+
+		for networkName, networkID := range pending.networkIDs {
+			if networkID != types.NoNetworkID {
+				existingNetworkIDs[networkName] = networkID
+				networkIDsUpdated = true
+			}
+		}
+		if networkIDsUpdated {
+			cnode.Annotations, err = util.UpdateNetworkIDAnnotationMap(cnode.Annotations, existingNetworkIDs)
+			if err != nil {
+				return fmt.Errorf("failed to update network-ids annotation for node %s: %w", nodeName, err)
+			}
+		}
+
+		for networkName, tunnelID := range pending.tunnelIDs {
+			if tunnelID != types.NoTunnelID {
+				existingTunnelIDs[networkName] = tunnelID
+				tunnelIDsUpdated = true
+			}
+		}
+		if tunnelIDsUpdated {
+			cnode.Annotations, err = util.UpdateUDNLayer2NodeGRLRPTunnelIDsMap(cnode.Annotations, existingTunnelIDs)
+			if err != nil {
+				return fmt.Errorf("failed to update tunnel-ids annotation for node %s: %w", nodeName, err)
+			}
+		}
+
+		klog.V(4).Infof("Updating node %s with batched annotations: [%s]", nodeName, pendingNodeUpdateToString(pending))
+
+		// It is possible to update the node annotations using status subresource
+		// because changes to metadata via status subresource are not restricted for nodes.
+		err = b.kube.UpdateNodeStatus(cnode)
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("Node %s not found during status update, dropping annotation update", nodeName)
+			return nil
+		}
+		return err
+	})
+}

--- a/go-controller/pkg/clustermanager/node/node_annotation_batcher_test.go
+++ b/go-controller/pkg/clustermanager/node/node_annotation_batcher_test.go
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package node
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var (
+	subnet1 = &net.IPNet{IP: net.ParseIP("10.1.0.0"), Mask: net.CIDRMask(24, 32)}
+	subnet2 = &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(24, 32)}
+	subnet3 = &net.IPNet{IP: net.ParseIP("10.3.0.0"), Mask: net.CIDRMask(24, 32)}
+	subnet4 = &net.IPNet{IP: net.ParseIP("10.4.0.0"), Mask: net.CIDRMask(24, 32)}
+	subnet5 = &net.IPNet{IP: net.ParseIP("10.5.0.0"), Mask: net.CIDRMask(24, 32)}
+)
+
+func newTestNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{},
+		},
+	}
+}
+
+func setupBatcherTest(t *testing.T, nodes ...*corev1.Node) (*NodeAnnotationBatcher, *fake.Clientset) {
+	t.Helper()
+	fakeClient := fake.NewSimpleClientset()
+
+	for _, node := range nodes {
+		_, err := fakeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create node %s: %v", node.Name, err)
+		}
+	}
+
+	kubeInterface := &kube.Kube{KClient: fakeClient}
+	batcher := NewNodeAnnotationBatcher(kubeInterface)
+
+	return batcher, fakeClient
+}
+
+func startBatcher(t *testing.T, batcher *NodeAnnotationBatcher) {
+	t.Helper()
+	if err := controller.Start(batcher.Reconciler()); err != nil {
+		t.Fatalf("Failed to start batcher: %v", err)
+	}
+}
+
+func stopBatcher(batcher *NodeAnnotationBatcher) {
+	controller.Stop(batcher.Reconciler())
+}
+
+const testSettleTime = 500 * time.Millisecond
+
+func TestNodeAnnotationBatcher_BasicBatching(t *testing.T) {
+	// This test reproduces the race condition where successive reconcile
+	// cycles for the same node read stale state and overwrite
+	// annotations set by the previous reconcile.
+	node1 := newTestNode("node1")
+	node2 := newTestNode("node2")
+	node3 := newTestNode("node3")
+
+	batcher, fakeClient := setupBatcherTest(t, node1, node2, node3)
+	startBatcher(t, batcher)
+	defer stopBatcher(batcher)
+
+	// Phase 1: first batch of updates — one network per node
+	batcher.EnqueueUpdate("node1", "network1", []*net.IPNet{subnet1}, 1, types.NoTunnelID)
+	batcher.EnqueueUpdate("node2", "network1", []*net.IPNet{subnet3}, 1, types.NoTunnelID)
+	batcher.EnqueueUpdate("node3", "network1", []*net.IPNet{subnet5}, 1, types.NoTunnelID)
+
+	// Phase 2: enqueue a second network for node1 and node2.
+	// This triggers a new reconcile that must merge with the phase 1 annotations.
+	batcher.EnqueueUpdate("node1", "network2", []*net.IPNet{subnet2}, 2, types.NoTunnelID)
+	batcher.EnqueueUpdate("node2", "network3", []*net.IPNet{subnet4}, 3, types.NoTunnelID)
+
+	time.Sleep(testSettleTime)
+
+	// Verify node1 has both networks (network1 from phase 1 + network2 from phase 2)
+	updatedNode1, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node1: %v", err)
+	}
+	subnets1, err := util.ParseNodeHostSubnetsAnnotation(updatedNode1)
+	if err != nil {
+		t.Fatalf("Failed to parse node1 subnet annotation: %v", err)
+	}
+	if len(subnets1) != 2 {
+		t.Fatalf("node1: expected 2 networks, got %d (phase 1 annotations likely overwritten by stale lister state)", len(subnets1))
+	}
+	if _, ok := subnets1["network1"]; !ok {
+		t.Error("node1: network1 subnet not found — phase 1 annotation was overwritten")
+	}
+	if _, ok := subnets1["network2"]; !ok {
+		t.Error("node1: network2 subnet not found")
+	}
+
+	networkIDs1, err := util.GetNodeNetworkIDsAnnotationNetworkIDs(updatedNode1)
+	if err != nil {
+		t.Fatalf("Failed to parse node1 network IDs: %v", err)
+	}
+	if networkIDs1["network1"] != 1 {
+		t.Errorf("node1: expected network1 ID 1, got %d", networkIDs1["network1"])
+	}
+	if networkIDs1["network2"] != 2 {
+		t.Errorf("node1: expected network2 ID 2, got %d", networkIDs1["network2"])
+	}
+
+	// Verify node2 has both networks (network1 from phase 1 + network3 from phase 2)
+	updatedNode2, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node2: %v", err)
+	}
+	subnets2, err := util.ParseNodeHostSubnetsAnnotation(updatedNode2)
+	if err != nil {
+		t.Fatalf("Failed to parse node2 subnet annotation: %v", err)
+	}
+	if len(subnets2) != 2 {
+		t.Fatalf("node2: expected 2 networks, got %d (phase 1 annotations likely overwritten by stale lister state)", len(subnets2))
+	}
+	if _, ok := subnets2["network1"]; !ok {
+		t.Error("node2: network1 subnet not found — phase 1 annotation was overwritten")
+	}
+	if _, ok := subnets2["network3"]; !ok {
+		t.Error("node2: network3 subnet not found")
+	}
+
+	networkIDs2, err := util.GetNodeNetworkIDsAnnotationNetworkIDs(updatedNode2)
+	if err != nil {
+		t.Fatalf("Failed to parse node2 network IDs: %v", err)
+	}
+	if networkIDs2["network1"] != 1 {
+		t.Errorf("node2: expected network1 ID 1, got %d", networkIDs2["network1"])
+	}
+	if networkIDs2["network3"] != 3 {
+		t.Errorf("node2: expected network3 ID 3, got %d", networkIDs2["network3"])
+	}
+
+	// Verify node3 still has network1 from phase 1 (no phase 2 update)
+	updatedNode3, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node3", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node3: %v", err)
+	}
+	subnets3, err := util.ParseNodeHostSubnetsAnnotation(updatedNode3)
+	if err != nil {
+		t.Fatalf("Failed to parse node3 subnet annotation: %v", err)
+	}
+	if len(subnets3) != 1 {
+		t.Fatalf("node3: expected 1 network, got %d", len(subnets3))
+	}
+	if _, ok := subnets3["network1"]; !ok {
+		t.Error("node3: network1 subnet not found")
+	}
+}
+
+func TestNodeAnnotationBatcher_UpdateMerging(t *testing.T) {
+	node1 := newTestNode("node1")
+	node2 := newTestNode("node2")
+
+	batcher, fakeClient := setupBatcherTest(t, node1, node2)
+	startBatcher(t, batcher)
+	defer stopBatcher(batcher)
+
+	batcher.EnqueueUpdate("node1", "blue", []*net.IPNet{subnet1}, 1, types.NoTunnelID)
+	batcher.EnqueueUpdate("node1", "blue", []*net.IPNet{subnet2}, 2, types.NoTunnelID)
+	batcher.EnqueueUpdate("node2", "blue", []*net.IPNet{subnet3}, 3, types.NoTunnelID)
+	batcher.EnqueueUpdate("node2", "blue", []*net.IPNet{subnet4}, 4, types.NoTunnelID)
+
+	time.Sleep(testSettleTime)
+
+	updatedNode1, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node1: %v", err)
+	}
+	subnets1, err := util.ParseNodeHostSubnetsAnnotation(updatedNode1)
+	if err != nil {
+		t.Fatalf("Failed to parse node1 subnet annotation: %v", err)
+	}
+	blueSubnets1 := subnets1["blue"]
+	if len(blueSubnets1) != 1 {
+		t.Fatalf("node1: expected 1 subnet for blue, got %d", len(blueSubnets1))
+	}
+	if blueSubnets1[0].String() != subnet2.String() {
+		t.Errorf("node1: expected subnet %s, got %s", subnet2.String(), blueSubnets1[0].String())
+	}
+	networkIDs1, err := util.GetNodeNetworkIDsAnnotationNetworkIDs(updatedNode1)
+	if err != nil {
+		t.Fatalf("Failed to parse node1 network IDs: %v", err)
+	}
+	if networkIDs1["blue"] != 2 {
+		t.Errorf("node1: expected blue network ID 2, got %d", networkIDs1["blue"])
+	}
+
+	updatedNode2, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node2: %v", err)
+	}
+	subnets2, err := util.ParseNodeHostSubnetsAnnotation(updatedNode2)
+	if err != nil {
+		t.Fatalf("Failed to parse node2 subnet annotation: %v", err)
+	}
+	blueSubnets2 := subnets2["blue"]
+	if len(blueSubnets2) != 1 {
+		t.Fatalf("node2: expected 1 subnet for blue, got %d", len(blueSubnets2))
+	}
+	if blueSubnets2[0].String() != subnet4.String() {
+		t.Errorf("node2: expected subnet %s, got %s", subnet4.String(), blueSubnets2[0].String())
+	}
+	networkIDs2, err := util.GetNodeNetworkIDsAnnotationNetworkIDs(updatedNode2)
+	if err != nil {
+		t.Fatalf("Failed to parse node2 network IDs: %v", err)
+	}
+	if networkIDs2["blue"] != 4 {
+		t.Errorf("node2: expected blue network ID 4, got %d", networkIDs2["blue"])
+	}
+}
+
+func TestNodeAnnotationBatcher_StopProcessesPendingUpdates(t *testing.T) {
+	node1 := newTestNode("node1")
+	node2 := newTestNode("node2")
+
+	batcher, fakeClient := setupBatcherTest(t, node1, node2)
+	startBatcher(t, batcher)
+
+	batcher.EnqueueUpdate("node1", "blue", []*net.IPNet{subnet1}, 1, types.NoTunnelID)
+	batcher.EnqueueUpdate("node2", "red", []*net.IPNet{subnet2}, 2, types.NoTunnelID)
+
+	// Stop drains the workqueue, processing pending items
+	stopBatcher(batcher)
+
+	updatedNode1, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node1: %v", err)
+	}
+	subnets1, err := util.ParseNodeHostSubnetsAnnotation(updatedNode1)
+	if err != nil {
+		t.Fatalf("Failed to parse node1 subnet annotation: %v", err)
+	}
+	if _, ok := subnets1["blue"]; !ok {
+		t.Error("node1: expected blue network subnet to be present after stop")
+	}
+
+	updatedNode2, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node2: %v", err)
+	}
+	subnets2, err := util.ParseNodeHostSubnetsAnnotation(updatedNode2)
+	if err != nil {
+		t.Fatalf("Failed to parse node2 subnet annotation: %v", err)
+	}
+	if _, ok := subnets2["red"]; !ok {
+		t.Error("node2: expected red network subnet to be present after stop")
+	}
+}
+
+func TestNodeAnnotationBatcher_TunnelIDAnnotation(t *testing.T) {
+	node1 := newTestNode("node1")
+	node2 := newTestNode("node2")
+
+	batcher, fakeClient := setupBatcherTest(t, node1, node2)
+	startBatcher(t, batcher)
+	defer stopBatcher(batcher)
+
+	batcher.EnqueueUpdate("node1", "blue", []*net.IPNet{subnet1}, 1, 100)
+	batcher.EnqueueUpdate("node1", "red", []*net.IPNet{subnet2}, 2, 200)
+	batcher.EnqueueUpdate("node2", "blue", []*net.IPNet{subnet3}, 1, 300)
+
+	time.Sleep(testSettleTime)
+
+	updatedNode1, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node1: %v", err)
+	}
+	tunnelID1Blue, err := util.ParseUDNLayer2NodeGRLRPTunnelIDs(updatedNode1, "blue")
+	if err != nil {
+		t.Fatalf("Failed to parse node1 blue tunnel ID: %v", err)
+	}
+	if tunnelID1Blue != 100 {
+		t.Errorf("node1: expected blue tunnel ID 100, got %d", tunnelID1Blue)
+	}
+	tunnelID1Red, err := util.ParseUDNLayer2NodeGRLRPTunnelIDs(updatedNode1, "red")
+	if err != nil {
+		t.Fatalf("Failed to parse node1 red tunnel ID: %v", err)
+	}
+	if tunnelID1Red != 200 {
+		t.Errorf("node1: expected red tunnel ID 200, got %d", tunnelID1Red)
+	}
+
+	updatedNode2, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "node2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get node2: %v", err)
+	}
+	tunnelID2Blue, err := util.ParseUDNLayer2NodeGRLRPTunnelIDs(updatedNode2, "blue")
+	if err != nil {
+		t.Fatalf("Failed to parse node2 blue tunnel ID: %v", err)
+	}
+	if tunnelID2Blue != 300 {
+		t.Errorf("node2: expected blue tunnel ID 300, got %d", tunnelID2Blue)
+	}
+}

--- a/go-controller/pkg/clustermanager/user_defined_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_cluster_manager.go
@@ -32,6 +32,9 @@ type userDefinedNetworkClusterManager struct {
 
 	errorReporter  NetworkStatusReporter
 	nodeReconciler *nodecontroller.NodeController
+
+	// nodeAnnotationBatcher batches node annotation updates across networks
+	nodeAnnotationBatcher *node.NodeAnnotationBatcher
 }
 
 func newUserDefinedNetworkClusterManager(
@@ -40,14 +43,16 @@ func newUserDefinedNetworkClusterManager(
 	networkManager networkmanager.Interface,
 	recorder record.EventRecorder,
 	nodeReconciler *nodecontroller.NodeController,
+	batcher *node.NodeAnnotationBatcher,
 ) (*userDefinedNetworkClusterManager, error) {
 	klog.Infof("Creating user-defined network cluster manager")
 	sncm := &userDefinedNetworkClusterManager{
-		ovnClient:      ovnClient,
-		watchFactory:   wf,
-		networkManager: networkManager,
-		recorder:       recorder,
-		nodeReconciler: nodeReconciler,
+		ovnClient:             ovnClient,
+		watchFactory:          wf,
+		networkManager:        networkManager,
+		recorder:              recorder,
+		nodeReconciler:        nodeReconciler,
+		nodeAnnotationBatcher: batcher,
 	}
 	return sncm, nil
 }
@@ -77,6 +82,7 @@ func (sncm *userDefinedNetworkClusterManager) NewNetworkController(nInfo util.Ne
 		sncm.networkManager,
 		sncm.errorReporter,
 		sncm.nodeReconciler,
+		sncm.nodeAnnotationBatcher,
 	)
 	return sncc, nil
 }
@@ -137,6 +143,29 @@ func (sncm *userDefinedNetworkClusterManager) CleanupStaleNetworks(validNetworks
 			staleNetworkControllers[netName] = oc
 		}
 
+		// network-ids covers L2 secondary UDNs (and others)
+		networkIDsMap, err := util.GetNodeNetworkIDsAnnotationNetworkIDs(node)
+		if err != nil {
+			networkIDsMap = nil
+		}
+		for netName := range networkIDsMap {
+			if netName == ovntypes.DefaultNetworkName {
+				continue
+			}
+			if _, ok := existingNetworksMap[netName]; ok {
+				continue
+			}
+			if _, ok := staleNetworkControllers[netName]; ok {
+				continue
+			}
+			oc, err := sncm.newDummyNetworkController(ovntypes.Layer2Topology, netName)
+			if err != nil {
+				klog.Errorf("Failed to create dummy controller for stale network %s: %v", netName, err)
+				continue
+			}
+			staleNetworkControllers[netName] = oc
+		}
+
 		// tunnel IDs cover L2 primary UDNs with IC
 		tunnelNetworks, err := util.GetNodeUDNLayer2TunnelIDAnnotationNetworkNames(node)
 		if err != nil {
@@ -184,9 +213,10 @@ func (sncm *userDefinedNetworkClusterManager) newDummyNetworkController(topoType
 		sncm.networkManager,
 		nil,
 		sncm.nodeReconciler,
+		sncm.nodeAnnotationBatcher,
 	)
 	if nc.hasNodeAllocation() {
-		nc.nodeAllocator = node.NewNodeAllocator(ovntypes.InvalidID, nc.GetNetInfo(), nc.watchFactory.NodeCoreInformer().Lister(), nc.kube, nil)
+		nc.nodeAllocator = node.NewNodeAllocator(ovntypes.InvalidID, nc.GetNetInfo(), nc.watchFactory.NodeCoreInformer().Lister(), nc.kube, nil, sncm.nodeAnnotationBatcher)
 	}
 	return nc, nil
 }

--- a/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
@@ -23,14 +23,25 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/ip"
+	node "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/node"
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	nodecontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllers/node"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+func createBatcherForClient(fakeClient *util.OVNClusterManagerClientset) *node.NodeAnnotationBatcher {
+	kubeInterface := &kube.Kube{KClient: fakeClient.KubeClient}
+	batcher := node.NewNodeAnnotationBatcher(kubeInterface)
+	gomega.Expect(controller.Start(batcher.Reconciler())).To(gomega.Succeed())
+	ginkgo.DeferCleanup(func() { controller.Stop(batcher.Reconciler()) })
+	return batcher
+}
 
 var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 	var (
@@ -85,7 +96,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 				gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+				batcher := createBatcherForClient(fakeClient)
+				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: cnitypes.NetConf{Name: "blue"}, Topology: ovntypes.Layer3Topology, Subnets: "192.168.0.0/16/24"})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -156,7 +168,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 					gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+					batcher := createBatcherForClient(fakeClient)
+					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					nc, err := sncm.NewNetworkController(netInfo)
@@ -190,7 +203,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 					gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+					batcher := createBatcherForClient(fakeClient)
+					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					nc := newNetworkClusterController(
@@ -201,6 +215,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						sncm.networkManager,
 						nil,
 						nodeController,
+						nil,
 					)
 					gomega.Expect(nc.init()).To(gomega.Succeed())
 					gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -252,7 +267,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 
-						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+						batcher := createBatcherForClient(fakeClient)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						_, err = sncm.NewNetworkController(netInfo)
@@ -376,7 +392,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 				nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 
-				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+				batcher := createBatcherForClient(fakeClient)
+				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Create a fake nad controller for blue network so that the red network gets cleared
@@ -396,6 +413,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					sncm.networkManager,
 					nil,
 					nodeController,
+					nil,
 				)
 				err = oc.init()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -488,7 +506,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 				nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 
-				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+				batcher := createBatcherForClient(fakeClient)
+				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// No valid networks passed — l2-primary should be detected as stale
@@ -558,7 +577,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 						gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+						batcher := createBatcherForClient(fakeClient)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -569,6 +589,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.networkManager,
 							nil,
 							nodeController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -614,7 +635,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 						gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+						batcher := createBatcherForClient(fakeClient)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -625,6 +647,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.networkManager,
 							nil,
 							nodeController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -666,7 +689,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 						gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+						batcher := createBatcherForClient(fakeClient)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -677,6 +701,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.networkManager,
 							nil,
 							nodeController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -738,7 +763,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 						gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+						batcher := createBatcherForClient(fakeClient)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -749,6 +775,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.networkManager,
 							nil,
 							nodeController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -813,7 +840,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 						gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+						batcher := createBatcherForClient(fakeClient)
+						sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						nc := newNetworkClusterController(
@@ -824,6 +852,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.networkManager,
 							nil,
 							nodeController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -882,7 +911,8 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					nodeController = nodecontroller.NewController(f, "clustermanager-node", networkmanager.Default().Interface())
 					gomega.Expect(nodeController.Start()).To(gomega.Succeed())
 
-					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+					batcher := createBatcherForClient(fakeClient)
+					sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController, batcher)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					nc := newNetworkClusterController(
@@ -893,6 +923,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						sncm.networkManager,
 						nil,
 						nodeController,
+						nil,
 					)
 					gomega.Expect(nc.init()).To(gomega.Succeed())
 					gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())

--- a/go-controller/pkg/controllers/node/node_annotation_cache.go
+++ b/go-controller/pkg/controllers/node/node_annotation_cache.go
@@ -80,19 +80,58 @@ func (c *NodeAnnotationCache) updateNodeAnnotationState(node *corev1.Node, updat
 // ParseUDNLayer2NodeGRLRPTunnelIDCached returns the per-network tunnel ID from the
 // node annotation map using this cache.
 func (c *NodeAnnotationCache) ParseUDNLayer2NodeGRLRPTunnelIDCached(node *corev1.Node, netName string) (int, error) {
-	tunnelIDs, err := c.parseNetworkMapCached(node, types.UDNLayer2NodeGRLRPTunnelIDAnnotation, true)
+	tunnelIDs, err := c.ParseUDNLayer2NodeGRLRPTunnelIDsMapCached(node)
 	if err != nil {
 		return types.InvalidID, err
 	}
+
 	tunnelID, ok := tunnelIDs[netName]
 	if !ok {
 		return types.InvalidID, util.NewAnnotationNotSetError("node %q has no %q annotation for network %s", node.Name, types.UDNLayer2NodeGRLRPTunnelIDAnnotation, netName)
 	}
-	id, err := strconv.Atoi(tunnelID)
+
+	return tunnelID, nil
+}
+
+// ParseUDNLayer2NodeGRLRPTunnelIDsMapCached returns the node annotation map of
+// networks to tunnel IDs from the cache
+func (c *NodeAnnotationCache) ParseUDNLayer2NodeGRLRPTunnelIDsMapCached(node *corev1.Node) (map[string]int, error) {
+	tunnelIDsStrMap, err := c.parseNetworkMapCached(node, types.UDNLayer2NodeGRLRPTunnelIDAnnotation, true)
 	if err != nil {
-		return types.InvalidID, err
+		return nil, err
 	}
-	return id, nil
+
+	result := make(map[string]int, len(tunnelIDsStrMap))
+	for netName, idStr := range tunnelIDsStrMap {
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tunnel ID for network %s: %v", netName, err)
+		}
+
+		result[netName] = id
+	}
+
+	return result, nil
+}
+
+// ParseNetworkIDsMapCached returns the node annotation map of networks to
+// network IDs from the cache
+func (c *NodeAnnotationCache) ParseNetworkIDsMapCached(node *corev1.Node) (map[string]int, error) {
+	networkIDsStrMap, err := c.parseNetworkMapCached(node, util.OvnNetworkIDs, true)
+	if err != nil {
+		return nil, err
+	}
+
+	networkIDsMap := make(map[string]int, len(networkIDsStrMap))
+	for netName, idStr := range networkIDsStrMap {
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse network ID for network %s: %v", netName, err)
+		}
+		networkIDsMap[netName] = id
+	}
+
+	return networkIDsMap, nil
 }
 
 // parseNetworkMapCached returns the parsed per-network string map for the
@@ -160,6 +199,17 @@ func parseGatewayConfigMapValue(annotationName, annotation string) (map[string]*
 	return out, nil
 }
 
+// ParseNodeHostSubnetsAnnotationCached returns the node annotation map of networks
+// to subnet allocations from the cache
+func (c *NodeAnnotationCache) ParseNodeHostSubnetsAnnotationCached(node *corev1.Node) (map[string][]*net.IPNet, error) {
+	return c.parseSubnetMapCached(node, types.NodeSubnetsAnnotation, true)
+}
+
+// parseSubnetMapCached returns the parsed per-network subnet map for the
+// given annotation, reusing a cached parse result when the raw annotation
+// value has not changed. If there is a cache miss, the annotation is parsed;
+// updateCache controls whether the parsed result replaces the cached value for
+// this node and annotation.
 func (c *NodeAnnotationCache) parseSubnetMapCached(node *corev1.Node, annotationName string, updateCache bool) (map[string][]*net.IPNet, error) {
 	annotation, ok := node.Annotations[annotationName]
 	if !ok {

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -62,6 +62,7 @@ type Interface interface {
 	SetAnnotationsOnNodeWithFieldManager(nodeName string, annotations map[string]interface{}, fieldManager string) error
 	SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error
 	SetLabelsOnNode(nodeName string, labels map[string]interface{}) error
+	GetNode(name string) (*corev1.Node, error)
 	PatchNode(old, new *corev1.Node) error
 	UpdateNodeStatus(node *corev1.Node) error
 	PatchPodStatusAnnotations(oldPod, newPod *corev1.Pod) error
@@ -382,6 +383,11 @@ func (k *Kube) PatchNode(old, new *corev1.Node) error {
 	}
 
 	return nil
+}
+
+// GetNode returns the Node resource from the kubernetes apiserver, given its name.
+func (k *Kube) GetNode(name string) (*corev1.Node, error) {
+	return k.KClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 // UpdateNodeStatus takes the node object and sets the provided update status

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -38,6 +38,36 @@ func (_m *Interface) Events() v1.EventInterface {
 	return r0
 }
 
+// GetNode provides a mock function with given fields: name
+func (_m *Interface) GetNode(name string) (*corev1.Node, error) {
+	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNode")
+	}
+
+	var r0 *corev1.Node
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*corev1.Node, error)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) *corev1.Node); ok {
+		r0 = rf(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*corev1.Node)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNodeForWindows provides a mock function with given fields: name
 func (_m *Interface) GetNodeForWindows(name string) (*corev1.Node, error) {
 	ret := _m.Called(name)

--- a/go-controller/pkg/kube/mocks/InterfaceOVN.go
+++ b/go-controller/pkg/kube/mocks/InterfaceOVN.go
@@ -182,6 +182,36 @@ func (_m *InterfaceOVN) GetEgressIPs() ([]*egressipv1.EgressIP, error) {
 	return r0, r1
 }
 
+// GetNode provides a mock function with given fields: name
+func (_m *InterfaceOVN) GetNode(name string) (*apicorev1.Node, error) {
+	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNode")
+	}
+
+	var r0 *apicorev1.Node
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*apicorev1.Node, error)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) *apicorev1.Node); ok {
+		r0 = rf(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*apicorev1.Node)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNodeForWindows provides a mock function with given fields: name
 func (_m *InterfaceOVN) GetNodeForWindows(name string) (*apicorev1.Node, error) {
 	ret := _m.Called(name)

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -563,6 +563,35 @@ func GetNodeUDNLayer2TunnelIDAnnotationNetworkNames(node *corev1.Node) ([]string
 	return networks, nil
 }
 
+// UpdateUDNLayer2NodeGRLRPTunnelIDsMap updates the UDN L2 node GR LRP tunnel ID annotation
+// with a complete map of all tunnel IDs. This is more efficient than updating networks individually.
+func UpdateUDNLayer2NodeGRLRPTunnelIDsMap(annotations map[string]string, tunnelIDsMap map[string]int) (map[string]string, error) {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	// Filter out invalid IDs (represents deletion)
+	filteredMap := make(map[string]string)
+	for netName, tunnelID := range tunnelIDsMap {
+		if tunnelID != types.InvalidID {
+			filteredMap[netName] = strconv.Itoa(tunnelID)
+		}
+	}
+
+	if len(filteredMap) == 0 {
+		delete(annotations, types.UDNLayer2NodeGRLRPTunnelIDAnnotation)
+		return annotations, nil
+	}
+
+	// Marshal the complete map
+	bytes, err := json.Marshal(filteredMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal tunnel-ids map: %v", err)
+	}
+	annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] = string(bytes)
+	return annotations, nil
+}
+
 func UDNLayer2NodeUsesTransitRouter(node *corev1.Node) bool {
 	return node.Annotations[Layer2TopologyVersion] == TransitRouterTopoVersion
 }
@@ -1279,6 +1308,35 @@ func UpdateNetworkIDAnnotation(annotations map[string]string, netName string, ne
 	if err != nil {
 		return nil, err
 	}
+	return annotations, nil
+}
+
+// UpdateNetworkIDAnnotationMap updates the OvnNetworkIDs annotation with a complete map
+// of all network IDs. This is more efficient than updating networks individually.
+func UpdateNetworkIDAnnotationMap(annotations map[string]string, networkIDsMap map[string]int) (map[string]string, error) {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	// Filter out invalid IDs (represents deletion)
+	filteredMap := make(map[string]string)
+	for netName, networkID := range networkIDsMap {
+		if networkID != types.InvalidID {
+			filteredMap[netName] = strconv.Itoa(networkID)
+		}
+	}
+
+	if len(filteredMap) == 0 {
+		delete(annotations, OvnNetworkIDs)
+		return annotations, nil
+	}
+
+	// Marshal the complete map
+	bytes, err := json.Marshal(filteredMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal network-ids map: %v", err)
+	}
+	annotations[OvnNetworkIDs] = string(bytes)
 	return annotations, nil
 }
 

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -181,6 +181,46 @@ func UpdateNodeHostSubnetAnnotation(annotations map[string]string, hostSubnets [
 	return annotations, nil
 }
 
+// UpdateNodeHostSubnetAnnotationMap updates the "k8s.ovn.org/node-subnets" annotation
+// with a complete map of all network subnets. This is more efficient than updating
+// networks individually when batching updates from multiple networks.
+func UpdateNodeHostSubnetAnnotationMap(annotations map[string]string, subnetsMap map[string][]*net.IPNet) (map[string]string, error) {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	// Filter out nil or empty subnet lists (represents deletion)
+	filteredMap := make(map[string][]*net.IPNet)
+	for netName, subnets := range subnetsMap {
+		if len(subnets) > 0 {
+			filteredMap[netName] = subnets
+		}
+	}
+
+	if len(filteredMap) == 0 {
+		delete(annotations, types.NodeSubnetsAnnotation)
+		return annotations, nil
+	}
+
+	// Convert IPNets to strings before marshaling (same as updateSubnetAnnotation)
+	subnetsStrMap := make(map[string][]string)
+	for netName, subnets := range filteredMap {
+		subnetsStr := make([]string, len(subnets))
+		for i, subnet := range subnets {
+			subnetsStr[i] = subnet.String()
+		}
+		subnetsStrMap[netName] = subnetsStr
+	}
+
+	// Marshal the string map
+	bytes, err := json.Marshal(subnetsStrMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal node-subnets map: %v", err)
+	}
+	annotations[types.NodeSubnetsAnnotation] = string(bytes)
+	return annotations, nil
+}
+
 // SetNodeHostSubnetAnnotation sets a "k8s.ovn.org/node-subnets" annotation
 // using a kube.Annotator
 func SetNodeHostSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnets []*net.IPNet) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Adds NodeAnnotationBatcher, which enqueues and batches Node Annotation updates to reduce KubeAPI spam and update contention when creating large numbers of UDNs at once. Uses the Controller framework to process per-node updates using multiple workers. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->