### PR TITLE
Add DAN support for Kata Containers with VFIO interfaces

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -99,6 +99,7 @@ fi
 # OVN_ENABLE_DNSNAMERESOLVER - enable dns name resolver support
 # OVN_ALLOW_ICMP_NETPOL - allow ICMP and ICMPv6 regardless of network policy
 # OVN_OBSERV_ENABLE - enable observability for ovnkube
+# OVNKUBE_ENABLE_KATA_DAN - when true, enable Kata DAN config generation support
 
 # The argument to the command is the operation to be performed
 # ovn-controller ovn-node display display_env ovn_debug
@@ -348,6 +349,11 @@ if [[ ! -z $ovn_k8s_node ]]; then
   echo "host-k8s-nodename is set, overriding K8S_NODE with $ovn_k8s_node"
   K8S_NODE=$ovn_k8s_node
 fi
+
+# OVNKUBE_ENABLE_KATA_DAN - enable Kata DAN config generation support
+ovnkube_enable_kata_dan=${OVNKUBE_ENABLE_KATA_DAN:-"false"}
+# Base directory of Kata Container's DAN(Directly Attachable Network) config
+kata_dan_conf_dir=/var/run/ovn-kubernetes/dans
 
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]]; then
@@ -2756,6 +2762,13 @@ ovn-node() {
     ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet=${ovn_v6_masquerade_subnet}"
   fi
 
+  kata_dan_conf_dir_flag=
+  if [[ ${ovnkube_enable_kata_dan} == "true" ]]; then
+    mkdir -p -m 0700 ${kata_dan_conf_dir}
+    kata_dan_conf_dir_flag="--kata-dan-conf-dir=${kata_dan_conf_dir}"
+  fi
+  echo "kata_dan_conf_dir_flag=${kata_dan_conf_dir_flag}"
+
   dynamic_udn_allocation_flag=
   if [[ ${ovn_enable_dynamic_udn_allocation} == "true" ]]; then
     dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation"
@@ -2816,6 +2829,7 @@ ovn-node() {
         ${dynamic_udn_allocation_flag} \
         ${dynamic_udn_grace_period} \
         ${network_qos_enabled_flag} \
+        ${kata_dan_conf_dir_flag} \
         --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
         --export-ovs-metrics \
         --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -4,8 +4,10 @@
 package cni
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -191,6 +193,13 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet, ovsCli
 
 	podInterfaceInfo.SkipIPConfig = kubevirt.IsPodLiveMigratable(pod)
 
+	if pr.IsVFIO && len(config.Default.KataDanConfDir) > 0 &&
+		pod.Spec.RuntimeClassName != nil && strings.HasPrefix(*pod.Spec.RuntimeClassName, KataRuntime) {
+		if err = pr.generateDanConfig(podInterfaceInfo, pr.CNIConf.DeviceID); err != nil {
+			return nil, fmt.Errorf("failed to generate DAN config for pod %s/%s: %v", pr.PodNamespace, pr.PodName, err)
+		}
+	}
+
 	response := &Response{KubeAuth: kubeAuth}
 	if !config.UnprivilegedMode {
 		netName := pr.netName
@@ -224,6 +233,18 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
 		return nil, fmt.Errorf("required CNI variable missing")
+	}
+	if pr.IsVFIO && len(config.Default.KataDanConfDir) > 0 {
+		danConfigPath := getDanConfigPath(config.Default.KataDanConfDir, pr.SandboxID)
+		if err := os.Remove(danConfigPath); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				klog.Warningf("Failed to remove DAN config %s for pod %s/%s on NAD %s with sandbox %s: %v",
+					danConfigPath, pr.PodNamespace, pr.PodName, pr.nadName, pr.SandboxID, err)
+			}
+		} else {
+			klog.V(5).Infof("Removed DAN config for pod %s/%s on NAD %s with sandbox %s (path %s).",
+				pr.PodNamespace, pr.PodName, pr.nadName, pr.SandboxID, danConfigPath)
+		}
 	}
 
 	pod, err := clientset.getPod(pr.PodNamespace, pr.PodName)

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -8,9 +8,12 @@ package cni
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -25,6 +28,8 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/knftables"
 
+	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -689,7 +694,93 @@ type defaultPodRequestInterfaceOps struct{}
 
 var podRequestInterfaceOps PodRequestInterfaceOps = &defaultPodRequestInterfaceOps{}
 
-// ConfigureInterface sets up the container interface
+func getDanConfigPath(danConfigDir, sandboxId string) string {
+	return filepath.Join(danConfigDir, sandboxId+".json")
+}
+
+func writeDanConfig(danConfigPath string, dan *ovncnitypes.DanConfig) error {
+
+	var curDanConfig *ovncnitypes.DanConfig
+	if _, err := os.Stat(danConfigPath); errors.Is(err, os.ErrNotExist) {
+		curDanConfig = dan
+	} else {
+		curDanConfig = &ovncnitypes.DanConfig{}
+		data, err := os.ReadFile(danConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to read Kata DAN config: %s", danConfigPath)
+		}
+		if err = json.Unmarshal(data, curDanConfig); err != nil {
+			return fmt.Errorf("failed to parse Kata DAN config: %s", danConfigPath)
+		}
+
+		curDanConfig.Devices = append(curDanConfig.Devices, dan.Devices...)
+	}
+
+	jsonData, err := json.MarshalIndent(curDanConfig, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(danConfigPath, jsonData, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write DAN config file %s, error: %v", danConfigPath, err)
+	}
+
+	return nil
+}
+
+func (pr *PodRequest) generateDanConfig(ifInfo *PodInterfaceInfo, pciDeviceID string) error {
+	klog.V(5).Infof("Generate DAN config for pod %s/%s on network %s NAD %s",
+		pr.PodNamespace, pr.PodName, pr.netName, pr.nadName)
+
+	var ipAddrs []string
+	var routes []ovncnitypes.Route
+
+	for _, a := range ifInfo.IPs {
+		ipAddrs = append(ipAddrs, a.String())
+	}
+
+	if len(ifInfo.Gateways) > 0 {
+		// add default gateway route
+		routes = append(routes,
+			ovncnitypes.Route{
+				Gateway: ifInfo.Gateways[0].String(),
+			})
+	}
+
+	for _, r := range ifInfo.Routes {
+		routes = append(routes,
+			ovncnitypes.Route{
+				Dest:    r.Dest.String(),
+				Gateway: r.NextHop.String(),
+			})
+	}
+
+	var dan ovncnitypes.DanConfig
+	dan.Netns = &pr.Netns
+
+	danDev := ovncnitypes.DanDevice{
+		Name:     pr.IfName,
+		GuestMac: ifInfo.MAC.String(),
+		Device: ovncnitypes.Device{
+			Type:        ovncnitypes.VfioDanDeviceType,
+			PciDeviceID: pciDeviceID,
+		},
+		NetworkInfo: ovncnitypes.NetworkInfo{
+			Interface: ovncnitypes.Interface{
+				IPAddresses: ipAddrs,
+				MTU:         uint64(ifInfo.MTU),
+			},
+			Routes: routes,
+		},
+	}
+
+	dan.Devices = append(dan.Devices, danDev)
+	danConfigPath := getDanConfigPath(config.Default.KataDanConfDir, pr.SandboxID)
+
+	return writeDanConfig(danConfigPath, &dan)
+}
+
 func (*defaultPodRequestInterfaceOps) ConfigureInterface(pr *PodRequest, getter PodInfoGetter, ifInfo *PodInterfaceInfo) ([]*current.Interface, error) {
 	netns, err := ns.GetNS(pr.Netns)
 	if err != nil {

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,6 +30,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	cni_type_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/containernetworking/cni/pkg/types"
 	cni_ns_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/containernetworking/plugins/pkg/ns"
@@ -1246,6 +1250,160 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 			}
 			tc.inpPodRequest.deletePodConntrack()
 			mockTypeResult.AssertExpectations(t)
+		})
+	}
+}
+
+func readFile(tb testing.TB, filename string) []byte {
+	tb.Helper()
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		tb.Fatalf("failed to read input yaml file: %v", err)
+	}
+	return data
+}
+
+func TestPodRequest_generateDanConfig(t *testing.T) {
+
+	tempDir := t.TempDir()
+	origDanConfDir := config.Default.KataDanConfDir
+	config.Default.KataDanConfDir = tempDir
+	t.Cleanup(func() {
+		config.Default.KataDanConfDir = origDanConfDir
+	})
+
+	ip1 := ovntest.MustParseIPNet("10.10.0.5/24")
+	gw1 := net.ParseIP("10.10.0.1").To4()
+	mac1, _ := net.ParseMAC("0a:58:0a:0a:00:05")
+	dest1 := ovntest.MustParseIPNet("10.10.0.0/16")
+	nextHop1 := gw1
+
+	ip2 := ovntest.MustParseIPNet("10.20.0.7/24")
+	gw2 := net.ParseIP("10.20.0.1").To4()
+	mac2, _ := net.ParseMAC("0a:58:0a:14:00:07")
+	dest2 := ovntest.MustParseIPNet("10.20.0.0/16")
+	nextHop2 := gw2
+
+	type Request struct {
+		podRequest *PodRequest
+		ifInfo     *PodInterfaceInfo
+	}
+
+	tests := []struct {
+		name     string
+		requests []Request
+	}{
+		{
+			name: "dan-one-network",
+			requests: []Request{
+				{
+					podRequest: &PodRequest{
+						PodNamespace: "ns",
+						PodName:      "foo",
+						PodUID:       "pod-1",
+						SandboxID:    "sandbox-1",
+						Netns:        "netns",
+						IfName:       "eth0",
+						IsVFIO:       true,
+						netName:      "default",
+						nadName:      "default",
+						CNIConf: &ovncnitypes.NetConf{
+							DeviceID: "0000:84:02.0",
+						},
+					},
+					ifInfo: &PodInterfaceInfo{
+						MTU: 1500,
+						PodAnnotation: util.PodAnnotation{
+							IPs:      []*net.IPNet{ip1},
+							MAC:      mac1,
+							Gateways: []net.IP{gw1},
+							Routes: []util.PodRoute{
+								{Dest: dest1, NextHop: nextHop1},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dan-two-network",
+			requests: []Request{
+				{
+					podRequest: &PodRequest{
+						PodNamespace: "ns",
+						PodName:      "foo",
+						PodUID:       "pod-2",
+						SandboxID:    "sandbox-2",
+						Netns:        "netns",
+						IfName:       "eth0",
+						IsVFIO:       true,
+						netName:      "default",
+						nadName:      "default",
+						CNIConf: &ovncnitypes.NetConf{
+							DeviceID: "0000:84:02.0",
+						},
+					},
+					ifInfo: &PodInterfaceInfo{
+						MTU: 1500,
+						PodAnnotation: util.PodAnnotation{
+
+							IPs:      []*net.IPNet{ip1},
+							MAC:      mac1,
+							Gateways: []net.IP{gw1},
+							Routes: []util.PodRoute{
+								{Dest: dest1, NextHop: nextHop1},
+							},
+						},
+					},
+				},
+				{
+					podRequest: &PodRequest{
+						PodNamespace: "ns",
+						PodName:      "foo",
+						PodUID:       "pod-2",
+						SandboxID:    "sandbox-2",
+						Netns:        "netns",
+						IfName:       "net1",
+						IsVFIO:       true,
+						netName:      "stream",
+						nadName:      "stream",
+						CNIConf: &ovncnitypes.NetConf{
+							DeviceID: "0000:84:02.1",
+						},
+					},
+					ifInfo: &PodInterfaceInfo{
+						MTU: 9000,
+						PodAnnotation: util.PodAnnotation{
+							IPs: []*net.IPNet{ip2},
+							MAC: mac2,
+							Routes: []util.PodRoute{
+								{Dest: dest2, NextHop: nextHop2},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			expected := readFile(t, fmt.Sprintf("testdata/%s.json", tc.name))
+			for _, r := range tc.requests {
+				err := r.podRequest.generateDanConfig(r.ifInfo, r.podRequest.CNIConf.DeviceID)
+				require.NoError(t, err)
+			}
+
+			danConfig := getDanConfigPath(config.Default.KataDanConfDir, tc.requests[0].podRequest.SandboxID)
+			actual := readFile(t, danConfig)
+
+			if diff := cmp.Diff(string(expected), string(actual),
+				cmpopts.AcyclicTransformer("multiline", func(s string) []string {
+					return strings.Split(s, "\n")
+				})); diff != "" {
+				t.Fatalf("Diff:\n%s", diff)
+			}
 		})
 	}
 }

--- a/go-controller/pkg/cni/testdata/dan-one-network.json
+++ b/go-controller/pkg/cni/testdata/dan-one-network.json
@@ -1,0 +1,30 @@
+{
+  "netns": "netns",
+  "devices": [
+    {
+      "name": "eth0",
+      "guest_mac": "0a:58:0a:0a:00:05",
+      "device": {
+        "type": "vfio",
+        "pci_device_id": "0000:84:02.0"
+      },
+      "network_info": {
+        "interface": {
+          "ip_addresses": [
+            "10.10.0.5/24"
+          ],
+          "mtu": 1500
+        },
+        "routes": [
+          {
+            "gateway": "10.10.0.1"
+          },
+          {
+            "dest": "10.10.0.0/16",
+            "gateway": "10.10.0.1"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/go-controller/pkg/cni/testdata/dan-two-network.json
+++ b/go-controller/pkg/cni/testdata/dan-two-network.json
@@ -1,0 +1,52 @@
+{
+  "netns": "netns",
+  "devices": [
+    {
+      "name": "eth0",
+      "guest_mac": "0a:58:0a:0a:00:05",
+      "device": {
+        "type": "vfio",
+        "pci_device_id": "0000:84:02.0"
+      },
+      "network_info": {
+        "interface": {
+          "ip_addresses": [
+            "10.10.0.5/24"
+          ],
+          "mtu": 1500
+        },
+        "routes": [
+          {
+            "gateway": "10.10.0.1"
+          },
+          {
+            "dest": "10.10.0.0/16",
+            "gateway": "10.10.0.1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "net1",
+      "guest_mac": "0a:58:0a:14:00:07",
+      "device": {
+        "type": "vfio",
+        "pci_device_id": "0000:84:02.1"
+      },
+      "network_info": {
+        "interface": {
+          "ip_addresses": [
+            "10.20.0.7/24"
+          ],
+          "mtu": 9000
+        },
+        "routes": [
+          {
+            "dest": "10.20.0.0/16",
+            "gateway": "10.20.0.1"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -31,6 +31,8 @@ const ServerRunDir string = "/var/run/ovn-kubernetes/cni/"
 const serverSocketName string = "ovn-cni-server.sock"
 const serverSocketPath string = ServerRunDir + "/" + serverSocketName
 
+const KataRuntime string = "kata"
+
 // KubeAPIAuth contains information necessary to create a Kube API client
 type KubeAPIAuth struct {
 	// Kubeconfig is the path to a kubeconfig

--- a/go-controller/pkg/cni/types/dan.go
+++ b/go-controller/pkg/cni/types/dan.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// A replicated definition of Kata Container's `DanConfig`:
+// https://github.com/kata-containers/kata-containers/blob/main/src/runtime-rs/crates/resource/src/network/dan.rs
+// For long term, Kata Container will switch to kata-runtime-rs, and the Golang kata-runtime will be deprecated,
+// it should provide a API repo to hold the DAN definition, so CNI projects can import it as go mod.
+type DanConfig struct {
+	Netns   *string     `json:"netns"`
+	Devices []DanDevice `json:"devices"`
+}
+
+type DanDevice struct {
+	Name        string      `json:"name"`
+	GuestMac    string      `json:"guest_mac"`
+	Device      Device      `json:"device"`
+	NetworkInfo NetworkInfo `json:"network_info"`
+}
+
+// DanDeviceType identifies the type of the network interface.
+type DanDeviceType string
+
+const (
+	VfioDanDeviceType      DanDeviceType = "vfio"
+	VhostUserDanDeviceType DanDeviceType = "vhost-user"
+	HostTapDanDeviceType   DanDeviceType = "host-tap"
+)
+
+type Device struct {
+	Type        DanDeviceType `json:"type"`
+	Path        string        `json:"path,omitempty"`
+	PciDeviceID string        `json:"pci_device_id,omitempty"`
+	TapName     string        `json:"tap_name,omitempty"`
+	QueueNum    int           `json:"queue_num,omitempty"`
+	QueueSize   int           `json:"queue_size,omitempty"`
+}
+
+type NetworkInfo struct {
+	Interface Interface     `json:"interface"`
+	Routes    []Route       `json:"routes,omitempty"`
+	Neighbors []ARPNeighbor `json:"neighbors,omitempty"`
+}
+
+type Interface struct {
+	IPAddresses []string `json:"ip_addresses"`
+	MTU         uint64   `json:"mtu"`
+	NType       string   `json:"ntype,omitempty"`
+	Flags       uint32   `json:"flags,omitempty"`
+}
+
+type Route struct {
+	Dest    string `json:"dest,omitempty"`
+	Gateway string `json:"gateway,omitempty"`
+	Source  string `json:"source,omitempty"`
+	Scope   uint32 `json:"scope,omitempty"`
+}
+
+type ARPNeighbor struct {
+	IPAddress    *string `json:"ip_address"`
+	HardwareAddr string  `json:"hardware_addr"`
+	State        uint32  `json:"state,omitempty"`
+	Flags        uint32  `json:"flags,omitempty"`
+}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -106,6 +106,7 @@ var (
 		Zone:                         types.OvnDefaultZone,
 		RawUDNAllowedDefaultServices: "default/kubernetes,kube-system/kube-dns",
 		Transport:                    "",
+		KataDanConfDir:               "", // disable by default
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -367,6 +368,9 @@ type DefaultConfig struct {
 	// Accepts: "" (empty, uses OVN default overlay) or "no-overlay".
 	// Defaults to "" (empty).
 	Transport string `gcfg:"transport"`
+
+	// Base directory of DAN(Directly Attachable Network) config for Kata Container.
+	KataDanConfDir string `gcfg:"kata-dan-conf-dir"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -1119,6 +1123,12 @@ var CommonFlags = []cli.Flag{
 			"Only used when enable-network-segmentation is set",
 		Value:       Default.RawUDNAllowedDefaultServices,
 		Destination: &cliConfig.Default.RawUDNAllowedDefaultServices,
+	},
+	&cli.StringFlag{
+		Name:        "kata-dan-conf-dir",
+		Usage:       "Base directory of DAN(Directly Attachable Network) config for Kata Container",
+		Destination: &cliConfig.Default.KataDanConfDir,
+		Value:       Default.KataDanConfDir,
 	},
 }
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1994,6 +1994,7 @@ func TestGetNodeManagementIP(t *testing.T) {
 			result := netInfo.GetNodeManagementIP(hostSubnet)
 			if result == nil {
 				t.Fatalf("GetNodeManagementIP returned nil")
+				return
 			}
 
 			if !result.IP.Equal(tc.expectedIP.IP) {
@@ -2403,6 +2404,7 @@ func TestGetNodeGatewayIP(t *testing.T) {
 			result := netInfo.GetNodeGatewayIP(hostSubnet)
 			if result == nil {
 				t.Fatalf("GetNodeGatewayIP returned nil")
+				return
 			}
 
 			if !result.IP.Equal(tc.expectedIP.IP) {

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -81,6 +81,11 @@ spec:
           # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
+        {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+        # mount kata container DAN config dir
+        - mountPath: /var/run/ovn-kubernetes/dans
+          name: host-kata-dan-config-dir
+        {{- end }}
         # CNI related mounts which we take over
         - mountPath: /opt/cni/bin
           name: host-opt-cni-bin
@@ -245,6 +250,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+        - name: OVNKUBE_ENABLE_KATA_DAN
+          value: "true"
+        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -273,6 +282,12 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
+      {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+      - name: host-kata-dan-config-dir
+        hostPath:
+          path: {{ .Values.global.kata.danConfigDir | default "/run/kata-containers/dans" }}
+          type: DirectoryOrCreate
+      {{- end }}
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -81,6 +81,11 @@ spec:
           # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
+        {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+        # mount kata container DAN config dir
+        - mountPath: /var/run/ovn-kubernetes/dans
+          name: host-kata-dan-config-dir
+        {{- end }}
         # CNI related mounts which we take over
         - mountPath: /opt/cni/bin
           name: host-opt-cni-bin
@@ -262,6 +267,10 @@ spec:
           value: {{ default "" .Values.nodeMgmtPortNetdev | quote }}
         - name: OVN_NETWORK_QOS_ENABLE
           value: {{ hasKey .Values.global "enableNetworkQos" | ternary .Values.global.enableNetworkQos false | quote }}
+        {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+        - name: OVNKUBE_ENABLE_KATA_DAN
+          value: "true"
+        {{- end }}
         - name: OVN_HOST_NETWORK_NAMESPACE
           valueFrom:
             configMapKeyRef:
@@ -392,6 +401,12 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
+      {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+      - name: host-kata-dan-config-dir
+        hostPath:
+          path: {{ .Values.global.kata.danConfigDir | default "/run/kata-containers/dans" }}
+          type: DirectoryOrCreate
+      {{- end }}
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -285,6 +285,11 @@ spec:
           # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
+        {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+        # mount kata container DAN config dir
+        - mountPath: /var/run/ovn-kubernetes/dans
+          name: host-kata-dan-config-dir
+        {{- end }}
         # CNI related mounts which we take over
         - mountPath: /opt/cni/bin
           name: host-opt-cni-bin
@@ -510,6 +515,10 @@ spec:
           value: {{ hasKey .Values.global "enableObservability" | ternary .Values.global.enableObservability false | quote }}
         - name: OVN_NETWORK_QOS_ENABLE
           value: {{ hasKey .Values.global "enableNetworkQos" | ternary .Values.global.enableNetworkQos false | quote }}
+        {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+        - name: OVNKUBE_ENABLE_KATA_DAN
+          value: "true"
+        {{- end }}
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
@@ -640,6 +649,12 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
+      {{- if and .Values.global.kata (eq .Values.global.kata.enableDAN true) }}
+      - name: host-kata-dan-config-dir
+        hostPath:
+          path: {{ .Values.global.kata.danConfigDir | default "/run/kata-containers/dans" }}
+          type: DirectoryOrCreate
+      {{- end }}
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -61,6 +61,11 @@ global:
   enableEgressQos: false
   # -- Enables network QoS support from/to pods
   enableNetworkQos: false
+  kata:
+    # -- enable Kata Containers DAN (Directly Attachable Network) integration; when true, mount DAN config dir into ovnkube-node and set OVNKUBE_ENABLE_KATA_DAN
+    enableDAN: false
+    # -- host path for Kata DAN config directory; mounted into the container at /var/run/ovn-kubernetes/dans
+    danConfigDir: /run/kata-containers/dans
   # -- Enables multicast support between the pods within the same namespace
   enableMulticast: ""
   # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -67,6 +67,11 @@ global:
   enableEgressQos: true
   # -- Enables network QoS support from/to pods
   enableNetworkQos: false
+  kata:
+    # -- enable Kata Containers DAN (Directly Attachable Network) integration; when true, mount DAN config dir into ovnkube-node and set OVNKUBE_ENABLE_KATA_DAN
+    enableDAN: false
+    # -- host path for Kata DAN config directory; mounted into the container at /var/run/ovn-kubernetes/dans
+    danConfigDir: /run/kata-containers/dans
   # -- Enables multicast support between the pods within the same namespace
   enableMulticast: ""
   # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes


### PR DESCRIPTION
## 📑 Description

This change adds DAN support in ovn-k8s CNI. When a Pod's network interface is a VFIO, ovn-k8s generates a DAN config file for the sandbox, which will be used by Kata runtime to configure the interface in guest VM.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
A unit test is added to verify that DAN config can be generated as expected.

For e2e verification:
1.  deploy Kata Container and enable hot_plug_vfio in kata config file
2. define SR-IOV VFIO resources on node
3. set OVNKUBE_ENABLE_KATA_DAN to true 
4. create a Pod with kata runtime and a VFIO device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Kata Containers DAN for VFIO-enabled pods.
  * New Kata DAN configuration option and Helm knobs to enable/mount the DAN config directory.

* **Bug Fixes**
  * Cleaner DAN config file removal during pod teardown, suppressing benign “not exists” errors.

* **Tests**
  * Unit tests added for DAN config generation covering single- and multi-network scenarios.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6434


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6407)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->