### PR TITLE
node: support --gateway-nexthop={self,default} keywords

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1599,7 +1599,12 @@ var OVNGatewayFlags = []cli.Flag{
 			"OVN gateway.  This is many times just the default gateway " +
 			"of the node in question. If not specified, the default gateway" +
 			"configured in the node is used. Only useful with " +
-			"\"init-gateways\"",
+			"\"init-gateways\". Special keyword values: \"self\" — derive the " +
+			"next-hop per-node from the first `via` route on --gateway-interface " +
+			"(or its OVS bridge), accepting any prefix not just the default route; " +
+			"\"default\" — use the system default route's gateway IP regardless of " +
+			"which interface carries it. Keywords are case-insensitive and resolve " +
+			"separately for IPv4 and IPv6 in dual-stack mode.",
 		Destination: &cliConfig.Gateway.NextHop,
 	},
 	&cli.UintFlag{

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -43,49 +43,114 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 		needIPv6NextHop = true
 	}
 
-	if config.Gateway.NextHop != "" {
-		nextHopsRaw := strings.Split(config.Gateway.NextHop, ",")
-		if len(nextHopsRaw) > 2 {
-			return nil, "", fmt.Errorf("unexpected next-hops are provided, more than 2 next-hops is not allowed: %s", config.Gateway.NextHop)
-		}
-		for _, nh := range nextHopsRaw {
-			// Parse NextHop to make sure it is valid before using. Return error if not valid.
-			nextHop := net.ParseIP(nh)
-			if nextHop == nil {
-				return nil, "", fmt.Errorf("failed to parse configured next-hop: %s", config.Gateway.NextHop)
-			}
-			if config.IPv4Mode {
-				if needIPv4NextHop {
-					if !utilnet.IsIPv6(nextHop) {
-						gatewayNextHops = append(gatewayNextHops, nextHop)
-						needIPv4NextHop = false
-					}
-				} else {
-					if !utilnet.IsIPv6(nextHop) {
-						return nil, "", fmt.Errorf("only one IPv4 next-hop is allowed: %s", config.Gateway.NextHop)
-					}
-				}
-			}
-
-			if config.IPv6Mode {
-				if needIPv6NextHop {
-					if utilnet.IsIPv6(nextHop) {
-						gatewayNextHops = append(gatewayNextHops, nextHop)
-						needIPv6NextHop = false
-					}
-				} else {
-					if utilnet.IsIPv6(nextHop) {
-						return nil, "", fmt.Errorf("only one IPv6 next-hop is allowed: %s", config.Gateway.NextHop)
-					}
-				}
-			}
-		}
-	}
+	// Translate gateway interface port→bridge up-front so the `self`
+	// keyword (below) can look up routes on the bridge that owns the IPs
+	// after OVS takeover.
 	gatewayIntf := config.Gateway.Interface
 	if gatewayIntf != "" && (config.IsModeDPU() || config.IsModeFull()) {
 		if bridgeName, _, err := util.RunOVSVsctl("port-to-br", gatewayIntf); err == nil {
 			// This is an OVS bridge's internal port
 			gatewayIntf = bridgeName
+		}
+	}
+
+	if config.Gateway.NextHop != "" {
+		switch strings.ToLower(strings.TrimSpace(config.Gateway.NextHop)) {
+		case "self":
+			// Derive per-node next-hop from the first `via` route on
+			// --gateway-interface (or its OVS bridge). Accepts any
+			// prefix, so works on interfaces that only carry a
+			// rack-scoped non-default route. Fatal if no via route is
+			// found — the user asked explicitly for self-derivation.
+			if gatewayIntf == "" {
+				return nil, "", fmt.Errorf("--gateway-nexthop=self requires --gateway-interface to be set")
+			}
+			if needIPv4NextHop {
+				nh, err := resolveNextHopSelf(gatewayIntf, netlink.FAMILY_V4)
+				if err != nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=self (IPv4): %w", err)
+				}
+				if nh == nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=self (IPv4): no via route found on %q", gatewayIntf)
+				}
+				gatewayNextHops = append(gatewayNextHops, nh)
+				needIPv4NextHop = false
+			}
+			if needIPv6NextHop {
+				nh, err := resolveNextHopSelf(gatewayIntf, netlink.FAMILY_V6)
+				if err != nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=self (IPv6): %w", err)
+				}
+				if nh == nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=self (IPv6): no via route found on %q", gatewayIntf)
+				}
+				gatewayNextHops = append(gatewayNextHops, nh)
+				needIPv6NextHop = false
+			}
+		case "default":
+			// Use the system default route's next-hop, regardless of
+			// which interface carries it. Useful for setups whose
+			// default route is the OVN gateway but whose IP may
+			// change (DHCP / migrations) so hardcoding is brittle.
+			if needIPv4NextHop {
+				nh, err := resolveNextHopDefault(netlink.FAMILY_V4)
+				if err != nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=default (IPv4): %w", err)
+				}
+				if nh == nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=default (IPv4): no IPv4 default route on the host")
+				}
+				gatewayNextHops = append(gatewayNextHops, nh)
+				needIPv4NextHop = false
+			}
+			if needIPv6NextHop {
+				nh, err := resolveNextHopDefault(netlink.FAMILY_V6)
+				if err != nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=default (IPv6): %w", err)
+				}
+				if nh == nil {
+					return nil, "", fmt.Errorf("--gateway-nexthop=default (IPv6): no IPv6 default route on the host")
+				}
+				gatewayNextHops = append(gatewayNextHops, nh)
+				needIPv6NextHop = false
+			}
+		default:
+			nextHopsRaw := strings.Split(config.Gateway.NextHop, ",")
+			if len(nextHopsRaw) > 2 {
+				return nil, "", fmt.Errorf("unexpected next-hops are provided, more than 2 next-hops is not allowed: %s", config.Gateway.NextHop)
+			}
+			for _, nh := range nextHopsRaw {
+				// Parse NextHop to make sure it is valid before using. Return error if not valid.
+				nextHop := net.ParseIP(nh)
+				if nextHop == nil {
+					return nil, "", fmt.Errorf("failed to parse configured next-hop: %s", config.Gateway.NextHop)
+				}
+				if config.IPv4Mode {
+					if needIPv4NextHop {
+						if !utilnet.IsIPv6(nextHop) {
+							gatewayNextHops = append(gatewayNextHops, nextHop)
+							needIPv4NextHop = false
+						}
+					} else {
+						if !utilnet.IsIPv6(nextHop) {
+							return nil, "", fmt.Errorf("only one IPv4 next-hop is allowed: %s", config.Gateway.NextHop)
+						}
+					}
+				}
+
+				if config.IPv6Mode {
+					if needIPv6NextHop {
+						if utilnet.IsIPv6(nextHop) {
+							gatewayNextHops = append(gatewayNextHops, nextHop)
+							needIPv6NextHop = false
+						}
+					} else {
+						if utilnet.IsIPv6(nextHop) {
+							return nil, "", fmt.Errorf("only one IPv6 next-hop is allowed: %s", config.Gateway.NextHop)
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1994,6 +1994,168 @@ var _ = Describe("Gateway unit tests", func() {
 			Expect(gatewayNextHops).To(Equal(gwIPs))
 		})
 
+		It("Resolves --gateway-nexthop=self from the first `via` route on the gateway interface", func() {
+			ifName := "enf1f0"
+			gwIP := net.ParseIP("10.0.0.11")
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{Name: ifName, Index: 5}
+			_, specificDst, err := net.ParseCIDR("10.128.0.0/11")
+			Expect(err).ToNot(HaveOccurred())
+			// non-default route with via — multi-rack VLAN case
+			rackRoute := netlink.Route{Dst: specificDst, LinkIndex: 5, Gw: gwIP}
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", ifName).Return(lnk, nil)
+			netlinkMock.On("RouteList", lnk, netlink.FAMILY_V4).Return([]netlink.Route{rackRoute}, nil)
+
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+				Err: fmt.Errorf(""),
+			})
+			Expect(util.SetExec(fexec)).To(Succeed())
+
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Gateway.Interface = ifName
+			config.Gateway.NextHop = "self"
+
+			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gatewayIntf).To(Equal(ifName))
+			Expect(gatewayNextHops).To(HaveLen(1))
+			Expect(gatewayNextHops[0]).To(Equal(gwIP))
+		})
+
+		It("Skips link-local via routes (e.g. OVN-K service masquerade) when resolving --gateway-nexthop=self", func() {
+			ifName := "brovn-ext"
+			rackGw := net.ParseIP("10.128.0.1")
+			masqGw := net.ParseIP("169.254.0.4")
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{Name: ifName, Index: 5}
+			_, rackDst, err := net.ParseCIDR("10.128.0.0/11")
+			Expect(err).ToNot(HaveOccurred())
+			_, masqDst, err := net.ParseCIDR("254.52.0.0/16")
+			Expect(err).ToNot(HaveOccurred())
+			// Masquerade route listed FIRST to reproduce the production
+			// bug where RouteList ordering put it ahead of the rack route.
+			routes := []netlink.Route{
+				{Dst: masqDst, LinkIndex: 5, Gw: masqGw},
+				{Dst: rackDst, LinkIndex: 5, Gw: rackGw},
+			}
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", ifName).Return(lnk, nil)
+			netlinkMock.On("RouteList", lnk, netlink.FAMILY_V4).Return(routes, nil)
+
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+				Err: fmt.Errorf(""),
+			})
+			Expect(util.SetExec(fexec)).To(Succeed())
+
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Gateway.Interface = ifName
+			config.Gateway.NextHop = "self"
+
+			gatewayNextHops, _, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gatewayNextHops).To(HaveLen(1))
+			Expect(gatewayNextHops[0]).To(Equal(rackGw))
+		})
+
+		It("Accepts --gateway-nexthop=SELF case-insensitively", func() {
+			ifName := "enf1f0"
+			gwIP := net.ParseIP("10.0.0.11")
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{Name: ifName, Index: 5}
+			_, dst, err := net.ParseCIDR("10.128.0.0/11")
+			Expect(err).ToNot(HaveOccurred())
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", ifName).Return(lnk, nil)
+			netlinkMock.On("RouteList", lnk, netlink.FAMILY_V4).Return(
+				[]netlink.Route{{Dst: dst, LinkIndex: 5, Gw: gwIP}}, nil)
+
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+				Err: fmt.Errorf(""),
+			})
+			Expect(util.SetExec(fexec)).To(Succeed())
+
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Gateway.Interface = ifName
+			config.Gateway.NextHop = "SELF"
+
+			gatewayNextHops, _, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gatewayNextHops[0]).To(Equal(gwIP))
+		})
+
+		It("Errors when --gateway-nexthop=self but the gateway interface has no via route", func() {
+			ifName := "enf1f0"
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{Name: ifName, Index: 5}
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", ifName).Return(lnk, nil)
+			// connected-scope route only, no Gw
+			netlinkMock.On("RouteList", lnk, netlink.FAMILY_V4).Return(
+				[]netlink.Route{{LinkIndex: 5}}, nil)
+
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+				Err: fmt.Errorf(""),
+			})
+			Expect(util.SetExec(fexec)).To(Succeed())
+
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Gateway.Interface = ifName
+			config.Gateway.NextHop = "self"
+
+			_, _, err := getGatewayNextHops()
+			Expect(err).To(MatchError(ContainSubstring("--gateway-nexthop=self")))
+			Expect(err).To(MatchError(ContainSubstring("no via route")))
+		})
+
+		It("Errors when --gateway-nexthop=self but no --gateway-interface is set", func() {
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Gateway.Interface = ""
+			config.Gateway.NextHop = "self"
+
+			_, _, err := getGatewayNextHops()
+			Expect(err).To(MatchError(ContainSubstring("--gateway-nexthop=self requires --gateway-interface")))
+		})
+
+		It("Resolves --gateway-nexthop=default from the system default route", func() {
+			defaultGwIP := net.ParseIP("10.32.0.1")
+			_, defaultDst, err := net.ParseCIDR("0.0.0.0/0")
+			Expect(err).ToNot(HaveOccurred())
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{Name: "k8s-ctl", Index: 7}
+			defaultRoute := netlink.Route{
+				Dst: defaultDst, LinkIndex: 7, Scope: netlink.SCOPE_UNIVERSE,
+				Gw: defaultGwIP, MTU: config.Default.MTU,
+			}
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByIndex", mock.Anything).Return(lnk, nil)
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(
+				[]netlink.Route{defaultRoute}, nil)
+
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Gateway.Interface = ""
+			config.Gateway.NextHop = "default"
+
+			gatewayNextHops, _, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gatewayNextHops).To(HaveLen(1))
+			Expect(gatewayNextHops[0]).To(Equal(defaultGwIP))
+		})
+
 		ovntest.OnSupportedPlatformsIt("Finds correct gateway interface and nexthops when gateway bridge is created", func() {
 			ifName := "enf1f0"
 			nextHopCfg := "10.0.0.11"

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -200,3 +200,53 @@ func multipathRouteMatchesIfIndex(r netlink.Route, ifIdx int) bool {
 	}
 	return true
 }
+
+// resolveNextHopSelf returns the first global-unicast `via` next-hop on
+// iface for the given address family. Unlike getDefaultGatewayInterfaceByFamily,
+// it accepts any prefix — not just the default route — so multi-rack setups
+// whose gateway interface only carries a rack-scoped /11 route can still
+// derive a usable next-hop.
+//
+// IsGlobalUnicast filters out unspecified (0.0.0.0/::), loopback,
+// link-local (169.254/16, fe80::/10) and multicast, so OVN-K's own
+// service masquerade route 254.52.0.0/16 via 169.254.0.4 (and any
+// other infra-internal link-local nexthop) is correctly skipped even
+// when RouteList returns it before the rack gateway route.
+//
+// Returns (nil, nil) when the interface has no eligible via route in the
+// requested family; the caller decides whether that is a hard error.
+func resolveNextHopSelf(iface string, family int) (net.IP, error) {
+	link, err := util.GetNetLinkOps().LinkByName(iface)
+	if err != nil {
+		return nil, fmt.Errorf("looking up %q: %w", iface, err)
+	}
+	routes, err := util.GetNetLinkOps().RouteList(link, family)
+	if err != nil {
+		return nil, fmt.Errorf("listing routes on %q: %w", iface, err)
+	}
+	for _, r := range routes {
+		if r.Gw != nil && r.Gw.IsGlobalUnicast() {
+			return r.Gw, nil
+		}
+		for _, nh := range r.MultiPath {
+			if nh.Gw != nil && nh.Gw.IsGlobalUnicast() {
+				return nh.Gw, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// resolveNextHopDefault returns the gateway IP of the system default route
+// (0.0.0.0/0 or ::/0) regardless of which interface it lives on. Returns
+// (nil, nil) when no default route exists in the requested family.
+func resolveNextHopDefault(family int) (net.IP, error) {
+	_, gw, err := getDefaultGatewayInterfaceByFamily(family, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(gw) == 0 {
+		return nil, nil
+	}
+	return gw, nil
+}


### PR DESCRIPTION
## Summary

Adds two new value semantics to the existing `--gateway-nexthop` flag, letting each node derive its own nexthop from local routing state instead of a single cluster-wide static IP:

| Value | Source of truth |
|---|---|
| `self` (new) | first `via` route on `--gateway-interface` (or its OVS bridge after port→bridge translation) — accepts any prefix, not just the default route |
| `default` (new) | the system default route's gateway IP, regardless of which interface carries it |
| `<ip>` / `<v4>,<v6>` | unchanged |
| unset | unchanged — existing auto-detection of default route on `--gateway-interface` |

Keywords are case-insensitive and resolve IPv4 / IPv6 separately in dual-stack. Resolution is fatal when no matching route is found — the user explicitly opted in, so a silent fallback would hide misconfiguration.

## Motivation

**1. Multi-rack clusters where each rack's upstream router has a different IP.** A cluster-wide static `--gateway-nexthop=<ip>` can't express per-node variation. The existing ovnkube-node netlink auto-detection (when `--gateway-nexthop` is unset) only matches default routes — it can't help on a node whose physical egress VLAN carries only a rack-scoped non-default route (e.g. `10.128.0.0/11 via <rack-gw>`). `--gateway-nexthop=self` lets each node compute its own nexthop from local routing.

**2. Default-route deployments that don't want to hardcode the gateway IP** (e.g. DHCP, IP migrations). `--gateway-nexthop=default` reads the system default at startup.

## Implementation notes

- `resolveNextHopSelf` reuses the existing `port-to-br` translation in `getGatewayNextHops` (moved a few lines earlier so it runs before the NextHop switch). This lets `self` work correctly when IPs have migrated to the OVS bridge — either after OVN-K's own shared-gateway takeover, or when an externally-managed OVS bridge (e.g. netplan declares the bridge directly and enslaves the host VLAN as uplink) owns the IPs from boot.

- via-route candidates are filtered through `IsGlobalUnicast()` which in one check rejects unspecified, loopback, link-local (169.254.0.0/16, fe80::/10) and multicast. This is important because OVN-K itself installs link-local routes on the gateway bridge (most notably the service masquerade route to 169.254.0.x); without this filter, `RouteList` ordering would non-deterministically return the masquerade route before the real rack-gateway route on some nodes. RFC 1918 private space and IPv6 ULA stay `IsGlobalUnicast()=true`, so legitimate private rack gateways still work.

- `resolveNextHopDefault` reuses `getDefaultGatewayInterfaceByFamily` with empty `gwIface` to search across all interfaces.

## Test plan

- [x] Unit tests added for: `self` on a non-default rack route; case-insensitive matching (`SELF`); empty `--gateway-interface` with `self` errors; no via route on interface errors; `default` resolves the system default; **link-local masquerade route listed before the rack route — rack route still wins** (regression test for the ordering bug `IsGlobalUnicast` fixes).
- [x] Existing `--gateway-nexthop=<ip>` IP-parsing tests untouched; the new keyword path is a separate switch case.
- [x] `go build` and `go vet` clean on Linux.
- [x] Production-validated on a 3-rack multi-rack cluster with non-default rack routes; resolver picks the correct per-node nexthop, including on nodes where OVN-K's own 169.254/16 masquerade route is present on the bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `self` and `default` special keywords for the `--gateway-nexthop` flag to automatically derive next-hop values from configured interfaces or system default routes.

* **Documentation**
  * Updated CLI help text documenting new gateway next-hop special keyword values and dual-stack IPv4/IPv6 handling.

* **Tests**
  * Expanded test coverage for gateway next-hop resolution including new derivation modes, case-insensitivity, and error validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->