### PR TITLE
helm(ovnkube-identity): pass OVN_ENABLE_INTERCONNECT to the wrapper

### DIFF
--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -70,6 +70,8 @@ spec:
                 name: ovn-config
           - name: OVNKUBE_LOGLEVEL
             value: {{ default 4 .Values.logLevel | quote }}
+          - name: OVN_ENABLE_INTERCONNECT
+            value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
           - name: OVN_HYBRID_OVERLAY_ENABLE
             value: {{ default "" .Values.global.enableHybridOverlay | quote }}
       volumes:


### PR DESCRIPTION
## Summary

The `ovnkube-identity` sub-chart was the only daemonset chart not plumbing `global.enableInterconnect` through to its container env. Without this env var, the wrapper script in the v1.3.0 image (`dist/images/ovnkube.sh`, `ovnkube-identity()` function) never appends `--enable-interconnect` to the binary, and the resulting Pod skips registering the `/pod` admission webhook.

The bug is observable when deploying the chart against the **v1.3.0** image (which the chart's `appVersion: \"1.3.0\"` targets). In `cmd/ovnkube-identity` on `release-1.3`, the `/pod` handler is gated on:

\`\`\`go
if cliCfg.enableInterconnect || len(cliCfg.csrAcceptanceConditions) > 1 {
    webhookMux.Handle(\"/pod\", podHandler)
}
\`\`\`

So without `--enable-interconnect`, kubelet pod-status patches return 404 on the webhook, and with `failurePolicy: Fail` every Pod update fails cluster-wide.

The `release-1.3` chart already passes this env var ([here](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/release-1.3/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml#L73-L74)) — this PR just forward-ports that line to master so charts published from master work with the v1.3.0 image they advertise.

## Test plan
- [ ] `helm template` with `global.enableInterconnect: true` renders `OVN_ENABLE_INTERCONNECT: \"true\"` in the identity DaemonSet
- [ ] `helm template` without `global.enableInterconnect` defaults to `\"false\"`
- [ ] `kubectl get pod -n ovn-kubernetes -l app=ovnkube-identity -o jsonpath='{...args}'` shows `--enable-interconnect` flag
- [ ] kubelet pod status patches succeed (no more 404 from the identity webhook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure interconnect functionality in OVN-Kubernetes deployments via a new Helm configuration option, which defaults to disabled for backwards compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->