### PR TITLE
node/util: translate OVS port to bridge in GetNetworkInterfaceIPAddresses

### DIFF
--- a/go-controller/pkg/node/util/util.go
+++ b/go-controller/pkg/node/util/util.go
@@ -15,7 +15,41 @@ import (
 )
 
 // GetNetworkInterfaceIPAddresses returns the IP addresses for the network interface 'iface'.
+//
+// In shared / local gateway mode OVS takes over the user-configured gateway
+// interface and the host IP migrates from the slave port to the bridge's
+// internal port. Every caller of this function wants "the IPs the host has
+// on this gateway path", which after takeover live on the bridge, not on
+// the slave port. Translate iface to the bridge name before looking up IPs:
+//
+//   1. `port-to-br <iface>`        — covers the normal "OVS has the port
+//                                     attached right now" state.
+//   2. `GetBridgeName(iface)` plus  — covers a transient state where OVN-K
+//      `br-exists` check             cleanup has detached the port but the
+//                                     bridge survived with the host IP
+//                                     still on its internal port. Without
+//                                     this fallback, init paths like
+//                                     gateway_init.go:424 crash because
+//                                     `port-to-br` no longer finds the
+//                                     port and the slave port has no IP.
+//   3. neither found               — keep iface as-is (covers the initial
+//                                     boot state before OVS takes over,
+//                                     and legitimate non-OVS callers like
+//                                     the DPU-host kubernetes node
+//                                     interface).
+//
+// Doing the translation here covers all 6 callers of this function
+// (gateway_init.go, gateway_shared_intf.go, bridgeconfig.go) at once,
+// mirroring the existing translation in initGatewayPreStart
+// (gateway_init.go:84-90).
 func GetNetworkInterfaceIPAddresses(iface string) ([]*net.IPNet, error) {
+	if bridgeName, _, err := pkgutil.RunOVSVsctl("port-to-br", iface); err == nil && bridgeName != "" {
+		iface = bridgeName
+	} else if bridgeName := pkgutil.GetBridgeName(iface); bridgeName != "" {
+		if _, _, err := pkgutil.RunOVSVsctl("br-exists", bridgeName); err == nil {
+			iface = bridgeName
+		}
+	}
 	allIPs, err := pkgutil.GetFilteredInterfaceV4V6IPs(iface)
 	if err != nil {
 		return nil, fmt.Errorf("could not find IP addresses: %v", err)


### PR DESCRIPTION
## Summary

(Replaces closed #6455 and #6456 — earlier iterations of this fix were incomplete.)

`GetNetworkInterfaceIPAddresses(iface)` has **six callers** across `gateway_init.go`, `gateway_shared_intf.go`, and `bridgeconfig/bridgeconfig.go`. All six pass an interface name ultimately rooted in `config.Gateway.Interface` (e.g. `ovn-ext`). In shared / local gateway mode OVS takes over that interface and the host IPv4 / IPv6 migrate from the slave port to the bridge's internal port (e.g. `brovn-ext` in local mode, `br-ex` in shared mode), so the slave port has no addresses. Every one of these callers then fails with:

```
failed to find IPv4 address on interface ovn-ext
```

## Impact

The most visible site is `gateway_init.go:424`, which runs during `DefaultNodeNetworkController` initialization when `config.Gateway.Interface != kubeIntf` (typical multi-VLAN setup where the K8s API VLAN and the OVN gateway VLAN are different). On every ovnkube-node pod restart in such a deployment the controller fails to start and crash-loops:

```
failed to init default node network controller: ... failed to find IPv4 address on interface ovn-ext
```

The other five sites (`gateway_init.go:226`, `gateway_init.go:407`, `gateway_shared_intf.go:2219`, `bridgeconfig.go:222`, `bridgeconfig.go:272`) hit the same mismatch in less catastrophic ways: log spam, masquerade reconciler dead-lock, masquerade resource non-recovery.

## Fix

Translate `iface` to the bridge name once at the util level so all six callers benefit. Three OVS port states are observed in production:

| state | `port-to-br <iface>` | host IPv4 on | fix path |
|---|---|---|---|
| 1. initial boot       | fails (not a port)    | physical iface     | iface unchanged |
| 2. OVS takeover       | returns bridge name   | bridge             | iface = bridge (path 1) |
| 3. OVS cleanup window | fails (port detached) | bridge (preserved) | iface = `GetBridgeName(iface)` (path 2) |

```go
if bridgeName, _, err := pkgutil.RunOVSVsctl(\"port-to-br\", iface); err == nil && bridgeName != \"\" {
    iface = bridgeName
} else if bridgeName := pkgutil.GetBridgeName(iface); bridgeName != \"\" {
    if _, _, err := pkgutil.RunOVSVsctl(\"br-exists\", bridgeName); err == nil {
        iface = bridgeName
    }
}
```

Path 2 uses `pkgutil.GetBridgeName(iface)` (= \`\"br\" + iface\`, `pkg/util/nicstobridge.go:25`) — the deterministic name OVN-K itself uses when creating the bridge — and verifies with `br-exists` so we only redirect when an OVS bridge by that name actually exists. When neither path matches (state 1 or a plain non-OVS netdev like the DPU-host kubernetes interface), the original `iface` is preserved — historical behaviour intact.

This mirrors the existing port-to-bridge translation in `initGatewayPreStart` (`gateway_init.go:84-90`) and centralises it inside the util, eliminating per-caller patching.

## Test plan

- [ ] Multi-VLAN cluster, `config.Gateway.Interface=<phys-iface>` ≠ `kubeIntf`, local gateway mode: ovnkube-node pod restarts cleanly (no \`DefaultNodeNetworkController\` init failure)
- [ ] Same node after an OVS cleanup window where the port has been detached but the bridge still holds the host IP: pod restart still succeeds (state 3)
- [ ] Shared gateway mode with `br-ex` naming behaves the same
- [ ] DPU-host mode where `kubeIntf` is a plain Linux netdev (not an OVS port): `port-to-br` and `br-exists` both miss, original iface preserved, no regression
- [ ] Unit test: pass a fake netdev that is not an OVS port → translation no-ops → existing behaviour

Production-validated on a 3-rack local-gateway cluster running `--gateway-interface=ovn-ext` with bridge `brovn-ext`, covering all three port states above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network interface IP address discovery in shared/local gateway scenarios to properly handle bridge name translation and transient cleanup states where port-to-bridge mappings may be temporarily unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->