### PR TITLE
Support NetworkConnect along with Advertised Networks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -548,7 +548,7 @@ jobs:
       ENABLE_ROUTE_ADVERTISEMENTS: "${{ matrix.routeadvertisements != '' }}"
       ENABLE_EVPN: "${{ matrix.target == 'evpn' }}"
       ADVERTISE_DEFAULT_NETWORK:  "${{ matrix.routeadvertisements == 'advertise-default' }}"
-      ENABLE_NETWORK_CONNECT: "${{ startsWith(matrix.target, 'network-segmentation') }}"
+      ENABLE_NETWORK_CONNECT: "${{ startsWith(matrix.target, 'network-segmentation') || matrix.target == 'bgp-helm' }}"
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (startsWith(matrix.target, 'network-segmentation') || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
       # Override PARALLEL=true for Serial tests target to run Serial tests

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_test.go
@@ -3841,6 +3841,214 @@ var _ = Describe("OVNKube Network Connect Controller Integration Tests", func() 
 				})
 			})
 
+			// =============================================================================
+			// Context: Advertised Override ACLs (pass-advertised for CNC + advertised UDN)
+			// =============================================================================
+			Context("Advertised Networks Override", func() {
+				const (
+					advCNCName  = "adv-cnc"
+					advTunnelID = 300
+				)
+
+				// startAdvertisedNetworks reuses startBothNetworks and marks all networks
+				// as advertised on node1 so IsPodNetworkAdvertisedAtNode returns true.
+				startAdvertisedNetworks := func() string {
+					subnetAnnotation := startBothNetworks()
+
+					fakeNM.Lock()
+					for _, ni := range fakeNM.PrimaryNetworks {
+						ni.(util.MutableNetInfo).SetPodNetworkAdvertisedVRFs(map[string][]string{
+							"node1": {"vrf-blue"},
+						})
+					}
+					fakeNM.Unlock()
+
+					return subnetAnnotation
+				}
+
+				findAdvertisedACLs := func(cncName string) []*nbdb.ACL {
+					predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLClusterNetworkConnect, controllerName,
+						map[libovsdbops.ExternalIDKey]string{
+							libovsdbops.ObjectNameKey: cncName,
+							libovsdbops.TypeKey:       "pass-advertised",
+						})
+					acls, err := libovsdbops.FindACLsWithPredicate(nbClient,
+						libovsdbops.GetPredicate[*nbdb.ACL](predicateIDs, nil))
+					Expect(err).NotTo(HaveOccurred())
+					return acls
+				}
+
+				verifyAdvertisedACLsExist := func() {
+					Eventually(func() int {
+						return len(findAdvertisedACLs(advCNCName))
+					}).WithTimeout(5 * time.Second).Should(BeNumerically(">", 0))
+				}
+
+				verifyNoAdvertisedACLs := func() {
+					Eventually(func() int {
+						return len(findAdvertisedACLs(advCNCName))
+					}).WithTimeout(5 * time.Second).Should(Equal(0))
+				}
+
+				verifySwitchHasAdvertisedACL := func(switchName string, expected bool) {
+					Eventually(func() error {
+						sw, err := libovsdbops.FindLogicalSwitchesWithPredicate(nbClient, func(s *nbdb.LogicalSwitch) bool {
+							return s.Name == switchName
+						})
+						if err != nil {
+							return err
+						}
+						if len(sw) != 1 {
+							return fmt.Errorf("expected 1 switch %s, got %d", switchName, len(sw))
+						}
+						acls := findAdvertisedACLs(advCNCName)
+						if len(acls) == 0 {
+							if expected {
+								return fmt.Errorf("no pass-advertised ACL found globally")
+							}
+							return nil
+						}
+						aclUUID := acls[0].UUID
+						hasACL := false
+						for _, uuid := range sw[0].ACLs {
+							if uuid == aclUUID {
+								hasACL = true
+								break
+							}
+						}
+						if hasACL != expected {
+							return fmt.Errorf("switch %s hasAdvertisedACL=%v, expected %v (switch ACLs: %v)",
+								switchName, hasACL, expected, sw[0].ACLs)
+						}
+						return nil
+					}).WithTimeout(5 * time.Second).Should(Succeed())
+				}
+
+				It("should create pass-advertised ACLs on advertised network switches when CNC is created", func() {
+					subnetAnnotation := startAdvertisedNetworks()
+
+					cnc := createTestCNC(advCNCName, advTunnelID, defaultConnectSubnets(), subnetAnnotation,
+						networkconnectv1.PodNetwork, networkconnectv1.ServiceNetwork)
+					_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					verifyAdvertisedACLsExist()
+					verifySwitchHasAdvertisedACL(redNetwork.SwitchName("node1"), true)
+					verifySwitchHasAdvertisedACL(blueNetwork.SwitchName("node1"), true)
+				})
+
+				It("should cleanup pass-advertised ACLs when CNC is deleted", func() {
+					subnetAnnotation := startAdvertisedNetworks()
+
+					cnc := createTestCNC(advCNCName, advTunnelID, defaultConnectSubnets(), subnetAnnotation,
+						networkconnectv1.PodNetwork, networkconnectv1.ServiceNetwork)
+					_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					verifyAdvertisedACLsExist()
+
+					err = fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Delete(
+						context.Background(), advCNCName, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					verifyNoAdvertisedACLs()
+				})
+
+				It("should remove pass-advertised ACL from switch when network stops being advertised", func() {
+					subnetAnnotation := startAdvertisedNetworks()
+
+					cnc := createTestCNC(advCNCName, advTunnelID, defaultConnectSubnets(), subnetAnnotation,
+						networkconnectv1.PodNetwork, networkconnectv1.ServiceNetwork)
+					_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					verifySwitchHasAdvertisedACL(redNetwork.SwitchName("node1"), true)
+					verifySwitchHasAdvertisedACL(blueNetwork.SwitchName("node1"), true)
+
+					// Stop advertising the red network (clear its VRFs)
+					fakeNM.Lock()
+					fakeNM.PrimaryNetworks["red-ns"].(util.MutableNetInfo).SetPodNetworkAdvertisedVRFs(map[string][]string{})
+					fakeNM.Unlock()
+
+					// Trigger reconcile by updating the CNC annotation (simulates NAD change requeue)
+					cnc, err = fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Get(
+						context.Background(), advCNCName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					if cnc.Annotations == nil {
+						cnc.Annotations = make(map[string]string)
+					}
+					cnc.Annotations["trigger-reconcile"] = "1"
+					_, err = fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Update(
+						context.Background(), cnc, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Red switch should no longer have the ACL, blue still should
+					verifySwitchHasAdvertisedACL(redNetwork.SwitchName("node1"), false)
+					verifySwitchHasAdvertisedACL(blueNetwork.SwitchName("node1"), true)
+				})
+
+				It("should create both partial connectivity and pass-advertised ACLs with ServiceNetwork only", func() {
+					subnetAnnotation := startAdvertisedNetworks()
+					seedBothNetworkLBs(fakeClientset, nbClient)
+
+					cnc := createTestCNC(advCNCName, advTunnelID, defaultConnectSubnets(), subnetAnnotation,
+						networkconnectv1.ServiceNetwork)
+					_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// pass-advertised ACL should exist
+					verifyAdvertisedACLsExist()
+
+					// Each switch should have partial ACLs (pass-service + drop-pod + pass-same-network)
+					// plus the pass-advertised ACL = 4 total
+					expectedPerSwitch := 3 + 1
+					verifySwitchACLCount := func(switchName string, expected int) {
+						Eventually(func() error {
+							sw, findErr := libovsdbops.FindLogicalSwitchesWithPredicate(nbClient, func(s *nbdb.LogicalSwitch) bool {
+								return s.Name == switchName
+							})
+							if findErr != nil {
+								return findErr
+							}
+							if len(sw) != 1 {
+								return fmt.Errorf("expected 1 switch %s, got %d", switchName, len(sw))
+							}
+							if len(sw[0].ACLs) != expected {
+								return fmt.Errorf("switch %s has %d ACLs, expected %d", switchName, len(sw[0].ACLs), expected)
+							}
+							return nil
+						}).WithTimeout(5 * time.Second).Should(Succeed())
+					}
+					verifySwitchACLCount(redNetwork.SwitchName("node1"), expectedPerSwitch)
+					verifySwitchACLCount(blueNetwork.SwitchName("node1"), expectedPerSwitch)
+				})
+
+				It("should not create pass-advertised ACLs when isolation mode is not strict", func() {
+					config.OVNKubernetesFeature.AdvertisedUDNIsolationMode = "loose"
+					subnetAnnotation := startAdvertisedNetworks()
+
+					cnc := createTestCNC(advCNCName, advTunnelID, defaultConnectSubnets(), subnetAnnotation,
+						networkconnectv1.PodNetwork, networkconnectv1.ServiceNetwork)
+					_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Wait for reconcile to complete (connect router created = reconcile ran)
+					Eventually(func() error {
+						return verifyConnectRouter(nbClient, advCNCName, advTunnelID)
+					}).WithTimeout(5 * time.Second).Should(Succeed())
+
+					// No pass-advertised ACLs should exist
+					Consistently(func() int {
+						return len(findAdvertisedACLs(advCNCName))
+					}).WithTimeout(2 * time.Second).Should(Equal(0))
+				})
+			})
+
 		}) // end Context for ipMode
 	}
 })

--- a/go-controller/pkg/ovn/controller/networkconnect/repair.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/repair.go
@@ -53,8 +53,8 @@ func (c *Controller) repairStaleCNCs() error {
 	return nil
 }
 
-// cleanupStaleACLs finds CNC names that have partial connectivity ACLs but are not in validCNCs,
-// and calls cleanupPartialConnectivity for each (removes ACLs from switches and destroys address sets).
+// cleanupStaleACLs finds CNC names that have ACLs (partial connectivity or advertised override)
+// but are not in validCNCs, and removes those ACLs from switches and destroys address sets.
 func (c *Controller) cleanupStaleACLs(validCNCs sets.Set[string]) error {
 	aclPredicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLClusterNetworkConnect, controllerName, nil)
 	aclPredicate := libovsdbops.GetPredicate[*nbdb.ACL](aclPredicateIDs, nil)
@@ -70,9 +70,15 @@ func (c *Controller) cleanupStaleACLs(validCNCs sets.Set[string]) error {
 		}
 	}
 	for _, cncName := range staleCNCNames.UnsortedList() {
-		klog.V(4).Infof("Cleaning up partial connectivity for stale CNC %s", cncName)
+		klog.V(4).Infof("Cleaning up ACLs for stale CNC %s", cncName)
 		if err := c.cleanupPartialConnectivity(cncName); err != nil {
 			klog.Warningf("Failed to cleanup partial connectivity for stale CNC %s: %v", cncName, err)
+		}
+		if err := c.cleanupAdvertisedOverrideACLs(cncName); err != nil {
+			klog.Warningf("Failed to cleanup advertised override ACLs for stale CNC %s: %v", cncName, err)
+		}
+		if err := c.destroyConnectedSubnetsAddressSet(cncName); err != nil {
+			klog.Warningf("Failed to destroy address set for stale CNC %s: %v", cncName, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/controller/networkconnect/topology.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/topology.go
@@ -242,6 +242,13 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 		}
 	}
 
+	// Pre-build the advertised network isolation override ACL (if strict isolation is enabled).
+	// Built once here and attached to each advertised network's switch inside the loop.
+	advertisedOverrideACL, err := c.prepareAdvertisedOverrideACL(cncName, allocatedSubnets)
+	if err != nil {
+		return fmt.Errorf("CNC %s: failed to prepare advertised override ACL: %w", cncName, err)
+	}
+
 	// Create/update the CNC's service LBG before the per-network loop (like partial connectivity ACLs).
 	// The LBG is created once (with UUID populated via lookup) and reused inside the loop for each network.
 	// If the LBG cannot be created, return early since per-network LBG ops require a valid LBG.
@@ -256,6 +263,11 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 			return fmt.Errorf("CNC %s: failed to find LBG %s after creation: %v", cncName, lbgName, err)
 		}
 	}
+
+	// Track which switches should have the advertised override ACL.
+	// Populated at the top of each loop iteration (before error-prone mutations)
+	// so that transient errors don't cause a switch to appear "stale".
+	advertisedOverrideSwitches := sets.New[string]()
 
 	// Ensure ports, routing policies and static routes for ALL desired networks.
 	// All operations are idempotent (CreateOrUpdate), so we reconcile them on every sync.
@@ -281,6 +293,49 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 		}
 		localActive := c.localZoneNode != nil && c.networkManager.NodeHasNetwork(c.localZoneNode.Name, netInfo.GetNetworkName())
 
+		klog.V(5).Infof("CNC %s: ensuring ACLs, ports, policies and routes for network %s (new=%v)", cncName, netInfo.GetNetworkName(), isNewNetwork)
+
+		// Build ops per network to keep transaction sizes bounded
+		var createOps []ovsdb.Operation
+
+		// If this network is advertised with strict isolation, attach the pre-built
+		// override ACL to this network's switch so the advertised isolation drop
+		// at priority 1050 doesn't block CNC-connected traffic.
+		// Also track the switch in the desired set so stale ACLs are cleaned up
+		// when a network stops being advertised.
+		// This block must run before other error-prone mutations so that
+		// advertisedOverrideSwitches is always populated for stale cleanup.
+		if advertisedOverrideACL != nil && localActive &&
+			util.IsPodNetworkAdvertisedAtNode(netInfo, c.localZoneNode.Name) {
+			advertisedSwitchName, err := c.getNetworkSwitchName(netInfo)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(
+					"CNC %s: failed to get switch name "+
+						"for network %s: %w",
+					cncName, netInfo.GetNetworkName(), err))
+				continue
+			}
+			advertisedOverrideSwitches.Insert(advertisedSwitchName)
+			createOps, err = c.ensureAdvertisedOverrideACLOps(createOps, advertisedOverrideACL, advertisedSwitchName)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(
+					"CNC %s: failed to ensure advertised "+
+						"override ACL for network %s: %w",
+					cncName, netInfo.GetNetworkName(), err))
+				continue
+			}
+		}
+
+		// Add partial connectivity ACLs to this network's switch (only if local).
+		// ACLs are attached to the switch, which only exists locally with dynamic UDN allocation.
+		if partialConnectivityDesired && localActive {
+			createOps, err = c.ensurePartialConnectivityACLsOps(createOps, partialConnState, networkID)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("CNC %s: failed to ensure partial connectivity ACLs for network %s: %w", cncName, netInfo.GetNetworkName(), err))
+				continue
+			}
+		}
+
 		// Check if the network router exists before trying to create ports on it.
 		// The network might be registered in the network manager but not yet created in OVN NB.
 		// If the router doesn't exist, skip this network and retry later.
@@ -290,21 +345,6 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 			if err != nil {
 				klog.V(4).Infof("Network router %s for network %s does not exist yet, will retry: %v", networkRouterName, netInfo.GetNetworkName(), err)
 				errs = append(errs, fmt.Errorf("network router %s for network %s does not exist yet: %w", networkRouterName, netInfo.GetNetworkName(), err))
-				continue
-			}
-		}
-
-		klog.V(5).Infof("CNC %s: ensuring ports, policies and routes for network %s (new=%v)", cncName, netInfo.GetNetworkName(), isNewNetwork)
-
-		// Build ops per network to keep transaction sizes bounded
-		var createOps []ovsdb.Operation
-
-		// Add partial connectivity ACLs to this network's switch (only if local).
-		// ACLs are attached to the switch, which only exists locally with dynamic UDN allocation.
-		if partialConnectivityDesired && localActive {
-			createOps, err = c.ensurePartialConnectivityACLsOps(createOps, partialConnState, networkID)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("CNC %s: failed to ensure partial connectivity ACLs for network %s: %w", cncName, netInfo.GetNetworkName(), err))
 				continue
 			}
 		}
@@ -561,6 +601,19 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 		if err := c.cleanupPartialConnectivity(cncName); err != nil {
 			errs = append(errs, fmt.Errorf("CNC %s: failed to cleanup partial connectivity: %w", cncName, err))
 		}
+		// Only destroy the shared address set if advertised override also doesn't need it
+		if advertisedOverrideACL == nil {
+			if err := c.destroyConnectedSubnetsAddressSet(cncName); err != nil {
+				errs = append(errs, fmt.Errorf("CNC %s: failed to destroy address set: %w", cncName, err))
+			}
+		}
+	}
+
+	// Remove the advertised override ACL from switches where the network is no longer advertised.
+	// This handles the case where a RouteAdvertisement is deleted/modified, causing a network
+	// to stop being advertised while still connected by the CNC.
+	if err := c.cleanupStaleAdvertisedOverrideACLs(cncName, advertisedOverrideSwitches, partialConnectivityDesired); err != nil {
+		errs = append(errs, fmt.Errorf("CNC %s: failed to cleanup stale advertised override ACLs: %w", cncName, err))
 	}
 
 	// Only update state flags if no errors occurred, so that on the next reconcile
@@ -580,9 +633,10 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 // cleanupNetworkConnections removes all network connections for a CNC.
 // This is called when a CNC is being deleted.
 // 1. If ServiceNetwork was enabled, cleanup cross-network LB attachments for this CNC
-// 2. If partial connectivity was enabled (service && !pod), cleanup ACLs and address sets
-// 3. Then delete network router ports from the network routers for this CNC
-// 4. Then delete routing policies on the network routers for this CNC
+// 2. If partial connectivity was enabled (service && !pod), cleanup partial connectivity ACLs
+// 3. Cleanup advertised override ACLs (always, since they're independent of connectivity mode)
+// 4. Destroy the shared address set (safe since the CNC is being deleted)
+// 5. Then delete network router ports and routing policies from network routers for this CNC
 func (c *Controller) cleanupNetworkConnections(cncName string, serviceConnectivityWasEnabled, podConnectivityWasEnabled bool) error {
 	// Cleanup cross-network LB attachments if ServiceNetwork was enabled
 	if serviceConnectivityWasEnabled {
@@ -597,6 +651,16 @@ func (c *Controller) cleanupNetworkConnections(cncName string, serviceConnectivi
 		if err := c.cleanupPartialConnectivity(cncName); err != nil {
 			return fmt.Errorf("failed to cleanup partial connectivity for CNC %s: %v", cncName, err)
 		}
+	}
+
+	// Cleanup advertised override ACLs unconditionally — they're independent of connectivity mode
+	if err := c.cleanupAdvertisedOverrideACLs(cncName); err != nil {
+		return fmt.Errorf("failed to cleanup advertised override ACLs for CNC %s: %v", cncName, err)
+	}
+
+	// Destroy the shared address set — safe since the entire CNC is being deleted
+	if err := c.destroyConnectedSubnetsAddressSet(cncName); err != nil {
+		return fmt.Errorf("failed to destroy address set for CNC %s: %v", cncName, err)
 	}
 
 	return c.cleanupNetworkConnectivity(cncName)
@@ -1492,6 +1556,20 @@ type partialConnectivityState struct {
 	networkSwitches map[int]string    // networkID -> switch name
 }
 
+// ensureConnectedSubnetsAddressSet creates or updates the address set containing pod subnets
+// of all connected networks for a CNC. This is shared between partial connectivity ACLs and
+// the advertised network isolation override ACL.
+func (c *Controller) ensureConnectedSubnetsAddressSet(cncName string, allSubnets []string) (hashNameV4, hashNameV6 string, err error) {
+	dbIDs := getConnectedUDNSubnetsAddressSetDbIDs(cncName)
+	as, asErr := c.addressSetFactory.NewAddressSet(dbIDs, allSubnets)
+	if asErr != nil {
+		return "", "", fmt.Errorf("failed to create address set: %w", asErr)
+	}
+
+	hashNameV4, hashNameV6 = as.GetASHashNames()
+	return hashNameV4, hashNameV6, nil
+}
+
 // preparePartialConnectivityACLs creates the address set and builds the shared ACLs, and per-network ACLs.
 // This is called once before the network creation loop.
 // Returns nil if there are fewer than 2 networks (no partial connectivity needed).
@@ -1544,17 +1622,11 @@ func (c *Controller) preparePartialConnectivityACLs(cncName string, allocatedSub
 		}
 	}
 
-	// Create address set directly (not as ops) - this is simpler than passing ops around
-	dbIDs := getConnectedUDNSubnetsAddressSetDbIDs(cncName)
-	as, err := c.addressSetFactory.NewAddressSet(dbIDs, allSubnets)
+	hashNameV4, hashNameV6, err := c.ensureConnectedSubnetsAddressSet(cncName, allSubnets)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create address set: %w", err)
+		return nil, fmt.Errorf("failed to ensure connected subnets address set for CNC %s: %w", cncName, err)
 	}
 
-	// Get the hashed address set names for ACL matches
-	hashNameV4, hashNameV6 := as.GetASHashNames()
-
-	// Build shared ACLs (pass-service at 500, drop at 450)
 	state.sharedACLs = c.buildSharedPartialConnectivityACLs(cncName, hashNameV4, hashNameV6)
 
 	return state, nil
@@ -1751,29 +1823,51 @@ func (c *Controller) buildPassSameNetworkACL(cncName string, networkID int, subn
 		passMatch, nbdb.ACLActionPass, nil, libovsdbutil.LportEgress, 0)
 }
 
-// cleanupPartialConnectivity removes partial connectivity ACLs and address sets for a CNC.
+// cleanupPartialConnectivity removes partial connectivity ACLs for a CNC.
+// Only removes ACLs with partial connectivity types (pass-service, drop-pod, pass-same-network-*).
+// Does NOT destroy the shared address set — call destroyConnectedSubnetsAddressSet separately
+// when neither partial connectivity nor advertised override needs it.
 func (c *Controller) cleanupPartialConnectivity(cncName string) error {
-	// Find all ACLs owned by this CNC using proper DbObjectIDs predicate
+	return c.cleanupCNCACLsByType(cncName, func(aclType string) bool {
+		return aclType == "pass-service" || aclType == "drop-pod" || strings.HasPrefix(aclType, "pass-same-network-")
+	}, "partial connectivity")
+}
+
+// cleanupAdvertisedOverrideACLs removes advertised network isolation override ACLs for a CNC.
+// Does NOT destroy the shared address set — call destroyConnectedSubnetsAddressSet separately
+// when neither partial connectivity nor advertised override needs it.
+func (c *Controller) cleanupAdvertisedOverrideACLs(cncName string) error {
+	return c.cleanupCNCACLsByType(cncName, func(aclType string) bool {
+		return aclType == "pass-advertised"
+	}, "advertised override")
+}
+
+// cleanupCNCACLsByType removes CNC ACLs matching the given type filter from all switches.
+func (c *Controller) cleanupCNCACLsByType(cncName string, typeFilter func(string) bool, description string) error {
 	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLClusterNetworkConnect, controllerName,
 		map[libovsdbops.ExternalIDKey]string{
 			libovsdbops.ObjectNameKey: cncName,
 		})
 	aclPredicate := libovsdbops.GetPredicate[*nbdb.ACL](predicateIDs, nil)
-	acls, err := libovsdbops.FindACLsWithPredicate(c.nbClient, aclPredicate)
+	allACLs, err := libovsdbops.FindACLsWithPredicate(c.nbClient, aclPredicate)
 	if err != nil {
 		return fmt.Errorf("failed to find ACLs for CNC %s: %w", cncName, err)
 	}
 
-	if len(acls) == 0 {
-		// No ACLs to clean up, but still try to clean address sets
-		goto cleanupAddressSets
+	var acls []*nbdb.ACL
+	for _, acl := range allACLs {
+		aclType := acl.ExternalIDs[libovsdbops.TypeKey.String()]
+		if typeFilter(aclType) {
+			acls = append(acls, acl)
+		}
 	}
 
-	// Remove ACLs from all switches that have them
-	// ACLs are owned by switches, so removing from switches will garbage-collect the ACL rows
+	if len(acls) == 0 {
+		return nil
+	}
+
 	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(c.nbClient,
 		func(sw *nbdb.LogicalSwitch) bool {
-			// Check if any of the ACLs are on this switch
 			for _, aclUUID := range sw.ACLs {
 				for _, acl := range acls {
 					if aclUUID == acl.UUID {
@@ -1784,16 +1878,147 @@ func (c *Controller) cleanupPartialConnectivity(cncName string) error {
 			return false
 		}, acls...)
 	if err != nil {
-		return fmt.Errorf("failed to remove ACLs from switches: %w", err)
+		return fmt.Errorf("failed to remove %s ACLs from switches: %w", description, err)
 	}
 
-cleanupAddressSets:
-	// Delete address sets using DestroyAddressSet which handles lookup+delete internally
-	err = c.addressSetFactory.DestroyAddressSet(getConnectedUDNSubnetsAddressSetDbIDs(cncName))
+	klog.V(4).Infof("CNC %s: cleaned up %s ACLs", cncName, description)
+	return nil
+}
+
+// cleanupStaleAdvertisedOverrideACLs removes the pass-advertised ACL from switches
+// that had it previously but are no longer in the desired set (e.g., the network stopped
+// being advertised due to a RouteAdvertisement change). If desiredSwitches is empty and
+// no advertised override ACL was built this sync, all pass-advertised ACLs are removed.
+func (c *Controller) cleanupStaleAdvertisedOverrideACLs(cncName string, desiredSwitches sets.Set[string], partialConnectivityActive bool) error {
+	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLClusterNetworkConnect, controllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: cncName,
+			libovsdbops.TypeKey:       "pass-advertised",
+		})
+	aclPredicate := libovsdbops.GetPredicate[*nbdb.ACL](predicateIDs, nil)
+	acls, err := libovsdbops.FindACLsWithPredicate(c.nbClient, aclPredicate)
+	if err != nil {
+		return fmt.Errorf("failed to find pass-advertised ACLs for CNC %s: %w", cncName, err)
+	}
+	if len(acls) == 0 {
+		return nil
+	}
+
+	// Find switches that have the ACL but are not in the desired set
+	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(c.nbClient,
+		func(sw *nbdb.LogicalSwitch) bool {
+			if desiredSwitches.Has(sw.Name) {
+				return false
+			}
+			for _, aclUUID := range sw.ACLs {
+				for _, acl := range acls {
+					if aclUUID == acl.UUID {
+						return true
+					}
+				}
+			}
+			return false
+		}, acls...)
+	if err != nil {
+		return fmt.Errorf("failed to remove stale advertised override ACLs from switches: %w", err)
+	}
+
+	// If no switches need the ACL anymore, clean up the ACL rows and
+	// destroy the shared address set if partial connectivity also doesn't need it.
+	if desiredSwitches.Len() == 0 {
+		if err := c.cleanupAdvertisedOverrideACLs(cncName); err != nil {
+			return err
+		}
+		if !partialConnectivityActive {
+			return c.destroyConnectedSubnetsAddressSet(cncName)
+		}
+	}
+
+	return nil
+}
+
+// destroyConnectedSubnetsAddressSet removes the shared address set for a CNC.
+// Call this only when neither partial connectivity nor advertised override needs it.
+func (c *Controller) destroyConnectedSubnetsAddressSet(cncName string) error {
+	err := c.addressSetFactory.DestroyAddressSet(getConnectedUDNSubnetsAddressSetDbIDs(cncName))
 	if err != nil {
 		return fmt.Errorf("failed to delete address sets for CNC %s: %w", cncName, err)
 	}
-
-	klog.V(4).Infof("CNC %s: cleaned up partial connectivity ACLs", cncName)
 	return nil
+}
+
+// buildAdvertisedNetworkPassACL builds an ACL that allows CNC-connected traffic to pass before
+// the advertised network isolation drop ACL. This is needed because the isolation drop at
+// priority 1050 in LportEgressAfterLB blocks inter-advertised-network traffic, but CNC intends
+// to allow it for connected networks. This ACL sits at priority 1075 in the same stage/tier.
+func (c *Controller) buildAdvertisedNetworkPassACL(cncName, hashNameV4, hashNameV6 string) *nbdb.ACL {
+	var match string
+	switch {
+	case config.IPv4Mode && config.IPv6Mode:
+		match = fmt.Sprintf("(ip4.dst == $%s || ip6.dst == $%s)", hashNameV4, hashNameV6)
+	case config.IPv4Mode:
+		match = fmt.Sprintf("ip4.dst == $%s", hashNameV4)
+	case config.IPv6Mode:
+		match = fmt.Sprintf("ip6.dst == $%s", hashNameV6)
+	}
+
+	if match == "" {
+		return nil
+	}
+
+	dbIDs := buildACLDBIDs(cncName, "pass-advertised")
+	return libovsdbutil.BuildACL(dbIDs, ovntypes.NetworkConnectAdvertisedPassPriority,
+		match, nbdb.ACLActionPass, nil, libovsdbutil.LportEgressAfterLB, 0)
+}
+
+// prepareAdvertisedOverrideACL builds the advertised network isolation override ACL once,
+// before the per-network loop. Returns nil if strict isolation is not enabled or no ACL is needed.
+func (c *Controller) prepareAdvertisedOverrideACL(cncName string, allocatedSubnets map[string][]*net.IPNet) (*nbdb.ACL, error) {
+	if config.OVNKubernetesFeature.AdvertisedUDNIsolationMode != config.AdvertisedUDNIsolationModeStrict {
+		return nil, nil
+	}
+
+	var allSubnets []string
+	for owner := range allocatedSubnets {
+		_, networkID, parseErr := util.ParseNetworkOwner(owner)
+		if parseErr != nil {
+			klog.Warningf("Failed to parse owner key %s: %v", owner, parseErr)
+			continue
+		}
+
+		netInfo := c.networkManager.GetNetworkByID(networkID)
+		if netInfo == nil {
+			klog.Warningf("Network with ID %d not found", networkID)
+			continue
+		}
+
+		for _, subnet := range netInfo.Subnets() {
+			if subnet.CIDR != nil {
+				allSubnets = append(allSubnets, subnet.CIDR.String())
+			}
+		}
+	}
+
+	hashNameV4, hashNameV6, err := c.ensureConnectedSubnetsAddressSet(cncName, allSubnets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure connected subnets address set: %w", err)
+	}
+
+	return c.buildAdvertisedNetworkPassACL(cncName, hashNameV4, hashNameV6), nil
+}
+
+// ensureAdvertisedOverrideACLOps builds ops to add the pre-built advertised override ACL
+// to a network's switch. The ACL is created/updated and then attached to the switch.
+func (c *Controller) ensureAdvertisedOverrideACLOps(ops []ovsdb.Operation, acl *nbdb.ACL, switchName string) ([]ovsdb.Operation, error) {
+	ops, err := libovsdbops.CreateOrUpdateACLsOps(c.nbClient, ops, nil, acl)
+	if err != nil {
+		return ops, fmt.Errorf("failed to create advertised override ACL ops: %w", err)
+	}
+
+	ops, err = libovsdbops.AddACLsToLogicalSwitchOps(c.nbClient, ops, switchName, acl)
+	if err != nil {
+		return ops, fmt.Errorf("failed to add advertised override ACL to switch %s: %w", switchName, err)
+	}
+
+	return ops, nil
 }

--- a/go-controller/pkg/ovn/controller/networkconnect/topology_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/topology_test.go
@@ -879,7 +879,8 @@ func TestCleanupNetworkConnections(t *testing.T) {
 			defer cleanup.Cleanup()
 
 			c := &Controller{
-				nbClient: nbClient,
+				nbClient:          nbClient,
+				addressSetFactory: addressset.NewOvnAddressSetFactory(nbClient, true, false),
 			}
 
 			err = c.cleanupNetworkConnections(tt.cncName, false, false)
@@ -3661,15 +3662,14 @@ func TestCleanupPartialConnectivityACLsOps(t *testing.T) {
 
 func TestCleanupPartialConnectivity(t *testing.T) {
 	tests := []struct {
-		name               string
-		cncName            string
-		initialDB          []libovsdbtest.TestData
-		expectACLsRemain   int // total ACLs remaining after cleanup
-		expectSwitchACLs   map[string]int
-		expectAddressSetGC bool // whether address set should be destroyed
+		name             string
+		cncName          string
+		initialDB        []libovsdbtest.TestData
+		expectACLsRemain int // total CNC ACLs remaining after cleanup
+		expectSwitchACLs map[string]int
 	}{
 		{
-			name:    "removes ACLs from all switches and destroys address set",
+			name:    "removes partial ACLs from all switches",
 			cncName: "test-cnc",
 			initialDB: []libovsdbtest.TestData{
 				&nbdb.ACL{
@@ -3714,10 +3714,9 @@ func TestCleanupPartialConnectivity(t *testing.T) {
 				"switch_netA": 0,
 				"switch_netB": 0,
 			},
-			expectAddressSetGC: true,
 		},
 		{
-			name:    "no ACLs to clean - only destroys address set",
+			name:    "no ACLs to clean - noop",
 			cncName: "empty-cnc",
 			initialDB: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
@@ -3725,9 +3724,8 @@ func TestCleanupPartialConnectivity(t *testing.T) {
 					Name: "switch_netA",
 				},
 			},
-			expectACLsRemain:   0,
-			expectSwitchACLs:   map[string]int{"switch_netA": 0},
-			expectAddressSetGC: true,
+			expectACLsRemain: 0,
+			expectSwitchACLs: map[string]int{"switch_netA": 0},
 		},
 		{
 			name:    "only cleans ACLs owned by specified CNC",
@@ -3757,9 +3755,38 @@ func TestCleanupPartialConnectivity(t *testing.T) {
 					ACLs: []string{"acl-cnca", "acl-cncb"},
 				},
 			},
-			expectACLsRemain:   1, // cnc-b's ACL remains
-			expectSwitchACLs:   map[string]int{"switch_netA": 1},
-			expectAddressSetGC: true,
+			expectACLsRemain: 1, // cnc-b's ACL remains
+			expectSwitchACLs: map[string]int{"switch_netA": 1},
+		},
+		{
+			name:    "does not remove pass-advertised ACLs",
+			cncName: "test-cnc",
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-partial",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "(ip4.dst == 172.16.1.0/24)",
+					Priority:    ovntypes.NetworkConnectPassServiceTrafficPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-service").GetExternalIDs(),
+				},
+				&nbdb.ACL{
+					UUID:        "acl-advertised",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $some_as",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-partial", "acl-advertised"},
+				},
+			},
+			expectACLsRemain: 1, // pass-advertised remains
+			expectSwitchACLs: map[string]int{"switch_netA": 1},
 		},
 	}
 
@@ -3794,6 +3821,348 @@ func TestCleanupPartialConnectivity(t *testing.T) {
 				require.Len(t, sw, 1)
 				assert.Len(t, sw[0].ACLs, expectedCount,
 					"switch %s ACL count mismatch", switchName)
+			}
+		})
+	}
+}
+
+func TestBuildAdvertisedNetworkPassACL(t *testing.T) {
+	tests := []struct {
+		name          string
+		ipv4Mode      bool
+		ipv6Mode      bool
+		asNameV4      string
+		asNameV6      string
+		expectNil     bool
+		matchContains []string
+		matchExcludes []string
+	}{
+		{
+			name:          "IPv4 only",
+			ipv4Mode:      true,
+			ipv6Mode:      false,
+			asNameV4:      "as_v4_hash",
+			asNameV6:      "as_v6_hash",
+			matchContains: []string{"ip4.dst == $as_v4_hash"},
+			matchExcludes: []string{"ip6"},
+		},
+		{
+			name:          "IPv6 only",
+			ipv4Mode:      false,
+			ipv6Mode:      true,
+			asNameV4:      "as_v4_hash",
+			asNameV6:      "as_v6_hash",
+			matchContains: []string{"ip6.dst == $as_v6_hash"},
+			matchExcludes: []string{"ip4"},
+		},
+		{
+			name:          "dual-stack",
+			ipv4Mode:      true,
+			ipv6Mode:      true,
+			asNameV4:      "as_v4_hash",
+			asNameV6:      "as_v6_hash",
+			matchContains: []string{"ip4.dst == $as_v4_hash", "ip6.dst == $as_v6_hash"},
+		},
+		{
+			name:      "no IP mode",
+			ipv4Mode:  false,
+			ipv6Mode:  false,
+			asNameV4:  "as_v4_hash",
+			asNameV6:  "as_v6_hash",
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.PrepareTestConfig()
+			require.NoError(t, err)
+
+			config.IPv4Mode = tt.ipv4Mode
+			config.IPv6Mode = tt.ipv6Mode
+
+			c := &Controller{}
+			acl := c.buildAdvertisedNetworkPassACL("test-cnc", tt.asNameV4, tt.asNameV6)
+
+			if tt.expectNil {
+				assert.Nil(t, acl)
+				return
+			}
+
+			require.NotNil(t, acl)
+			assert.Equal(t, nbdb.ACLActionPass, acl.Action)
+			assert.Equal(t, nbdb.ACLDirectionFromLport, acl.Direction)
+			assert.Equal(t, ovntypes.NetworkConnectAdvertisedPassPriority, acl.Priority)
+			assert.Equal(t, "test-cnc", acl.ExternalIDs[libovsdbops.ObjectNameKey.String()])
+
+			require.NotNil(t, acl.Options)
+			assert.Equal(t, "true", acl.Options["apply-after-lb"],
+				"ACL must be in the LportEgressAfterLB stage")
+
+			for _, s := range tt.matchContains {
+				assert.Contains(t, acl.Match, s)
+			}
+			for _, s := range tt.matchExcludes {
+				assert.NotContains(t, acl.Match, s)
+			}
+		})
+	}
+}
+
+func TestCleanupAdvertisedOverrideACLs(t *testing.T) {
+	tests := []struct {
+		name             string
+		cncName          string
+		initialDB        []libovsdbtest.TestData
+		expectACLsRemain int
+		expectSwitchACLs map[string]int
+	}{
+		{
+			name:    "removes only pass-advertised ACLs",
+			cncName: "test-cnc",
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-partial",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "(ip4.dst == 172.16.1.0/24)",
+					Priority:    ovntypes.NetworkConnectPassServiceTrafficPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-service").GetExternalIDs(),
+				},
+				&nbdb.ACL{
+					UUID:        "acl-advertised",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $some_as",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-partial", "acl-advertised"},
+				},
+			},
+			expectACLsRemain: 1, // pass-service remains
+			expectSwitchACLs: map[string]int{"switch_netA": 1},
+		},
+		{
+			name:    "no pass-advertised ACLs - noop",
+			cncName: "test-cnc",
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-partial",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "(ip4.dst == 172.16.1.0/24)",
+					Priority:    ovntypes.NetworkConnectPassServiceTrafficPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-service").GetExternalIDs(),
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-partial"},
+				},
+			},
+			expectACLsRemain: 1,
+			expectSwitchACLs: map[string]int{"switch_netA": 1},
+		},
+		{
+			name:    "does not touch other CNC's pass-advertised ACLs",
+			cncName: "cnc-a",
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-a",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $as_a",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("cnc-a", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.ACL{
+					UUID:        "acl-b",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $as_b",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("cnc-b", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-a", "acl-b"},
+				},
+			},
+			expectACLsRemain: 1, // cnc-b's ACL remains
+			expectSwitchACLs: map[string]int{"switch_netA": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: tt.initialDB,
+			}, nil)
+			require.NoError(t, err)
+			defer cleanup.Cleanup()
+
+			c := &Controller{nbClient: nbClient}
+
+			err = c.cleanupAdvertisedOverrideACLs(tt.cncName)
+			require.NoError(t, err)
+
+			allPredicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLClusterNetworkConnect, controllerName, nil)
+			acls, err := libovsdbops.FindACLsWithPredicate(nbClient, libovsdbops.GetPredicate[*nbdb.ACL](allPredicateIDs, nil))
+			require.NoError(t, err)
+			assert.Len(t, acls, tt.expectACLsRemain, "remaining ACL count mismatch")
+
+			for switchName, expectedCount := range tt.expectSwitchACLs {
+				sw, err := libovsdbops.FindLogicalSwitchesWithPredicate(nbClient, func(s *nbdb.LogicalSwitch) bool {
+					return s.Name == switchName
+				})
+				require.NoError(t, err)
+				require.Len(t, sw, 1)
+				assert.Len(t, sw[0].ACLs, expectedCount, "switch %s ACL count mismatch", switchName)
+			}
+		})
+	}
+}
+
+func TestCleanupStaleAdvertisedOverrideACLs(t *testing.T) {
+	tests := []struct {
+		name                      string
+		cncName                   string
+		desiredSwitches           sets.Set[string]
+		partialConnectivityActive bool
+		initialDB                 []libovsdbtest.TestData
+		expectACLsRemain          int
+		expectSwitchACLs          map[string]int
+	}{
+		{
+			name:            "removes ACL from stale switch, keeps on desired switch",
+			cncName:         "test-cnc",
+			desiredSwitches: sets.New[string]("switch_netA"),
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-adv",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $some_as",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-adv"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-B",
+					Name: "switch_netB",
+					ACLs: []string{"acl-adv"},
+				},
+			},
+			expectACLsRemain: 1,
+			expectSwitchACLs: map[string]int{
+				"switch_netA": 1,
+				"switch_netB": 0,
+			},
+		},
+		{
+			name:                      "all switches stale, partial active - removes ACLs, keeps address set",
+			cncName:                   "test-cnc",
+			desiredSwitches:           sets.New[string](),
+			partialConnectivityActive: true,
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-adv",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $some_as",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-adv"},
+				},
+			},
+			expectACLsRemain: 0,
+			expectSwitchACLs: map[string]int{"switch_netA": 0},
+		},
+		{
+			name:                      "all switches stale, no partial - removes ACLs and destroys address set",
+			cncName:                   "test-cnc",
+			desiredSwitches:           sets.New[string](),
+			partialConnectivityActive: false,
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.ACL{
+					UUID:        "acl-adv",
+					Action:      nbdb.ACLActionPass,
+					Direction:   nbdb.ACLDirectionFromLport,
+					Match:       "ip4.dst == $some_as",
+					Priority:    ovntypes.NetworkConnectAdvertisedPassPriority,
+					ExternalIDs: buildACLDBIDs("test-cnc", "pass-advertised").GetExternalIDs(),
+					Options:     map[string]string{"apply-after-lb": "true"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+					ACLs: []string{"acl-adv"},
+				},
+			},
+			expectACLsRemain: 0,
+			expectSwitchACLs: map[string]int{"switch_netA": 0},
+		},
+		{
+			name:            "no ACLs exist - noop",
+			cncName:         "test-cnc",
+			desiredSwitches: sets.New[string](),
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					UUID: "sw-A",
+					Name: "switch_netA",
+				},
+			},
+			expectACLsRemain: 0,
+			expectSwitchACLs: map[string]int{"switch_netA": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+				NBData: tt.initialDB,
+			}, nil)
+			require.NoError(t, err)
+			defer cleanup.Cleanup()
+
+			c := &Controller{
+				nbClient:          nbClient,
+				addressSetFactory: addressset.NewOvnAddressSetFactory(nbClient, true, false),
+			}
+
+			err = c.cleanupStaleAdvertisedOverrideACLs(tt.cncName, tt.desiredSwitches, tt.partialConnectivityActive)
+			require.NoError(t, err)
+
+			allPredicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.ACLClusterNetworkConnect, controllerName, nil)
+			acls, err := libovsdbops.FindACLsWithPredicate(nbClient, libovsdbops.GetPredicate[*nbdb.ACL](allPredicateIDs, nil))
+			require.NoError(t, err)
+			assert.Len(t, acls, tt.expectACLsRemain, "remaining ACL count mismatch")
+
+			for switchName, expectedCount := range tt.expectSwitchACLs {
+				sw, err := libovsdbops.FindLogicalSwitchesWithPredicate(nbClient, func(s *nbdb.LogicalSwitch) bool {
+					return s.Name == switchName
+				})
+				require.NoError(t, err)
+				require.Len(t, sw, 1)
+				assert.Len(t, sw[0].ACLs, expectedCount, "switch %s ACL count mismatch", switchName)
 			}
 		})
 	}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -92,10 +92,6 @@ const (
 	DefaultAllowPriority = 1001
 	// Default deny acl rule priority
 	DefaultDenyPriority = 1000
-	// Pass priority for isolated advertised networks
-	AdvertisedNetworkPassPriority = 1100
-	// Deny priority for isolated advertised networks
-	AdvertisedNetworkDenyPriority = 1050
 
 	// PrimaryACLTier Priorities
 
@@ -110,6 +106,14 @@ const (
 	NetworkConnectPassSameNetworkPriority = 475
 	// Priority for dropping pod-to-pod traffic between connected networks
 	NetworkConnectDropPodTrafficPriority = 450
+	// Pass priority for isolated advertised networks
+	AdvertisedNetworkPassPriority = 1100
+	// Pass priority for CNC-connected traffic to override advertised network isolation.
+	// Sits between AdvertisedNetworkPassPriority (1100, intra-network) and
+	// AdvertisedNetworkDenyPriority (1050, inter-network drop) in the LportEgressAfterLB stage.
+	NetworkConnectAdvertisedPassPriority = 1075
+	// Deny priority for isolated advertised networks
+	AdvertisedNetworkDenyPriority = 1050
 
 	// ACL Tiers
 	// Tier 0 is called Primary as it is evaluated before any other feature-related Tiers.

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -370,6 +371,61 @@ func createLayer3PrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnNam
 // createLayer2PrimaryUDNWithSubnets creates a Layer2 primary UDN with custom subnets
 func createLayer2PrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName, v4Subnet, v6Subnet string) {
 	createPrimaryUDNWithSubnets(cs, namespace, udnName, "Layer2", v4Subnet, v6Subnet)
+}
+
+// ============================================================================
+// RouteAdvertisement Helpers
+// ============================================================================
+
+// createOrUpdateRouteAdvertisement creates or updates a RouteAdvertisement that advertises
+// PodNetwork for CUDNs matching the given label selector.
+// NOTE: route_advertisements.go has a typed createRouteAdvertisements helper, but it depends
+// on infraapi.Context for cleanup which this test file doesn't use.
+func createOrUpdateRouteAdvertisement(raName string, networkMatchLabels map[string]string) {
+	labelSelectorStr := ""
+	for k, v := range networkMatchLabels {
+		if labelSelectorStr != "" {
+			labelSelectorStr += "\n            "
+		}
+		labelSelectorStr += fmt.Sprintf("%s: \"%s\"", k, v)
+	}
+	manifest := fmt.Sprintf(`
+apiVersion: k8s.ovn.org/v1
+kind: RouteAdvertisements
+metadata:
+  name: %s
+spec:
+  networkSelectors:
+    - networkSelectionType: "ClusterUserDefinedNetworks"
+      clusterUserDefinedNetworkSelector:
+        networkSelector:
+          matchLabels:
+            %s
+  nodeSelector: {}
+  frrConfigurationSelector: {}
+  advertisements:
+    - PodNetwork
+`, raName, labelSelectorStr)
+	_, err := e2ekubectl.RunKubectlInput("", manifest, "apply", "-f", "-")
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// deleteRouteAdvertisement deletes a RouteAdvertisement
+func deleteRouteAdvertisement(raName string) {
+	_, _ = e2ekubectl.RunKubectl("", "delete", "routeadvertisements", raName, "--wait", "--timeout=30s", "--ignore-not-found")
+}
+
+// waitForRouteAdvertisementAccepted waits for a RouteAdvertisement's Accepted condition
+func waitForRouteAdvertisementAccepted(raName string) {
+	Eventually(func() string {
+		out, err := e2ekubectl.RunKubectl("", "get", "routeadvertisements", raName,
+			"-o", `jsonpath={.status.conditions[?(@.type=="Accepted")].reason}`)
+		if err != nil {
+			return ""
+		}
+		return out
+	}, 30*time.Second, time.Second).Should(Equal("Accepted"),
+		fmt.Sprintf("waiting for RouteAdvertisement %s to be accepted", raName))
 }
 
 // getCNCAnnotations gets CNC annotations
@@ -4707,6 +4763,167 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 				}, 5*time.Second, 1*time.Second).Should(BeTrue(),
 					fmt.Sprintf("UDP connectivity from %s to blue service %s:9090", blackPod.Name, blueIP))
 			}
+		})
+	})
+
+	/*
+	   This test validates CNC's interaction with advertised network isolation:
+
+	   1. CNC override: the pass-advertised ACL (priority 1075 at LportEgressAfterLB)
+	      overrides the isolation drop (priority 1050), allowing cross-network connectivity.
+	   2. CNC lifecycle: deleting the CNC removes the override ACL, causing isolation to
+	      block connectivity; re-creating the CNC restores the override and connectivity.
+	   3. RA lifecycle: deleting the RA removes isolation ACLs and triggers cleanup of the
+	      stale override ACL; connectivity is maintained via basic CNC.
+
+	   Test Scenario:
+	   - Create two L3 primary CUDNs in separate namespaces, both labeled for RA + CNC selection
+	   - Create a RouteAdvertisement targeting both CUDNs (making them "advertised")
+	   - Create a CNC connecting both CUDNs with PodNetwork connectivity
+	   - Deploy one pod per network on different nodes
+	   - Verify pod-to-pod connectivity WORKS (CNC override ACL at 1075 > isolation drop at 1050)
+	   - Delete the CNC (override removed, isolation blocks)
+	   - Verify pod-to-pod connectivity is BLOCKED (isolation drop re-asserts)
+	   - Re-create the CNC (override re-added)
+	   - Verify connectivity WORKS again
+	   - Delete the RA (networks stop being advertised, stale override cleaned up)
+	   - Verify connectivity still WORKS (no isolation, basic CNC active)
+	*/
+	Context("Advertised UDN isolation with CNC", feature.RouteAdvertisements, func() {
+		const nodeHostnameKey = "kubernetes.io/hostname"
+
+		It("should allow connectivity with CNC override, block after CNC deletion, restore after CNC re-creation, and survive RA deletion", func() {
+			if os.Getenv("ADVERTISED_UDN_ISOLATION_MODE") == "loose" {
+				Skip("test requires strict advertised UDN isolation mode (ADVERTISED_UDN_ISOLATION_MODE != 'loose')")
+			}
+
+			testID := rand.String(5)
+			cncName := generateCNCName()
+			raName := fmt.Sprintf("test-ra-%s", testID)
+
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), cs, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodes.Items)).To(BeNumerically(">=", 2), "test requires at least 2 schedulable nodes")
+			node1Name, node2Name := nodes.Items[0].Name, nodes.Items[1].Name
+
+			redCUDN := fmt.Sprintf("red-cudn-%s", testID)
+			blueCUDN := fmt.Sprintf("blue-cudn-%s", testID)
+			redNs := fmt.Sprintf("red-ns-%s", testID)
+			blueNs := fmt.Sprintf("blue-ns-%s", testID)
+
+			cudnLabel := map[string]string{"advertised-cnc-test": testID}
+			nextSubnets := newTestNetworkSubnetsAllocator()
+
+			pods := make(map[string]*corev1.Pod)
+			podIPs := make(map[string][]string)
+
+			DeferCleanup(func() {
+				By("Cleanup: Deleting all test resources")
+				deleteCNC(cncName)
+				deleteRouteAdvertisement(raName)
+				for _, pod := range pods {
+					_ = cs.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+				}
+				deleteCUDN(redCUDN)
+				deleteCUDN(blueCUDN)
+				deleteNamespace(cs, redNs)
+				deleteNamespace(cs, blueNs)
+			})
+
+			By("1. Creating namespaces for red and blue CUDNs")
+			createUDNNamespaceWithName(cs, redNs, nil)
+			createUDNNamespaceWithName(cs, blueNs, nil)
+
+			By("2. Creating red CUDN (L3) with advertised label")
+			v4, v6 := nextSubnets()
+			createLayer3PrimaryCUDNWithSubnets(cs, redCUDN, cudnLabel, v4, v6, redNs)
+			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, redCUDN), 60*time.Second, time.Second).Should(Succeed())
+
+			By("2. Creating blue CUDN (L3) with advertised label")
+			v4, v6 = nextSubnets()
+			createLayer3PrimaryCUDNWithSubnets(cs, blueCUDN, cudnLabel, v4, v6, blueNs)
+			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, blueCUDN), 60*time.Second, time.Second).Should(Succeed())
+
+			By("3. Creating RouteAdvertisement targeting both CUDNs")
+			createOrUpdateRouteAdvertisement(raName, cudnLabel)
+			waitForRouteAdvertisementAccepted(raName)
+
+			By("4. Creating CNC connecting both advertised CUDNs")
+			createOrUpdateCNC(cs, cncName, cudnLabel, nil)
+
+			By("4. Waiting for CNC annotations")
+			verifyCNCHasBothAnnotations(cncName)
+			verifyCNCSubnetAnnotationNetworkCount(cncName, 2)
+
+			By("5. Deploying pods on each network (different nodes for cross-node testing)")
+			redPodConfig := httpServerPodConfig("red-pod", redNs)
+			redPodConfig.nodeSelector = map[string]string{nodeHostnameKey: node1Name}
+			pods["red-pod"] = runUDNPod(cs, redNs, redPodConfig, nil)
+			podIPs["red-pod"] = getPrimaryNetworkPodIPs(redNs, "red-pod", redCUDN)
+
+			bluePodConfig := httpServerPodConfig("blue-pod", blueNs)
+			bluePodConfig.nodeSelector = map[string]string{nodeHostnameKey: node2Name}
+			pods["blue-pod"] = runUDNPod(cs, blueNs, bluePodConfig, nil)
+			podIPs["blue-pod"] = getPrimaryNetworkPodIPs(blueNs, "blue-pod", blueCUDN)
+
+			By("6. Verifying cross-network connectivity WORKS (CNC override ACL at 1075 overrides isolation drop at 1050)")
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"red-pod": pods["red-pod"]},
+				map[string][]string{"blue-pod": podIPs["blue-pod"]},
+				true,
+			)
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"blue-pod": pods["blue-pod"]},
+				map[string][]string{"red-pod": podIPs["red-pod"]},
+				true,
+			)
+
+			By("7. Deleting CNC to remove override ACLs")
+			deleteCNC(cncName)
+
+			By("8. Verifying cross-network connectivity is BLOCKED (advertised isolation drop re-asserts)")
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"red-pod": pods["red-pod"]},
+				map[string][]string{"blue-pod": podIPs["blue-pod"]},
+				false,
+			)
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"blue-pod": pods["blue-pod"]},
+				map[string][]string{"red-pod": podIPs["red-pod"]},
+				false,
+			)
+
+			By("9. Re-creating CNC (override ACL re-added)")
+			createOrUpdateCNC(cs, cncName, cudnLabel, nil)
+			verifyCNCHasBothAnnotations(cncName)
+			verifyCNCSubnetAnnotationNetworkCount(cncName, 2)
+
+			By("10. Verifying connectivity WORKS again (CNC override re-established)")
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"red-pod": pods["red-pod"]},
+				map[string][]string{"blue-pod": podIPs["blue-pod"]},
+				true,
+			)
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"blue-pod": pods["blue-pod"]},
+				map[string][]string{"red-pod": podIPs["red-pod"]},
+				true,
+			)
+
+			By("11. Deleting RouteAdvertisement (networks stop being advertised, stale override ACL cleaned up)")
+			deleteRouteAdvertisement(raName)
+
+			By("12. Verifying connectivity still WORKS (no isolation to block, basic CNC connectivity)")
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"red-pod": pods["red-pod"]},
+				map[string][]string{"blue-pod": podIPs["blue-pod"]},
+				true,
+			)
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{"blue-pod": pods["blue-pod"]},
+				map[string][]string{"red-pod": podIPs["red-pod"]},
+				true,
+			)
 		})
 	})
 })

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -151,10 +151,9 @@ if [[ "${WHAT}" != "${NETWORK_SEGMENTATION_TESTS}"* ]]; then
   skip $NETWORK_SEGMENTATION_TESTS
 fi
 
-# Only run cluster network connect tests if they are explicitly requested
-# To conserve CI resources, we run these tests as part of the network segmentation tests
+# Only run cluster network connect tests when the feature is enabled
 CLUSTER_NETWORK_CONNECT_TESTS="ClusterNetworkConnect"
-if [[ "${WHAT}" != "${CLUSTER_NETWORK_CONNECT_TESTS}"* ]]; then
+if [ "$ENABLE_NETWORK_CONNECT" != "true" ]; then
   skip $CLUSTER_NETWORK_CONNECT_TESTS
 fi
 


### PR DESCRIPTION

## 📑 Description

Problem
-------
When a User Defined Network (UDN) is advertised with strict isolation
(AdvertisedUDNIsolationMode=strict), the advertised network controller
installs a deny ACL at priority 1050 in the LportEgressAfterLB stage to
block inter-network traffic. This conflicts with ClusterNetworkConnect
(CNC), which is designed to allow cross-network connectivity: traffic
from CNC-connected pods is dropped by the isolation ACL before it can
reach the connected network.

Options considered
------------------
A) Have the CNC controller remove or lower the priority of the
   advertised isolation deny ACL when a CNC connects to that network.
   Rejected: this creates ownership conflicts between two controllers
   managing the same ACL, introduces race conditions during reconcile,
   and breaks the isolation guarantee for non-CNC traffic.

B) Have the advertised network controller carve out an exception in its
   deny ACL match expression for CNC-connected subnets.
   Rejected: the advertised controller has no knowledge of CNC state,
   creating a tight coupling between unrelated controllers. The match
   expression would grow unbounded as CNCs are added/removed.

C) Have the CNC controller install its own higher-priority pass ACL at
   the same pipeline stage (LportEgressAfterLB) that explicitly allows
   traffic destined for CNC-connected subnets. This ACL sits between
   the AdvertisedNetworkPassPriority (1100, intra-network pass) and
   AdvertisedNetworkDenyPriority (1050, inter-network deny).
   Selected: this is additive, each controller owns its own ACLs, there
   are no race conditions, and cleanup is straightforward.

This is different from original design https://ovn-kubernetes.io/okeps/okep-5224-connecting-udns/okep-5224-connecting-udns/#connecting-advertised-udns in terms of implementation details

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

E2Es added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advertised-network isolation for ClusterNetworkConnect, enabling selective cross-network pod connectivity for advertised networks.

* **Tests**
  * Added unit and e2e tests covering advertised-network ACLs, cleanup behaviors, address-set lifecycle, and connectivity scenarios with route advertisements.

* **Bug Fixes / Improvements**
  * Broader stale-rule cleanup, improved advertised-rule attach/remove behavior, refined shared-subnet lifecycle, and adjusted ACL priority handling.

* **Chores**
  * CI test gating for network-connect enabled and workflow env updated; e2e helpers for route advertisements added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->