### PR TITLE
Cluster Manager: Add support for managed VTEP mode

### DIFF
--- a/docs/features/bgp-integration/evpn.md
+++ b/docs/features/bgp-integration/evpn.md
@@ -103,10 +103,6 @@ spec:
 ```
 
 > [!NOTE]
-> Managed VTEP mode is not yet implemented. Currently only unmanaged mode is
-> supported.
-
-> [!NOTE]
 > Using the node IP as VTEP IP should be avoided. Assigning the VTEP IP to a
 > device without a physical link carrier (e.g. a dummy interface) keeps the
 > address up when a physical link goes down, enabling EVPN multihoming and
@@ -688,6 +684,70 @@ spec:
 
 Notice that the VRF EVPN section uses ASN 65100 from the explicit VRF router
 instead of inheriting 65000 from the underlay.
+
+## Mode Switching
+
+The VTEP mode can be changed between Managed and Unmanaged at runtime. Each
+direction requires specific user actions to ensure a smooth transition.
+
+### Managed VTEP CIDR requirements
+
+In managed mode, ovnkube-cluster-manager allocates VTEP IPs from the configured
+CIDRs. The CIDRs **must not overlap** with any node host IP reported in
+`k8s.ovn.org/host-cidrs`. If overlap is detected, the VTEP is rejected with
+`Accepted=False` and reason `CIDROverlap`. This prevents the allocator from
+handing out an IP that is already in use on a node interface.
+
+Use a dedicated, non-overlapping IP range for managed VTEP CIDRs (e.g.
+`100.64.0.0/24` from the CGNAT space). If the user wants to use existing node
+IPs as VTEP IPs, unmanaged mode should be used instead.
+
+### Unmanaged to Managed
+
+Before switching the VTEP mode from Unmanaged to Managed:
+
+1. **Remove VTEP IPs from custom interfaces on all nodes.** In unmanaged mode,
+   the user (or an external provider) configures VTEP IPs on dedicated
+   interfaces (e.g. dummy or loopback devices). These IPs appear in
+   `k8s.ovn.org/host-cidrs`. If they remain when switching to managed mode,
+   the overlap check rejects the VTEP. The managed-mode node controller
+   configures IPs on its own `evlo-*` dummy devices automatically.
+
+2. **Update the VTEP CR:**
+   ```shell
+   kubectl patch vtep evpn-vtep --type merge -p '{"spec":{"mode":"Managed"}}'
+   ```
+
+3. ovnkube-cluster-manager creates an allocator, preserves any in-range IPs
+   from existing node annotations, and allocates fresh IPs for nodes that don't
+   have one. ovnkube-node reads the annotation and configures the allocated IP
+   on a dedicated `evlo-*` dummy device.
+
+> [!NOTE]
+> If the VTEP CIDRs are different from those used during the unmanaged phase,
+> out-of-range IPs are discarded and fresh IPs are allocated. There is no
+> downtime guarantee in this case.
+
+### Managed to Unmanaged
+
+Before switching the VTEP mode from Managed to Unmanaged:
+
+1. **Configure VTEP IPs on dedicated interfaces on all nodes.** In unmanaged
+   mode, ovnkube-node discovers IPs from local interfaces. The IPs must be
+   within the VTEP CIDRs and configured as primary addresses on dedicated
+   devices (e.g. dummy interfaces). Using the node's primary IP should be
+   avoided — see the [VTEP IP note](#step-2-create-a-vtep).
+
+2. **Update the VTEP CR:**
+   ```shell
+   kubectl patch vtep evpn-vtep --type merge -p '{"spec":{"mode":"Unmanaged"}}'
+   ```
+
+3. ovnkube-cluster-manager cleans up its annotation entries on all nodes and
+   drops the allocator. There is a brief transient window where the VTEP shows
+   `Accepted=False` / `AllocationFailed` until ovnkube-node writes the
+   discovered IPs. The managed-mode `evlo-*` dummy devices are cleaned up
+   automatically by the node controller.
 
 ## Troubleshooting
 

--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+	frrapi "github.com/metallb/frr-k8s/api/v1beta1"
+	frrfake "github.com/metallb/frr-k8s/pkg/client/clientset/versioned/fake"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
@@ -29,9 +31,12 @@ import (
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	networkconnect "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
+	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	rafake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
+	vtepfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
@@ -1749,6 +1754,315 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 				}
 				gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 			})
+		})
+	})
+
+	ginkgo.Context("Managed VTEP + RouteAdvertisements integration", func() {
+		// Full end-to-end user workflow: operator creates a managed VTEP, a CUDN
+		// with EVPN IP-VRF, an RA, and a source FRRConfiguration. The cluster
+		// manager (VTEP controller + UDN controller + network manager + RA
+		// controller all running together) must:
+		//   1. Allocate one VTEP IP per node and write k8s.ovn.org/vteps.
+		//   2. Create a NAD for the CUDN (UDN controller), register the network
+		//      (network manager)
+		//   3. then generate per-node FRRConfigurations that
+		//      include a /32 host route for each allocated VTEP IP (RA controller).
+		ginkgo.It("VTEP controller allocates IPs and RA generates /32 host-route FRRConfigurations", func() {
+			app.Action = func(ctx *cli.Context) error {
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// These flags must be set after InitConfig, which resets all
+				// feature flags to their defaults.
+				config.OVNKubernetesFeature.EnableMultiNetwork = true
+				config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+				config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+				config.OVNKubernetesFeature.EnableEVPN = true
+				config.OVNKubernetesFeature.EnableEgressIP = true
+				config.Gateway.Mode = config.GatewayModeLocal
+
+				const (
+					vtepName    = "evpn-vtep"
+					vtepCIDR    = "100.64.0.0/24"
+					cudnName    = "blue"
+					frrNS       = "frr-system"
+					bgpASN      = 65000
+					bgpPeer     = "192.168.1.1"
+					ipVRFVNI    = int32(2000)
+					routeTarget = "65000:2000"
+				)
+
+				// Two bare nodes: no VTEP annotation yet; node-subnets annotation
+				// is set so RA can compute prefixes for the pod network.
+				node1 := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-subnets": `{"cluster_udn_blue":"10.2.1.0/24"}`,
+						},
+					},
+				}
+				node2 := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-subnets": `{"cluster_udn_blue":"10.2.2.0/24"}`,
+						},
+					},
+				}
+				// The UDN controller creates NADs in namespaces matching the CUDN's
+				// NamespaceSelector. The namespace must carry RequiredUDNNamespaceLabel
+				// so the UDN controller considers it eligible for primary network NADs.
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "blue",
+						// kubernetes.io/metadata.name is added automatically by the
+						// API server but not by the fake client — add it explicitly
+						// so the CUDN's NamespaceSelector matchLabels can find it.
+						Labels: map[string]string{
+							ovntypes.RequiredUDNNamespaceLabel: "",
+							"kubernetes.io/metadata.name":      "blue",
+						},
+					},
+				}
+
+				// Managed VTEP: CM will allocate one IP per node from vtepCIDR.
+				vtep := &vtepv1.VTEP{
+					ObjectMeta: metav1.ObjectMeta{Name: vtepName},
+					Spec:       vtepv1.VTEPSpec{Mode: vtepv1.VTEPModeManaged, CIDRs: []vtepv1.CIDR{vtepCIDR}},
+				}
+
+				// CUDN referencing the VTEP for EVPN IP-VRF.
+				// The UDN controller will create a corresponding NAD; the network
+				// manager will register it so the RA controller can resolve it.
+				cudn := &udnv1.ClusterUserDefinedNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   cudnName,
+						Labels: map[string]string{"evpn": "true"},
+					},
+					Spec: udnv1.ClusterUserDefinedNetworkSpec{
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "blue"},
+						},
+						Network: udnv1.NetworkSpec{
+							Topology:  udnv1.NetworkTopologyLayer3,
+							Transport: udnv1.TransportOptionEVPN,
+							Layer3: &udnv1.Layer3Config{
+								Role:    udnv1.NetworkRolePrimary,
+								Subnets: []udnv1.Layer3Subnet{{CIDR: "10.2.0.0/16"}},
+							},
+							EVPN: &udnv1.EVPNConfig{
+								VTEP:  vtepName,
+								IPVRF: &udnv1.VRFConfig{VNI: ipVRFVNI, RouteTarget: routeTarget},
+							},
+						},
+					},
+				}
+
+				// Source FRRConfiguration: represents the pre-existing BGP session
+				// on each node that the RA controller will extend.
+				frrCfg := &frrapi.FRRConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "base-frr", Namespace: frrNS},
+					Spec: frrapi.FRRConfigurationSpec{
+						BGP: frrapi.BGPConfig{
+							Routers: []frrapi.Router{{
+								ASN: bgpASN,
+								Neighbors: []frrapi.Neighbor{
+									{ASN: bgpASN, Address: bgpPeer, DisableMP: true},
+								},
+							}},
+						},
+					},
+				}
+
+				// RouteAdvertisements: selects CUDNs labelled "evpn=true",
+				// advertises pod network, resolves VRF automatically.
+				ra := &ratypes.RouteAdvertisements{
+					ObjectMeta: metav1.ObjectMeta{Name: "evpn-ra"},
+					Spec: ratypes.RouteAdvertisementsSpec{
+						TargetVRF:                "auto",
+						Advertisements:           []ratypes.AdvertisementType{ratypes.PodNetwork},
+						NodeSelector:             metav1.LabelSelector{},
+						FRRConfigurationSelector: metav1.LabelSelector{},
+						NetworkSelectors: []apitypes.NetworkSelector{{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"evpn": "true"},
+								},
+							},
+						}},
+					},
+				}
+
+				// The RA is intentionally NOT pre-seeded. In production, creation
+				// order doesn't matter: controllers retry via informer requeues
+				// and eventually converge. In this test we defer RA creation until
+				// the NAD exists and the network is registered so the RA
+				// controller's first reconcile succeeds immediately. Without this
+				// ordering the RA controller's HandleError path writes a transient
+				// Accepted=False, which the UDN transport validation reacts to,
+				// adding extra reconcile churn and making the test slow/flaky.
+				fakeClient := util.GetOVNClientset(node1, node2, ns, vtep, cudn, frrCfg).
+					GetClusterManagerClientset()
+				// AddVTEPApplyReactor is needed because the VTEP controller writes status
+				// via server-side apply (ApplyStatus), which the fake client cannot handle
+				// natively — it can't decode the apply patch and merge it with the existing
+				// object. The reactor does that manually.
+				testing.AddVTEPApplyReactor(fakeClient.VTEPClient.(*vtepfake.Clientset))
+				// AddRAApplyReactor handles the RA controller's ApplyStatus calls.
+				// Without it the Accepted status is never persisted, so the UDN
+				// controller's transport validation never sees an accepted RA.
+				testing.AddRAApplyReactor(fakeClient.RouteAdvertisementsClient.(*rafake.Clientset))
+				// AddGenerateNameReactor is needed because the RA controller creates
+				// FRRConfiguration objects using GenerateName. The fake client does not
+				// implement generateName, so without this reactor created objects have an
+				// empty name and cannot be found by subsequent List calls.
+				testing.AddGenerateNameReactor(fakeClient.FRRClient.(*frrfake.Clientset))
+
+				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				c, cancel := context.WithCancel(ctx.Context)
+				defer cancel()
+
+				clusterMngr, err := NewClusterManager(fakeClient, f, "identity", nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = clusterMngr.Start(c)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer clusterMngr.Stop()
+
+				ginkgo.By("UDN controller creates a NAD for the CUDN in the blue namespace")
+				gomega.Eventually(func() (int, error) {
+					nads, err := fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().
+						NetworkAttachmentDefinitions("blue").List(context.TODO(), metav1.ListOptions{})
+					if err != nil {
+						return 0, err
+					}
+					return len(nads.Items), nil
+				}, 30).Should(gomega.BeNumerically(">", 0),
+					"UDN controller must create a NAD in namespace blue")
+
+				// Create the RA now that the NAD and network are ready (see
+				// comment above for why we defer this in the test).
+				_, err = fakeClient.RouteAdvertisementsClient.K8sV1().
+					RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("RA controller marks the RouteAdvertisements as Accepted")
+				gomega.Eventually(func() (metav1.ConditionStatus, error) {
+					r, err := fakeClient.RouteAdvertisementsClient.K8sV1().
+						RouteAdvertisements().Get(context.TODO(), ra.Name, metav1.GetOptions{})
+					if err != nil {
+						return metav1.ConditionUnknown, nil
+					}
+					cond := meta.FindStatusCondition(r.Status.Conditions, ratypes.RouteAdvertisementsAccepted)
+					if cond == nil {
+						return metav1.ConditionUnknown, nil
+					}
+					return cond.Status, nil
+				}, 30).Should(gomega.Equal(metav1.ConditionTrue),
+					"RA controller must accept the RouteAdvertisements CR")
+
+				ginkgo.By("VTEP controller allocates one IP per node from the managed CIDR")
+				_, vtepNet, _ := net.ParseCIDR(vtepCIDR)
+				nodeIPs := map[string]string{}
+				for _, nodeName := range []string{"node1", "node2"} {
+					name := nodeName
+					gomega.Eventually(func() (string, error) {
+						n, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+						if err != nil {
+							return "", err
+						}
+						vteps, err := util.ParseNodeVTEPs(n)
+						if util.IsAnnotationNotSetError(err) {
+							return "", nil
+						}
+						if err != nil {
+							return "", err
+						}
+						entry, ok := vteps[vtepName]
+						if !ok || len(entry.IPs) == 0 {
+							return "", nil
+						}
+						return entry.IPs[0], nil
+					}, 30).Should(gomega.MatchRegexp(`^100\.64\.0\.\d+$`),
+						"node %s must get a VTEP IP in %s", name, vtepCIDR)
+
+					n, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					vteps, err := util.ParseNodeVTEPs(n)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					nodeIPs[name] = vteps[vtepName].IPs[0]
+					gomega.Expect(vtepNet.Contains(net.ParseIP(nodeIPs[name]))).To(gomega.BeTrue(),
+						"IP %s must be inside VTEP CIDR %s", nodeIPs[name], vtepCIDR)
+				}
+				gomega.Expect(nodeIPs["node1"]).NotTo(gomega.Equal(nodeIPs["node2"]),
+					"each node must receive a distinct VTEP IP")
+
+				ginkgo.By("RA controller generates one FRRConfiguration per node")
+				// The CUDN already has the "evpn=true" label so the RA network selector
+				// matches it. The UDN controller creates the NAD and propagates the CUDN
+				// labels onto it; once the network manager registers the network the RA
+				// controller can reconcile and generate FRRConfigurations.
+				gomega.Eventually(func() ([]frrapi.FRRConfiguration, error) {
+					list, err := fakeClient.FRRClient.ApiV1beta1().
+						FRRConfigurations(frrNS).List(context.TODO(), metav1.ListOptions{})
+					if err != nil {
+						return nil, err
+					}
+					var generated []frrapi.FRRConfiguration
+					for _, fc := range list.Items {
+						if _, ok := fc.Annotations[ovntypes.OvnRouteAdvertisementsKey]; ok {
+							generated = append(generated, fc)
+						}
+					}
+					return generated, nil
+				}, 30).Should(gomega.HaveLen(2),
+					"expected one RA-generated FRRConfiguration per node")
+
+				ginkgo.By("each FRRConfiguration carries a /32 host route for the node's CM-allocated VTEP IP")
+				frrList, err := fakeClient.FRRClient.ApiV1beta1().
+					FRRConfigurations(frrNS).List(context.TODO(), metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				expectedHostRoutes := map[string]bool{}
+				for _, ip := range nodeIPs {
+					expectedHostRoutes[ip+"/32"] = false
+				}
+
+				for _, fc := range frrList.Items {
+					if _, ok := fc.Annotations[ovntypes.OvnRouteAdvertisementsKey]; !ok {
+						continue // skip the pre-existing base-frr
+					}
+					var found bool
+					for _, router := range fc.Spec.BGP.Routers {
+						if router.VRF != "" {
+							continue // EVPN VRF router — host routes live in default VRF
+						}
+						for _, prefix := range router.Prefixes {
+							if _, expected := expectedHostRoutes[prefix]; expected {
+								expectedHostRoutes[prefix] = true
+								found = true
+							}
+						}
+					}
+					gomega.Expect(found).To(gomega.BeTrue(),
+						"FRRConfiguration %s has no /32 VTEP host route in the default-VRF router", fc.Name)
+				}
+
+				for route, seen := range expectedHostRoutes {
+					gomega.Expect(seen).To(gomega.BeTrue(),
+						"/32 host route %s not found in any generated FRRConfiguration", route)
+				}
+
+				return nil
+			}
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})
 

--- a/go-controller/pkg/clustermanager/node/subnet_allocator.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator.go
@@ -19,6 +19,12 @@ var ErrSubnetAllocatorFull = fmt.Errorf("no subnets available")
 
 type SubnetAllocator interface {
 	AddNetworkRange(network *net.IPNet, hostSubnetLen int) error
+	// ReplaceNetworkRange replaces an existing range (identified by oldNetwork)
+	// with a new, wider range (newNetwork) of the same IP family. All existing
+	// allocations from the old range are preserved: since the new range is a
+	// supernet, every previously allocated IP is still valid within it.
+	// Returns an error if oldNetwork is not found or newNetwork is invalid.
+	ReplaceNetworkRange(oldNetwork, newNetwork *net.IPNet, hostSubnetLen int) error
 	MarkAllocatedNetworks(string, ...*net.IPNet) error
 	// Usage returns the number of used/allocated v4 and v6 subnets
 	Usage() (uint64, uint64)
@@ -107,6 +113,56 @@ func (sna *BaseSubnetAllocator) AddNetworkRange(network *net.IPNet, hostSubnetLe
 		sna.v4ranges = append(sna.v4ranges, snr)
 	}
 	return nil
+}
+
+// ReplaceNetworkRange replaces an existing range (identified by oldNetwork)
+// with a new, wider range (newNetwork) of the same IP family. Existing
+// allocations from the old range are preserved: each entry in the old
+// range's allocMap is copied into the new range's allocMap since every
+// previously allocated IP still falls within the supernet. The allocation
+// cursor (next) is reset to 0; allocateNetwork will skip any already-taken
+// IPs via allocMap, so the reset is safe and avoids cursor arithmetic against
+// the new subnetBits.
+func (sna *BaseSubnetAllocator) ReplaceNetworkRange(oldNetwork, newNetwork *net.IPNet, hostSubnetLen int) error {
+	sna.Lock()
+	defer sna.Unlock()
+
+	newSnr, err := newSubnetAllocatorRange(newNetwork, hostSubnetLen)
+	if err != nil {
+		return fmt.Errorf("invalid new network range %s: %w", newNetwork, err)
+	}
+
+	// Verify that newNetwork is a supernet of oldNetwork: the old network's
+	// base IP must be contained in the new network, and the new prefix must
+	// be shorter (wider).
+	oldOnes, _ := oldNetwork.Mask.Size()
+	newOnes, _ := newNetwork.Mask.Size()
+	if !newNetwork.Contains(oldNetwork.IP) || newOnes > oldOnes {
+		return fmt.Errorf("new network %s is not a supernet of old network %s", newNetwork, oldNetwork)
+	}
+
+	ranges := &sna.v4ranges
+	if utilnet.IsIPv6(newNetwork.IP) {
+		ranges = &sna.v6ranges
+	}
+
+	for i, snr := range *ranges {
+		if snr.network.String() == oldNetwork.String() {
+			// Copy existing allocations into the new range.
+			for subnet, owner := range snr.allocMap {
+				newSnr.allocMap[subnet] = owner
+			}
+			newSnr.used = snr.used
+			// Preserve the allocation cursor. The enumeration order of IPs
+			// within the range is deterministic and stable across a widen
+			// (subnetBits increases but existing indices stay the same), so
+			// copying next avoids a redundant linear scan from 0.
+			newSnr.next = snr.next
+			(*ranges)[i] = newSnr
+			return nil
+		}
+	}
+	return fmt.Errorf("network range %s not found", oldNetwork)
 }
 
 // MarkAllocatedNetworks will mark the given subnets as already allocated by

--- a/go-controller/pkg/clustermanager/node/subnet_allocator.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator.go
@@ -325,8 +325,8 @@ type subnetAllocatorRange struct {
 
 func newSubnetAllocatorRange(network *net.IPNet, hostSubnetLen int) (*subnetAllocatorRange, error) {
 	clusterCIDRLen, addrLen := network.Mask.Size()
-	if hostSubnetLen >= addrLen {
-		return nil, fmt.Errorf("host capacity cannot be zero")
+	if hostSubnetLen > addrLen {
+		return nil, fmt.Errorf("host subnet length cannot exceed address length")
 	} else if hostSubnetLen < clusterCIDRLen {
 		return nil, fmt.Errorf("subnet capacity cannot be larger than number of networks available")
 	}

--- a/go-controller/pkg/clustermanager/node/subnet_allocator_test.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator_test.go
@@ -704,3 +704,179 @@ func TestListAllNetworks(t *testing.T) {
 		}
 	}
 }
+
+// TestReplaceNetworkRange verifies that ReplaceNetworkRange preserves existing
+// allocations and allows new ones from the expanded range.
+func TestReplaceNetworkRange(t *testing.T) {
+	// /30 with /32 host length holds 4 IPs (10.0.0.0–10.0.0.3).
+	sna, err := newSubnetAllocator("10.0.0.0/30", 32)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+	ip1, err := sna.AllocateIPv4Network("node-1")
+	if err != nil {
+		t.Fatalf("Failed to allocate for node-1: %v", err)
+	}
+	ip2, err := sna.AllocateIPv4Network("node-2")
+	if err != nil {
+		t.Fatalf("Failed to allocate for node-2: %v", err)
+	}
+	if _, err := sna.AllocateIPv4Network("node-3"); err != nil {
+		t.Fatalf("Failed to allocate for node-3: %v", err)
+	}
+	if _, err := sna.AllocateIPv4Network("node-4"); err != nil {
+		t.Fatalf("Failed to allocate for node-4: %v", err)
+	}
+
+	// Range is exhausted; node-5 must fail with ErrSubnetAllocatorFull.
+	_, allocErr := sna.AllocateIPv4Network("node-5")
+	if allocErr != ErrSubnetAllocatorFull {
+		t.Fatalf("Expected ErrSubnetAllocatorFull before replace, got: %v", allocErr)
+	}
+
+	// Expand to /28 (holds 16 IPs). Existing allocations must be preserved.
+	oldNet := ovntest.MustParseIPNet("10.0.0.0/30")
+	newNet := ovntest.MustParseIPNet("10.0.0.0/28")
+	if err := sna.ReplaceNetworkRange(oldNet, newNet, 32); err != nil {
+		t.Fatalf("ReplaceNetworkRange failed: %v", err)
+	}
+
+	// node-1 and node-2 must still return their original IPs (idempotent alloc).
+	realloc1, err := sna.AllocateIPv4Network("node-1")
+	if err != nil {
+		t.Fatalf("Re-allocate node-1 after replace failed: %v", err)
+	}
+	if realloc1.String() != ip1.String() {
+		t.Fatalf("node-1 IP changed after replace: got %s want %s", realloc1, ip1)
+	}
+	realloc2, err := sna.AllocateIPv4Network("node-2")
+	if err != nil {
+		t.Fatalf("Re-allocate node-2 after replace failed: %v", err)
+	}
+	if realloc2.String() != ip2.String() {
+		t.Fatalf("node-2 IP changed after replace: got %s want %s", realloc2, ip2)
+	}
+
+	// node-5 should now get an IP from the expanded range.
+	ip5, err := sna.AllocateIPv4Network("node-5")
+	if err != nil {
+		t.Fatalf("Failed to allocate for node-5 after expand: %v", err)
+	}
+	if !newNet.Contains(ip5.IP) {
+		t.Fatalf("node-5 IP %s not in expanded range %s", ip5, newNet)
+	}
+}
+
+// TestReplaceNetworkRangeNotFound verifies that ReplaceNetworkRange errors
+// when the old range does not exist.
+func TestReplaceNetworkRangeNotFound(t *testing.T) {
+	sna, err := newSubnetAllocator("10.0.0.0/24", 32)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+	oldNet := ovntest.MustParseIPNet("10.1.0.0/24")
+	newNet := ovntest.MustParseIPNet("10.1.0.0/16")
+	if err := sna.ReplaceNetworkRange(oldNet, newNet, 32); err == nil {
+		t.Fatal("Expected error for non-existent range, got nil")
+	}
+}
+
+// TestReplaceNetworkRangeNotSupernet verifies that ReplaceNetworkRange rejects
+// a new range that is not a supernet of the old range.
+func TestReplaceNetworkRangeNotSupernet(t *testing.T) {
+	sna, err := newSubnetAllocator("10.0.0.0/24", 32)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+	oldNet := ovntest.MustParseIPNet("10.0.0.0/24")
+
+	// Shrinking (more specific mask) must be rejected.
+	smallerNet := ovntest.MustParseIPNet("10.0.0.0/26")
+	if err := sna.ReplaceNetworkRange(oldNet, smallerNet, 32); err == nil {
+		t.Fatal("Expected error for shrinking range, got nil")
+	}
+
+	// Completely different range must be rejected.
+	differentNet := ovntest.MustParseIPNet("192.168.0.0/16")
+	if err := sna.ReplaceNetworkRange(oldNet, differentNet, 32); err == nil {
+		t.Fatal("Expected error for non-supernet range, got nil")
+	}
+}
+
+// TestReplaceNetworkRangeDifferentBase verifies that a valid supernet whose
+// base address differs from the old range is accepted. For example,
+// 10.0.0.128/25 can be replaced by 10.0.0.0/24 since the /24 contains
+// the entire /25.
+func TestReplaceNetworkRangeDifferentBase(t *testing.T) {
+	sna := NewSubnetAllocator()
+	if err := sna.AddNetworkRange(ovntest.MustParseIPNet("10.0.0.128/25"), 32); err != nil {
+		t.Fatal("Failed to add network range: ", err)
+	}
+
+	ip1, err := sna.AllocateIPv4Network("node-1")
+	if err != nil {
+		t.Fatalf("Failed to allocate for node-1: %v", err)
+	}
+
+	oldNet := ovntest.MustParseIPNet("10.0.0.128/25")
+	newNet := ovntest.MustParseIPNet("10.0.0.0/24")
+	if err := sna.ReplaceNetworkRange(oldNet, newNet, 32); err != nil {
+		t.Fatalf("ReplaceNetworkRange with different base failed: %v", err)
+	}
+
+	// node-1 keeps its IP.
+	realloc1, err := sna.AllocateIPv4Network("node-1")
+	if err != nil {
+		t.Fatalf("Re-allocate node-1 after replace failed: %v", err)
+	}
+	if realloc1.String() != ip1.String() {
+		t.Fatalf("node-1 IP changed after replace: got %s want %s", realloc1, ip1)
+	}
+
+	// node-2 gets a new IP from the expanded /24 range (may be below 10.0.0.128).
+	ip2, err := sna.AllocateIPv4Network("node-2")
+	if err != nil {
+		t.Fatalf("Failed to allocate for node-2 after expand: %v", err)
+	}
+	if !newNet.Contains(ip2.IP) {
+		t.Fatalf("node-2 IP %s not in expanded range %s", ip2, newNet)
+	}
+}
+
+// TestReplaceNetworkRangeIPv6 verifies that ReplaceNetworkRange works for
+// IPv6 ranges.
+func TestReplaceNetworkRangeIPv6(t *testing.T) {
+	sna := NewSubnetAllocator()
+	if err := sna.AddNetworkRange(ovntest.MustParseIPNet("fd00::/126"), 128); err != nil {
+		t.Fatal("Failed to add IPv6 range: ", err)
+	}
+
+	ip1, err := sna.AllocateIPv6Network("node-1")
+	if err != nil {
+		t.Fatalf("Failed to allocate IPv6 for node-1: %v", err)
+	}
+
+	oldNet := ovntest.MustParseIPNet("fd00::/126")
+	newNet := ovntest.MustParseIPNet("fd00::/120")
+	if err := sna.ReplaceNetworkRange(oldNet, newNet, 128); err != nil {
+		t.Fatalf("ReplaceNetworkRange IPv6 failed: %v", err)
+	}
+
+	// node-1 keeps its IP.
+	realloc1, err := sna.AllocateIPv6Network("node-1")
+	if err != nil {
+		t.Fatalf("Re-allocate node-1 IPv6 after replace failed: %v", err)
+	}
+	if realloc1.String() != ip1.String() {
+		t.Fatalf("node-1 IPv6 changed after replace: got %s want %s", realloc1, ip1)
+	}
+
+	// node-2 gets a new IP from the expanded range.
+	ip2, err := sna.AllocateIPv6Network("node-2")
+	if err != nil {
+		t.Fatalf("Failed to allocate IPv6 for node-2 after expand: %v", err)
+	}
+	if !newNet.Contains(ip2.IP) {
+		t.Fatalf("node-2 IPv6 %s not in expanded range %s", ip2, newNet)
+	}
+}

--- a/go-controller/pkg/clustermanager/node/subnet_allocator_test.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator_test.go
@@ -324,7 +324,7 @@ func TestAllocateSubnetInvalidHostBitsOrCIDR(t *testing.T) {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
 	}
 
-	_, err = newSubnetAllocator("10.1.0.0/16", 32)
+	_, err = newSubnetAllocator("10.1.0.0/16", 33)
 	if err == nil {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
 	}
@@ -334,9 +334,37 @@ func TestAllocateSubnetInvalidHostBitsOrCIDR(t *testing.T) {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
 	}
 
-	_, err = newSubnetAllocator("fd01::/64", 128)
+	_, err = newSubnetAllocator("fd01::/64", 129)
 	if err == nil {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
+	}
+}
+
+func TestAllocateSubnetSingleIP(t *testing.T) {
+	// IPv4: /24 with hostSubnetLen=32 gives 256 individual /32 allocations
+	sna, err := newSubnetAllocator("10.1.0.0/24", 32)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	if err := allocateExpected(sna, 0, "10.1.0.0/32"); err != nil {
+		t.Fatal(err)
+	}
+	if err := allocateExpected(sna, 1, "10.1.0.1/32"); err != nil {
+		t.Fatal(err)
+	}
+
+	// IPv6: /120 with hostSubnetLen=128 gives 256 individual /128 allocations
+	sna, err = newSubnetAllocator("fd01::/120", 128)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	if err := allocateExpected(sna, 0, "fd01::/128"); err != nil {
+		t.Fatal(err)
+	}
+	if err := allocateExpected(sna, 1, "fd01::1/128"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,8 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	ctesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	utilnet "k8s.io/utils/net"
@@ -460,35 +457,6 @@ func (tn testNAD) NAD() *nadtypes.NetworkAttachmentDefinition {
 		})
 	}
 	return nad
-}
-
-type Fake interface {
-	PrependReactor(verb, resource string, reaction ctesting.ReactionFunc)
-}
-
-var count = uint32(0)
-
-// source
-// https://stackoverflow.com/questions/68794562/kubernetes-fake-client-doesnt-handle-generatename-in-objectmeta/68794563#68794563
-func addGenerateNameReactor[T Fake](client any) {
-	fake := client.(Fake)
-	fake.PrependReactor(
-		"create",
-		"*",
-		func(action ctesting.Action) (handled bool, ret runtime.Object, err error) {
-			ret = action.(ctesting.CreateAction).GetObject()
-			meta, ok := ret.(metav1.Object)
-			if !ok {
-				return
-			}
-
-			if meta.GetName() == "" && meta.GetGenerateName() != "" {
-				meta.SetName(meta.GetGenerateName() + fmt.Sprintf("%d", atomic.AddUint32(&count, 1)))
-			}
-
-			return
-		},
-	)
 }
 
 func init() {
@@ -2314,7 +2282,7 @@ exit
 			}
 
 			fakeClientset := util.GetOVNClientset().GetClusterManagerClientset()
-			addGenerateNameReactor[*frrfake.Clientset](fakeClientset.FRRClient)
+			ovntest.AddGenerateNameReactor(fakeClientset.FRRClient.(*frrfake.Clientset))
 
 			// create test objects
 			if tt.ra != nil {

--- a/go-controller/pkg/clustermanager/vtep/allocator.go
+++ b/go-controller/pkg/clustermanager/vtep/allocator.go
@@ -25,6 +25,18 @@ const (
 // natural overflow: the first range is exhausted before the next is used.
 type vtepIPAllocator struct {
 	allocator node.SubnetAllocator
+	// cidrs records the CIDRs the allocator was built with in their original
+	// spec order. It is a slice (not a set) because CEL rules on VTEPSpec
+	// validate CIDRs positionally: existing entries can only be widened
+	// in-place (same index), and new ones can only be appended. This means
+	// cidrs[i] always corresponds to the i-th network range that was added
+	// to the underlying allocator for its IP family. We cannot use
+	// SubnetAllocator.ListAllIPv4/IPv6Networks() as a substitute because
+	// those return ranges grouped by family (all v4, then all v6), which
+	// loses the interleaved ordering of a dual-stack spec (e.g.
+	// [v4, v6, v4]). Without the original ordering we could not map
+	// spec[i] to the correct allocator range for replaceRange.
+	cidrs []vtepv1.CIDR
 }
 
 // newVTEPIPAllocator creates an allocator from the given VTEP CIDRs. Each
@@ -32,6 +44,7 @@ type vtepIPAllocator struct {
 func newVTEPIPAllocator(cidrs []vtepv1.CIDR) (*vtepIPAllocator, error) {
 	a := &vtepIPAllocator{
 		allocator: node.NewSubnetAllocator(),
+		cidrs:     make([]vtepv1.CIDR, 0, len(cidrs)),
 	}
 	for _, cidr := range cidrs {
 		if err := a.addCIDR(cidr); err != nil {
@@ -39,6 +52,20 @@ func newVTEPIPAllocator(cidrs []vtepv1.CIDR) (*vtepIPAllocator, error) {
 		}
 	}
 	return a, nil
+}
+
+// cidrsMatch returns true if the allocator's current CIDRs are identical
+// (same length, same values in order) to the given slice.
+func (a *vtepIPAllocator) cidrsMatch(cidrs []vtepv1.CIDR) bool {
+	if len(a.cidrs) != len(cidrs) {
+		return false
+	}
+	for i := range cidrs {
+		if a.cidrs[i] != cidrs[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *vtepIPAllocator) addCIDR(cidr vtepv1.CIDR) error {
@@ -53,6 +80,7 @@ func (a *vtepIPAllocator) addCIDR(cidr vtepv1.CIDR) error {
 	if err := a.allocator.AddNetworkRange(ipNet, hostLen); err != nil {
 		return fmt.Errorf("failed to add CIDR %q to allocator: %w", cidr, err)
 	}
+	a.cidrs = append(a.cidrs, cidr)
 	return nil
 }
 
@@ -83,7 +111,8 @@ func (a *vtepIPAllocator) markAllocatedForNode(nodeName string, ips []net.IP) er
 // replaceRange replaces an existing CIDR in the allocator with a wider one.
 // The new CIDR must be a supernet of the old one (guaranteed by CEL validation
 // in managed mode). Existing allocations from the old range are preserved.
-func (a *vtepIPAllocator) replaceRange(oldCIDR, newCIDR vtepv1.CIDR) error {
+// The cidrs tracking slice is updated at the same index.
+func (a *vtepIPAllocator) replaceRange(idx int, oldCIDR, newCIDR vtepv1.CIDR) error {
 	_, oldNet, err := net.ParseCIDR(string(oldCIDR))
 	if err != nil {
 		return fmt.Errorf("invalid old CIDR %q: %w", oldCIDR, err)
@@ -96,7 +125,11 @@ func (a *vtepIPAllocator) replaceRange(oldCIDR, newCIDR vtepv1.CIDR) error {
 	if utilnet.IsIPv6CIDR(newNet) {
 		hostLen = ipv6HostSubnetLen
 	}
-	return a.allocator.ReplaceNetworkRange(oldNet, newNet, hostLen)
+	if err := a.allocator.ReplaceNetworkRange(oldNet, newNet, hostLen); err != nil {
+		return err
+	}
+	a.cidrs[idx] = newCIDR
+	return nil
 }
 
 // releaseNode frees all allocations for the given node.

--- a/go-controller/pkg/clustermanager/vtep/allocator.go
+++ b/go-controller/pkg/clustermanager/vtep/allocator.go
@@ -80,6 +80,25 @@ func (a *vtepIPAllocator) markAllocatedForNode(nodeName string, ips []net.IP) er
 	return a.allocator.MarkAllocatedNetworks(nodeName, ipNets...)
 }
 
+// replaceRange replaces an existing CIDR in the allocator with a wider one.
+// The new CIDR must be a supernet of the old one (guaranteed by CEL validation
+// in managed mode). Existing allocations from the old range are preserved.
+func (a *vtepIPAllocator) replaceRange(oldCIDR, newCIDR vtepv1.CIDR) error {
+	_, oldNet, err := net.ParseCIDR(string(oldCIDR))
+	if err != nil {
+		return fmt.Errorf("invalid old CIDR %q: %w", oldCIDR, err)
+	}
+	_, newNet, err := net.ParseCIDR(string(newCIDR))
+	if err != nil {
+		return fmt.Errorf("invalid new CIDR %q: %w", newCIDR, err)
+	}
+	hostLen := ipv4HostSubnetLen
+	if utilnet.IsIPv6CIDR(newNet) {
+		hostLen = ipv6HostSubnetLen
+	}
+	return a.allocator.ReplaceNetworkRange(oldNet, newNet, hostLen)
+}
+
 // releaseNode frees all allocations for the given node.
 func (a *vtepIPAllocator) releaseNode(nodeName string) {
 	a.allocator.ReleaseAllNetworks(nodeName)

--- a/go-controller/pkg/clustermanager/vtep/allocator.go
+++ b/go-controller/pkg/clustermanager/vtep/allocator.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package vtep
+
+import (
+	"fmt"
+	"net"
+
+	utilnet "k8s.io/utils/net"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/node"
+	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
+)
+
+const (
+	ipv4HostSubnetLen = 32
+	ipv6HostSubnetLen = 128
+)
+
+// vtepIPAllocator allocates individual VTEP IPs from a set of CIDRs for
+// managed-mode VTEPs. It wraps node.SubnetAllocator with /32 (IPv4) and
+// /128 (IPv6) host subnet lengths, so each "subnet" allocation is exactly
+// one IP address. Multiple CIDRs of the same family are supported with
+// natural overflow: the first range is exhausted before the next is used.
+type vtepIPAllocator struct {
+	allocator node.SubnetAllocator
+}
+
+// newVTEPIPAllocator creates an allocator from the given VTEP CIDRs. Each
+// CIDR is added as a network range with a single-IP host prefix (/32 or /128).
+func newVTEPIPAllocator(cidrs []vtepv1.CIDR) (*vtepIPAllocator, error) {
+	a := &vtepIPAllocator{
+		allocator: node.NewSubnetAllocator(),
+	}
+	for _, cidr := range cidrs {
+		if err := a.addCIDR(cidr); err != nil {
+			return nil, err
+		}
+	}
+	return a, nil
+}
+
+func (a *vtepIPAllocator) addCIDR(cidr vtepv1.CIDR) error {
+	_, ipNet, err := net.ParseCIDR(string(cidr))
+	if err != nil {
+		return fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	hostLen := ipv4HostSubnetLen
+	if utilnet.IsIPv6CIDR(ipNet) {
+		hostLen = ipv6HostSubnetLen
+	}
+	if err := a.allocator.AddNetworkRange(ipNet, hostLen); err != nil {
+		return fmt.Errorf("failed to add CIDR %q to allocator: %w", cidr, err)
+	}
+	return nil
+}
+
+// allocateForNode allocates the next available IP per family for the given
+// node. The underlying allocator is idempotent: if the node already has an
+// allocation for a family it is returned as-is. Returns one /32 or /128
+// net.IPNet per configured family (IPv4 first, then IPv6).
+func (a *vtepIPAllocator) allocateForNode(nodeName string) ([]*net.IPNet, error) {
+	return a.allocator.AllocateNetworks(nodeName)
+}
+
+// markAllocatedForNode reserves specific IPs for a node. Each IP is
+// wrapped in a /32 or /128 net.IPNet before being passed to the
+// underlying allocator. Used during initial sync to restore allocations
+// from node annotations.
+func (a *vtepIPAllocator) markAllocatedForNode(nodeName string, ips []net.IP) error {
+	ipNets := make([]*net.IPNet, 0, len(ips))
+	for _, ip := range ips {
+		mask := net.CIDRMask(ipv4HostSubnetLen, ipv4HostSubnetLen)
+		if utilnet.IsIPv6(ip) {
+			mask = net.CIDRMask(ipv6HostSubnetLen, ipv6HostSubnetLen)
+		}
+		ipNets = append(ipNets, &net.IPNet{IP: ip, Mask: mask})
+	}
+	return a.allocator.MarkAllocatedNetworks(nodeName, ipNets...)
+}
+
+// releaseNode frees all allocations for the given node.
+func (a *vtepIPAllocator) releaseNode(nodeName string) {
+	a.allocator.ReleaseAllNetworks(nodeName)
+}

--- a/go-controller/pkg/clustermanager/vtep/allocator_test.go
+++ b/go-controller/pkg/clustermanager/vtep/allocator_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package vtep
+
+import (
+	"net"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
+)
+
+func cidrs(ss ...string) []vtepv1.CIDR {
+	out := make([]vtepv1.CIDR, len(ss))
+	for i, s := range ss {
+		out[i] = vtepv1.CIDR(s)
+	}
+	return out
+}
+
+func ipNetStrings(ipNets []*net.IPNet) []string {
+	out := make([]string, len(ipNets))
+	for i, ipNet := range ipNets {
+		out[i] = ipNet.String()
+	}
+	return out
+}
+
+var _ = ginkgo.Describe("vtepIPAllocator", func() {
+
+	ginkgo.It("adds IPv4 CIDRs as /32 ranges and IPv6 CIDRs as /128 ranges", func() {
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/24", "fd00::/120"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		v4count, v6count := a.allocator.RangeCount()
+		gomega.Expect(v4count).To(gomega.Equal(uint64(1)))
+		gomega.Expect(v6count).To(gomega.Equal(uint64(1)))
+
+		ips, err := a.allocateForNode("node-1")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ips).To(gomega.HaveLen(2))
+		gomega.Expect(ips[0].Mask).To(gomega.Equal(net.CIDRMask(32, 32)))
+		gomega.Expect(ips[1].Mask).To(gomega.Equal(net.CIDRMask(128, 128)))
+	})
+
+	ginkgo.It("allocateForNode is idempotent and returns the same IPs on repeated calls", func() {
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/24", "fd00::/120"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		first, err := a.allocateForNode("node-1")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(first).To(gomega.HaveLen(2))
+
+		second, err := a.allocateForNode("node-1")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ipNetStrings(second)).To(gomega.Equal(ipNetStrings(first)))
+	})
+
+	ginkgo.It("adds multiple same-family CIDRs as separate ranges", func() {
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/30", "10.0.1.0/30"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		v4count, _ := a.allocator.RangeCount()
+		gomega.Expect(v4count).To(gomega.Equal(uint64(2)))
+	})
+
+	ginkgo.It("rejects invalid CIDRs", func() {
+		_, err := newVTEPIPAllocator(cidrs("not-a-cidr"))
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("markAllocatedForNode wraps IPs in correct /32 and /128 masks", func() {
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/24", "fd00::/120"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = a.markAllocatedForNode("node-1", []net.IP{
+			net.ParseIP("10.0.0.50"),
+			net.ParseIP("fd00::aa"),
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Idempotent allocate should return the marked IPs
+		ips, err := a.allocateForNode("node-1")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ipNetStrings(ips)).To(gomega.Equal([]string{"10.0.0.50/32", "fd00::aa/128"}))
+	})
+
+	ginkgo.It("markAllocatedForNode detects conflicts with existing allocations", func() {
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/24"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = a.markAllocatedForNode("node-1", []net.IP{net.ParseIP("10.0.0.10")})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = a.markAllocatedForNode("node-2", []net.IP{net.ParseIP("10.0.0.10")})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("IPv4 and IPv6 overflow independently with different-sized CIDRs", func() {
+		// IPv4: two /31 ranges (2 IPs each = 4 total)
+		// IPv6: one /126 range (4 IPs)
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/31", "10.0.1.0/31", "fd00::/126"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		v4count, v6count := a.allocator.RangeCount()
+		gomega.Expect(v4count).To(gomega.Equal(uint64(2)))
+		gomega.Expect(v6count).To(gomega.Equal(uint64(1)))
+
+		// Allocate 2 nodes: both families serve from their first range
+		ips0, err := a.allocateForNode("node-0")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ips0).To(gomega.HaveLen(2))
+
+		ips1, err := a.allocateForNode("node-1")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ips1).To(gomega.HaveLen(2))
+
+		// Allocate node-2: IPv4 first /31 exhausted, overflows to second /31;
+		// IPv6 still has room in its /126
+		ips2, err := a.allocateForNode("node-2")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ips2).To(gomega.HaveLen(2))
+		gomega.Expect(ips2[0].IP.String()).To(gomega.Equal("10.0.1.0"))
+	})
+
+	ginkgo.It("addCIDR expands capacity after exhaustion", func() {
+		a, err := newVTEPIPAllocator(cidrs("10.0.0.0/31"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// /31 with /32 host length = 2 IPs
+		_, err = a.allocateForNode("node-0")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = a.allocateForNode("node-1")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Pool exhausted
+		_, err = a.allocateForNode("node-2")
+		gomega.Expect(err).To(gomega.HaveOccurred())
+
+		// Expand with a new CIDR
+		err = a.addCIDR("10.0.1.0/31")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Should now succeed from the new range
+		ips, err := a.allocateForNode("node-2")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(ipNetStrings(ips)).To(gomega.Equal([]string{"10.0.1.0/32"}))
+	})
+})

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -137,14 +137,86 @@ func NewController(
 	return c
 }
 
-// Start begins the VTEP controller.
+// Start begins the VTEP controller. It uses StartWithInitialSync so that
+// event handlers are registered first (queuing events), then the initial
+// sync restores allocator state from existing node annotations, and finally
+// workers start processing the queue. This ensures IPs allocated before a
+// restart are preserved and not reassigned.
 func (c *Controller) Start() error {
 	defer klog.Infof("Cluster manager VTEP controller started")
-	return controllerutil.Start(
+	return controllerutil.StartWithInitialSync(
+		c.syncManagedAllocators,
 		c.vtepController,
 		c.cudnController,
 		c.nodeController,
 	)
+}
+
+// syncManagedAllocators restores allocator state for all managed VTEPs from
+// existing node annotations. This runs once at startup before the controller
+// workers begin, ensuring that previously allocated IPs are reserved in the
+// allocator and won't be reassigned to different nodes.
+func (c *Controller) syncManagedAllocators() error {
+	vteps, err := c.vtepLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list VTEPs: %w", err)
+	}
+
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var errs []error
+	for _, vtep := range vteps {
+		if vtep.Spec.Mode != vtepv1.VTEPModeManaged {
+			continue
+		}
+		allocator, err := newVTEPIPAllocator(vtep.Spec.CIDRs)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("VTEP %s: failed to create allocator: %w", vtep.Name, err))
+			continue
+		}
+		for _, node := range nodes {
+			nodeVTEPs, err := util.ParseNodeVTEPs(node)
+			if err != nil {
+				if !util.IsAnnotationNotSetError(err) {
+					klog.Warningf("VTEP %s: failed to parse annotation on node %s, skipping: %v", vtep.Name, node.Name, err)
+				}
+				continue
+			}
+			entry, ok := nodeVTEPs[vtep.Name]
+			if !ok || len(entry.IPs) == 0 {
+				klog.Warningf("VTEP %s: no existing allocation found on node %s, skipping", vtep.Name, node.Name)
+				continue
+			}
+			ips := make([]net.IP, 0, len(entry.IPs))
+			for _, ipStr := range entry.IPs {
+				ip := net.ParseIP(ipStr)
+				if ip == nil {
+					errs = append(errs, fmt.Errorf("VTEP %s: invalid IP %q in annotation on node %s", vtep.Name, ipStr, node.Name))
+					continue
+				}
+				ips = append(ips, ip)
+			}
+			if err := allocator.markAllocatedForNode(node.Name, ips); err != nil {
+				// The IPs in the annotation are invalid for managed mode: either
+				// out of the managed CIDRs (stale from unmanaged->managed mode change or CIDR
+				// change) or already owned by another node (conflict). Remove the
+				// stale entry so handleManagedMode can allocate a fresh valid IP
+				// without the node-side controller briefly observing a stale IP.
+				klog.Warningf("VTEP %s: removing invalid IPs %v from node %s annotation: %v", vtep.Name, ips, node.Name, err)
+				if removeErr := util.RemoveNodeVTEPEntry(node.Name, vtep.Name, c.nodeLister.Get, c.kube.UpdateNodeStatus); removeErr != nil {
+					errs = append(errs, fmt.Errorf("VTEP %s: failed to remove stale annotation from node %s: %w", vtep.Name, node.Name, removeErr))
+				}
+			}
+		}
+		c.allocatorsMu.Lock()
+		c.allocators[vtep.Name] = allocator
+		c.allocatorsMu.Unlock()
+		klog.Infof("Synced allocator for managed VTEP %s", vtep.Name)
+	}
+	return errors.Join(errs...)
 }
 
 // Stop shuts down the VTEP controller.

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -242,6 +242,19 @@ func (c *Controller) reconcileVTEP(key string) error {
 			reasonEVPNIPv6NotSupported, err.Error())
 	}
 
+	if err := c.validateManagedCIDRsAgainstNodeIPs(vtep); err != nil {
+		existingCond := meta.FindStatusCondition(vtep.Status.Conditions, conditionTypeAccepted)
+		if existingCond == nil || existingCond.Status != metav1.ConditionFalse || existingCond.Reason != reasonCIDROverlap || existingCond.Message != err.Error() {
+			vtepRef, refErr := reference.GetReference(vtepscheme.Scheme, vtep)
+			if refErr != nil {
+				return fmt.Errorf("failed to get object reference for VTEP %s: %w", vtep.Name, refErr)
+			}
+			c.eventRecorder.Event(vtepRef, corev1.EventTypeWarning, reasonCIDROverlap, err.Error())
+		}
+		return c.updateStatusCondition(vtep, conditionTypeAccepted, metav1.ConditionFalse,
+			reasonCIDROverlap, err.Error())
+	}
+
 	// When a VTEP transitions from Managed to Unmanaged, clean up the
 	// CM-written annotations and drop the allocator so the node-side
 	// controller can take over.
@@ -490,6 +503,56 @@ func (c *Controller) validateCIDRsAcrossVTEPs(vtep *vtepv1.VTEP) error {
 	return errors.Join(errs...)
 }
 
+// validateManagedCIDRsAgainstNodeIPs checks that a managed VTEP's CIDRs do
+// not overlap with any node's host IPs (from k8s.ovn.org/host-cidrs). If the
+// allocator hands out an IP that is already assigned to a node's primary
+// interface, two nodes would claim the same IP on the same L2 segment.
+// Unmanaged VTEPs are skipped because the user controls IP assignment.
+func (c *Controller) validateManagedCIDRsAgainstNodeIPs(vtep *vtepv1.VTEP) error {
+	if vtep.Spec.Mode != vtepv1.VTEPModeManaged {
+		return nil
+	}
+
+	vtepCIDRs, err := parseVTEPCIDRs(vtep)
+	if err != nil {
+		return err
+	}
+
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	// We check every node because nodes can be on different subnets
+	// (multi-rack, multi-AZ). A VTEP CIDR might overlap with one
+	// subnet but not another, so we can't short-circuit after one node.
+	var overlapping []string
+	for _, node := range nodes {
+		hostCIDRStrs, err := util.ParseNodeHostCIDRs(node)
+		if err != nil {
+			continue
+		}
+		hostNets := make([]*net.IPNet, 0, hostCIDRStrs.Len())
+		for cidr := range hostCIDRStrs {
+			_, ipNet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				continue
+			}
+			hostNets = append(hostNets, ipNet)
+		}
+		if util.NetworksOverlap(vtepCIDRs, hostNets) {
+			overlapping = append(overlapping, node.Name)
+		}
+	}
+
+	if len(overlapping) > 0 {
+		sort.Strings(overlapping)
+		return fmt.Errorf("managed VTEP CIDRs overlap with node host IPs on nodes: [%s]",
+			strings.Join(overlapping, ", "))
+	}
+	return nil
+}
+
 // requeueConflictingVTEPs re-queues VTEPs whose Accepted=False/CIDROverlap
 // condition message mentions the deleted VTEP by name, so they can
 // re-evaluate whether their conflicts are resolved.
@@ -540,8 +603,16 @@ func parseVTEPCIDRs(vtep *vtepv1.VTEP) ([]*net.IPNet, error) {
 
 // validateNodeVTEPIPs validates that every node has a VTEP IP entry in the
 // k8s.ovn.org/vteps annotation for this VTEP. For unmanaged mode, ovnkube-node
-// discovers IPs and writes the annotation; this controller only reads and
-// validates. The RA controller reads the same annotation when generating FRR
+// discovers IPs from local interfaces and writes the annotation; this
+// controller only checks that each node has a non-empty entry.
+//
+// We intentionally do not verify that the annotated IPs fall within the VTEP's
+// configured CIDRs. The node-side controller is the authority for unmanaged
+// VTEPs: it has visibility into local interfaces and filters out VIPs /
+// secondary addresses before writing the annotation. If the node writes an
+// out-of-range IP, that is a node-side misconfiguration, not something the CM
+// should reject — doing so would create a fight between the two controllers.
+// The RA controller reads the same annotation when generating FRR
 // configurations.
 func (c *Controller) validateNodeVTEPIPs(vtep *vtepv1.VTEP) error {
 	nodes, err := c.nodeLister.List(labels.Everything())
@@ -604,6 +675,13 @@ func (c *Controller) validateNodeVTEPIPs(vtep *vtepv1.VTEP) error {
 // stability — nodes keep the same VTEP IPs they had before the switch.
 // Out-of-range IPs (e.g. CIDRs changed before the switch) are skipped and
 // a fresh IP is allocated in step 2.
+//
+// User action required before switching to Managed: the user must remove
+// any VTEP IPs from custom dummy/loopback interfaces on the nodes. If
+// those IPs remain, they appear in k8s.ovn.org/host-cidrs and
+// validateManagedCIDRsAgainstNodeIPs will reject the VTEP with
+// CIDROverlap. The managed-mode node controller (evlo-* devices) handles
+// IP configuration automatically once the CM accepts the VTEP.
 func (c *Controller) handleManagedMode(vtep *vtepv1.VTEP) error {
 	allocator, err := c.getOrUpdateAllocator(vtep)
 	if err != nil {

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -35,6 +35,7 @@ import (
 	vtepscheme "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/clientset/versioned/scheme"
 	vteplisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/listers/vtep/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -48,10 +49,19 @@ type Controller struct {
 	vtepLister     vteplisters.VTEPLister
 	cudnLister     udnlisters.ClusterUserDefinedNetworkLister
 	nodeLister     corelisters.NodeLister
+	kube           kube.Interface
 	vtepController controllerutil.Controller
 	cudnController controllerutil.Controller
 	nodeController controllerutil.Controller
 	eventRecorder  record.EventRecorder
+
+	// allocators holds per-VTEP IP allocators for managed-mode VTEPs.
+	// Keyed by VTEP name. Created on first reconcile, updated on CIDR
+	// changes, removed on VTEP deletion. Currently only accessed from
+	// vtepController (Threadiness=1), but protected by a mutex for
+	// safety if threadiness changes or cross-controller access is added.
+	allocatorsMu sync.Mutex
+	allocators   map[string]*vtepIPAllocator
 
 	// cudnVTEPIndex tracks which VTEP each EVPN-enabled CUDN references
 	// (cudnName → vtepName). Populated on CUDN create, consulted on CUDN
@@ -77,7 +87,9 @@ func NewController(
 		vtepLister:    vtepLister,
 		cudnLister:    wf.ClusterUserDefinedNetworkInformer().Lister(),
 		nodeLister:    wf.NodeCoreInformer().Lister(),
+		kube:          &kube.Kube{KClient: ovnClient.KubeClient},
 		eventRecorder: recorder,
+		allocators:    make(map[string]*vtepIPAllocator),
 		cudnVTEPIndex: make(map[string]string),
 	}
 
@@ -165,10 +177,6 @@ func (c *Controller) reconcileVTEP(key string) error {
 		return err
 	}
 
-	if vtep.Spec.Mode == vtepv1.VTEPModeManaged {
-		return c.handleManagedModeNotSupported(vtep)
-	}
-
 	if err := c.validateCIDRsAcrossVTEPs(vtep); err != nil {
 		existingCond := meta.FindStatusCondition(vtep.Status.Conditions, conditionTypeAccepted)
 		if existingCond == nil || existingCond.Status != metav1.ConditionFalse || existingCond.Reason != reasonCIDROverlap || existingCond.Message != err.Error() {
@@ -195,19 +203,23 @@ func (c *Controller) reconcileVTEP(key string) error {
 			reasonEVPNIPv6NotSupported, err.Error())
 	}
 
-	if err := c.validateNodeVTEPIPs(vtep); err != nil {
+	var allocationErr error
+	if vtep.Spec.Mode == vtepv1.VTEPModeManaged {
+		allocationErr = c.handleManagedMode(vtep)
+	} else {
+		allocationErr = c.validateNodeVTEPIPs(vtep)
+	}
+	if allocationErr != nil {
 		existingCond := meta.FindStatusCondition(vtep.Status.Conditions, conditionTypeAccepted)
-		if existingCond == nil || existingCond.Status != metav1.ConditionFalse || existingCond.Reason != reasonAllocationFailed || existingCond.Message != err.Error() {
+		if existingCond == nil || existingCond.Status != metav1.ConditionFalse || existingCond.Reason != reasonAllocationFailed || existingCond.Message != allocationErr.Error() {
 			vtepRef, refErr := reference.GetReference(vtepscheme.Scheme, vtep)
 			if refErr != nil {
 				return fmt.Errorf("failed to get object reference for VTEP %s: %w", vtep.Name, refErr)
 			}
-			c.eventRecorder.Event(vtepRef, corev1.EventTypeWarning, reasonAllocationFailed, err.Error())
+			c.eventRecorder.Event(vtepRef, corev1.EventTypeWarning, reasonAllocationFailed, allocationErr.Error())
 		}
-		// Don't retry: the node controller watches for k8s.ovn.org/vteps
-		// annotation changes and re-queues all VTEPs when annotations appear.
 		return c.updateStatusCondition(vtep, conditionTypeAccepted, metav1.ConditionFalse,
-			reasonAllocationFailed, err.Error())
+			reasonAllocationFailed, allocationErr.Error())
 	}
 
 	return c.updateStatusCondition(vtep, conditionTypeAccepted, metav1.ConditionTrue,
@@ -246,9 +258,21 @@ func (c *Controller) handleVTEPDeletion(vtep *vtepv1.VTEP) error {
 	}
 
 	if len(referencingCUDNs) > 0 {
-		// we don't retry here since when a CUDN is deleted, this controller will be notified and will re-queue the VTEP
 		klog.Infof("VTEP %s is still referenced by CUDNs [%s], blocking deletion", vtep.Name, strings.Join(referencingCUDNs, ", "))
 		return nil
+	}
+
+	c.allocatorsMu.Lock()
+	_, wasManaged := c.allocators[vtep.Name]
+	c.allocatorsMu.Unlock()
+
+	if wasManaged || vtep.Spec.Mode == vtepv1.VTEPModeManaged {
+		if err := c.cleanupManagedVTEPAnnotations(vtep.Name); err != nil {
+			return fmt.Errorf("failed to clean up managed VTEP annotations for %s: %w", vtep.Name, err)
+		}
+		c.allocatorsMu.Lock()
+		delete(c.allocators, vtep.Name)
+		c.allocatorsMu.Unlock()
 	}
 
 	_, err = c.vtepClient.K8sV1().VTEPs().Apply(
@@ -261,6 +285,23 @@ func (c *Controller) handleVTEPDeletion(vtep *vtepv1.VTEP) error {
 	}
 	klog.Infof("Removed finalizer from VTEP %s, deletion unblocked", vtep.Name)
 	return nil
+}
+
+// cleanupManagedVTEPAnnotations removes the VTEP entry from the
+// k8s.ovn.org/vteps annotation on all nodes.
+func (c *Controller) cleanupManagedVTEPAnnotations(vtepName string) error {
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var errs []error
+	for _, node := range nodes {
+		if err := util.RemoveNodeVTEPEntry(node.Name, vtepName, c.nodeLister.Get, c.kube.UpdateNodeStatus); err != nil {
+			errs = append(errs, fmt.Errorf("node %s: %w", node.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // getCUDNsReferencingVTEP returns the names of CUDNs that reference the given VTEP.
@@ -452,20 +493,89 @@ func (c *Controller) validateNodeVTEPIPs(vtep *vtepv1.VTEP) error {
 	return errors.Join(errs...)
 }
 
-func (c *Controller) handleManagedModeNotSupported(vtep *vtepv1.VTEP) error {
-	existingCond := meta.FindStatusCondition(vtep.Status.Conditions, conditionTypeAccepted)
-	if existingCond == nil || existingCond.Status != metav1.ConditionFalse || existingCond.Reason != reasonManagedModeNotSupported {
-		vtepRef, err := reference.GetReference(vtepscheme.Scheme, vtep)
-		if err != nil {
-			return fmt.Errorf("failed to get object reference for VTEP %s: %w", vtep.Name, err)
-		}
-		c.eventRecorder.Event(vtepRef, corev1.EventTypeWarning, reasonManagedModeNotSupported,
-			"Managed VTEP mode is not yet implemented; only Unmanaged mode is currently supported")
+// handleManagedMode ensures every node has an allocated VTEP IP and the
+// annotation is up to date. It creates the allocator lazily on first call
+// and allocates IPs for all current nodes.
+func (c *Controller) handleManagedMode(vtep *vtepv1.VTEP) error {
+	allocator, err := c.getOrCreateAllocator(vtep)
+	if err != nil {
+		return fmt.Errorf("failed to create allocator for VTEP %s: %w", vtep.Name, err)
 	}
 
-	return c.updateStatusCondition(vtep, conditionTypeAccepted, metav1.ConditionFalse,
-		reasonManagedModeNotSupported,
-		"Managed VTEP mode is not yet implemented; only Unmanaged mode is currently supported")
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var errs []error
+	for _, node := range nodes {
+		if err := c.allocateAndAnnotateNode(vtep.Name, node.Name, allocator); err != nil {
+			errs = append(errs, fmt.Errorf("node %s: %w", node.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// getOrCreateAllocator returns the existing allocator for this VTEP or creates
+// a new one from the VTEP's CIDRs.
+func (c *Controller) getOrCreateAllocator(vtep *vtepv1.VTEP) (*vtepIPAllocator, error) {
+	c.allocatorsMu.Lock()
+	defer c.allocatorsMu.Unlock()
+	if a, ok := c.allocators[vtep.Name]; ok {
+		return a, nil
+	}
+	a, err := newVTEPIPAllocator(vtep.Spec.CIDRs)
+	if err != nil {
+		return nil, err
+	}
+	c.allocators[vtep.Name] = a
+	return a, nil
+}
+
+// allocateAndAnnotateNode allocates a VTEP IP for the node and writes the
+// k8s.ovn.org/vteps annotation using retry-on-conflict to avoid races with
+// the node-side controller that writes entries for unmanaged VTEPs into the
+// same annotation.
+func (c *Controller) allocateAndAnnotateNode(vtepName, nodeName string, allocator *vtepIPAllocator) error {
+	allocated, err := allocator.allocateForNode(nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to allocate IP: %w", err)
+	}
+
+	ips := make([]string, 0, len(allocated))
+	for _, ipNet := range allocated {
+		ips = append(ips, ipNet.IP.String())
+	}
+
+	node, err := c.nodeLister.Get(nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+	// Writing the annotation triggers the node watcher which re-queues all
+	// VTEPs. Skip the write if the annotation already matches so we don't
+	// produce an infinite reconcile loop.
+	vteps, err := util.ParseNodeVTEPs(node)
+	if err == nil {
+		if existing, ok := vteps[vtepName]; ok && ipsEqual(existing.IPs, ips) {
+			return nil
+		}
+	}
+
+	return util.SetNodeVTEPEntry(nodeName, vtepName, ips, c.nodeLister.Get, c.kube.UpdateNodeStatus)
+}
+
+// ipsEqual returns true if two string slices contain the same IPs
+// (order-sensitive, matching the allocator's deterministic output).
+func ipsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // reconcileCUDN handles CUDN create and delete events relevant to VTEP
@@ -538,18 +648,26 @@ func (c *Controller) reconcileNode(_ string) error {
 	return nil
 }
 
-// nodeNeedsUpdate triggers VTEP reconciliation only when the k8s.ovn.org/vteps
-// annotation changes. Creates (oldObj==nil) are ignored because a fresh node
-// won't have the VTEP annotation yet; the annotation-change event will handle
-// it once set. On restart, the informer fires synthetic creates for all
-// existing nodes (which may already carry the annotation), but the VTEP
-// informer also fires creates for all VTEPs, and each VTEP reconciliation
-// reads node annotations via the lister, so skipping node creates is safe.
+// nodeNeedsUpdate triggers VTEP reconciliation on node creates and when the
+// k8s.ovn.org/vteps annotation changes.
+//
+// Creates (oldObj==nil) are accepted because managed-mode VTEPs need the
+// cluster-manager to allocate IPs for newly joined nodes. Without this, a
+// node joining a running cluster would not get a VTEP IP until an unrelated
+// event (e.g. a VTEP spec change) happened to trigger a VTEP reconcile.
+// For unmanaged mode the extra reconcile from a node create is harmless:
+// validateNodeVTEPIPs will report AllocationFailed until the node-side
+// controller writes the annotation, which then triggers the annotation-
+// change path.
+//
 // Deletes (newObj==nil) bypass ObjNeedsUpdate in the controller framework,
 // so that branch is unreachable here.
 func nodeNeedsUpdate(oldObj, newObj *corev1.Node) bool {
-	if oldObj == nil || newObj == nil {
+	if newObj == nil {
 		return false
+	}
+	if oldObj == nil {
+		return true
 	}
 	return util.NodeVTEPsAnnotationChanged(oldObj, newObj)
 }

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -177,40 +177,7 @@ func (c *Controller) syncManagedAllocators() error {
 			errs = append(errs, fmt.Errorf("VTEP %s: failed to create allocator: %w", vtep.Name, err))
 			continue
 		}
-		for _, node := range nodes {
-			nodeVTEPs, err := util.ParseNodeVTEPs(node)
-			if err != nil {
-				if !util.IsAnnotationNotSetError(err) {
-					klog.Warningf("VTEP %s: failed to parse annotation on node %s, skipping: %v", vtep.Name, node.Name, err)
-				}
-				continue
-			}
-			entry, ok := nodeVTEPs[vtep.Name]
-			if !ok || len(entry.IPs) == 0 {
-				klog.Warningf("VTEP %s: no existing allocation found on node %s, skipping", vtep.Name, node.Name)
-				continue
-			}
-			ips := make([]net.IP, 0, len(entry.IPs))
-			for _, ipStr := range entry.IPs {
-				ip := net.ParseIP(ipStr)
-				if ip == nil {
-					errs = append(errs, fmt.Errorf("VTEP %s: invalid IP %q in annotation on node %s", vtep.Name, ipStr, node.Name))
-					continue
-				}
-				ips = append(ips, ip)
-			}
-			if err := allocator.markAllocatedForNode(node.Name, ips); err != nil {
-				// The IPs in the annotation are invalid for managed mode: either
-				// out of the managed CIDRs (stale from unmanaged->managed mode change or CIDR
-				// change) or already owned by another node (conflict). Remove the
-				// stale entry so handleManagedMode can allocate a fresh valid IP
-				// without the node-side controller briefly observing a stale IP.
-				klog.Warningf("VTEP %s: removing invalid IPs %v from node %s annotation: %v", vtep.Name, ips, node.Name, err)
-				if removeErr := util.RemoveNodeVTEPEntry(node.Name, vtep.Name, c.nodeLister.Get, c.kube.UpdateNodeStatus); removeErr != nil {
-					errs = append(errs, fmt.Errorf("VTEP %s: failed to remove stale annotation from node %s: %w", vtep.Name, node.Name, removeErr))
-				}
-			}
-		}
+		c.markExistingAllocationsFromNodes(vtep.Name, allocator, nodes)
 		c.allocatorsMu.Lock()
 		c.allocators[vtep.Name] = allocator
 		c.allocatorsMu.Unlock()
@@ -273,6 +240,48 @@ func (c *Controller) reconcileVTEP(key string) error {
 		}
 		return c.updateStatusCondition(vtep, conditionTypeAccepted, metav1.ConditionFalse,
 			reasonEVPNIPv6NotSupported, err.Error())
+	}
+
+	// When a VTEP transitions from Managed to Unmanaged, clean up the
+	// CM-written annotations and drop the allocator so the node-side
+	// controller can take over.
+	//
+	// User action required: after switching to Unmanaged, the user must
+	// configure VTEP IPs on dedicated interfaces (e.g. dummy devices) on
+	// each node. ovnkube-node will discover them. The CM-allocated IPs
+	// on the evlo-* dummy devices (created by the managed-mode node
+	// controller) are cleaned up automatically by the node side.
+	//
+	// There is a transient window between CM cleanup and node-side write
+	// where the VTEP annotation entry is absent. During this window
+	// validateNodeVTEPIPs reports AllocationFailed. The system self-heals
+	// once the node writes its discovered IP.
+	//
+	// Race with node-side during the cleanup window: the CM removes the VTEP
+	// entry from each node's annotation using RetryOnConflict+UpdateNodeStatus,
+	// while ovnkube-node concurrently writes its discovered IP using the same
+	// pattern (TODO: node-side should also use RetryOnConflict+UpdateNodeStatus;
+	// currently it uses strategic merge patch). Both sides may 409-conflict
+	// during cleanup. This is safe: the wasManaged guard ensures the CM only
+	// runs cleanup once per mode switch. After cleanup the allocator is gone so
+	// wasManaged is false on all subsequent reconciles, and the CM never touches
+	// the annotation again. Node-side eventually wins and the system converges.
+	// NOTE: Design isn't ideal but this is what happens when two processes share the
+	// same annotation resource. Moving modes is expected to be a rare operation so we
+	// can live with this.
+	if vtep.Spec.Mode != vtepv1.VTEPModeManaged {
+		c.allocatorsMu.Lock()
+		_, wasManaged := c.allocators[vtep.Name]
+		c.allocatorsMu.Unlock()
+		if wasManaged {
+			klog.Infof("VTEP %s switched from Managed to Unmanaged, cleaning up annotations", vtep.Name)
+			if err := c.cleanupManagedVTEPAnnotations(vtep.Name); err != nil {
+				return fmt.Errorf("failed to clean up managed VTEP annotations for %s: %w", vtep.Name, err)
+			}
+			c.allocatorsMu.Lock()
+			delete(c.allocators, vtep.Name)
+			c.allocatorsMu.Unlock()
+		}
 	}
 
 	var allocationErr error
@@ -566,12 +575,39 @@ func (c *Controller) validateNodeVTEPIPs(vtep *vtepv1.VTEP) error {
 }
 
 // handleManagedMode ensures every node has an allocated VTEP IP and the
-// annotation is up to date. It creates the allocator lazily on first call
-// and allocates IPs for all current nodes.
+// annotation is up to date. Each reconcile does two things in order:
+//
+// NOTE: this iterates all nodes on every VTEP reconcile. At large scale
+// (e.g. 5000 nodes × 20 VTEPs) this is 100k in-memory lister lookups +
+// annotation parses per event burst, which is acceptable since the lister
+// is an in-memory cache and each parse is a small JSON unmarshal. Nodes
+// that already have the correct annotation are skipped via an early-exit
+// check, so no API calls are made for them. TODO: If scale becomes a concern, a
+// per-VTEP "pending nodes" set could reduce redundant work.
+//  1. getOrUpdateAllocator: get the existing allocator, create one if this is
+//     the first managed reconcile (e.g. Unmanaged->Managed switch), or update
+//     it if the CIDRs changed. On first creation, existing node annotations
+//     are immediately marked so in-range IPs are preserved within this same
+//     reconcile.
+//  2. allocateAndAnnotateNode for every node: for nodes whose IPs were
+//     successfully marked above, allocateForNode is idempotent and returns the
+//     same IP. For nodes with stale/out-of-range IPs (mark was skipped), a
+//     fresh IP is allocated and the annotation is overwritten -- all in this
+//     same reconcile, not deferred.
+//
+// Mode switch: Unmanaged -> Managed
+//
+// On the first managed reconcile after a mode switch, getOrUpdateAllocator
+// creates a new allocator and calls markExistingAllocationsFromNodes to
+// reserve any in-range IPs already present in node annotations (written by
+// the node-side controller during the Unmanaged phase). This preserves IP
+// stability — nodes keep the same VTEP IPs they had before the switch.
+// Out-of-range IPs (e.g. CIDRs changed before the switch) are skipped and
+// a fresh IP is allocated in step 2.
 func (c *Controller) handleManagedMode(vtep *vtepv1.VTEP) error {
-	allocator, err := c.getOrCreateAllocator(vtep)
+	allocator, err := c.getOrUpdateAllocator(vtep)
 	if err != nil {
-		return fmt.Errorf("failed to create allocator for VTEP %s: %w", vtep.Name, err)
+		return fmt.Errorf("failed to get/create allocator for VTEP %s: %w", vtep.Name, err)
 	}
 
 	nodes, err := c.nodeLister.List(labels.Everything())
@@ -588,20 +624,109 @@ func (c *Controller) handleManagedMode(vtep *vtepv1.VTEP) error {
 	return errors.Join(errs...)
 }
 
-// getOrCreateAllocator returns the existing allocator for this VTEP or creates
-// a new one from the VTEP's CIDRs.
-func (c *Controller) getOrCreateAllocator(vtep *vtepv1.VTEP) (*vtepIPAllocator, error) {
+// markExistingAllocationsFromNodes reads node annotations and marks any
+// existing IPs for vtepName in the allocator so they are not reassigned.
+// IPs that are invalid for the current managed CIDRs (stale from an
+// unmanaged->managed mode switch or CIDR change, or conflicting with another
+// node) are removed from the annotation so the node-side controller does not
+// briefly observe a stale IP.
+func (c *Controller) markExistingAllocationsFromNodes(vtepName string, allocator *vtepIPAllocator, nodes []*corev1.Node) {
+	for _, node := range nodes {
+		nodeVTEPs, err := util.ParseNodeVTEPs(node)
+		if err != nil {
+			if !util.IsAnnotationNotSetError(err) {
+				klog.Warningf("VTEP %s: failed to parse annotation on node %s, skipping: %v", vtepName, node.Name, err)
+			}
+			continue
+		}
+		entry, ok := nodeVTEPs[vtepName]
+		if !ok || len(entry.IPs) == 0 {
+			continue
+		}
+		ips := make([]net.IP, 0, len(entry.IPs))
+		for _, ipStr := range entry.IPs {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				klog.Warningf("VTEP %s: invalid IP %q in annotation on node %s, skipping", vtepName, ipStr, node.Name)
+				continue
+			}
+			ips = append(ips, ip)
+		}
+		if err := allocator.markAllocatedForNode(node.Name, ips); err != nil {
+			// The IPs in the annotation are invalid for managed mode: either
+			// out of the managed CIDRs (stale from unmanaged->managed mode change or CIDR
+			// change) or already owned by another node (conflict). Remove the
+			// stale entry so handleManagedMode can allocate a fresh valid IP
+			// without the node-side controller briefly observing a stale IP.
+			klog.Warningf("VTEP %s: removing invalid IPs %v from node %s annotation: %v", vtepName, ips, node.Name, err)
+			if removeErr := util.RemoveNodeVTEPEntry(node.Name, vtepName, c.nodeLister.Get, c.kube.UpdateNodeStatus); removeErr != nil {
+				klog.Errorf("VTEP %s: failed to remove stale annotation from node %s: %v", vtepName, node.Name, removeErr)
+			}
+		}
+	}
+}
+
+// getOrUpdateAllocator returns the allocator for this VTEP, creating it if
+// it doesn't exist (e.g. first reconcile or mode switch from Unmanaged) or
+// updating it when CIDRs have changed (append or widen).
+//
+// On first creation, existing node annotations are marked in the allocator so
+// that IPs written by the node-side controller during Unmanaged phase are
+// preserved rather than reassigned.
+//
+// On CIDR change, new CIDRs are appended and widened CIDRs are replaced
+// in-place. Since CEL rules guarantee CIDRs can only be appended or widened
+// in managed mode, existing allocations always remain valid.
+func (c *Controller) getOrUpdateAllocator(vtep *vtepv1.VTEP) (*vtepIPAllocator, error) {
 	c.allocatorsMu.Lock()
 	defer c.allocatorsMu.Unlock()
-	if a, ok := c.allocators[vtep.Name]; ok {
+
+	existing, ok := c.allocators[vtep.Name]
+	if !ok {
+		// First time seeing this VTEP in managed mode (fresh start or
+		// Unmanaged->Managed switch). Create allocator and mark any existing
+		// node annotations so we don't reassign IPs already in use.
+		a, err := newVTEPIPAllocator(vtep.Spec.CIDRs)
+		if err != nil {
+			return nil, err
+		}
+		nodes, err := c.nodeLister.List(labels.Everything())
+		if err != nil {
+			return nil, fmt.Errorf("failed to list nodes: %w", err)
+		}
+		c.markExistingAllocationsFromNodes(vtep.Name, a, nodes)
+		c.allocators[vtep.Name] = a
 		return a, nil
 	}
-	a, err := newVTEPIPAllocator(vtep.Spec.CIDRs)
-	if err != nil {
-		return nil, err
+
+	if existing.cidrsMatch(vtep.Spec.CIDRs) {
+		return existing, nil
 	}
-	c.allocators[vtep.Name] = a
-	return a, nil
+
+	// CIDRs have changed. CEL guarantees only appends and widenings are
+	// allowed in managed mode, so:
+	//  - indices < len(existing.cidrs): check if widened, replace if so
+	//  - indices >= len(existing.cidrs): new CIDRs, append them
+	klog.Infof("VTEP %s: CIDRs changed, updating allocator", vtep.Name)
+	for i, newCIDR := range vtep.Spec.CIDRs {
+		if i < len(existing.cidrs) {
+			if existing.cidrs[i] == newCIDR {
+				continue
+			}
+			// Existing CIDR was widened.
+			if err := existing.replaceRange(i, existing.cidrs[i], newCIDR); err != nil {
+				return nil, fmt.Errorf("failed to replace CIDR %q with %q: %w", existing.cidrs[i], newCIDR, err)
+			}
+			klog.Infof("VTEP %s: widened CIDR[%d] from %s to %s", vtep.Name, i, existing.cidrs[i], newCIDR)
+		} else {
+			// New CIDR appended to the spec.
+			if err := existing.addCIDR(newCIDR); err != nil {
+				return nil, fmt.Errorf("failed to add new CIDR %q: %w", newCIDR, err)
+			}
+			klog.Infof("VTEP %s: appended new CIDR %s", vtep.Name, newCIDR)
+		}
+	}
+	return existing, nil
 }
 
 // allocateAndAnnotateNode allocates a VTEP IP for the node and writes the
@@ -711,13 +836,35 @@ func cudnNeedsUpdate(oldObj, newObj *udnv1.ClusterUserDefinedNetwork) bool {
 // (or on node create/delete). It re-queues all VTEPs so validateNodeVTEPIPs
 // can re-validate VTEP IPs for the affected node.
 //
+// On node delete, the node is absent from the lister. For managed-mode VTEPs
+// we release the node's allocation so the IP can be reused by a future node.
+//
 // NOTE: currently we re-queue all VTEPs because every node participates in
 // every VTEP (FRR runs on all nodes). If partial VTEP participation is
 // supported in the future, we could compare the node's IPs against each
 // VTEP's CIDRs and only re-queue overlapping VTEPs.
-func (c *Controller) reconcileNode(_ string) error {
+func (c *Controller) reconcileNode(nodeName string) error {
+	_, err := c.nodeLister.Get(nodeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.releaseNodeFromAllocators(nodeName)
+		} else {
+			klog.Warningf("Failed to get node %s during reconcile: %v", nodeName, err)
+		}
+	}
 	c.vtepController.ReconcileAll()
 	return nil
+}
+
+// releaseNodeFromAllocators frees the node's IP allocation from all managed
+// VTEP allocators so the IP can be reused by a new node.
+func (c *Controller) releaseNodeFromAllocators(nodeName string) {
+	c.allocatorsMu.Lock()
+	defer c.allocatorsMu.Unlock()
+	for vtepName, allocator := range c.allocators {
+		allocator.releaseNode(nodeName)
+		klog.V(4).Infof("Released VTEP %s allocation for deleted node %s", vtepName, nodeName)
+	}
 }
 
 // nodeNeedsUpdate triggers VTEP reconciliation on node creates and when the

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -6,6 +6,7 @@ package vtep
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 
@@ -85,19 +87,22 @@ func getVTEPFinalizers(client *vtepfake.Clientset, vtepName string) ([]string, e
 // newNodeWithVTEPAnnotation creates a node with the k8s.ovn.org/vteps annotation.
 // vtepIPs is a map of VTEP name to list of IPs discovered on this node.
 func newNodeWithVTEPAnnotation(name string, vtepIPs map[string][]string) *corev1.Node {
-	vteps := make(map[string]util.VTEPNodeAnnotation, len(vtepIPs))
-	for vtepName, ips := range vtepIPs {
-		vteps[vtepName] = util.VTEPNodeAnnotation{IPs: ips}
-	}
-	annotation, _ := json.Marshal(vteps)
-	return &corev1.Node{
+	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
-			Annotations: map[string]string{
-				util.OVNNodeVTEPs: string(annotation),
-			},
 		},
 	}
+	if len(vtepIPs) > 0 {
+		vteps := make(map[string]util.VTEPNodeAnnotation, len(vtepIPs))
+		for vtepName, ips := range vtepIPs {
+			vteps[vtepName] = util.VTEPNodeAnnotation{IPs: ips}
+		}
+		annotation, _ := json.Marshal(vteps)
+		node.Annotations = map[string]string{
+			util.OVNNodeVTEPs: string(annotation),
+		}
+	}
+	return node
 }
 
 func getVTEPCondition(client *vtepfake.Clientset, vtepName, conditionType string) (*metav1.Condition, error) {
@@ -167,153 +172,264 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		}
 	})
 
-	ginkgo.Context("Managed mode gate", func() {
-		ginkgo.It("sets Accepted=False for a VTEP with mode Managed", func() {
+	ginkgo.Context("Managed mode", func() {
+		ginkgo.It("allocates IPs and writes annotations for all nodes", func() {
 			vtep := newVTEP("managed-vtep", vtepv1.VTEPModeManaged, "100.64.0.0/24")
-			start(vtep)
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			start(vtep, node1, node2)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
 				return getVTEPCondition(fakeVTEP, "managed-vtep", conditionTypeAccepted)
 			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionFalse),
-				gomega.HaveField("Reason", gomega.Equal("ManagedModeNotSupported")),
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal("Allocated")),
 			))
 
-			gomega.Eventually(fakeRecorder.Events).Should(gomega.Receive(
-				gomega.ContainSubstring("ManagedModeNotSupported"),
-			))
+			for _, nodeName := range []string{"node-1", "node-2"} {
+				name := nodeName
+				gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+					n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+					if err != nil {
+						return nil, err
+					}
+					return util.ParseNodeVTEPs(n)
+				}).WithTimeout(5 * time.Second).Should(gomega.HaveKey("managed-vtep"))
+			}
 		})
 
-		ginkgo.It("sets Accepted=True for a VTEP with mode Unmanaged", func() {
-			vtep := newVTEP("unmanaged-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
+		ginkgo.It("sets Accepted=True with no nodes", func() {
+			vtep := newVTEP("managed-no-nodes", vtepv1.VTEPModeManaged, "100.64.0.0/24")
 			start(vtep)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "unmanaged-vtep", conditionTypeAccepted)
+				return getVTEPCondition(fakeVTEP, "managed-no-nodes", conditionTypeAccepted)
 			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
 				gomega.HaveField("Status", metav1.ConditionTrue),
 				gomega.HaveField("Reason", gomega.Equal("Allocated")),
 			))
 		})
 
-		ginkgo.It("sets Accepted=False when mode changes from Unmanaged to Managed", func() {
-			vtep := newVTEP("mode-change-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			start(vtep)
+		ginkgo.It("allocates IPs from multiple CIDRs", func() {
+			// /30 gives 4 IPs; 5 nodes exhaust the first /30 and one node must
+			// overflow into the second /30. We can't predict which node gets
+			// which IP (allocation order is not guaranteed), so we verify that
+			// at least one node's IP comes from the second CIDR.
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			node3 := newNodeWithVTEPAnnotation("node-3", nil)
+			node4 := newNodeWithVTEPAnnotation("node-4", nil)
+			node5 := newNodeWithVTEPAnnotation("node-5", nil)
+			vtep := newVTEP("managed-multi-cidr", vtepv1.VTEPModeManaged, "10.0.0.0/30", "10.0.1.0/30")
+			start(vtep, node1, node2, node3, node4, node5)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "mode-change-vtep", conditionTypeAccepted)
+				return getVTEPCondition(fakeVTEP, "managed-multi-cidr", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			// All 5 nodes must have an annotation entry.
+			for _, nodeName := range []string{"node-1", "node-2", "node-3", "node-4", "node-5"} {
+				name := nodeName
+				gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+					n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+					if err != nil {
+						return nil, err
+					}
+					return util.ParseNodeVTEPs(n)
+				}).WithTimeout(5 * time.Second).Should(gomega.HaveKey("managed-multi-cidr"))
+			}
+
+			// At least one node must have an IP from the second CIDR (10.0.1.x),
+			// proving overflow into the second range occurred.
+			gomega.Eventually(func() bool {
+				for _, nodeName := range []string{"node-1", "node-2", "node-3", "node-4", "node-5"} {
+					n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+					if err != nil {
+						continue
+					}
+					vteps, err := util.ParseNodeVTEPs(n)
+					if err != nil || len(vteps["managed-multi-cidr"].IPs) == 0 {
+						continue
+					}
+					if strings.HasPrefix(vteps["managed-multi-cidr"].IPs[0], "10.0.1.") {
+						return true
+					}
+				}
+				return false
+			}).WithTimeout(5 * time.Second).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("allocates independent IPs to nodes across multiple managed VTEPs", func() {
+			// Two managed VTEPs with non-overlapping CIDRs; both should allocate
+			// to the same set of nodes independently.
+			vtepA := newVTEP("mvtep-a", vtepv1.VTEPModeManaged, "10.0.0.0/24")
+			vtepB := newVTEP("mvtep-b", vtepv1.VTEPModeManaged, "10.1.0.0/24")
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			start(vtepA, vtepB, node1, node2)
+
+			for _, vtepName := range []string{"mvtep-a", "mvtep-b"} {
+				name := vtepName
+				gomega.Eventually(func() (*metav1.Condition, error) {
+					return getVTEPCondition(fakeVTEP, name, conditionTypeAccepted)
+				}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+					gomega.HaveField("Status", metav1.ConditionTrue),
+					gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+				))
+			}
+
+			// Every node must have annotation entries for both VTEPs, with IPs
+			// from their respective CIDRs.
+			for _, nodeName := range []string{"node-1", "node-2"} {
+				nName := nodeName
+				gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+					n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nName, metav1.GetOptions{})
+					if err != nil {
+						return nil, err
+					}
+					return util.ParseNodeVTEPs(n)
+				}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+					gomega.HaveKey("mvtep-a"),
+					gomega.HaveKey("mvtep-b"),
+				))
+			}
+
+			// Verify IPs are from the correct CIDRs and distinct across nodes.
+			ips := map[string]map[string]string{} // vtepName -> nodeName -> IP
+			for _, nodeName := range []string{"node-1", "node-2"} {
+				nName := nodeName
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				vteps, err := util.ParseNodeVTEPs(n)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, vtepName := range []string{"mvtep-a", "mvtep-b"} {
+					if ips[vtepName] == nil {
+						ips[vtepName] = map[string]string{}
+					}
+					ips[vtepName][nName] = vteps[vtepName].IPs[0]
+				}
+			}
+			gomega.Expect(ips["mvtep-a"]["node-1"]).To(gomega.HavePrefix("10.0.0."))
+			gomega.Expect(ips["mvtep-a"]["node-2"]).To(gomega.HavePrefix("10.0.0."))
+			gomega.Expect(ips["mvtep-b"]["node-1"]).To(gomega.HavePrefix("10.1.0."))
+			gomega.Expect(ips["mvtep-b"]["node-2"]).To(gomega.HavePrefix("10.1.0."))
+			gomega.Expect(ips["mvtep-a"]["node-1"]).NotTo(gomega.Equal(ips["mvtep-a"]["node-2"]))
+			gomega.Expect(ips["mvtep-b"]["node-1"]).NotTo(gomega.Equal(ips["mvtep-b"]["node-2"]))
+		})
+
+		ginkgo.It("allocates an IP for a node that joins after startup", func() {
+			vtep := newVTEP("managed-late-node", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			start(vtep, node1)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "managed-late-node", conditionTypeAccepted)
 			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
 
-			vtep, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "mode-change-vtep", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			vtep.Spec.Mode = vtepv1.VTEPModeManaged
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), vtep, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "mode-change-vtep", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionFalse),
-				gomega.HaveField("Reason", gomega.Equal("ManagedModeNotSupported")),
-			))
-
-			gomega.Eventually(fakeRecorder.Events).Should(gomega.Receive(
-				gomega.ContainSubstring("ManagedModeNotSupported"),
-			))
-		})
-
-		ginkgo.It("sets Accepted=True when mode changes from Managed to Unmanaged", func() {
-			vtep := newVTEP("mode-recover-vtep", vtepv1.VTEPModeManaged, "100.64.0.0/24")
-			start(vtep)
-
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "mode-recover-vtep", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionFalse),
-				gomega.HaveField("Reason", gomega.Equal("ManagedModeNotSupported")),
-			))
-
-			vtep, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "mode-recover-vtep", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			vtep.Spec.Mode = vtepv1.VTEPModeUnmanaged
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), vtep, metav1.UpdateOptions{})
+			// A new node joins after the controller is already running.
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			_, err := fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node2, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "mode-recover-vtep", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionTrue),
-				gomega.HaveField("Reason", gomega.Equal("Allocated")),
-			))
+			gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-2", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return util.ParseNodeVTEPs(n)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveKey("managed-late-node"))
 		})
 	})
 
 	ginkgo.Context("Finalizer management", func() {
-		ginkgo.It("adds finalizer to a new VTEP", func() {
-			vtep := newVTEP("finalize-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			start(vtep)
+		ginkgo.DescribeTable("adds finalizer to a new VTEP",
+			func(mode vtepv1.VTEPMode) {
+				vtep := newVTEP("finalize-vtep", mode, "100.64.0.0/24")
+				start(vtep)
+				gomega.Eventually(func() ([]string, error) {
+					return getVTEPFinalizers(fakeVTEP, "finalize-vtep")
+				}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
+			},
+			ginkgo.Entry("unmanaged", vtepv1.VTEPModeUnmanaged),
+			ginkgo.Entry("managed", vtepv1.VTEPModeManaged),
+		)
 
-			gomega.Eventually(func() ([]string, error) {
-				return getVTEPFinalizers(fakeVTEP, "finalize-vtep")
-			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
-		})
+		ginkgo.DescribeTable("removes finalizer and allows deletion when no CUDNs reference the VTEP",
+			func(mode vtepv1.VTEPMode, node *corev1.Node) {
+				vtep := newVTEP("delete-vtep", mode, "100.64.0.0/24")
+				if node != nil {
+					start(vtep, node)
+				} else {
+					start(vtep)
+				}
 
-		ginkgo.It("removes finalizer and allows deletion when no CUDNs reference the VTEP", func() {
-			vtep := newVTEP("delete-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			start(vtep)
+				gomega.Eventually(func() ([]string, error) {
+					return getVTEPFinalizers(fakeVTEP, "delete-vtep")
+				}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
-			gomega.Eventually(func() ([]string, error) {
-				return getVTEPFinalizers(fakeVTEP, "delete-vtep")
-			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
+				v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "delete-vtep", metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				now := metav1.Now()
+				v.DeletionTimestamp = &now
+				_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "delete-vtep", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(func() ([]string, error) {
+					return getVTEPFinalizers(fakeVTEP, "delete-vtep")
+				}).WithTimeout(5 * time.Second).ShouldNot(gomega.ContainElement(finalizerVTEP))
+			},
+			ginkgo.Entry("unmanaged", vtepv1.VTEPModeUnmanaged, (*corev1.Node)(nil)),
+			// managed needs a node so the allocator can initialise before deletion
+			ginkgo.Entry("managed", vtepv1.VTEPModeManaged, newNodeWithVTEPAnnotation("node-1", nil)),
+		)
 
-			gomega.Eventually(func() ([]string, error) {
-				return getVTEPFinalizers(fakeVTEP, "delete-vtep")
-			}).WithTimeout(5 * time.Second).ShouldNot(gomega.ContainElement(finalizerVTEP))
-		})
+		ginkgo.DescribeTable("blocks deletion when a CUDN references the VTEP",
+			func(mode vtepv1.VTEPMode, node *corev1.Node) {
+				cudn := newCUDNWithEVPN("test-cudn", "blocked-vtep")
+				vtep := newVTEP("blocked-vtep", mode, "100.64.0.0/24")
+				if node != nil {
+					start(vtep, cudn, node)
+				} else {
+					start(vtep, cudn)
+				}
 
-		ginkgo.It("blocks deletion when a CUDN references the VTEP", func() {
-			cudn := newCUDNWithEVPN("test-cudn", "blocked-vtep")
-			vtep := newVTEP("blocked-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			start(vtep, cudn)
+				gomega.Eventually(func() ([]string, error) {
+					return getVTEPFinalizers(fakeVTEP, "blocked-vtep")
+				}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
-			gomega.Eventually(func() ([]string, error) {
-				return getVTEPFinalizers(fakeVTEP, "blocked-vtep")
-			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
+				v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "blocked-vtep", metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				now := metav1.Now()
+				v.DeletionTimestamp = &now
+				_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "blocked-vtep", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Consistently(func() ([]string, error) {
+					return getVTEPFinalizers(fakeVTEP, "blocked-vtep")
+				}).WithTimeout(3 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
-			gomega.Consistently(func() ([]string, error) {
-				return getVTEPFinalizers(fakeVTEP, "blocked-vtep")
-			}).WithTimeout(3 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
+				// Delete the CUDN — the VTEP should now be garbage-collected
+				err = fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
+					context.Background(), "test-cudn", metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Delete the CUDN — the VTEP should now be garbage-collected
-			err = fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
-				context.Background(), "test-cudn", metav1.DeleteOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			gomega.Eventually(func() bool {
-				_, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "blocked-vtep", metav1.GetOptions{})
-				return apierrors.IsNotFound(err)
-			}).WithTimeout(5 * time.Second).Should(gomega.BeTrue())
-		})
+				gomega.Eventually(func() bool {
+					_, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "blocked-vtep", metav1.GetOptions{})
+					return apierrors.IsNotFound(err)
+				}).WithTimeout(5 * time.Second).Should(gomega.BeTrue())
+			},
+			ginkgo.Entry("unmanaged", vtepv1.VTEPModeUnmanaged, (*corev1.Node)(nil)),
+			ginkgo.Entry("managed", vtepv1.VTEPModeManaged, newNodeWithVTEPAnnotation("node-1", nil)),
+		)
 	})
 
 	ginkgo.Context("Cross-VTEP CIDR overlap validation", func() {
 		ginkgo.It("sets Accepted=True when VTEPs have non-overlapping CIDRs", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/24")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.1.0.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.1.0.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -327,7 +443,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("sets Accepted=False on both VTEPs when CIDRs overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/16")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.1.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -349,7 +465,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("converges without infinite re-queue loop when VTEPs overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/16")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.1.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -373,7 +489,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("emits a CIDROverlap warning event when VTEPs overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/16")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.1.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -387,7 +503,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("sets Accepted=False on all three VTEPs when CIDRs overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/8")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.1.0.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.1.0.0/24")
 			vtepC := newVTEP("vtep-c", vtepv1.VTEPModeUnmanaged, "10.2.0.0/24")
 			start(vtepA, vtepB, vtepC)
 
@@ -402,8 +518,8 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		})
 
 		ginkgo.It("updates conflict message when a new overlapping VTEP joins an existing conflict", func() {
-			// vtep-b and vtep-c overlap via vtep-b's /8
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.0.0/8")
+			// vtep-b (managed) and vtep-c overlap via vtep-b's /8
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.0.0/8")
 			vtepC := newVTEP("vtep-c", vtepv1.VTEPModeUnmanaged, "10.2.0.0/24")
 			start(vtepB, vtepC)
 
@@ -417,7 +533,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				gomega.HaveField("Message", gomega.Not(gomega.ContainSubstring("vtep-a"))),
 			))
 
-			// Create vtep-a which also overlaps with vtep-b
+			// Create vtep-a (unmanaged) which also overlaps with vtep-b
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.1.0.0/24")
 			_, err := fakeVTEP.K8sV1().VTEPs().Create(context.Background(), vtepA, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -446,8 +562,8 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
 			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
 
-			// Create an overlapping VTEP
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			// Create an overlapping managed VTEP
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.1.0/24")
 			_, err := fakeVTEP.K8sV1().VTEPs().Create(context.Background(), vtepB, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -463,7 +579,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("sets Accepted=False on both when a mask expansion causes overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/24")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.1.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -493,7 +609,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("sets Accepted=False on both when a newly appended CIDR causes overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/24")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.1.0.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.1.0.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -523,7 +639,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("clears Accepted=False when overlapping CIDR is removed from the list", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/24", "10.1.0.0/16")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.1.0.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.1.0.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -558,7 +674,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("clears Accepted=False when user edits CIDRs to remove overlap", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/16")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.0.1.0/24")
 			start(vtepA, vtepB)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -593,7 +709,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 		ginkgo.It("clears Accepted=False only when all conflicts are resolved", func() {
 			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/8")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.1.0.0/24")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeManaged, "10.1.0.0/24")
 			vtepC := newVTEP("vtep-c", vtepv1.VTEPModeUnmanaged, "10.2.0.0/24")
 			start(vtepA, vtepB, vtepC)
 
@@ -637,7 +753,19 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		})
 	})
 
-	ginkgo.Context("Node VTEP IP validation", func() {
+	ginkgo.Context("Unmanaged mode", func() {
+		ginkgo.It("sets Accepted=True with no nodes", func() {
+			vtep := newVTEP("unmanaged-no-nodes", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
+			start(vtep)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "unmanaged-no-nodes", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+		})
+
 		ginkgo.It("sets Accepted=True when a node has a VTEP IP in the annotation", func() {
 			node := newNodeWithVTEPAnnotation("node-1", map[string][]string{"vtep-discover": {"100.64.0.5"}})
 			vtep := newVTEP("vtep-discover", vtepv1.VTEPModeUnmanaged, "100.64.0.0/16")
@@ -699,96 +827,6 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			gomega.Eventually(fakeRecorder.Events).Should(gomega.Receive(
 				gomega.ContainSubstring(reasonAllocationFailed),
 			))
-		})
-
-		ginkgo.It("does not fire duplicate events when failure state is unchanged", func() {
-			// Test both AllocationFailed and CIDROverlap dedup in a single scenario:
-			// vtep-a and vtep-b overlap, and vtep-a also has a missing node annotation.
-			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-b": {"10.0.0.1"}})
-			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/16")
-			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
-			start(vtepA, vtepB, node)
-
-			// vtep-a should be Accepted=False due to CIDR overlap (checked before node validation)
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionFalse),
-				gomega.HaveField("Reason", gomega.Equal(reasonCIDROverlap)),
-			))
-
-			// vtep-b should also be Accepted=False due to CIDR overlap
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "vtep-b", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionFalse),
-				gomega.HaveField("Reason", gomega.Equal(reasonCIDROverlap)),
-			))
-
-			// Drain all events from initial convergence. We expect one
-			// CIDROverlap event per VTEP (2 total), but a 3rd is possible:
-			//  1. vtep-a reconciles first → overlap → event #1 → patches status
-			//  2. vtep-b reconciles → overlap → event #2 → patches status.
-			//     If the informer cache hasn't synced vtep-a's status yet,
-			//     validateCIDRsAcrossVTEPs re-queues vtep-a.
-			//  3. vtep-a re-reconciles → lister.Get still returns the stale
-			//     object (no conditions) → dedup guard sees existingCond==nil
-			//     → fires event #3 (duplicate).
-			// This is a benign race between the worker and the async informer
-			// cache sync. In steady state the guard works correctly.
-			gomega.Eventually(func() bool {
-				select {
-				case <-fakeRecorder.Events:
-					return false
-				default:
-					return true
-				}
-			}).WithTimeout(3 * time.Second).Should(gomega.BeTrue())
-
-			// Re-reconcile both — no new events since the lister is now in sync
-			controller.vtepController.Reconcile("vtep-a")
-			controller.vtepController.Reconcile("vtep-b")
-			gomega.Consistently(fakeRecorder.Events).WithTimeout(2 * time.Second).ShouldNot(gomega.Receive())
-
-			// Resolve the overlap by changing vtep-a's CIDRs to non-overlapping
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-a", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			v.Spec.CIDRs = []vtepv1.CIDR{"192.168.0.0/16"}
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// vtep-b should recover to Accepted=True now that the overlap is gone
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "vtep-b", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionTrue),
-				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
-			))
-
-			// vtep-a should now fail with AllocationFailed (node has no entry for it)
-			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
-			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
-				gomega.HaveField("Status", metav1.ConditionFalse),
-				gomega.HaveField("Reason", gomega.Equal(reasonAllocationFailed)),
-			))
-
-			// Drain AllocationFailed events. We expect 1, but a 2nd is
-			// possible: vtep-b's re-queue (from the else-if conflict-resolved
-			// path) may re-queue vtep-a while the lister still shows the old
-			// CIDROverlap condition, causing the dedup guard to miss the match.
-			gomega.Eventually(func() bool {
-				select {
-				case <-fakeRecorder.Events:
-					return false
-				default:
-					return true
-				}
-			}).WithTimeout(3 * time.Second).Should(gomega.BeTrue())
-
-			// Re-reconcile vtep-a — no new event since AllocationFailed state is unchanged
-			controller.vtepController.Reconcile("vtep-a")
-			gomega.Consistently(fakeRecorder.Events).WithTimeout(2 * time.Second).ShouldNot(gomega.Receive())
 		})
 
 		ginkgo.It("sets Accepted=True when multiple nodes have VTEP IPs", func() {
@@ -879,15 +917,97 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		})
 	})
 
-	ginkgo.Context("IPv6 CIDR rejection for EVPN VTEPs", func() {
-		ginkgo.It("sets Accepted=False when an EVPN CUDN references a VTEP with IPv6 CIDRs", func() {
-			vtep := newVTEP("vtep-v6", vtepv1.VTEPModeUnmanaged, "fd00::/64")
-			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v6": {"fd00::1"}})
-			cudn := newCUDNWithEVPN("cudn-evpn-v6", "vtep-v6")
+	ginkgo.Context("Event deduplication", func() {
+		ginkgo.It("does not fire duplicate CIDROverlap or AllocationFailed events when failure state is unchanged", func() {
+			// vtep-a and vtep-b overlap; vtep-a also has a missing node annotation.
+			// Tests dedup across both CIDROverlap and AllocationFailed reasons.
+			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-b": {"10.0.0.1"}})
+			vtepA := newVTEP("vtep-a", vtepv1.VTEPModeUnmanaged, "10.0.0.0/16")
+			vtepB := newVTEP("vtep-b", vtepv1.VTEPModeUnmanaged, "10.0.1.0/24")
+			start(vtepA, vtepB, node)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonCIDROverlap)),
+			))
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-b", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonCIDROverlap)),
+			))
+
+			// Drain all events from initial convergence. We expect one
+			// CIDROverlap event per VTEP (2 total), but a 3rd is possible:
+			//  1. vtep-a reconciles first → overlap → event #1 → patches status
+			//  2. vtep-b reconciles → overlap → event #2 → patches status.
+			//     If the informer cache hasn't synced vtep-a's status yet,
+			//     validateCIDRsAcrossVTEPs re-queues vtep-a.
+			//  3. vtep-a re-reconciles → lister.Get still returns the stale
+			//     object (no conditions) → dedup guard sees existingCond==nil
+			//     → fires event #3 (duplicate).
+			// This is a benign race between the worker and the async informer
+			// cache sync. In steady state the guard works correctly.
+			gomega.Eventually(func() bool {
+				select {
+				case <-fakeRecorder.Events:
+					return false
+				default:
+					return true
+				}
+			}).WithTimeout(3 * time.Second).Should(gomega.BeTrue())
+
+			// Re-reconcile both — no new events since the lister is now in sync
+			controller.vtepController.Reconcile("vtep-a")
+			controller.vtepController.Reconcile("vtep-b")
+			gomega.Consistently(fakeRecorder.Events).WithTimeout(2 * time.Second).ShouldNot(gomega.Receive())
+
+			// Resolve the overlap by changing vtep-a's CIDRs to non-overlapping
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-a", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.CIDRs = []vtepv1.CIDR{"192.168.0.0/16"}
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// vtep-b recovers, vtep-a now fails with AllocationFailed
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-b", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocationFailed)),
+			))
+
+			// Drain AllocationFailed events. We expect 1, but a 2nd is
+			// possible: vtep-b's re-queue (from the else-if conflict-resolved
+			// path) may re-queue vtep-a while the lister still shows the old
+			// CIDROverlap condition, causing the dedup guard to miss the match.
+			gomega.Eventually(func() bool {
+				select {
+				case <-fakeRecorder.Events:
+					return false
+				default:
+					return true
+				}
+			}).WithTimeout(3 * time.Second).Should(gomega.BeTrue())
+
+			// Re-reconcile vtep-a — no new event since AllocationFailed state is unchanged
+			controller.vtepController.Reconcile("vtep-a")
+			gomega.Consistently(fakeRecorder.Events).WithTimeout(2 * time.Second).ShouldNot(gomega.Receive())
+		})
+
+		ginkgo.It("does not fire duplicate IPv6NotSupported events when failure state is unchanged", func() {
+			vtep := newVTEP("vtep-v6-dedup", vtepv1.VTEPModeUnmanaged, "fd00::/64")
+			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v6-dedup": {"fd00::1"}})
+			cudn := newCUDNWithEVPN("cudn-evpn-v6-dedup", "vtep-v6-dedup")
 			start(vtep, node, cudn)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
-				return getVTEPCondition(fakeVTEP, "vtep-v6", conditionTypeAccepted)
+				return getVTEPCondition(fakeVTEP, "vtep-v6-dedup", conditionTypeAccepted)
 			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
 				gomega.HaveField("Status", metav1.ConditionFalse),
 				gomega.HaveField("Reason", gomega.Equal(reasonEVPNIPv6NotSupported)),
@@ -907,13 +1027,45 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				}
 			}).WithTimeout(3 * time.Second).Should(gomega.BeTrue())
 
-			controller.vtepController.Reconcile("vtep-v6")
+			controller.vtepController.Reconcile("vtep-v6-dedup")
 			gomega.Consistently(fakeRecorder.Events).WithTimeout(2 * time.Second).ShouldNot(gomega.Receive())
 		})
+	})
 
-		ginkgo.It("sets Accepted=True when a VTEP has only IPv4 CIDRs and is referenced by an EVPN CUDN", func() {
-			vtep := newVTEP("vtep-v4", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v4": {"100.64.0.1"}})
+	ginkgo.Context("IPv6 CIDR rejection for EVPN VTEPs", func() {
+		ginkgo.It("sets Accepted=False when an EVPN CUDN references an unmanaged VTEP with IPv6 CIDRs", func() {
+			vtep := newVTEP("vtep-v6", vtepv1.VTEPModeUnmanaged, "fd00::/64")
+			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v6": {"fd00::1"}})
+			cudn := newCUDNWithEVPN("cudn-evpn-v6", "vtep-v6")
+			start(vtep, node, cudn)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-v6", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonEVPNIPv6NotSupported)),
+			))
+		})
+
+		ginkgo.It("sets Accepted=False when an EVPN CUDN references a managed VTEP with IPv6 CIDRs", func() {
+			// IPv6 is rejected regardless of mode; CM still won't allocate.
+			vtep := newVTEP("vtep-v6-managed", vtepv1.VTEPModeManaged, "fd00::/120")
+			node := newNodeWithVTEPAnnotation("node1", nil)
+			cudn := newCUDNWithEVPN("cudn-evpn-v6-managed", "vtep-v6-managed")
+			start(vtep, node, cudn)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-v6-managed", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonEVPNIPv6NotSupported)),
+			))
+		})
+
+		// managed: IPv4-only VTEP with an EVPN CUDN is accepted
+		ginkgo.It("sets Accepted=True when a managed VTEP has only IPv4 CIDRs and is referenced by an EVPN CUDN", func() {
+			vtep := newVTEP("vtep-v4", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			node := newNodeWithVTEPAnnotation("node1", nil)
 			cudn := newCUDNWithEVPN("cudn-evpn-v4", "vtep-v4")
 			start(vtep, node, cudn)
 
@@ -925,7 +1077,8 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 
-		ginkgo.It("allows IPv6 CIDRs on VTEPs not referenced by any EVPN CUDN", func() {
+		// unmanaged: IPv6 CIDR without an EVPN CUDN is accepted
+		ginkgo.It("allows IPv6 CIDRs on an unmanaged VTEP not referenced by any EVPN CUDN", func() {
 			vtep := newVTEP("vtep-v6-no-evpn", vtepv1.VTEPModeUnmanaged, "fd00::/64")
 			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v6-no-evpn": {"fd00::1"}})
 			start(vtep, node)
@@ -938,9 +1091,10 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 
-		ginkgo.It("rejects when VTEP has dual-stack CIDRs and is referenced by an EVPN CUDN", func() {
-			vtep := newVTEP("vtep-ds", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24", "fd00::/64")
-			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-ds": {"100.64.0.1", "fd00::1"}})
+		// managed: dual-stack VTEP with an EVPN CUDN is rejected
+		ginkgo.It("rejects when a managed VTEP has dual-stack CIDRs and is referenced by an EVPN CUDN", func() {
+			vtep := newVTEP("vtep-ds", vtepv1.VTEPModeManaged, "100.64.0.0/24", "fd00::/120")
+			node := newNodeWithVTEPAnnotation("node1", nil)
 			cudn := newCUDNWithEVPN("cudn-evpn-ds", "vtep-ds")
 			start(vtep, node, cudn)
 
@@ -952,7 +1106,8 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 
-		ginkgo.It("transitions to IPv6NotSupported when an EVPN CUDN is created referencing a VTEP with IPv6 CIDRs", func() {
+		// unmanaged: EVPN CUDN added after startup triggers rejection
+		ginkgo.It("transitions to IPv6NotSupported when an EVPN CUDN is created referencing an unmanaged VTEP with IPv6 CIDRs", func() {
 			vtep := newVTEP("vtep-v6-late", vtepv1.VTEPModeUnmanaged, "fd00::/64")
 			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v6-late": {"fd00::1"}})
 			start(vtep, node)
@@ -977,9 +1132,10 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 
-		ginkgo.It("transitions to IPv6NotSupported when an IPv6 CIDR is appended to a VTEP referenced by an EVPN CUDN", func() {
-			vtep := newVTEP("vtep-v4-append", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v4-append": {"100.64.0.1"}})
+		// managed: appending an IPv6 CIDR to a managed VTEP with an EVPN CUDN triggers rejection
+		ginkgo.It("transitions to IPv6NotSupported when an IPv6 CIDR is appended to a managed VTEP referenced by an EVPN CUDN", func() {
+			vtep := newVTEP("vtep-v4-append", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			node := newNodeWithVTEPAnnotation("node1", nil)
 			cudn := newCUDNWithEVPN("cudn-evpn-append", "vtep-v4-append")
 			start(vtep, node, cudn)
 
@@ -992,7 +1148,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-v4-append", metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			v.Spec.CIDRs = []vtepv1.CIDR{"100.64.0.0/24", "fd00::/64"}
+			v.Spec.CIDRs = []vtepv1.CIDR{"100.64.0.0/24", "fd00::/120"}
 			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1004,7 +1160,8 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 
-		ginkgo.It("recovers from IPv6NotSupported when the IPv6 CIDR is removed from the VTEP", func() {
+		// unmanaged: removing the IPv6 CIDR from a dual-stack VTEP recovers it
+		ginkgo.It("recovers from IPv6NotSupported when the IPv6 CIDR is removed from an unmanaged VTEP", func() {
 			vtep := newVTEP("vtep-ds-remove", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24", "fd00::/64")
 			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-ds-remove": {"100.64.0.1", "fd00::1"}})
 			cudn := newCUDNWithEVPN("cudn-evpn-remove", "vtep-ds-remove")
@@ -1031,9 +1188,10 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 
-		ginkgo.It("recovers from IPv6NotSupported when the EVPN CUDN is deleted", func() {
-			vtep := newVTEP("vtep-v6-recover", vtepv1.VTEPModeUnmanaged, "fd00::/64")
-			node := newNodeWithVTEPAnnotation("node1", map[string][]string{"vtep-v6-recover": {"fd00::1"}})
+		// managed: deleting the EVPN CUDN recovers the VTEP
+		ginkgo.It("recovers from IPv6NotSupported when the EVPN CUDN is deleted from a managed VTEP", func() {
+			vtep := newVTEP("vtep-v6-recover", vtepv1.VTEPModeManaged, "fd00::/120")
+			node := newNodeWithVTEPAnnotation("node1", nil)
 			cudn := newCUDNWithEVPN("cudn-evpn-recover", "vtep-v6-recover")
 			start(vtep, node, cudn)
 
@@ -1391,8 +1549,11 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		})
 
 		ginkgo.It("does not issue any VTEP API update when vteps annotation change is unrelated", func() {
-			node := newNodeWithVTEPAnnotation("node-stable", map[string][]string{"vtep-stable": {"100.64.0.1"}})
-			vtep := newVTEP("vtep-stable", vtepv1.VTEPModeUnmanaged, "100.64.0.0/16")
+			// Use managed mode: CM writes the annotation itself, so once settled
+			// an unrelated annotation change on the node should not re-trigger
+			// any VTEP status API calls.
+			node := newNodeWithVTEPAnnotation("node-stable", nil)
+			vtep := newVTEP("vtep-stable", vtepv1.VTEPModeManaged, "100.64.0.0/24")
 			start(vtep, node)
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
@@ -1402,6 +1563,21 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
 			))
 
+			// Wait for CM to write the annotation, then record the allocated IP.
+			var allocatedIP string
+			gomega.Eventually(func() (string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-stable", metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if err != nil || len(vteps["vtep-stable"].IPs) == 0 {
+					return "", err
+				}
+				allocatedIP = vteps["vtep-stable"].IPs[0]
+				return allocatedIP, nil
+			}).WithTimeout(5 * time.Second).ShouldNot(gomega.BeEmpty())
+
 			// Controller is idle after initial reconcile settled; safe to add reactor.
 			var patchCount atomic.Int32
 			fakeVTEP.PrependReactor("patch", "vteps", func(_ ktesting.Action) (bool, runtime.Object, error) {
@@ -1409,11 +1585,11 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				return false, nil, nil
 			})
 
-			// Update node: add a different VTEP entry (vtep-stable unchanged)
+			// Update node: add an entry for a different VTEP (vtep-stable unchanged).
 			n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-stable", metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			vtepAnnotation, _ := json.Marshal(map[string]util.VTEPNodeAnnotation{
-				"vtep-stable":  {IPs: []string{"100.64.0.1"}},
+				"vtep-stable":  {IPs: []string{allocatedIP}},
 				"vtep-another": {IPs: []string{"10.0.0.50"}},
 			})
 			n.Annotations[util.OVNNodeVTEPs] = string(vtepAnnotation)
@@ -1426,13 +1602,54 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			}).WithTimeout(3 * time.Second).Should(gomega.Equal(int32(0)))
 		})
 
+		ginkgo.It("does not issue node update when managed VTEP annotation already matches", func() {
+			node := newNodeWithVTEPAnnotation("node-noop", nil)
+			vtep := newVTEP("vtep-noop", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			start(vtep, node)
+
+			// Wait for the CM to allocate an IP and write the annotation.
+			gomega.Eventually(func() (string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-noop", metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if err != nil || len(vteps["vtep-noop"].IPs) == 0 {
+					return "", err
+				}
+				return vteps["vtep-noop"].IPs[0], nil
+			}).WithTimeout(5 * time.Second).ShouldNot(gomega.BeEmpty())
+
+			// Record node update count after initial allocation settles.
+			var nodeUpdateCount atomic.Int32
+			fakeClientset.KubeClient.(*fake.Clientset).PrependReactor("update", "nodes", func(_ ktesting.Action) (bool, runtime.Object, error) {
+				nodeUpdateCount.Add(1)
+				return false, nil, nil
+			})
+
+			// Force a re-reconcile of the VTEP by touching its spec (no-op label).
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-noop", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if v.Labels == nil {
+				v.Labels = map[string]string{}
+			}
+			v.Labels["trigger"] = "re-reconcile"
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// The ipsEqual guard must prevent any node annotation writes.
+			gomega.Consistently(func() int32 {
+				return nodeUpdateCount.Load()
+			}).WithTimeout(3 * time.Second).Should(gomega.Equal(int32(0)))
+		})
+
 		ginkgo.It("reconciles multiple VTEPs when a single node's vteps annotation changes", func() {
+			// vtep-a is unmanaged (node supplies the IP), vtep-b is managed (CM allocates).
 			node := newNodeWithVTEPAnnotation("node-shared", map[string][]string{
 				"vtep-a-multi": {"100.64.0.1"},
-				"vtep-b-multi": {"200.10.0.1"},
 			})
 			vtepA := newVTEP("vtep-a-multi", vtepv1.VTEPModeUnmanaged, "100.64.0.0/16")
-			vtepB := newVTEP("vtep-b-multi", vtepv1.VTEPModeUnmanaged, "200.10.0.0/16")
+			vtepB := newVTEP("vtep-b-multi", vtepv1.VTEPModeManaged, "200.10.0.0/24")
 			start(vtepA, vtepB, node)
 
 			for _, name := range []string{"vtep-a-multi", "vtep-b-multi"} {
@@ -1444,12 +1661,15 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				))
 			}
 
-			// Change the node IPs for both VTEPs
+			// Change the unmanaged VTEP's IP on the node; CM-managed entry
+			// should be preserved as-is.
 			n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-shared", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			existing, err := util.ParseNodeVTEPs(n)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			vtepAnnotation, _ := json.Marshal(map[string]util.VTEPNodeAnnotation{
 				"vtep-a-multi": {IPs: []string{"100.64.0.99"}},
-				"vtep-b-multi": {IPs: []string{"200.10.0.99"}},
+				"vtep-b-multi": existing["vtep-b-multi"], // keep CM-written entry unchanged
 			})
 			n.Annotations[util.OVNNodeVTEPs] = string(vtepAnnotation)
 			_, err = fakeClientset.KubeClient.CoreV1().Nodes().Update(context.Background(), n, metav1.UpdateOptions{})
@@ -1518,6 +1738,61 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				gomega.HaveField("Status", metav1.ConditionTrue),
 				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
 			))
+		})
+
+		ginkgo.It("restores correct IP when node annotation is overwritten with a bogus value", func() {
+			// CM allocates an IP for the node. Something (e.g. a misbehaving
+			// controller) then overwrites the annotation with a wrong IP.
+			// The annotation change triggers a node-watch reconcile;
+			// allocateAndAnnotateNode detects the mismatch (allocator still
+			// holds the original IP for this node) and rewrites the correct one.
+			vtep := newVTEP("vtep-restore", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			node := newNodeWithVTEPAnnotation("node-restore", nil)
+			start(vtep, node)
+
+			// Wait for CM to write the initial allocation.
+			var allocatedIP string
+			gomega.Eventually(func() (string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-restore", metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if util.IsAnnotationNotSetError(err) || len(vteps["vtep-restore"].IPs) == 0 {
+					return "", nil
+				}
+				if err != nil {
+					return "", err
+				}
+				allocatedIP = vteps["vtep-restore"].IPs[0]
+				return allocatedIP, nil
+			}).WithTimeout(5 * time.Second).ShouldNot(gomega.BeEmpty())
+
+			// Overwrite with a bogus IP outside the CIDR.
+			n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-restore", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			bogus, _ := json.Marshal(map[string]util.VTEPNodeAnnotation{
+				"vtep-restore": {IPs: []string{"1.2.3.4"}},
+			})
+			n.Annotations[util.OVNNodeVTEPs] = string(bogus)
+			_, err = fakeClientset.KubeClient.CoreV1().Nodes().Update(context.Background(), n, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// CM must restore the original IP.
+			gomega.Eventually(func() (string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-restore", metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if util.IsAnnotationNotSetError(err) || len(vteps["vtep-restore"].IPs) == 0 {
+					return "", nil
+				}
+				if err != nil {
+					return "", err
+				}
+				return vteps["vtep-restore"].IPs[0], nil
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal(allocatedIP))
 		})
 	})
 })

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -6,8 +6,8 @@ package vtep
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -341,6 +341,85 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				}
 				return util.ParseNodeVTEPs(n)
 			}).WithTimeout(5 * time.Second).Should(gomega.HaveKey("managed-late-node"))
+		})
+	})
+
+	ginkgo.Context("Initial sync", func() {
+		ginkgo.It("preserves existing allocations across restart", func() {
+			node1 := newNodeWithVTEPAnnotation("node-1", map[string][]string{
+				"sync-vtep": {"100.64.0.3"},
+			})
+			node2 := newNodeWithVTEPAnnotation("node-2", map[string][]string{
+				"sync-vtep": {"100.64.0.5"},
+			})
+			node3 := newNodeWithVTEPAnnotation("node-3", nil)
+			vtep := newVTEP("sync-vtep", vtepv1.VTEPModeManaged, "100.64.0.0/29")
+			start(vtep, node1, node2, node3)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "sync-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal("Allocated")),
+			))
+
+			// node-1 and node-2 should keep their existing IPs
+			gomega.Eventually(func() ([]string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-1", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if err != nil {
+					return nil, err
+				}
+				return vteps["sync-vtep"].IPs, nil
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal([]string{"100.64.0.3"}))
+
+			gomega.Eventually(func() ([]string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-2", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if err != nil {
+					return nil, err
+				}
+				return vteps["sync-vtep"].IPs, nil
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal([]string{"100.64.0.5"}))
+
+			// node-3 should get an IP that is NOT 100.64.0.3 or 100.64.0.5
+			gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-3", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return util.ParseNodeVTEPs(n)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveKey("sync-vtep"),
+				gomega.Not(gomega.HaveKeyWithValue("sync-vtep", util.VTEPNodeAnnotation{IPs: []string{"100.64.0.3"}})),
+				gomega.Not(gomega.HaveKeyWithValue("sync-vtep", util.VTEPNodeAnnotation{IPs: []string{"100.64.0.5"}})),
+			))
+		})
+
+		ginkgo.It("skips unmanaged VTEPs during sync", func() {
+			node := newNodeWithVTEPAnnotation("node-1", map[string][]string{
+				"unmanaged-sync": {"100.64.0.1"},
+			})
+			vtep := newVTEP("unmanaged-sync", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
+			start(vtep, node)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "unmanaged-sync", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal("Allocated")),
+			))
+
+			// Verify no allocator was created for the unmanaged VTEP
+			controller.allocatorsMu.Lock()
+			gomega.Expect(controller.allocators).NotTo(gomega.HaveKey("unmanaged-sync"))
+			controller.allocatorsMu.Unlock()
 		})
 	})
 

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -1145,6 +1145,54 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		})
 	})
 
+	ginkgo.Context("Managed VTEP CIDR vs node host IP validation", func() {
+		ginkgo.It("sets Accepted=False when managed VTEP CIDRs overlap with node host IPs", func() {
+			node := newNodeWithVTEPAnnotation("node-1", nil)
+			hostCIDRs, _ := json.Marshal([]string{"192.168.1.10/24"})
+			node.Annotations = map[string]string{util.OVNNodeHostCIDRs: string(hostCIDRs)}
+			vtep := newVTEP("vtep-host-overlap", vtepv1.VTEPModeManaged, "192.168.1.0/24")
+			start(vtep, node)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-host-overlap", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonCIDROverlap)),
+				gomega.HaveField("Message", gomega.ContainSubstring("node-1")),
+			))
+		})
+
+		ginkgo.It("sets Accepted=True when managed VTEP CIDRs do not overlap with node host IPs", func() {
+			node := newNodeWithVTEPAnnotation("node-1", nil)
+			hostCIDRs, _ := json.Marshal([]string{"192.168.1.10/24"})
+			node.Annotations = map[string]string{util.OVNNodeHostCIDRs: string(hostCIDRs)}
+			vtep := newVTEP("vtep-no-host-overlap", vtepv1.VTEPModeManaged, "10.0.0.0/24")
+			start(vtep, node)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-no-host-overlap", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+		})
+
+		ginkgo.It("skips validation for unmanaged VTEPs", func() {
+			node := newNodeWithVTEPAnnotation("node-1", map[string][]string{"vtep-unmanaged-hostip": {"192.168.1.50"}})
+			hostCIDRs, _ := json.Marshal([]string{"192.168.1.10/24"})
+			node.Annotations[util.OVNNodeHostCIDRs] = string(hostCIDRs)
+			vtep := newVTEP("vtep-unmanaged-hostip", vtepv1.VTEPModeUnmanaged, "192.168.1.0/24")
+			start(vtep, node)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "vtep-unmanaged-hostip", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+		})
+	})
+
 	ginkgo.Context("Unmanaged mode", func() {
 		ginkgo.It("sets Accepted=True with no nodes", func() {
 			vtep := newVTEP("unmanaged-no-nodes", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -423,6 +423,319 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		})
 	})
 
+	ginkgo.Context("Mutability", func() {
+		ginkgo.It("appends a new CIDR and allocates IPs from it when the original is exhausted", func() {
+			// /30 gives 4 IPs; fill them all up.
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			node3 := newNodeWithVTEPAnnotation("node-3", nil)
+			node4 := newNodeWithVTEPAnnotation("node-4", nil)
+			vtep := newVTEP("append-vtep", vtepv1.VTEPModeManaged, "10.0.0.0/30")
+			start(vtep, node1, node2, node3, node4)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "append-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			// Add node-5 now -- range is exhausted so VTEP should go AllocationFailed.
+			node5 := newNodeWithVTEPAnnotation("node-5", nil)
+			_, err := fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node5, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "append-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocationFailed)),
+			))
+
+			// Append a second /30 CIDR -- this should unblock allocation.
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "append-vtep", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.CIDRs = append(v.Spec.CIDRs, "10.0.0.4/30")
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// VTEP should recover to Accepted=True and node-5 gets an IP from the new /30.
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "append-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-5", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return util.ParseNodeVTEPs(n)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveKey("append-vtep"),
+				gomega.WithTransform(func(m map[string]util.VTEPNodeAnnotation) string {
+					if len(m["append-vtep"].IPs) == 0 {
+						return ""
+					}
+					return m["append-vtep"].IPs[0]
+				}, gomega.HavePrefix("10.0.0.")),
+			))
+		})
+
+		ginkgo.It("widens an existing CIDR and allocates new IPs from the expanded range", func() {
+			// /30 gives 4 IPs; fill them all up.
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			node3 := newNodeWithVTEPAnnotation("node-3", nil)
+			node4 := newNodeWithVTEPAnnotation("node-4", nil)
+			vtep := newVTEP("widen-vtep", vtepv1.VTEPModeManaged, "10.0.1.0/30")
+			start(vtep, node1, node2, node3, node4)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "widen-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+
+			// Collect existing IPs before widening.
+			getNodeVTEPIP := func(nodeName string) string {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				vteps, err := util.ParseNodeVTEPs(n)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(vteps["widen-vtep"].IPs).NotTo(gomega.BeEmpty())
+				return vteps["widen-vtep"].IPs[0]
+			}
+			ip1 := getNodeVTEPIP("node-1")
+			ip2 := getNodeVTEPIP("node-2")
+
+			// Add node-5 now -- range is exhausted so VTEP should go AllocationFailed.
+			node5 := newNodeWithVTEPAnnotation("node-5", nil)
+			_, err := fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node5, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "widen-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocationFailed)),
+			))
+
+			// Widen /30 to /28 (16 IPs) -- this should unblock allocation.
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "widen-vtep", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.CIDRs = []vtepv1.CIDR{"10.0.1.0/28"}
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// VTEP should recover and node-5 gets an IP from the expanded range.
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "widen-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), "node-5", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return util.ParseNodeVTEPs(n)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveKey("widen-vtep"))
+
+			// Existing nodes must keep their original IPs.
+			gomega.Expect(getNodeVTEPIP("node-1")).To(gomega.Equal(ip1))
+			gomega.Expect(getNodeVTEPIP("node-2")).To(gomega.Equal(ip2))
+		})
+
+		ginkgo.It("preserves existing node IPs when switching from Unmanaged to Managed", func() {
+			// ovnkube-node already wrote IPs for both nodes during Unmanaged phase.
+			// Use non-sequential IPs so the test can't pass accidentally if the
+			// allocator just happens to assign the same first addresses.
+			node1 := newNodeWithVTEPAnnotation("node-1", map[string][]string{"mode-switch-vtep": {"100.64.0.42"}})
+			node2 := newNodeWithVTEPAnnotation("node-2", map[string][]string{"mode-switch-vtep": {"100.64.0.99"}})
+			vtep := newVTEP("mode-switch-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
+			start(vtep, node1, node2)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "mode-switch-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+
+			// Switch to Managed mode.
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "mode-switch-vtep", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.Mode = vtepv1.VTEPModeManaged
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "mode-switch-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			// Existing IPs must be preserved.
+			getIP := func(nodeName string) string {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				vteps, err := util.ParseNodeVTEPs(n)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(vteps["mode-switch-vtep"].IPs).NotTo(gomega.BeEmpty())
+				return vteps["mode-switch-vtep"].IPs[0]
+			}
+			gomega.Expect(getIP("node-1")).To(gomega.Equal("100.64.0.42"))
+			gomega.Expect(getIP("node-2")).To(gomega.Equal("100.64.0.99"))
+		})
+
+		ginkgo.It("overwrites stale node IPs when switching Unmanaged to Managed with changed CIDRs", func() {
+			// Nodes have IPs from the old CIDR (192.168.0.x) but the VTEP now uses a different CIDR.
+			node1 := newNodeWithVTEPAnnotation("node-1", map[string][]string{"stale-vtep": {"192.168.0.1"}})
+			node2 := newNodeWithVTEPAnnotation("node-2", map[string][]string{"stale-vtep": {"192.168.0.2"}})
+			vtep := newVTEP("stale-vtep", vtepv1.VTEPModeUnmanaged, "192.168.0.0/24")
+			start(vtep, node1, node2)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "stale-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+
+			// Switch to Managed with a completely different CIDR.
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "stale-vtep", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.Mode = vtepv1.VTEPModeManaged
+			v.Spec.CIDRs = []vtepv1.CIDR{"10.0.2.0/24"}
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "stale-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			// Stale IPs must be replaced with IPs from the new CIDR.
+			for _, nodeName := range []string{"node-1", "node-2"} {
+				gomega.Eventually(func() (string, error) {
+					n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+					if err != nil {
+						return "", err
+					}
+					vteps, err := util.ParseNodeVTEPs(n)
+					if err != nil {
+						return "", err
+					}
+					if len(vteps["stale-vtep"].IPs) == 0 {
+						return "", nil
+					}
+					return vteps["stale-vtep"].IPs[0], nil
+				}).WithTimeout(5 * time.Second).Should(gomega.HavePrefix("10.0.2."))
+			}
+		})
+
+		ginkgo.It("allocates fresh IPs for nodes whose CIDR was dropped before Unmanaged->Managed switch", func() {
+			// During Unmanaged phase the VTEP had two CIDRs and nodes got IPs from both.
+			// node-1 and node-2 have IPs from the first CIDR (10.0.4.0/29).
+			// node-3 and node-4 have IPs from the second CIDR (10.0.5.0/29) which
+			// will be removed before the mode switch (allowed in Unmanaged mode).
+			node1 := newNodeWithVTEPAnnotation("node-1", map[string][]string{"partial-stale-vtep": {"10.0.4.1"}})
+			node2 := newNodeWithVTEPAnnotation("node-2", map[string][]string{"partial-stale-vtep": {"10.0.4.2"}})
+			node3 := newNodeWithVTEPAnnotation("node-3", map[string][]string{"partial-stale-vtep": {"10.0.5.1"}})
+			node4 := newNodeWithVTEPAnnotation("node-4", map[string][]string{"partial-stale-vtep": {"10.0.5.2"}})
+			vtep := newVTEP("partial-stale-vtep", vtepv1.VTEPModeUnmanaged, "10.0.4.0/29", "10.0.5.0/29")
+			start(vtep, node1, node2, node3, node4)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "partial-stale-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+
+			// Remove the second CIDR and switch to Managed (both in one update,
+			// as CEL allows free CIDR changes while still Unmanaged).
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "partial-stale-vtep", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.Mode = vtepv1.VTEPModeManaged
+			v.Spec.CIDRs = []vtepv1.CIDR{"10.0.4.0/29"}
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "partial-stale-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocated)),
+			))
+
+			getIP := func(nodeName string) string {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				vteps, err := util.ParseNodeVTEPs(n)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(vteps["partial-stale-vtep"].IPs).NotTo(gomega.BeEmpty())
+				return vteps["partial-stale-vtep"].IPs[0]
+			}
+
+			// node-1 and node-2 must keep their IPs from the surviving CIDR.
+			gomega.Eventually(func() string { return getIP("node-1") }).
+				WithTimeout(5 * time.Second).Should(gomega.Equal("10.0.4.1"))
+			gomega.Eventually(func() string { return getIP("node-2") }).
+				WithTimeout(5 * time.Second).Should(gomega.Equal("10.0.4.2"))
+
+			// node-3 and node-4 had stale IPs from the dropped CIDR; they must
+			// get fresh IPs from 10.0.4.0/29.
+			for _, nodeName := range []string{"node-3", "node-4"} {
+				gomega.Eventually(func() string { return getIP(nodeName) }).
+					WithTimeout(5 * time.Second).Should(gomega.HavePrefix("10.0.4."))
+			}
+		})
+
+		ginkgo.It("cleans up annotations and removes allocator when switching from Managed to Unmanaged", func() {
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			vtep := newVTEP("managed-to-unmanaged", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			start(vtep, node1, node2)
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "managed-to-unmanaged", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+
+			// Confirm allocator exists.
+			controller.allocatorsMu.Lock()
+			gomega.Expect(controller.allocators).To(gomega.HaveKey("managed-to-unmanaged"))
+			controller.allocatorsMu.Unlock()
+
+			// Switch to Unmanaged.
+			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "managed-to-unmanaged", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v.Spec.Mode = vtepv1.VTEPModeUnmanaged
+			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Allocator must be removed.
+			gomega.Eventually(func() bool {
+				controller.allocatorsMu.Lock()
+				defer controller.allocatorsMu.Unlock()
+				_, exists := controller.allocators["managed-to-unmanaged"]
+				return exists
+			}).WithTimeout(5 * time.Second).Should(gomega.BeFalse())
+
+			// Node annotations for the managed VTEP should be cleaned up.
+			for _, nodeName := range []string{"node-1", "node-2"} {
+				gomega.Eventually(func() (map[string]util.VTEPNodeAnnotation, error) {
+					n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+					if err != nil {
+						return nil, err
+					}
+					vteps, err := util.ParseNodeVTEPs(n)
+					if util.IsAnnotationNotSetError(err) {
+						return map[string]util.VTEPNodeAnnotation{}, nil
+					}
+					return vteps, err
+				}).WithTimeout(5 * time.Second).ShouldNot(gomega.HaveKey("managed-to-unmanaged"))
+			}
+		})
+	})
+
 	ginkgo.Context("Finalizer management", func() {
 		ginkgo.DescribeTable("adds finalizer to a new VTEP",
 			func(mode vtepv1.VTEPMode) {
@@ -1510,6 +1823,65 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			gomega.Consistently(func() (*metav1.Condition, error) {
 				return getVTEPCondition(fakeVTEP, "vtep-node-change", conditionTypeAccepted)
 			}).WithTimeout(3 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+		})
+
+		ginkgo.It("releases managed VTEP allocation when a node is deleted", func() {
+			// /30 gives exactly 4 IPs (.0-.3); fill the pool with 4 nodes.
+			node1 := newNodeWithVTEPAnnotation("node-1", nil)
+			node2 := newNodeWithVTEPAnnotation("node-2", nil)
+			node3 := newNodeWithVTEPAnnotation("node-3", nil)
+			node4 := newNodeWithVTEPAnnotation("node-4", nil)
+			vtep := newVTEP("release-vtep", vtepv1.VTEPModeManaged, "10.0.3.0/30")
+			start(vtep, node1, node2, node3, node4)
+
+			getNodeVTEPIP := func(nodeName string) (string, error) {
+				n, err := fakeClientset.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				vteps, err := util.ParseNodeVTEPs(n)
+				if util.IsAnnotationNotSetError(err) || len(vteps["release-vtep"].IPs) == 0 {
+					return "", nil
+				}
+				if err != nil {
+					return "", err
+				}
+				return vteps["release-vtep"].IPs[0], nil
+			}
+
+			// Wait for all 4 nodes to be allocated — pool is now full.
+			for _, name := range []string{"node-1", "node-2", "node-3", "node-4"} {
+				n := name
+				gomega.Eventually(func() (string, error) {
+					return getNodeVTEPIP(n)
+				}).WithTimeout(5 * time.Second).ShouldNot(gomega.BeEmpty())
+			}
+
+			// Record node-4's IP before touching anything.
+			releasedIP, err := getNodeVTEPIP("node-4")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(releasedIP).NotTo(gomega.BeEmpty())
+
+			// Create node-5 while the pool is still full — it must fail to allocate.
+			node5 := newNodeWithVTEPAnnotation("node-5", nil)
+			_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node5, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "release-vtep", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.SatisfyAll(
+				gomega.HaveField("Status", metav1.ConditionFalse),
+				gomega.HaveField("Reason", gomega.Equal(reasonAllocationFailed)),
+			))
+
+			// Now delete node-4 — its IP is freed.
+			err = fakeClientset.KubeClient.CoreV1().Nodes().Delete(context.Background(), "node-4", metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// node-5 must now be allocated and receive exactly the freed IP.
+			gomega.Eventually(func() (string, error) {
+				return getNodeVTEPIP("node-5")
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal(releasedIP))
 		})
 
 		ginkgo.It("re-validates VTEP when a node is deleted", func() {

--- a/go-controller/pkg/clustermanager/vtep/status.go
+++ b/go-controller/pkg/clustermanager/vtep/status.go
@@ -22,11 +22,10 @@ const (
 
 	conditionTypeAccepted = "Accepted"
 
-	reasonManagedModeNotSupported = "ManagedModeNotSupported"
-	reasonAllocated               = "Allocated"
-	reasonAllocationFailed        = "AllocationFailed"
-	reasonCIDROverlap             = "CIDROverlap"
-	reasonEVPNIPv6NotSupported    = "EVPNIPv6NotSupported"
+	reasonAllocated            = "Allocated"
+	reasonAllocationFailed     = "AllocationFailed"
+	reasonCIDROverlap          = "CIDROverlap"
+	reasonEVPNIPv6NotSupported = "EVPNIPv6NotSupported"
 )
 
 func (c *Controller) updateStatusCondition(vtep *vtepv1.VTEP, conditionType string, status metav1.ConditionStatus, reason, message string) error {

--- a/go-controller/pkg/testing/util.go
+++ b/go-controller/pkg/testing/util.go
@@ -6,6 +6,7 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -16,6 +17,8 @@ import (
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	networkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
 	networkconnectfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/clientset/versioned/fake"
+	rav1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	rafake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
 	vtepfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -199,4 +202,66 @@ func BuildNAD(name, namespace string, network *ovncnitypes.NetConf) (*nadapi.Net
 		return nil, err
 	}
 	return GenerateNADWithConfig(name, namespace, string(config)), nil
+}
+
+// AddRAApplyReactor handles ApplyStatus calls for RouteAdvertisements on the
+// fake client. The fake client does not implement server-side apply, so the RA
+// controller's ApplyStatus call would be silently ignored and the Accepted
+// status would never be persisted. This reactor decodes the status patch and
+// updates the object in the fake tracker so informer caches see the change.
+func AddRAApplyReactor(fakeClient *rafake.Clientset) {
+	fakeClient.PrependReactor("patch", "routeadvertisements", func(action ktesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(ktesting.PatchAction)
+		if patchAction.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		name := patchAction.GetName()
+		existingObj, err := fakeClient.Tracker().Get(
+			rav1.SchemeGroupVersion.WithResource("routeadvertisements"), "", name)
+		if err != nil {
+			return true, nil, err
+		}
+		ra := existingObj.(*rav1.RouteAdvertisements).DeepCopy()
+
+		type patchShape struct {
+			Status rav1.RouteAdvertisementsStatus `json:"status"`
+		}
+		var p patchShape
+		if err := json.Unmarshal(patchAction.GetPatch(), &p); err != nil {
+			return true, nil, err
+		}
+		ra.Status = p.Status
+		if err := fakeClient.Tracker().Update(
+			rav1.SchemeGroupVersion.WithResource("routeadvertisements"), ra, ""); err != nil {
+			return true, nil, err
+		}
+		return true, ra, nil
+	})
+}
+
+// FakeClientWithReactor is satisfied by any fake clientset that supports
+// PrependReactor (e.g. *frrfake.Clientset, *rafake.Clientset, …).
+type FakeClientWithReactor interface {
+	PrependReactor(verb, resource string, reaction ktesting.ReactionFunc)
+}
+
+// AddGenerateNameReactor wires a Create reactor that assigns a deterministic
+// name to objects whose GenerateName is set. The Kubernetes fake client does
+// not implement generateName natively; without this reactor objects created
+// with GenerateName end up with an empty name and cannot be found by List/Get.
+func AddGenerateNameReactor(fakeClient FakeClientWithReactor) {
+	var count uint32
+	fakeClient.PrependReactor("create", "*",
+		func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			ret = action.(ktesting.CreateAction).GetObject()
+			meta, ok := ret.(metav1.Object)
+			if !ok {
+				return
+			}
+			if meta.GetName() == "" && meta.GetGenerateName() != "" {
+				meta.SetName(meta.GetGenerateName() + fmt.Sprintf("%d", atomic.AddUint32(&count, 1)))
+			}
+			return
+		},
+	)
 }

--- a/go-controller/pkg/util/vtep_node_annotations.go
+++ b/go-controller/pkg/util/vtep_node_annotations.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -58,4 +59,75 @@ func MarshalNodeVTEPs(vteps map[string]VTEPNodeAnnotation) (map[string]interface
 // be non-nil;
 func NodeVTEPsAnnotationChanged(oldNode, newNode *corev1.Node) bool {
 	return oldNode.Annotations[OVNNodeVTEPs] != newNode.Annotations[OVNNodeVTEPs]
+}
+
+// SetNodeVTEPEntry sets or updates a VTEP entry in the k8s.ovn.org/vteps
+// annotation on a node using retry-on-conflict. The annotation is a shared
+// JSON blob written by both the cluster-manager (managed VTEPs) and
+// ovnkube-node (unmanaged VTEPs), so concurrent writes are expected.
+func SetNodeVTEPEntry(nodeName, vtepName string, ips []string, getNode func(string) (*corev1.Node, error), updateNode func(*corev1.Node) error) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := getNode(nodeName)
+		if err != nil {
+			return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		}
+		cnode := node.DeepCopy()
+
+		vteps, err := ParseNodeVTEPs(cnode)
+		if err != nil {
+			if !IsAnnotationNotSetError(err) {
+				return fmt.Errorf("failed to parse VTEP annotation: %w", err)
+			}
+			vteps = map[string]VTEPNodeAnnotation{}
+		}
+
+		vteps[vtepName] = VTEPNodeAnnotation{IPs: ips}
+		return applyVTEPAnnotation(cnode, vteps, updateNode)
+	})
+}
+
+// RemoveNodeVTEPEntry removes a VTEP entry from the k8s.ovn.org/vteps
+// annotation on a node using retry-on-conflict. If the entry does not exist
+// or the annotation is not set, this is a no-op.
+func RemoveNodeVTEPEntry(nodeName, vtepName string, getNode func(string) (*corev1.Node, error), updateNode func(*corev1.Node) error) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := getNode(nodeName)
+		if err != nil {
+			return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		}
+
+		vteps, err := ParseNodeVTEPs(node)
+		if err != nil {
+			if IsAnnotationNotSetError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to parse VTEP annotation: %w", err)
+		}
+
+		if _, ok := vteps[vtepName]; !ok {
+			return nil
+		}
+
+		cnode := node.DeepCopy()
+		delete(vteps, vtepName)
+		return applyVTEPAnnotation(cnode, vteps, updateNode)
+	})
+}
+
+func applyVTEPAnnotation(node *corev1.Node, vteps map[string]VTEPNodeAnnotation, updateNode func(*corev1.Node) error) error {
+	annotations, err := MarshalNodeVTEPs(vteps)
+	if err != nil {
+		return fmt.Errorf("failed to marshal VTEP annotation: %w", err)
+	}
+	for k, v := range annotations {
+		if v == nil {
+			delete(node.Annotations, k)
+		} else {
+			if node.Annotations == nil {
+				node.Annotations = map[string]string{}
+			}
+			node.Annotations[k] = v.(string)
+		}
+	}
+	return updateNode(node)
 }


### PR DESCRIPTION
## 📑 Description

Adds support for managed VTEP mode from cluster manager side

1. an allocator logic is added
2. mutability logic is added (there is slight assymmetry in logic in how we do the mutation)
    1. Managed → Unmanaged: The IPs in the annotation were virtual allocations from the CM's pool. They don't correspond to any actual interface on the node. In unmanaged mode, the node-side controller needs to discover a real interface IP within the CIDRs. That discovered IP will almost certainly be different from what the CM allocated, so there's nothing meaningful to "preserve" — the managed IP was never on a real interface.
    2. Unmanaged → Managed: The IPs in the annotation came from real interfaces on the host. The CM can read them, mark them as allocated in the pool, and keep using them. The IPs are valid within the CIDRs and already "exist" — preserving them avoids unnecessary churn.
    3. adding new cidrs and expansion of mask is handled for managed mode
4. unit and integration tests added, e2e's will follow in the node side PR

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managed-mode VTEP IP allocation implemented end-to-end with per-VTEP allocators, initial sync/recovery, and managed→unmanaged cleanup.
  * Ability to widen CIDR ranges while preserving prior allocations and allocation order.
  * Subnet handling supports single-IP host subnets (/32 and /128).
  * Safe helpers for concurrent updates of node VTEP annotations.

* **Tests**
  * Large test expansion: allocator behavior, range replacement, single-IP allocations, managed-mode scenarios, integration coverage, and many edge cases.

* **Documentation**
  * EVPN docs: Managed mode guidance and mode-switching procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->