### PR TITLE
ovnkube: treat pidfile-contains-own-pid as stale in setupPIDFile

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -173,7 +173,22 @@ func setupPIDFile(pidfile string) error {
 		if err != nil {
 			return fmt.Errorf("pidfile %s exists but can't be read: %v", pidfile, err)
 		}
-		_, err1 := os.Stat("/proc/" + string(pid[:]) + "/cmdline")
+		pidStr := strings.TrimSpace(string(pid))
+		// In containerized deployments ovnkube usually runs at a low,
+		// deterministic PID (1 or 8 etc.) because of the pod's PID
+		// namespace. If the pidfile lives on a hostPath that persists
+		// across pod restarts, a fresh container reads back its OWN
+		// future PID and the /proc/<pid>/cmdline check below would
+		// always succeed (the pid is self), falsely concluding another
+		// ovnkube is running. Treat self-PID-in-pidfile as a stale
+		// leftover, same as the dead-process branch below.
+		if pidStr == fmt.Sprintf("%d", os.Getpid()) {
+			if err := os.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+				klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
+			}
+			return nil
+		}
+		_, err1 := os.Stat("/proc/" + pidStr + "/cmdline")
 		if os.IsNotExist(err1) {
 			// Left over pid from dead process
 			if err := os.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {


### PR DESCRIPTION
## 📑 Description

In containerized deployments ovnkube usually runs at a low, deterministic PID (1 or 8 etc.) because of the pod's PID namespace. The default pidfile path `/var/run/ovn-kubernetes/ovnkube.pid` lives on a hostPath volume that persists across pod restarts, so a fresh container reads back its **own future PID** from the pidfile — and the existing `/proc/<pid>/cmdline` lookup in `setupPIDFile()` always succeeds because the pid is self.

### Symptom

Every cold start goes through exactly one extra fatal exit:

```
$ kubectl -n ovn-kubernetes get pod -l app=ovnkube-control-plane
NAME                                  READY  STATUS    RESTARTS  AGE
ovnkube-control-plane-7c4d96bcfd-xyz  3/3    Running   1         5m
```

- First container start: pidfile exists from previous incarnation → reads `8` → `os.Stat("/proc/8/cmdline")` succeeds (PID 8 is self) → `fmt.Errorf("pidfile %s exists and ovnkube is running")` → fatal exit
- Deferred `delPidfile()` removes the file
- K8s restarts the container
- Second container start: pidfile no longer exists → normal path → succeeds → stays up

The container ends up healthy, but `RESTARTS=1` persists for the lifetime of the pod. Most-reported under ovnkube-cluster-manager (where the issue was first surfaced) but **any role with a persistent pidfile mount can hit it** — node mode in some helm value combinations exposes the same path. Monitoring rules of the form `RESTARTS > 0` fire indefinitely, and helm rollouts look noisier than they are.

### Root cause

`setupPIDFile()` (cmd/ovnkube/ovnkube.go:161) was originally designed for a host-system service where the pidfile and `/proc` PIDs live in the same namespace and only point to "self" after a successful own-write. In a container PID namespace, ovnkube's PID is determined by the pod's init pid graph (usually a low number), and any persistent pidfile on hostPath ends up storing exactly that same PID across restarts.

### Fix

Add a self-PID check before the `/proc/<pid>/cmdline` lookup: if the pidfile already contains `os.Getpid()` it is by definition stale (we are the only ovnkube in this pod, and we have not written the file yet in this incarnation) and should be overwritten, same as the dead-process branch below.

```go
pidStr := strings.TrimSpace(string(pid))
if pidStr == fmt.Sprintf("%d", os.Getpid()) {
    // stale leftover from prior container in same pod PID namespace
    overwrite pidfile, return nil
}
// existing /proc check ...
```

Also `TrimSpace()` the file contents before either check, in case a future writer ever appends a trailing newline (the in-tree writer uses `fmt.Sprintf("%d")` which has none, but defense in depth).

Note: the current fix silently overwrites the stale pidfile. I'm happy to add a `klog.Warningf` on this branch if reviewers prefer it for observability.

## ✅ Checks

- [ ] My code requires changes to the documentation — no
- [ ] My code requires tests — no (the bug only manifests inside a container PID namespace + persistent hostPath, hard to capture in a unit test without a heavy harness)
- [x] All the tests have passed in the CI

## How to verify it

Production-validated on a 3-node cluster running ovnkube-control-plane on hostPath-mounted pidfile:

- Before: `kubectl -n ovn-kubernetes get pod -l app=ovnkube-control-plane` showed `RESTARTS=1` permanently after every helm rollout (and on every cold start of the pod).
- After: `RESTARTS=0` stays 0 across helm upgrades and pod restarts. The self-PID branch fires silently on the first start, the second-start /proc check is no longer hit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process identification reliability in containerized environments by fixing whitespace handling issues and refining stale process detection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->