### PR TITLE
egressip: verify secondary EgressIP is absent from OVS bridge

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -2462,6 +2462,8 @@ spec:
 	   4. Create two pods matching the EgressIP: one running on each of the egress nodes
 	   5. Check connectivity from a pod to an external "node" hosted on the OVN network and verify the expected src IP
 	   6. Check connectivity from a pod to an external "node" hosted on the secondary host network and verify the expected src IP
+	   6a. Verify that the secondary host network EgressIP is NOT in the bridge-egress-ips node annotation
+	   6b. Verify that the secondary host network EgressIP is NOT configured on the OVS bridge
 	   7. Check connectivity from one pod to the other and verify that the connection is achieved
 	   8. Check connectivity from both pods to the api-server (running hostNetwork:true) and verifying that the connection is achieved
 	   9. Update one of the pods, unmatching the EgressIP
@@ -2552,6 +2554,18 @@ spec:
 		ginkgo.By("3. Check that correct Egress IPs are assigned")
 		gomega.Expect(verifyEgressIPStatusContainsIPs(statuses, []string{egressIPOVN, egressIPSecondaryHost})).Should(gomega.BeTrue())
 
+		// Determine which node hosts each EgressIP for use in later verification steps.
+		var nodeNameHostingOVNEIP, nodeNameHostingSecondaryHostEIP string
+		for _, status := range statuses {
+			if status.EgressIP == egressIPOVN {
+				nodeNameHostingOVNEIP = status.Node
+			} else if status.EgressIP == egressIPSecondaryHost {
+				nodeNameHostingSecondaryHostEIP = status.Node
+			}
+		}
+		gomega.Expect(nodeNameHostingOVNEIP).ShouldNot(gomega.BeEmpty())
+		gomega.Expect(nodeNameHostingSecondaryHostEIP).ShouldNot(gomega.BeEmpty())
+
 		ginkgo.By("4. Create two pods matching the EgressIP: one running on each of the egress nodes")
 		createGenericPodWithLabel(f, pod1Name, pod1Node.name, f.Namespace.Name, getAgnHostHTTPPortBindFullCMD(clusterNetworkHTTPPort), podEgressLabel)
 		createGenericPodWithLabel(f, pod2Name, pod2Node.name, f.Namespace.Name, getAgnHostHTTPPortBindFullCMD(clusterNetworkHTTPPort), podEgressLabel)
@@ -2587,6 +2601,26 @@ spec:
 		framework.ExpectNoError(err, "Step 6. Check connectivity from pod (%s/%s) to an external container attached to "+
 			"a network that is secondary host network and verify that the src IP is the expected egressIP, failed: %v",
 			podNamespace.Name, pod2Name, err)
+
+		ginkgo.By("6a. Verify that the secondary host network EgressIP is NOT in the bridge-egress-ips node annotation")
+		// The secondary EgressIP must not be configured on the OVS bridge. Prior to the fix, the node's
+		// BridgeEIPAddrManager would incorrectly add secondary network IPs to the bridge and annotation.
+		annotJSON, err := e2ekubectl.RunKubectl("", "get", "node", nodeNameHostingSecondaryHostEIP,
+			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", strings.ReplaceAll(util.OVNNodeBridgeEgressIPs, "/", "\\/")))
+		framework.ExpectNoError(err, "should be able to get %s annotation on node %s", util.OVNNodeBridgeEgressIPs, nodeNameHostingSecondaryHostEIP)
+		gomega.Expect(annotJSON).ShouldNot(gomega.ContainSubstring(egressIPSecondaryHost),
+			fmt.Sprintf("secondary EgressIP %s should NOT be in %s annotation on node %s, got: %s",
+				egressIPSecondaryHost, util.OVNNodeBridgeEgressIPs, nodeNameHostingSecondaryHostEIP, annotJSON))
+
+		ginkgo.By("6b. Verify that the secondary host network EgressIP is NOT configured on the OVS bridge")
+		// Directly inspect the bridge interface addresses on the node hosting the secondary EgressIP.
+		bridgeName := deploymentconfig.Get().ExternalBridgeName()
+		brAddrOutput, err := infraprovider.Get().ExecK8NodeCommand(nodeNameHostingSecondaryHostEIP,
+			[]string{"ip", "addr", "show", "dev", bridgeName})
+		framework.ExpectNoError(err, "should be able to list addresses on bridge %s on node %s", bridgeName, nodeNameHostingSecondaryHostEIP)
+		gomega.Expect(brAddrOutput).ShouldNot(gomega.ContainSubstring(egressIPSecondaryHost),
+			fmt.Sprintf("secondary EgressIP %s should NOT be configured on bridge %s on node %s",
+				egressIPSecondaryHost, bridgeName, nodeNameHostingSecondaryHostEIP))
 
 		ginkgo.By("7. Check connectivity from one pod to the other and verify that the connection is achieved")
 		pod2IP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, podNamespace.Name, pod2Name)
@@ -2648,16 +2682,6 @@ spec:
 			"a network that isn't OVN network and verify that the src IP is the expected egress IP, failed, err: %v", podNamespace.Name, pod2Name, err)
 
 		ginkgo.By("14. Set the node hosting the OVN egress IP as unavailable")
-		var nodeNameHostingOVNEIP, nodeNameHostingSecondaryHostEIP string
-		for _, status := range statuses {
-			if status.EgressIP == egressIPOVN {
-				nodeNameHostingOVNEIP = status.Node
-			} else if status.EgressIP == egressIPSecondaryHost {
-				nodeNameHostingSecondaryHostEIP = status.Node
-			}
-		}
-		gomega.Expect(nodeNameHostingOVNEIP).ShouldNot(gomega.BeEmpty())
-		gomega.Expect(nodeNameHostingSecondaryHostEIP).ShouldNot(gomega.BeEmpty())
 		egressNodeAvailabilityHandler.Disable(nodeNameHostingOVNEIP)
 
 		ginkgo.By("15. Check that the status is of length one")

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -2462,7 +2462,7 @@ spec:
 	   4. Create two pods matching the EgressIP: one running on each of the egress nodes
 	   5. Check connectivity from a pod to an external "node" hosted on the OVN network and verify the expected src IP
 	   6. Check connectivity from a pod to an external "node" hosted on the secondary host network and verify the expected src IP
-	   6a. Verify that the secondary host network EgressIP is NOT in the bridge-egress-ips node annotation
+	   6a. Verify EgressIP SNAT configuration in OVN NB DB
 	   6b. Verify that the secondary host network EgressIP is NOT configured on the OVS bridge
 	   7. Check connectivity from one pod to the other and verify that the connection is achieved
 	   8. Check connectivity from both pods to the api-server (running hostNetwork:true) and verifying that the connection is achieved
@@ -2602,22 +2602,51 @@ spec:
 			"a network that is secondary host network and verify that the src IP is the expected egressIP, failed: %v",
 			podNamespace.Name, pod2Name, err)
 
-		ginkgo.By("6a. Verify that the secondary host network EgressIP is NOT in the bridge-egress-ips node annotation")
-		// The secondary EgressIP must not be configured on the OVS bridge. Prior to the fix, the node's
-		// BridgeEIPAddrManager would incorrectly add secondary network IPs to the bridge and annotation.
-		annotJSON, err := e2ekubectl.RunKubectl("", "get", "node", nodeNameHostingSecondaryHostEIP,
-			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", strings.ReplaceAll(util.OVNNodeBridgeEgressIPs, "/", "\\/")))
-		framework.ExpectNoError(err, "should be able to get %s annotation on node %s", util.OVNNodeBridgeEgressIPs, nodeNameHostingSecondaryHostEIP)
-		gomega.Expect(annotJSON).ShouldNot(gomega.ContainSubstring(egressIPSecondaryHost),
-			fmt.Sprintf("secondary EgressIP %s should NOT be in %s annotation on node %s, got: %s",
-				egressIPSecondaryHost, util.OVNNodeBridgeEgressIPs, nodeNameHostingSecondaryHostEIP, annotJSON))
+		ginkgo.By("6a. Verify EgressIP SNAT configuration in OVN NB DB")
+		// Query the OVN Northbound database to confirm that SNAT entries exist for the
+		// pod's logical IP with the expected EgressIPs as external IPs. This validates
+		// that the EgressIP system is functioning correctly at the OVN level.
+		pod1IP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, podNamespace.Name, pod1Name)
+		framework.ExpectNoError(err, "step 6a failed to get pod %s IP", pod1Name)
+		ovnKubernetesNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+		dbPods, err := e2ekubectl.RunKubectl(ovnKubernetesNamespace, "get", "pods", "-l", "name=ovnkube-db",
+			"-o=jsonpath='{.items..metadata.name}'")
+		dbContainerName := "nb-ovsdb"
+		if isInterconnectEnabled() {
+			dbPods, err = e2ekubectl.RunKubectl(ovnKubernetesNamespace, "get", "pods", "-l", "app=ovnkube-node",
+				"--field-selector", fmt.Sprintf("spec.nodeName=%s", nodeNameHostingOVNEIP),
+				"-o=jsonpath='{.items..metadata.name}'")
+		}
+		if err != nil || len(dbPods) == 0 {
+			framework.Failf("step 6a failed to find OVN DB pod, err: %v", err)
+		}
+		dbPod := strings.Split(dbPods, " ")[0]
+		dbPod = strings.TrimPrefix(dbPod, "'")
+		dbPod = strings.TrimSuffix(dbPod, "'")
+		if len(dbPod) == 0 {
+			framework.Failf("step 6a OVN DB pod name is empty after parsing")
+		}
+		logicalIP := fmt.Sprintf("logical_ip=%s", pod1IP.String())
+		if isIPv6TestRun {
+			logicalIP = fmt.Sprintf("logical_ip=\"%s\"", pod1IP.String())
+		}
+		snats, err := e2ekubectl.RunKubectl(ovnKubernetesNamespace, "exec", dbPod, "-c", dbContainerName, "--",
+			"ovn-nbctl", "--no-leader-only", "--columns=external_ip", "find", "nat", logicalIP)
+		framework.ExpectNoError(err, "step 6a failed to query OVN NAT table for pod %s (IP: %s)", pod1Name, pod1IP.String())
+		gomega.Expect(snats).Should(gomega.ContainSubstring(egressIPOVN),
+			"OVN EgressIP %s should have a SNAT entry for pod %s (IP: %s) in OVN NB DB, got: %s",
+			egressIPOVN, pod1Name, pod1IP.String(), snats)
 
 		ginkgo.By("6b. Verify that the secondary host network EgressIP is NOT configured on the OVS bridge")
 		// Directly inspect the bridge interface addresses on the node hosting the secondary EgressIP.
+		// BridgeEIPAddrManager.parseAndValidateEIP() should skip secondary network IPs via isOVNNetworkIP(),
+		// so the secondary EgressIP must not appear on the bridge.
 		bridgeName := deploymentconfig.Get().ExternalBridgeName()
 		brAddrOutput, err := infraprovider.Get().ExecK8NodeCommand(nodeNameHostingSecondaryHostEIP,
 			[]string{"ip", "addr", "show", "dev", bridgeName})
 		framework.ExpectNoError(err, "should be able to list addresses on bridge %s on node %s", bridgeName, nodeNameHostingSecondaryHostEIP)
+		framework.Logf("Bridge %s addresses on node %s (secondary EgressIP %s should be absent):\n%s",
+			bridgeName, nodeNameHostingSecondaryHostEIP, egressIPSecondaryHost, brAddrOutput)
 		gomega.Expect(brAddrOutput).ShouldNot(gomega.ContainSubstring(egressIPSecondaryHost),
 			fmt.Sprintf("secondary EgressIP %s should NOT be configured on bridge %s on node %s",
 				egressIPSecondaryHost, bridgeName, nodeNameHostingSecondaryHostEIP))

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -2448,6 +2448,8 @@ spec:
 		   4. Create two pods matching the EgressIP: one running on each of the egress nodes
 		   5. Check connectivity from a pod to an external "node" hosted on the OVN network and verify the expected src IP
 		   6. Check connectivity from a pod to an external "node" hosted on the secondary host network and verify the expected src IP
+		   6a. Verify EgressIP SNAT configuration in OVN NB DB
+		   6b. Verify that the secondary host network EgressIP is NOT configured on the OVS bridge
 		   7. Check connectivity from one pod to the other and verify that the connection is achieved
 		   8. Check connectivity from both pods to the api-server (running hostNetwork:true) and verifying that the connection is achieved
 		   9. Update one of the pods, unmatching the EgressIP
@@ -2535,6 +2537,18 @@ spec:
 					"failed: status 1 has node %q and status 2 has node %q", statuses[0].Node, statuses[1].Node)
 			}
 
+			// Determine which node hosts each EgressIP for use in later verification steps.
+			var nodeNameHostingOVNEIP, nodeNameHostingSecondaryHostEIP string
+			for _, status := range statuses {
+				if status.EgressIP == egressIPOVN {
+					nodeNameHostingOVNEIP = status.Node
+				} else if status.EgressIP == egressIPSecondaryHost {
+					nodeNameHostingSecondaryHostEIP = status.Node
+				}
+			}
+			gomega.Expect(nodeNameHostingOVNEIP).ShouldNot(gomega.BeEmpty())
+			gomega.Expect(nodeNameHostingSecondaryHostEIP).ShouldNot(gomega.BeEmpty())
+
 			ginkgo.By("3. Check that correct Egress IPs are assigned")
 			gomega.Expect(verifyEgressIPStatusContainsIPs(statuses, []string{egressIPOVN, egressIPSecondaryHost})).Should(gomega.BeTrue())
 
@@ -2573,6 +2587,55 @@ spec:
 			framework.ExpectNoError(err, "Step 6. Check connectivity from pod (%s/%s) to an external container attached to "+
 				"a network that is secondary host network and verify that the src IP is the expected egressIP, failed: %v",
 				podNamespace.Name, pod2Name, err)
+
+			ginkgo.By("6a. Verify EgressIP SNAT configuration in OVN NB DB")
+			// Query the OVN Northbound database to confirm that SNAT entries exist for the
+			// pod's logical IP with the expected EgressIPs as external IPs. This validates
+			// that the EgressIP system is functioning correctly at the OVN level.
+			pod1IP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, podNamespace.Name, pod1Name)
+			framework.ExpectNoError(err, "step 6a failed to get pod %s IP", pod1Name)
+			ovnKubernetesNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+			dbPods, err := e2ekubectl.RunKubectl(ovnKubernetesNamespace, "get", "pods", "-l", "name=ovnkube-db",
+				"-o=jsonpath='{.items..metadata.name}'")
+			dbContainerName := "nb-ovsdb"
+			if isInterconnectEnabled() {
+				dbPods, err = e2ekubectl.RunKubectl(ovnKubernetesNamespace, "get", "pods", "-l", "app=ovnkube-node",
+					"--field-selector", fmt.Sprintf("spec.nodeName=%s", nodeNameHostingOVNEIP),
+					"-o=jsonpath='{.items..metadata.name}'")
+			}
+			if err != nil || len(dbPods) == 0 {
+				framework.Failf("step 6a failed to find OVN DB pod, err: %v", err)
+			}
+			dbPod := strings.Split(dbPods, " ")[0]
+			dbPod = strings.TrimPrefix(dbPod, "'")
+			dbPod = strings.TrimSuffix(dbPod, "'")
+			if len(dbPod) == 0 {
+				framework.Failf("step 6a OVN DB pod name is empty after parsing")
+			}
+			logicalIP := fmt.Sprintf("logical_ip=%s", pod1IP.String())
+			if isIPv6TestRun {
+				logicalIP = fmt.Sprintf("logical_ip=\"%s\"", pod1IP.String())
+			}
+			snats, err := e2ekubectl.RunKubectl(ovnKubernetesNamespace, "exec", dbPod, "-c", dbContainerName, "--",
+				"ovn-nbctl", "--no-leader-only", "--columns=external_ip", "find", "nat", logicalIP)
+			framework.ExpectNoError(err, "step 6a failed to query OVN NAT table for pod %s (IP: %s)", pod1Name, pod1IP.String())
+			gomega.Expect(snats).Should(gomega.ContainSubstring(egressIPOVN),
+				"OVN EgressIP %s should have a SNAT entry for pod %s (IP: %s) in OVN NB DB, got: %s",
+				egressIPOVN, pod1Name, pod1IP.String(), snats)
+
+			ginkgo.By("6b. Verify that the secondary host network EgressIP is NOT configured on the OVS bridge")
+			// Directly inspect the bridge interface addresses on the node hosting the secondary EgressIP.
+			// BridgeEIPAddrManager.parseAndValidateEIP() should skip secondary network IPs via isOVNNetworkIP(),
+			// so the secondary EgressIP must not appear on the bridge.
+			bridgeName := deploymentconfig.Get().ExternalBridgeName()
+			brAddrOutput, err := infraprovider.Get().ExecK8NodeCommand(nodeNameHostingSecondaryHostEIP,
+				[]string{"ip", "addr", "show", "dev", bridgeName})
+			framework.ExpectNoError(err, "should be able to list addresses on bridge %s on node %s", bridgeName, nodeNameHostingSecondaryHostEIP)
+			framework.Logf("Bridge %s addresses on node %s (secondary EgressIP %s should be absent):\n%s",
+				bridgeName, nodeNameHostingSecondaryHostEIP, egressIPSecondaryHost, brAddrOutput)
+			gomega.Expect(brAddrOutput).ShouldNot(gomega.ContainSubstring(egressIPSecondaryHost),
+				fmt.Sprintf("secondary EgressIP %s should NOT be configured on bridge %s on node %s",
+					egressIPSecondaryHost, bridgeName, nodeNameHostingSecondaryHostEIP))
 
 			ginkgo.By("7. Check connectivity from one pod to the other and verify that the connection is achieved")
 			pod2IP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, podNamespace.Name, pod2Name)
@@ -2634,16 +2697,6 @@ spec:
 				"a network that isn't OVN network and verify that the src IP is the expected egress IP, failed, err: %v", podNamespace.Name, pod2Name, err)
 
 			ginkgo.By("14. Set the node hosting the OVN egress IP as unavailable")
-			var nodeNameHostingOVNEIP, nodeNameHostingSecondaryHostEIP string
-			for _, status := range statuses {
-				if status.EgressIP == egressIPOVN {
-					nodeNameHostingOVNEIP = status.Node
-				} else if status.EgressIP == egressIPSecondaryHost {
-					nodeNameHostingSecondaryHostEIP = status.Node
-				}
-			}
-			gomega.Expect(nodeNameHostingOVNEIP).ShouldNot(gomega.BeEmpty())
-			gomega.Expect(nodeNameHostingSecondaryHostEIP).ShouldNot(gomega.BeEmpty())
 			egressNodeAvailabilityHandler.Disable(nodeNameHostingOVNEIP)
 
 			ginkgo.By("15. Check that the status is of length one")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
  Add verification steps to the mixed OVN + secondary host network
  egress IP E2E test to ensure that secondary network EgressIPs are
  not incorrectly configured on the OVS bridge or added to the
  bridge-egress-ips node annotation.

  Prior to the fix, the BridgeEIPAddrManager
  would incorrectly add secondary host network EgressIPs to the OVS
  bridge and the k8s.ovn.org/bridge-egress-ips annotation, causing
  conflicts.

  The new steps (6a, 6b) check that:
  - The secondary EgressIP is absent from the bridge-egress-ips node annotation
  - The secondary EgressIP is not configured as an address on the OVS bridge interface

  Also moves the node-name determination (which node hosts OVN vs
  secondary EgressIP) from step 14 to after step 3, removing the
  redundant computation later in the test.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective

Set up cluster 
./kind.sh -wk 3 -eb -mne -nse
Execute the tests
 go test -v -timeout 120m -ginkgo.v -ginkgo.focus='\[secondary-host-eip\] Using different methods to disable a node or pod availability for egres' -provider skeleton
-->