### PR TITLE
helm,ovnkube.sh: drive per-node OVN_ENCAP_IP from a host interface

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -279,6 +279,29 @@ ovnkube_node_mgmt_port_netdev=${OVNKUBE_NODE_MGMT_PORT_NETDEV:-}
 ovnkube_node_mgmt_port_dp_resource_name=${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME:-}
 ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE:-false}
 ovnkube_metrics_scale_enable=${OVNKUBE_METRICS_SCALE_ENABLE:-false}
+# OVN_ENCAP_INTERFACE - if set and OVN_ENCAP_IP is empty, derive OVN_ENCAP_IP
+# from this host interface (global-scope IPv4 + IPv6, comma-joined for
+# dual-stack). Lets the chart drive a per-node encap IP from values without
+# having to annotate every Node out-of-band.
+ovn_encap_interface=${OVN_ENCAP_INTERFACE:-}
+if [[ -n "${ovn_encap_interface}" && -z "${OVN_ENCAP_IP:-}" ]]; then
+    encap_v4=$(ip -4 -o addr show "${ovn_encap_interface}" scope global 2>/dev/null \
+               | awk '{split($4,a,"/"); print a[1]; exit}')
+    encap_v6=$(ip -6 -o addr show "${ovn_encap_interface}" scope global 2>/dev/null \
+               | awk '{split($4,a,"/"); print a[1]; exit}')
+    if [[ -n "${encap_v4}" && -n "${encap_v6}" ]]; then
+        OVN_ENCAP_IP="${encap_v4},${encap_v6}"
+    elif [[ -n "${encap_v4}" ]]; then
+        OVN_ENCAP_IP="${encap_v4}"
+    elif [[ -n "${encap_v6}" ]]; then
+        OVN_ENCAP_IP="${encap_v6}"
+    fi
+    if [[ -n "${OVN_ENCAP_IP}" ]]; then
+        echo "Derived OVN_ENCAP_IP=${OVN_ENCAP_IP} from interface ${ovn_encap_interface}"
+    else
+        echo "WARN: interface ${ovn_encap_interface} has no global-scope IP; OVN_ENCAP_IP left unset"
+    fi
+fi
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node
 ovn_encap_ip=${OVN_ENCAP_IP:-}
 # OVN_KUBERNETES_CONNTRACK_ZONE - conntrack zone number used for openflow rules (default 64000)

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -190,6 +190,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_ENCAP_INTERFACE
+          value: {{ default "" .Values.global.encapInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -192,6 +192,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_ENCAP_INTERFACE
+          value: {{ default "" .Values.global.encapInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -192,6 +192,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_ENCAP_INTERFACE
+          value: {{ default "" .Values.global.encapInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -347,6 +347,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_ENCAP_INTERFACE
+          value: {{ default "" .Values.global.encapInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -409,6 +409,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_ENCAP_INTERFACE
+          value: {{ default "" .Values.global.encapInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -19,6 +19,11 @@ global:
   extGatewayNetworkInterface: ""
   # -- GENEVE UDP port (default 6081)
   encapPort: 6081
+  # -- Host interface from which to derive OVN_ENCAP_IP per node (e.g. "ovn-int").
+  # If set, the global-scope v4 (and v6, dual-joined with a comma) of this
+  # interface is used as --encap-ip for ovnkube-node. Leave empty to keep the
+  # ovnkube-node auto-detection (uses the node's primary IP).
+  encapInterface: ""
   # -- The gateway mode (shared or local), if not given, gateway functionality is disabled
   gatewayMode: shared
   # -- Optional extra gateway options

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -25,6 +25,11 @@ global:
   extGatewayNetworkInterface: ""
   # -- GENEVE UDP port (default 6081)
   encapPort: 6081
+  # -- Host interface from which to derive OVN_ENCAP_IP per node (e.g. "ovn-int").
+  # If set, the global-scope v4 (and v6, dual-joined with a comma) of this
+  # interface is used as --encap-ip for ovnkube-node. Leave empty to keep the
+  # ovnkube-node auto-detection (uses the node's primary IP).
+  encapInterface: ""
   # -- The gateway mode (shared or local), if not given, gateway functionality is disabled
   gatewayMode: shared
   # -- Optional extra gateway options


### PR DESCRIPTION
## Summary

Today the chart only exposes the OVN encap IP as a literal env var, and `dist/images/ovnkube.sh` only accepts a pre-resolved IP. For deployments that want GENEVE tunnels on a dedicated physical interface (separate from the K8s control-plane VLAN), there is no single helm value that works — every Node would need an out-of-band `OVN_ENCAP_IP` set to its own IP on that interface.

Add a values-driven, per-Node interface-to-IP lookup so a single `global.encapInterface` setting works cluster-wide.

## Changes

- **`dist/images/ovnkube.sh`** — when `OVN_ENCAP_INTERFACE` is set and `OVN_ENCAP_IP` is empty, derive `OVN_ENCAP_IP` from the host interface using \`ip -o addr show <iface> scope global\` (IPv4 + IPv6, comma-joined for dual-stack). When unset or the interface has no global-scope address, falls back to existing behaviour (ovs-vsctl external_ids → ovnkube-node auto-detect).
- **helm templates** — thread `global.encapInterface` through `OVN_ENCAP_INTERFACE` on every daemonset that runs ovnkube-node: ovnkube-node, the two DPU variants (ovnkube-node-dpu, ovnkube-node-dpu-host), ovnkube-single-node-zone and its DPU variant.
- **`helm/values-single-node-zone{,-dpu}.yaml`** — document the new value with empty default (no behaviour change for existing deployments).

## Motivating example

A production cluster where:

- `k8s-ctl` VLAN: K8s API, etcd, SSH (`10.32.0.0/20`)
- `ovn-int` VLAN: intended for OVN GENEVE tunnels (`10.160.0.0/20`)

Without this change, ovnkube-node's auto-detection picks the node's primary IP (on `k8s-ctl`), so every cross-node pod packet rides the control-plane network. With `global.encapInterface: ovn-int`, each Node's `ovs-vsctl external_ids:ovn-encap-ip` ends up as that Node's `10.160.0.0/20` address — single helm value, no per-Node annotation.

## Test plan

- [ ] `helm template` with `global.encapInterface` unset → `OVN_ENCAP_INTERFACE` renders as empty quoted string, downstream behaviour unchanged
- [ ] `helm template` with `global.encapInterface=ovn-int` → `OVN_ENCAP_INTERFACE: \"ovn-int\"` shows up in all 5 affected daemonsets
- [ ] In a Node with a v4-only `ovn-int` interface, `kubectl exec ds/ovnkube-node -- ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip` returns the v4 address of that interface
- [ ] Dual-stack `ovn-int` interface produces `\"v4,v6\"` joined
- [ ] Interface that does not exist on the Node prints a `WARN: ... no global-scope IP` and falls through to current behaviour (no startup failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `encapInterface` configuration option to specify which network interface is used for OVN encapsulation. When configured, the specified interface's IP address is used; when left empty, the system auto-detects using the node's primary IP.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->