### PR TITLE
Implement versioned documentation architecture

### DIFF
--- a/.github/workflows/docs-versioning.yml
+++ b/.github/workflows/docs-versioning.yml
@@ -1,0 +1,66 @@
+# Builds and publishes the multi-version docs site with mike to the gh-pages
+# branch (master + release-* versions). Triggered on docs-related pushes,
+# when a release-* branch is created, or via workflow_dispatch.
+name: Publish Versioned Docs
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs-versioning.yml'
+      - 'hack/build-docs.sh'
+      - 'requirements.txt'
+  # Creating a new release-* ref (e.g. git push origin master:release-1.4) often
+  # has no path diff, so the paths filter above would skip it. The create event
+  # covers that case; the job if: below ignores tags and non-release branches.
+  create:
+  workflow_dispatch:
+    inputs:
+      releases:
+        description: >
+          Branches to deploy: "all" (default) or a comma-separated list of
+          existing branches (e.g. release-1.1,master). Invalid names fail the job.
+        required: false
+        default: 'all'
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    if: >
+      github.event_name != 'create' ||
+      startsWith(github.ref, 'refs/heads/release-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy Versions
+        env:
+          # create / push always rebuild all versions so labels stay consistent.
+          # workflow_dispatch may narrow the set via the releases input.
+          RELEASES: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.releases || 'all') || 'all' }}
+        run: |
+          pushd docs
+            make build-docs PUSH=1 RELEASES="${RELEASES}"
+          popd

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,58 +1,16 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Test and Deploy static content to Pages
+# docs-versioning.yml now handles deployment using mike (multi-version site
+# on the gh-pages branch) while this workflow handles the docs build pieces.
+name: Test Docs Build
 
 on:
-  push:
-    branches: ["master"]
   pull_request:
     branches: ["master"]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
-  # build and deploy pages on merges
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: pip install mkdocs-material
-      - run: pip install mkdocs-awesome-pages-plugin # Install the missing plugin
-      - run: pip install $(mkdocs-get-deps)
-      - run: mkdocs build
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload site folder
-          path: './site'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-  # test that docs build correctly on PRs
   test-deploy:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -61,7 +19,7 @@ jobs:
           python-version: 3.x
       - run: |
           pip install mkdocs-material
-          pip install mkdocs-awesome-pages-plugin # Install the missing plugin
+          pip install mkdocs-awesome-pages-plugin
           pip install $(mkdocs-get-deps)
       - run: mkdocs build --strict
       - name: Upload Artifact (Test)

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ovn-kubernetes-anp-test-report.yaml
 **/ginkgo.report
 
 .gocache
+
+# MkDocs build output (local mkdocs build / mike deploy)
+/site/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Docs versioning (mike). See developer-guide/documentation.md and hack/build-docs.sh.
+#
+# Examples (from the docs/ directory):
+#   make build-docs
+#   make build-docs PUSH=1
+#   make build-docs RELEASES=release-1.1
+#   make build-docs RELEASES=release-1.1,master PUSH=1
+#
+# Or from the repository root:
+#   make -C docs build-docs PUSH=1
+
+RELEASES ?= all
+PUSH ?= 0
+
+.PHONY: build-docs
+build-docs:
+	../hack/build-docs.sh $(if $(filter 1 true YES yes,$(PUSH)),--push) --releases "$(RELEASES)"

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -54,25 +54,111 @@ for more details.
 ## Website Guide
 
 We are utilizing [GitHub Pages](https://docs.github.com/en/pages/quickstart) to host the ovn-kubernetes.io website. The website's
-content is composed in Markdown and stored within the 'docs' directory at the root
+content is composed in Markdown and stored within the `docs/` directory at the root
 of our repository. For static site generation, we employ the [MkDocs](https://www.mkdocs.org/user-guide/writing-your-docs/) framework,
-managed by the 'mkdocs.yml' configuration file located next to the 'docs' folder.
-Additionally, we use the [Material](https://squidfunk.github.io/mkdocs-material/setup/) framework on top of  MkDocs, which enhances our
+managed by the `mkdocs.yml` configuration file located next to the `docs/` folder.
+Additionally, we use the [Material](https://squidfunk.github.io/mkdocs-material/setup/) framework on top of MkDocs, which enhances our
 site with advanced features like customizable navigation, color schemes, and site
-search capabilities
+search capabilities.
 
-Any changes to the files in the doc folder or the mkdocs.yml file is picked up by
-a GitHub Action workflow that will automatically publish the changes to the website.
+The published site is **versioned** with [mike](https://github.com/jimporter/mike).
+Each `release-*` branch and `master` appears in a version dropdown on the docs site.
+Deploy logic lives in
+[`hack/build-docs.sh`](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/hack/build-docs.sh)
+and is invoked via `make -C docs build-docs` (see
+[`docs/Makefile`](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/Makefile)).
+The
+[Publish Versioned Docs](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/.github/workflows/docs-versioning.yml)
+workflow runs that target with `PUSH=1` and updates the `gh-pages` branch.
+
+The [docs.yml](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/.github/workflows/docs.yml)
+workflow keeps a `test-deploy` job so pull requests still validate that docs build
+cleanly. It does not publish the live site; publishing is owned by the versioning
+workflow so the two do not overwrite each other.
+
+### Versioned docs: how publishing works
+
+The versioning workflow runs on pushes to `master` or any `release-*` branch when
+docs-related paths change (`docs/**`, `mkdocs.yml`, the workflow file,
+`hack/build-docs.sh`, or `requirements.txt`). By default each run rebuilds **all**
+versions so Latest/Stable/Legacy labels and the version dropdown stay consistent.
+
+- The nav structure (`nav:` in `mkdocs.yml`) is **per-branch**. A new page added
+  on `master` does not appear in older release versions (and will not break them).
+  To ship a page in an older release, backport the markdown **and** update that
+  branch's `mkdocs.yml` nav.
+- Visual styling is shared: the build copies `docs/stylesheets/extra.css` from
+  `master` onto every version at build time. Make CSS changes on `master` only.
+  Do not edit `extra.css` on release branches — the file is overwritten, and
+  `hack/build-docs.sh` hard-fails if it has local modifications on a `release-*`
+  branch.
+- When a new `release-X.Y` branch is created, the workflow discovers it
+  (via the `create` event and/or a docs push) and the dropdown labels shift:
+  - highest `release-*` → `<ver> (Latest)` (also the mike `latest` alias)
+  - second-highest → `<ver> (Stable)`
+  - older releases → `<ver> (Legacy)`
+  - `master` → `Master (Dev)`
+  Example today: `1.3 (Latest)`, `1.2 (Stable)`, `1.1 (Legacy)`, `1.0 (Legacy)`.
+  After `release-1.4` appears: `1.4 (Latest)`, `1.3 (Stable)`, and older stay
+  `(Legacy)`. No workflow edits are required.
+- Every branch that is deployed must have a root `mkdocs.yml`. The build injects
+  `extra.version.provider: mike` if missing, but the file itself must exist.
+- Do not manually push to or develop on `gh-pages`. The versioning workflow owns it.
+- Prefer `make -C docs build-docs` over ad-hoc `mike` commands so the same
+  validations run locally and in CI.
+
+### Manual rebuild (workflow_dispatch)
+
+Anyone with write access can trigger a rebuild from the **Actions** tab
+(Publish Versioned Docs). The `releases` input defaults to `all`. Set it to a
+comma-separated list of existing branches (for example `release-1.1` or
+`release-1.1,master`) to rebuild only those. Unknown branch names fail the job.
+
+### What triggers a rebuild (and what does not)
+
+| Event | Rebuilds docs site? |
+|-------|---------------------|
+| Push to `master` / `release-*` changing `docs/**`, `mkdocs.yml`, the versioning workflow, `hack/build-docs.sh`, or `requirements.txt` | Yes (all versions) |
+| Creating a new `release-*` branch | Yes (`create` event; labels recompute) |
+| Manual **workflow_dispatch** | Yes (`all` or the branches you list) |
+| Go-only / non-docs commits on `master` or `release-*` | No (by design) |
+
+### After this lands on master (one-time + first-run checks)
+
+Upstream currently has GitHub Pages enabled but **no `gh-pages` branch** — the
+old site was published with the Actions `deploy-pages` flow. Mike needs branch
+publishing. A repo admin must do this once after the first successful
+**Publish Versioned Docs** run (or right before it):
+
+1. Open
+   [Settings → Pages](https://github.com/ovn-kubernetes/ovn-kubernetes/settings/pages)
+   on `ovn-kubernetes/ovn-kubernetes`.
+2. Under **Build and deployment → Source**, choose **Deploy from a branch**.
+3. Branch: **`gh-pages`** / folder: **`/` (root)**. Save.
+4. Keep the custom domain (`ovn-kubernetes.io`) as already configured.
+
+Then verify the first merge deploy:
+
+1. Actions → **Publish Versioned Docs** is green for the merge commit.
+2. The `gh-pages` branch exists and contains `versions.json` plus `master/`,
+   `1.3/`, `1.2/`, …
+3. Locally: `git fetch origin gh-pages && mike list` shows titles like
+   `Master (Dev)`, `1.3 (Latest)`, `1.2 (Stable)`, `1.1 (Legacy)`, `1.0 (Legacy)`.
+4. On the live site, the version dropdown switches and each version’s nav/content
+   matches that release branch.
+
+If Pages is still set to **GitHub Actions**, the workflow can succeed while the
+public site does not update — fix the Source setting above.
 
 ## How to test your documentation changes?
 
 ### Option 1) Build and view docs with a PR
 
 Pushing docs changes to the ovn-kubernetes/ovn-kubernetes project as a pull request will
-run the job name "[Test and Deploy static content to Pages](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/.github/workflows/docs.yml)" which has a step to save the
+run the job name "[Test Docs Build](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/.github/workflows/docs.yml)" which has a step to save the
 docs artifacts. You can download those as a .zip file, extract and view them locally.
 
-### Option 2) Build and serve docs locally
+### Option 2) Build and serve a single version locally
 
 In order to test changes locally to either mkdocs.yml or to files under docs/ folder,
 please follow the instructions below.
@@ -127,3 +213,44 @@ Now you can browse the website on your browser using the above URL.
 As you make changes and save the files, the mkdocs server notices that and re-builds the website.
 It also spews out any WARNINGS or ERRORS with respect to the changes that you have just made. If
 the changes look good, then go ahead and submit the PR.
+
+### Option 3) Preview versioned docs locally with mike
+
+Install dependencies once:
+
+```bash
+pip install -r requirements.txt
+```
+
+**Preview unmerged work on your feature branch** (CSS, `mkdocs.yml`, dropdown UI).
+`make -C docs build-docs` is the wrong tool for this — it checks out remote
+`origin/master` / `origin/release-*` and will not show your local PR changes.
+
+```bash
+# On your feature branch:
+mike deploy --title "Master (Dev)" master
+mike set-default master
+mike serve
+```
+
+Open `http://localhost:8000`. For a single-version preview without mike, use
+`mkdocs serve` as in Option 2.
+
+**Mimic what CI publishes** (content from remote branches only):
+
+```bash
+make -C docs build-docs                 # all origin/release-* + origin/master
+make -C docs build-docs RELEASES=master # only origin/master
+mike serve
+```
+
+Push the local `gh-pages` branch only if you intend to update the remote
+(CI already does this with `PUSH=1`):
+
+```bash
+make -C docs build-docs PUSH=1
+```
+
+`hack/build-docs.sh` refuses to run while checked out on `gh-pages`, and
+refuses to continue if `extra.css` is dirty on a `release-*` branch. There
+is no interactive override.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1170,3 +1170,30 @@ body:has(#__drawer:checked) {
     height: 100dvh;
   }
 }
+/* VERSION SELECTOR: Material injects .md-version into the first header topic,
+   which normally fades out on scroll when the page title takes over. Keep the
+   version control visible and clickable at all times. */
+.md-header__title--active .md-header__topic:first-child {
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  transform: none !important;
+  z-index: 2;
+}
+
+.md-header__title--active .md-header__topic:first-child > .md-ellipsis {
+  max-width: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.md-version {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-size: 0.9rem;
+  position: relative;
+  right: 2rem;
+  z-index: 3;
+}

--- a/hack/build-docs.sh
+++ b/hack/build-docs.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and deploy versioned documentation with mike.
+#
+# Usage:
+#   hack/build-docs.sh [--push] [--releases all|branch[,branch...]]
+#
+# Prefer the docs/ Makefile wrapper:
+#   make -C docs build-docs
+#   make -C docs build-docs PUSH=1
+#   make -C docs build-docs RELEASES=release-1.1
+#   make -C docs build-docs RELEASES=release-1.1,master PUSH=1
+#
+# RELEASES defaults to "all" (every origin/release-* branch plus master).
+# --push pushes the gh-pages branch to origin (used by CI).
+# See docs/developer-guide/documentation.md for team guidance.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+PUSH=false
+RELEASES="${RELEASES:-all}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--push] [--releases all|branch[,branch...]]
+
+Options:
+  --push              Push the gh-pages branch to origin after deploy
+  --releases VALUE    Branches to deploy: "all" (default) or a comma-separated
+                      list of existing branches (e.g. release-1.1,master)
+  -h, --help          Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --push)
+      PUSH=true
+      shift
+      ;;
+    --releases)
+      RELEASES="${2:?--releases requires a value}"
+      shift 2
+      ;;
+    --releases=*)
+      RELEASES="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# --- Safety validations (hard-fail; no interactive override) ---
+#
+# Temporary / manual edits of gh-pages or of extra.css on release branches are
+# not allowed. The automated versioning process owns gh-pages, and release
+# branches always receive master's extra.css at build time.
+
+current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+if [[ "${current_branch}" == "gh-pages" ]]; then
+  die "refusing to run from the 'gh-pages' branch.
+
+The docs-versioning process owns gh-pages. Check out master (or a release
+branch) and use 'make -C docs build-docs' instead.
+See docs/developer-guide/documentation.md for details."
+fi
+
+if [[ "${current_branch}" =~ ^release- ]]; then
+  if ! git diff --quiet -- docs/stylesheets/extra.css 2>/dev/null || \
+     ! git diff --cached --quiet -- docs/stylesheets/extra.css 2>/dev/null; then
+    die "docs/stylesheets/extra.css has local modifications on '${current_branch}'.
+
+This file is overwritten from master during versioned docs builds.
+Make CSS/styling changes on 'master' instead.
+See docs/developer-guide/documentation.md for details."
+  fi
+fi
+
+command -v mike >/dev/null 2>&1 || die "mike is not installed. Run: pip install -r requirements.txt"
+command -v mkdocs >/dev/null 2>&1 || die "mkdocs is not installed. Run: pip install -r requirements.txt"
+
+# mike deploy checks out origin/* refs and would otherwise leave the repo in
+# detached HEAD. Restore the caller's starting branch/commit on exit.
+START_REF="$(git symbolic-ref -q --short HEAD 2>/dev/null || git rev-parse HEAD)"
+restore_start_ref() {
+  local ec=$?
+  if [[ -n "${START_REF}" ]] && ! git checkout -f "${START_REF}" >/dev/null 2>&1; then
+    echo "WARNING: could not restore git checkout to '${START_REF}'" >&2
+  fi
+  exit "${ec}"
+}
+trap restore_start_ref EXIT
+
+git fetch origin gh-pages --depth=1 2>/dev/null || true
+
+# Cache master's stylesheet so every version gets the same look.
+# DOCS_EXTRA_CSS=/path/to/extra.css overrides this for local feature-branch
+# previews (so unmerged CSS is applied to every deployed version).
+mkdir -p /tmp/master-stylesheets
+if [[ -n "${DOCS_EXTRA_CSS:-}" ]]; then
+  [[ -f "${DOCS_EXTRA_CSS}" ]] || die "DOCS_EXTRA_CSS is set but not a file: ${DOCS_EXTRA_CSS}"
+  cp "${DOCS_EXTRA_CSS}" /tmp/master-stylesheets/extra.css
+elif git show origin/master:docs/stylesheets/extra.css > /tmp/master-stylesheets/extra.css 2>/dev/null; then
+  :
+elif git show master:docs/stylesheets/extra.css > /tmp/master-stylesheets/extra.css 2>/dev/null; then
+  :
+else
+  die "could not read docs/stylesheets/extra.css from origin/master (or master)"
+fi
+
+# Collect all release-* branches, sorted by version (ascending)
+mapfile -t ALL_RELEASES < <(
+  git branch -r --list 'origin/release-*' \
+    | sed 's|^[[:space:]]*origin/||' \
+    | sed '/^$/d' \
+    | sort -V
+)
+
+# Labels (recomputed every full deploy when a new release-* appears):
+#   highest release-*  → "<ver> (Latest)"  (+ mike alias "latest")
+#   second-highest     → "<ver> (Stable)"
+#   older releases     → "<ver> (Legacy)"
+#   master             → "Master (Dev)"
+LATEST_RELEASE=""
+STABLE_RELEASE=""
+if [[ ${#ALL_RELEASES[@]} -gt 0 ]]; then
+  LATEST_RELEASE="${ALL_RELEASES[-1]}"
+fi
+if [[ ${#ALL_RELEASES[@]} -gt 1 ]]; then
+  STABLE_RELEASE="${ALL_RELEASES[-2]}"
+fi
+
+deploy_master=false
+branches_to_deploy=()
+
+if [[ "${RELEASES}" == "all" ]]; then
+  branches_to_deploy=("${ALL_RELEASES[@]+"${ALL_RELEASES[@]}"}")
+  deploy_master=true
+else
+  IFS=',' read -r -a requested <<< "${RELEASES}"
+  for raw in "${requested[@]}"; do
+    branch="$(echo "${raw}" | xargs)"
+    [[ -n "${branch}" ]] || continue
+    if [[ "${branch}" == "master" ]]; then
+      deploy_master=true
+      continue
+    fi
+    if [[ ! "${branch}" =~ ^release- ]]; then
+      die "invalid RELEASES entry '${branch}': expected 'master', 'release-*', or 'all'"
+    fi
+    if ! git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+      die "branch 'origin/${branch}' does not exist.
+Available release branches: ${ALL_RELEASES[*]:-none}"
+    fi
+    branches_to_deploy+=("${branch}")
+  done
+  if [[ ${#branches_to_deploy[@]} -eq 0 && "${deploy_master}" != "true" ]]; then
+    die "no branches selected. Use --releases all or a comma-separated list."
+  fi
+fi
+
+# Optional --push flag for mike (empty when not pushing).
+MIKE_PUSH=()
+if [[ "${PUSH}" == "true" ]]; then
+  MIKE_PUSH=(--push)
+fi
+
+ensure_mike_provider() {
+  # Material only renders the version dropdown when extra.version.provider
+  # is set. Older release branches often have the mike plugin but no extra:.
+  python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path("mkdocs.yml")
+text = path.read_text()
+if re.search(r"provider:\s*mike", text):
+    sys.exit(0)
+
+version_under_extra = "  version:\n    provider: mike\n"
+full_extra = "extra:\n  version:\n    provider: mike\n"
+
+if re.search(r"^extra:\s*$", text, re.M):
+    text, n = re.subn(r"(^extra:\s*\n)", r"\1" + version_under_extra, text, count=1, flags=re.M)
+    if n != 1:
+        sys.exit("failed to inject version under existing extra:")
+elif re.search(r"^extra_css:", text, re.M):
+    text, n = re.subn(r"^extra_css:", full_extra + "extra_css:", text, count=1, flags=re.M)
+    if n != 1:
+        sys.exit("failed to inject extra: before extra_css:")
+else:
+    text = full_extra + text
+
+path.write_text(text)
+if not re.search(r"provider:\s*mike", path.read_text()):
+    sys.exit("failed to inject extra.version.provider: mike into mkdocs.yml")
+PY
+}
+
+deploy_release_branch() {
+  local branch="$1"
+  local version
+  version="$(echo "${branch}" | sed 's/release-//')"
+
+  echo "==> Deploying ${branch} as version ${version}"
+  git checkout -f "origin/${branch}"
+
+  # Each branch keeps its own mkdocs.yml (and nav), but gets master's
+  # stylesheet for a consistent visual appearance.
+  mkdir -p docs/stylesheets
+  cp /tmp/master-stylesheets/extra.css docs/stylesheets/extra.css
+
+  ensure_mike_provider
+
+  if [[ -n "${LATEST_RELEASE}" && "${branch}" == "${LATEST_RELEASE}" ]]; then
+    mike deploy ${MIKE_PUSH[@]+"${MIKE_PUSH[@]}"} --update-aliases \
+      --title "${version} (Latest)" "${version}" latest
+  elif [[ -n "${STABLE_RELEASE}" && "${branch}" == "${STABLE_RELEASE}" ]]; then
+    mike deploy ${MIKE_PUSH[@]+"${MIKE_PUSH[@]}"} \
+      --title "${version} (Stable)" "${version}"
+  else
+    mike deploy ${MIKE_PUSH[@]+"${MIKE_PUSH[@]}"} \
+      --title "${version} (Legacy)" "${version}"
+  fi
+}
+
+for branch in "${branches_to_deploy[@]+"${branches_to_deploy[@]}"}"; do
+  [[ -n "${branch}" ]] || continue
+  deploy_release_branch "${branch}"
+done
+
+if [[ "${deploy_master}" == "true" ]]; then
+  echo "==> Deploying master as Master (Dev)"
+  git checkout -f origin/master
+  # Same stylesheet as release versions (supports DOCS_EXTRA_CSS previews).
+  mkdir -p docs/stylesheets
+  cp /tmp/master-stylesheets/extra.css docs/stylesheets/extra.css
+  ensure_mike_provider
+  mike deploy ${MIKE_PUSH[@]+"${MIKE_PUSH[@]}"} --title "Master (Dev)" master
+
+  # Master is the default landing page (only when deploying master / all)
+  mike set-default ${MIKE_PUSH[@]+"${MIKE_PUSH[@]}"} master
+fi
+
+echo "Docs versioning deploy complete (releases=${RELEASES}, push=${PUSH})."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,12 @@ site_url: https://www.ovn.org/ovn-kubernetes/
 repo_url: https://github.com/ovn-kubernetes/ovn-kubernetes
 repo_name: ovn-kubernetes/ovn-kubernetes
 edit_uri: edit/master/docs
+extra:
+  version:
+    provider: mike
+    default:
+      - latest
+      - master
 extra_css:
   - stylesheets/extra.css
 site_dir: site

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mkdocs-macros-plugin
 mkdocs-material
 mkdocs-material-extensions
 mkdocs-mermaid2-plugin
-mike
+mike==2.1.4
 pep562
 Pygments
 pymdown-extensions


### PR DESCRIPTION
## Overview:

This PR moves OVN-Kubernetes docs from a single flat MkDocs publish to a multi-version site using [mike](https://github.com/jimporter/mike).

Users can switch versions from a dropdown, for example:

Legacy — older release-* docs (e.g. v1.0, v1.1)
Stable — highest release-* (also aliased as latest)
Development / default — master

Previously, each publish replaced one unversioned site, so older release docs were lost. Now each release-* branch and master keeps its own snapshot on gh-pages. New release branches are auto-discovered; no workflow edits are required when a release is cut.

### Changes:

1) mike + Material: mkdocs.yml sets extra.version.provider: mike and enables the mike plugin; Material uses versions.json for the dropdown.
2) Deploy logic: [hack/build-docs.sh](vscode-file://vscode-app/tmp/.mount_CursoraFjiPL/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/hack/build-docs.sh) discovers origin/release-* + master, labels Stable/Legacy, updates the latest alias, copies extra.css from master onto every version, and restores the caller’s git branch after deploy checkouts.
3) Makefile entrypoint: [docs/Makefile](vscode-file://vscode-app/tmp/.mount_CursoraFjiPL/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/Makefile) exposes make build-docs / PUSH=1 / RELEASES=….
4) CI: [.github/workflows/docs-versioning.yml](vscode-file://vscode-app/tmp/.mount_CursoraFjiPL/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/.github/workflows/docs-versioning.yml) runs make -C docs build-docs PUSH=1 on docs-related pushes to master / release-*, and supports workflow_dispatch with a releases input (all or a comma-separated branch list).
5) Conflict avoidance: [.github/workflows/docs.yml](vscode-file://vscode-app/tmp/.mount_CursoraFjiPL/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/.github/workflows/docs.yml) no longer deploys the live site; it only runs PR mkdocs build --strict + artifact upload.
6) Deps: pin mike==2.1.4 in requirements.txt.
7) Docs: team guidance lives in [docs/developer-guide/documentation.md](vscode-file://vscode-app/tmp/.mount_CursoraFjiPL/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/developer-guide/documentation.md) (no separate README_VERSIONING.md).
8) Safety (hard-fail, no interactive override): hack/build-docs.sh refuses to run on gh-pages, and refuses if docs/stylesheets/extra.css is dirty on a release-* branch. There are no git hooks and no (y/N) prompts.

### Before:
<img width="1916" height="277" alt="Screenshot From 2026-05-07 20-13-56" src="https://github.com/user-attachments/assets/009838db-a9b9-4271-a3fa-ec32df417324" />

### After:
<img width="1876" height="131" alt="Screenshot From 2026-07-12 16-54-00" src="https://github.com/user-attachments/assets/14c5f1bb-d69a-4598-a816-e34114e86a59" />

https://github.com/user-attachments/assets/b5f5a841-8c04-4587-8262-9a875f143b6a

## Docs Versioning: What Developers Need to Know

1) Do not push to or develop on gh-pages — docs-versioning.yml owns it. Manual changes are overwritten on the next run. Running make -C docs build-docs while checked out on gh-pages hard-fails.
2) Do not edit docs/stylesheets/extra.css on release-* branches — builds copy this file from master. Dirty local CSS on a release branch hard-fails the script. Make CSS changes on master only.
3) Nav is per-branch — a new page on master does not appear in older releases until backported with that branch’s mkdocs.yml nav.
4) New release-* branches are auto-detected — previous highest release becomes Legacy; the new one becomes Stable + latest.
5) Local preview
 a) Feature-branch UI: mike deploy / mike serve on your branch (not make build-docs).
b) CI-like publish: make -C docs build-docs then mike serve.
6) Manual rebuild: Actions → Publish Versioned Docs → releases = all or e.g. release-1.1,master.

Full details: docs/developer-guide/documentation.md.

<img width="990" height="144" alt="Screenshot From 2026-07-15 15-15-22" src="https://github.com/user-attachments/assets/d31ef1da-4997-4199-8b91-3b3ac7267ec7" />

<img width="990" height="144" alt="Screenshot From 2026-07-15 15-15-33" src="https://github.com/user-attachments/assets/0664c190-f688-476e-ae7e-0a15096ef088" />

## Impact on Daily Workflow:
None. The hooks only trigger in two very specific scenarios (pushing to gh-pages or editing extra.css on release branches). Normal feature development, PR pushes, commits, builds, and merges are completely unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation versioning so users can view and switch between master, release, and tagged docs.

* **Chores**
  * Added an automated workflow to publish and manage versioned documentation and keep the "latest" alias updated.
  * Enabled version-aware site configuration.

* **Style**
  * Added styling for a visible documentation version label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



