### PR TITLE
Fix ECMP route duplicates on ovnkube-node pod restart

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -402,7 +402,7 @@ func (nb *northBoundClient) createOrUpdateBFDStaticRoute(bfdEnabled bool, gw str
 			item.Nexthop == lrsr.Nexthop &&
 			item.OutputPort != nil &&
 			*item.OutputPort == *lrsr.OutputPort &&
-			item.Policy == lrsr.Policy
+			libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy)
 	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nb.nbClient, ops, gr, &lrsr, p,
 		&lrsr.Options)

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -386,7 +386,7 @@ func (nb *northBoundClient) createOrUpdateBFDStaticRoute(bfdEnabled bool, gw str
 			item.Nexthop == lrsr.Nexthop &&
 			item.OutputPort != nil &&
 			*item.OutputPort == *lrsr.OutputPort &&
-			item.Policy == lrsr.Policy
+			libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy)
 	}
 	ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nb.nbClient, ops, gr, &lrsr, p,
 		&lrsr.Options)

--- a/go-controller/pkg/ovn/controller/apbroute/network_client_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package apbroute
+
+import (
+	"testing"
+
+	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+)
+
+// TestPolicyComparisonInPredicate tests that the predicate function in createOrUpdateBFDStaticRoute
+// correctly compares Policy values (not pointers) to avoid creating duplicate routes.
+// This is a regression test for https://issues.redhat.com/browse/OCPBUGS-70272
+func TestPolicyComparisonInPredicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		route1   *nbdb.LogicalRouterStaticRoute
+		route2   *nbdb.LogicalRouterStaticRoute
+		expected bool
+	}{
+		{
+			name: "same policy values but different pointers",
+			route1: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policyPtr(nbdb.LogicalRouterStaticRoutePolicySrcIP),
+			},
+			route2: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policyPtr(nbdb.LogicalRouterStaticRoutePolicySrcIP),
+			},
+			expected: true,
+		},
+		{
+			name: "both policies are nil",
+			route1: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     nil,
+			},
+			route2: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     nil,
+			},
+			expected: true,
+		},
+		{
+			name: "nil policy equals DstIP policy",
+			route1: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     nil,
+			},
+			route2: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policyPtr(nbdb.LogicalRouterStaticRoutePolicyDstIP),
+			},
+			expected: true,
+		},
+		{
+			name: "different policy values",
+			route1: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policyPtr(nbdb.LogicalRouterStaticRoutePolicySrcIP),
+			},
+			route2: &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policyPtr(nbdb.LogicalRouterStaticRoutePolicyDstIP),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Verify pointer addresses are different when both policies are non-nil
+			if tt.route1.Policy != nil && tt.route2.Policy != nil && tt.route1.Policy == tt.route2.Policy {
+				t.Fatal("Test setup error: policy pointers should be different when both are non-nil")
+			}
+
+			// The predicate function from createOrUpdateBFDStaticRoute
+			// This uses the actual production helper libovsdbops.PolicyEqualPredicate
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == tt.route2.IPPrefix &&
+					item.Nexthop == tt.route2.Nexthop &&
+					item.OutputPort != nil &&
+					*item.OutputPort == *tt.route2.OutputPort &&
+					libovsdbops.PolicyEqualPredicate(item.Policy, tt.route2.Policy)
+			}
+
+			result := p(tt.route1)
+			if result != tt.expected {
+				t.Errorf("Predicate returned %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func policyPtr(p nbdb.LogicalRouterStaticRoutePolicy) *nbdb.LogicalRouterStaticRoutePolicy {
+	return &p
+}

--- a/go-controller/pkg/ovn/controller/apbroute/network_client_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client_test.go
@@ -4,6 +4,9 @@
 package apbroute
 
 import (
+	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -14,4 +17,50 @@ var _ = Describe("northBoundClient", func() {
 
 		Expect(nb.deletePodSNAT("remote-node", "GR_remote-node", nil, nil)).To(Succeed())
 	})
+
+	// The predicate below mirrors createOrUpdateBFDStaticRoute's route-lookup predicate.
+	DescribeTable("compares route Policy by value in the lookup predicate",
+		func(policy1, policy2 *nbdb.LogicalRouterStaticRoutePolicy, expected bool) {
+			route1 := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policy1,
+			}
+			route2 := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:   "10.128.2.25/32",
+				Nexthop:    "10.74.237.104",
+				OutputPort: stringPtr("rtoe-GR_test-worker"),
+				Policy:     policy2,
+			}
+
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == route2.IPPrefix &&
+					item.Nexthop == route2.Nexthop &&
+					item.OutputPort != nil &&
+					*item.OutputPort == *route2.OutputPort &&
+					libovsdbops.PolicyEqualPredicate(item.Policy, route2.Policy)
+			}
+
+			Expect(p(route1)).To(Equal(expected))
+		},
+		// Each Entry allocates its own Policy pointers via policyPtr so the predicate
+		// is exercised on value equality, not on reused pointers matching trivially.
+		Entry("same policy values but different pointers",
+			policyPtr(nbdb.LogicalRouterStaticRoutePolicySrcIP), policyPtr(nbdb.LogicalRouterStaticRoutePolicySrcIP), true),
+		Entry("both policies are nil",
+			(*nbdb.LogicalRouterStaticRoutePolicy)(nil), (*nbdb.LogicalRouterStaticRoutePolicy)(nil), true),
+		Entry("nil policy equals DstIP policy",
+			(*nbdb.LogicalRouterStaticRoutePolicy)(nil), policyPtr(nbdb.LogicalRouterStaticRoutePolicyDstIP), true),
+		Entry("different policy values",
+			policyPtr(nbdb.LogicalRouterStaticRoutePolicySrcIP), policyPtr(nbdb.LogicalRouterStaticRoutePolicyDstIP), false),
+	)
 })
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func policyPtr(p nbdb.LogicalRouterStaticRoutePolicy) *nbdb.LogicalRouterStaticRoutePolicy {
+	return &p
+}


### PR DESCRIPTION
## Summary

Fixes duplicate ECMP routes being created on each ovnkube-node pod restart when using AdminPolicyBasedExternalRoute (APBER).

## Problem

When an ovnkube-node pod restarts, the predicate function in `createOrUpdateBFDStaticRoute()` compares Policy pointers using `==` instead of comparing their values. This causes the predicate to fail to match existing routes, leading to `CreateOrUpdate` creating new routes instead of updating existing ones.

Each pod restart creates additional duplicate routes, resulting in multiple identical ECMP routes for the same destination.

## Root Cause

Line 402 in `network_client.go`:
```go
item.Policy == lrsr.Policy  // Pointer comparison - always fails
```

Even when both policies have the same value (e.g., "src-ip"), they are different pointer addresses, so the comparison fails.

## Solution

Use `libovsdbops.PolicyEqualPredicate()` which properly compares Policy pointer values:
```go
libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy)  // Value comparison
```

This is the standard pattern used in 13 other places in the codebase (gateway.go, hybrid.go, etc.).

## Testing
- Built and tested a custom OVN-Kubernetes image containing the fix for ECMP duplicates issue.
- Created [image](quay.io/smulje/ovn-kubernetes@sha256:91e30164a988ffaca782792ed0388be744707e877f27c7570e714c801c55976f
) with fix included
- Tested in OpenShift 4.20 cluster:
  - Confirmed bug: 0 routes → 1 → 2 → 3 duplicates with each pod restart
  - Confirmed fix: Detects existing routes correctly, prevents duplicates