### PR TITLE
BGP: Skip route import for networks not advertised on default VRF

### DIFF
--- a/go-controller/pkg/ovn/routeimport/route_import.go
+++ b/go-controller/pkg/ovn/routeimport/route_import.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"slices"
 	"sync"
 	"time"
 
@@ -108,6 +109,15 @@ func (c *controller) AddNetwork(network util.NetInfo) error {
 	c.Lock()
 	defer c.Unlock()
 
+	// This controller only imports routes for networks advertised on the
+	// default VRF, which is the VRF the OVN GW is on. EVPN networks are
+	// immutable and never advertise on the default VRF, so skip tracking
+	// them to avoid noop reconciliations.
+	if network.Transport() == types.NetworkTransportEVPN {
+		c.log.V(5).Info("Not tracking EVPN network", "name", network.GetNetworkName())
+		return nil
+	}
+
 	networkID := network.GetNetworkID()
 	if c.networkIDs[networkID] != "" {
 		return fmt.Errorf("already tracking network %q with ID %d",
@@ -156,12 +166,12 @@ func (c *controller) NeedsReconciliation(network util.NetInfo) bool {
 	c.RLock()
 	defer c.RUnlock()
 
-	if c.networks[network.GetNetworkName()] == nil {
+	old := c.networks[network.GetNetworkName()]
+	if old == nil {
 		return false
 	}
 
-	// TODO check if overlay mode changed
-	return false
+	return c.isAdvertisedOnDefaultVRF(network) != c.isAdvertisedOnDefaultVRF(old)
 }
 
 func (c *controller) ReconcileNetwork(name string) error {
@@ -346,18 +356,23 @@ func (c *controller) syncNetwork(network string) error {
 	c.setTableForNetworkUnlocked(info.GetNetworkID(), table)
 	c.Unlock()
 
-	var ignoreSubnets []*net.IPNet
-	if info.Transport() != types.NetworkTransportNoOverlay {
-		// if the network is overlay mode, skip routes to the pod network
-		ignoreSubnets = make([]*net.IPNet, len(info.Subnets()))
-		for i, subnet := range info.Subnets() {
-			ignoreSubnets[i] = subnet.CIDR
+	// we only import routes if network imports default VRF since that is the
+	// only VRF the OVN gateway can use
+	var expected sets.Set[route]
+	if c.isAdvertisedOnDefaultVRF(info) {
+		var ignoreSubnets []*net.IPNet
+		if info.Transport() != types.NetworkTransportNoOverlay {
+			// ignore routes to the pod network unless it is no-overlay mode
+			ignoreSubnets = make([]*net.IPNet, len(info.Subnets()))
+			for i, subnet := range info.Subnets() {
+				ignoreSubnets[i] = subnet.CIDR
+			}
 		}
-	}
 
-	expected, err := c.getBGPRoutes(table, ignoreSubnets)
-	if err != nil {
-		return err
+		expected, err = c.getBGPRoutes(table, ignoreSubnets)
+		if err != nil {
+			return err
+		}
 	}
 
 	router := info.GetNetworkScopedGWRouterName(c.node)
@@ -467,6 +482,10 @@ func (c *controller) getOVNRoutes(router string) (sets.Set[route], map[route]str
 	}
 	c.log.V(5).Info("Listed OVN routes", "router", router, "routes", stringer{routes}, "took", time.Since(start))
 	return routes, uuids, nil
+}
+
+func (c *controller) isAdvertisedOnDefaultVRF(network util.NetInfo) bool {
+	return slices.Contains(network.GetPodNetworkAdvertisedOnNodeVRFs(c.node), types.DefaultNetworkName)
 }
 
 func (c *controller) getNetwork(network string) util.NetInfo {

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -37,7 +37,10 @@ func Test_controller_syncNetwork(t *testing.T) {
 		config.Default.ClusterSubnets = origClusterSubnets
 	})
 
+	advertisedOnDefaultVRF := map[string][]string{node: {types.DefaultNetworkName}}
+
 	defaultNetwork := &util.DefaultNetInfo{}
+	defaultNetwork.SetPodNetworkAdvertisedVRFs(advertisedOnDefaultVRF)
 	defaultNetworkRouter := defaultNetwork.GetNetworkScopedGWRouterName(node)
 	defaultNetworkRouterPort := types.GWRouterToExtSwitchPrefix + defaultNetworkRouter
 
@@ -58,6 +61,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 	udn.On("Subnets").Return(nil)
 	udn.On("GetNetworkScopedGWRouterName", node).Return("router")
 	udn.On("Transport").Return("")
+	udn.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 
 	cudn := &multinetworkmocks.NetInfo{}
 	cudn.On("IsDefault").Return(false)
@@ -66,6 +70,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 	cudn.On("Subnets").Return(nil)
 	cudn.On("GetNetworkScopedGWRouterName", node).Return("router")
 	cudn.On("Transport").Return("")
+	cudn.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 
 	// Create CUDN with subnets for overlay mode testing
 	cudnOverlay := &multinetworkmocks.NetInfo{}
@@ -83,6 +88,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 	})
 	cudnOverlay.On("GetNetworkScopedGWRouterName", node).Return("cudn-overlay-router")
 	cudnOverlay.On("Transport").Return("") // Empty means overlay (geneve)
+	cudnOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 	cudnOverlayRouter := cudnOverlay.GetNetworkScopedGWRouterName(node)
 	cudnOverlayRouterPort := types.GWRouterToExtSwitchPrefix + cudnOverlayRouter
 
@@ -102,8 +108,20 @@ func Test_controller_syncNetwork(t *testing.T) {
 	})
 	cudnNoOverlay.On("GetNetworkScopedGWRouterName", node).Return("cudn-nooverlay-router")
 	cudnNoOverlay.On("Transport").Return(types.NetworkTransportNoOverlay)
+	cudnNoOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 	cudnNoOverlayRouter := cudnNoOverlay.GetNetworkScopedGWRouterName(node)
 	cudnNoOverlayRouterPort := types.GWRouterToExtSwitchPrefix + cudnNoOverlayRouter
+
+	udnNotOnDefaultVRF := &multinetworkmocks.NetInfo{}
+	udnNotOnDefaultVRF.On("IsDefault").Return(false)
+	udnNotOnDefaultVRF.On("GetNetworkName").Return("udn-not-default-vrf")
+	udnNotOnDefaultVRF.On("GetNetworkID").Return(5)
+	udnNotOnDefaultVRF.On("Subnets").Return(nil)
+	udnNotOnDefaultVRF.On("GetNetworkScopedGWRouterName", node).Return("not-default-vrf-router")
+	udnNotOnDefaultVRF.On("Transport").Return("")
+	udnNotOnDefaultVRF.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(nil)
+	udnNotOnDefaultVRFRouter := udnNotOnDefaultVRF.GetNetworkScopedGWRouterName(node)
+	udnNotOnDefaultVRFRouterPort := types.GWRouterToExtSwitchPrefix + udnNotOnDefaultVRFRouter
 
 	type fields struct {
 		networkIDs map[int]string
@@ -315,6 +333,24 @@ func Test_controller_syncNetwork(t *testing.T) {
 				&nbdb.LogicalRouter{UUID: "router", Name: cudnNoOverlayRouter, StaticRoutes: []string{"keep-1", "add-1"}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "192.168.1.0/24", Nexthop: "2.2.2.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+		},
+		{
+			name: "removes routes for network not advertised on default VRF",
+			args: args{"udn-not-default-vrf"},
+			fields: fields{
+				networkIDs: map[int]string{5: "udn-not-default-vrf"},
+				networks:   map[string]util.NetInfo{"udn-not-default-vrf": udnNotOnDefaultVRF},
+			},
+			link: &netlink.Vrf{Table: 5},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: udnNotOnDefaultVRFRouter, StaticRoutes: []string{"remove-1", "keep-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "remove-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &udnNotOnDefaultVRFRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "5.5.5.0/24", Nexthop: "5.5.5.1"},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: udnNotOnDefaultVRFRouter, StaticRoutes: []string{"keep-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "5.5.5.0/24", Nexthop: "5.5.5.1"},
 			},
 		},
 	}


### PR DESCRIPTION
The route import controller only needs to import routes for networks advertised on the default VRF since that is the VRF the OVN gateway is on. Skip importing routes for networks not advertised on the default VRF and clean up any previously imported routes. This naturally skips importing routes for EVPN and VRF-Lite configurations as those are never advertised on the default VRF. Additionally, skip tracking EVPN networks entirely as they are immutable and never advertise on the default VRF, avoiding noop reconciliations.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed route synchronization for networks not advertised on the default VRF
  * Routes now properly cleaned up when networks lack default VRF advertisement

* **Improvements**
  * Optimized handling of EVPN networks in route tracking
  * Enhanced network reconciliation logic to account for VRF advertisement status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->