### PR TITLE
[WIP][DNM] no-overlay mode with no RA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -469,7 +469,8 @@ jobs:
         # Valid options are:
         # target: ["shard-conformance", "control-plane", "multi-homing", "node-ip-mac-migration",
         #          "external-gateway", "kv-live-migration", "network-segmentation",
-        #          "network-segmentation-dynamic", "bgp", "bgp-no-overlay", "bgp-no-overlay-dynamic", "bgp-loose-isolation",
+        #          "network-segmentation-dynamic", "bgp", "bgp-no-overlay", "bgp-no-overlay-dynamic",
+        #          "bgp-no-overlay-unmanaged-no-ra", "bgp-loose-isolation",
         #          "evpn", "traffic-flow-test-only", "tools", "serial"]
         #         shard-conformance: hybrid-overlay = multicast-enable = emptylb-enable = false
         #         control-plane: hybrid-overlay = multicast-enable = emptylb-enable = true
@@ -521,6 +522,8 @@ jobs:
           # no-overlay (e.g. BGP route advertisements, network-segmentation) where implementations are not strictly orthogonal.
           - {"target": "bgp-no-overlay-dynamic", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "snat-enabled"}
           - {"target": "bgp-no-overlay",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "true"}
+          - {"target": "bgp-no-overlay-unmanaged-no-ra", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "unmanaged-no-ra", "network-segmentation": "enable-network-segmentation", "no-overlay": "true"}
+          - {"target": "bgp-no-overlay-unmanaged-no-ra", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",     "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "unmanaged-no-ra", "network-segmentation": "enable-network-segmentation", "no-overlay": "snat-enabled"}
           - {"target": "bgp-loose-isolation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "advertised-udn-isolation-mode": "loose"}
           - {"target": "evpn", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "evpn": "enable-evpn"}
           - {"target": "traffic-flow-test-only", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24", "network-segmentation": "enable-network-segmentation"}
@@ -542,7 +545,7 @@ jobs:
       KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'network-segmentation') }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || startsWith(matrix.target, 'network-segmentation') || matrix.target == 'tools' || matrix.target == 'traffic-flow-test-only' || matrix.routeadvertisements != '' }}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || startsWith(matrix.target, 'network-segmentation') || matrix.target == 'tools' || matrix.target == 'traffic-flow-test-only' || matrix.routeadvertisements != '' || matrix.network-segmentation == 'enable-network-segmentation' }}"
       ENABLE_NETWORK_SEGMENTATION: "${{ startsWith(matrix.target, 'network-segmentation') || matrix.network-segmentation == 'enable-network-segmentation' }}"
       PLATFORM_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       PLATFORM_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
@@ -726,7 +729,11 @@ jobs:
           make -C test control-plane WHAT="ClusterNetworkConnect"
         elif [ "${{ matrix.target }}" == "evpn" ]; then
           make -C test control-plane WHAT="EVPN"
-        elif [ "${{ matrix.target }}" == "bgp" ] || [ "${{ matrix.target }}" == "bgp-no-overlay" ] || [ "${{ matrix.target }}" == "bgp-no-overlay-dynamic" ] || [ "${{ matrix.target }}" == "bgp-loose-isolation" ]; then
+        elif [ "${{ matrix.target }}" == "bgp-no-overlay-unmanaged-no-ra" ]; then
+          SKIP_ROUTE_ADVERTISEMENTS_TESTS=true make -C test control-plane
+          SKIP_ROUTE_ADVERTISEMENTS_TESTS=true make -C test control-plane WHAT="Network Segmentation"
+          make -C test control-plane WHAT="Network Segmentation: unmanaged no-overlay CUDN without RouteAdvertisements"
+        elif [[ "${{ matrix.target }}" == bgp* ]]; then
           make -C test control-plane
         elif [ "${{ matrix.target }}" == "serial" ]; then
           # Run only Serial tests with ginkgo focus

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1290,6 +1290,38 @@ kind_get_nodes() {
   kind get nodes --name "${KIND_CLUSTER_NAME}" | grep -v external-load-balancer
 }
 
+configure_pod_subnet_routes_on_runner_host() {
+  # Add routes for pod networks dynamically into the host for return traffic to pass back
+  if [ "$ADVERTISE_DEFAULT_NETWORK" != "true" ]; then
+    return
+  fi
+
+  echo "Adding routes for Kubernetes pod networks to the host..."
+  local nodes
+  nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+  echo "Found nodes: $nodes"
+  for node in $nodes; do
+    local node_ips node_ipv4 node_ipv6 subnet_json subnets subnet
+    node_ips=$(kubectl get node "$node" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+    node_ipv4=$(echo "$node_ips" | tr ' ' '\n' | grep -v ':' | head -n 1 || true)
+    node_ipv6=$(echo "$node_ips" | tr ' ' '\n' | grep ':' | head -n 1 || true)
+    subnet_json=$(kubectl get node "$node" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
+    subnets=$(echo "$subnet_json" | jq -r '.default[]?')
+
+    for subnet in $subnets; do
+      if [[ "$subnet" == *:* ]]; then
+        if [ -n "$node_ipv6" ]; then
+          echo "Adding IPv6 route for $node ($node_ipv6): $subnet"
+          sudo ip -6 route replace "$subnet" via "$node_ipv6"
+        fi
+      elif [ -n "$node_ipv4" ]; then
+        echo "Adding IPv4 route for $node ($node_ipv4): $subnet"
+        sudo ip route replace "$subnet" via "$node_ipv4"
+      fi
+    done
+  done
+}
+
 set_dnsnameresolver_images() {
   if [ "$KIND_LOCAL_REGISTRY" == true ];then
     COREDNS_WITH_OCP_DNSNAMERESOLVER="localhost:5000/coredns-with-ocp-dnsnameresolver:latest"
@@ -1901,43 +1933,7 @@ EOF
 }
 
 configure_frr_k8s_routes() {
-  # Add routes for pod networks dynamically into the github runner for return traffic to pass back
-  if [ "$ADVERTISE_DEFAULT_NETWORK" = "true" ]; then
-    echo "Adding routes for Kubernetes pod networks..."
-    NODES=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
-    echo "Found nodes: $NODES"
-    for node in $NODES; do
-      # Get the addresses
-      node_ips=$(kubectl get node $node -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-      # Get subnet information
-      subnet_json=$(kubectl get node $node -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
-      
-      if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
-        # Extract IPv4 address (first address)
-        node_ipv4=$(echo "$node_ips" | awk '{print $1}')
-        ipv4_subnet=$(echo "$subnet_json" | jq -r '.default[0]')
-        
-        # Add IPv4 route
-        if [ -n "$ipv4_subnet" ] && [ -n "$node_ipv4" ]; then
-          echo "Adding IPv4 route for $node ($node_ipv4): $ipv4_subnet"
-          sudo ip route replace $ipv4_subnet via $node_ipv4
-        fi
-      fi
-
-      # Add IPv6 route if enabled
-      if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-        # Extract IPv6 address (second address, if present)
-        node_ipv6=$(echo "$node_ips" | awk '{print $2}')
-        ipv6_subnet=$(echo "$subnet_json" | jq -r '.default[1] // empty')
-        
-        if [ -n "$ipv6_subnet" ] && [ -n "$node_ipv6" ]; then
-          echo "Adding IPv6 route for $node ($node_ipv6): $ipv6_subnet"
-          sudo ip -6 route replace $ipv6_subnet via $node_ipv6
-        fi
-      fi
-    done
-  fi
-
+  configure_pod_subnet_routes_on_runner_host
   rm -rf "${FRR_TMP_DIR}"
 }
 

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -254,15 +254,15 @@ set_common_default_params() {
   ENABLE_NO_OVERLAY=${ENABLE_NO_OVERLAY:-false}
   ENABLE_NO_OVERLAY_OUTBOUND_SNAT=${ENABLE_NO_OVERLAY_OUTBOUND_SNAT:-false}
   ENABLE_NO_OVERLAY_MANAGED_ROUTING=${ENABLE_NO_OVERLAY_MANAGED_ROUTING:-false}
-  if [ "$ENABLE_NO_OVERLAY" == true ] && [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ]; then
-    echo "No-overlay mode requires route advertisement to be enabled (-rae)"
-    exit 1
-  fi
-  if [ "$ENABLE_NO_OVERLAY" == true ] && [ "$ADVERTISE_DEFAULT_NETWORK" != true ] && [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ]; then
-    echo "No-overlay mode requires advertise the default network (-adv) in unmanaged routing mode"
-    exit 1
-  fi
   if [ "$ENABLE_NO_OVERLAY" == true ]; then
+    local enable_no_overlay_unmanaged_no_ra=false
+    if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ] && [ "$ADVERTISE_DEFAULT_NETWORK" != true ]; then
+      enable_no_overlay_unmanaged_no_ra=true
+    fi
+    if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ] && [ "$enable_no_overlay_unmanaged_no_ra" != true ]; then
+      echo "No-overlay mode requires RouteAdvertisements (-rae), except for unmanaged no-overlay with no default-network advertisement"
+      exit 1
+    fi
     # Set default MTU for no-overlay mode (1500) if not already set
     OVN_MTU=${OVN_MTU:-1500}
   else
@@ -1290,12 +1290,35 @@ kind_get_nodes() {
   kind get nodes --name "${KIND_CLUSTER_NAME}" | grep -v external-load-balancer
 }
 
+is_default_network_unmanaged_no_overlay_without_ra() {
+  [ "${ENABLE_NO_OVERLAY}" = true ] &&
+    [ "${ENABLE_NO_OVERLAY_MANAGED_ROUTING}" != true ] &&
+    [ "${ADVERTISE_DEFAULT_NETWORK}" != true ]
+}
+
+needs_host_pod_subnet_routes() {
+  [ "${ADVERTISE_DEFAULT_NETWORK}" = true ] || is_default_network_unmanaged_no_overlay_without_ra
+}
+
+needs_external_frr_router() {
+  if [ "${DPU_MODE:-none}" == "host" ]; then
+    return 1
+  fi
+  if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ] && [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ]; then
+    return 0
+  fi
+  is_default_network_unmanaged_no_overlay_without_ra
+}
+
 configure_pod_subnet_routes_on_runner_host() {
-  # Add routes for pod networks dynamically into the host for return traffic to pass back
-  if [ "$ADVERTISE_DEFAULT_NETWORK" != "true" ]; then
+  if ! needs_host_pod_subnet_routes; then
     return
   fi
 
+  # Add routes for pod networks dynamically into the host for return traffic to pass back.
+  # This is needed when pod IPs are externally visible, either because
+  # the default network is advertised through BGP or because unmanaged no-overlay
+  # without RAs relies on static underlay routes instead of RouteAdvertisements.
   echo "Adding routes for Kubernetes pod networks to the host..."
   local nodes
   nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
@@ -1320,6 +1343,219 @@ configure_pod_subnet_routes_on_runner_host() {
       fi
     done
   done
+}
+
+# In unmanaged no-overlay without RAs, the default network is not advertised through BGP.
+# The external FRR container still acts as the underlay next hop, so it needs
+# static routes for each node pod subnet pointing at that node's InternalIP.
+configure_no_overlay_unmanaged_no_ra_frr_static_routes() {
+  if ! is_default_network_unmanaged_no_overlay_without_ra; then
+    return
+  fi
+
+  if ! $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^frr$'; then
+    echo "error: unmanaged no-overlay without RAs static route setup requires the external frr container"
+    exit 1
+  fi
+
+  echo "Configuring static pod-subnet routes on external FRR for unmanaged no-overlay without RAs..."
+  local nodes
+  nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+  echo "Found nodes: $nodes"
+
+  local configured_routes=0
+  for node in $nodes; do
+    local node_ips node_ipv4 node_ipv6 subnet_json subnets
+    node_ips=$(kubectl get node "$node" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+    node_ipv4=$(echo "$node_ips" | tr ' ' '\n' | grep -v ':' | head -n 1 || true)
+    node_ipv6=$(echo "$node_ips" | tr ' ' '\n' | grep ':' | head -n 1 || true)
+    subnet_json=$(kubectl get node "$node" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
+    subnets=$(echo "$subnet_json" | jq -r '.default[]?')
+
+    for subnet in $subnets; do
+      if [[ "$subnet" == *:* ]]; then
+        if [ -n "$node_ipv6" ]; then
+          echo "Adding IPv6 route on external FRR for $node ($node_ipv6): $subnet"
+          $OCI_BIN exec frr ip -6 route replace "$subnet" via "$node_ipv6"
+          configured_routes=$((configured_routes + 1))
+        fi
+      elif [ -n "$node_ipv4" ]; then
+        echo "Adding IPv4 route on external FRR for $node ($node_ipv4): $subnet"
+        $OCI_BIN exec frr ip route replace "$subnet" via "$node_ipv4"
+        configured_routes=$((configured_routes + 1))
+      fi
+    done
+  done
+
+  if [ "$configured_routes" -eq 0 ]; then
+    echo "error: no unmanaged no-overlay without RAs static pod-subnet routes were configured on external FRR"
+    exit 1
+  fi
+
+  $OCI_BIN exec frr ip route || true
+  $OCI_BIN exec frr ip -6 route || true
+}
+
+# In local-gateway no-overlay, pod traffic leaves OVN through the management
+# port source route and then uses the node host routing table. In RA-backed
+# setups BGP installs more-specific remote pod-subnet routes there. This kind
+# setup does not learn those routes without RAs, so install equivalent routes
+# on every kind node.
+configure_no_overlay_unmanaged_no_ra_node_static_routes() {
+  if ! is_default_network_unmanaged_no_overlay_without_ra; then
+    return
+  fi
+
+  echo "Configuring static remote pod-subnet routes on kind nodes for unmanaged no-overlay without RAs..."
+  local nodes
+  nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+  echo "Found nodes: $nodes"
+
+  local configured_routes=0
+  local local_node remote_node
+  for local_node in $nodes; do
+    # Host-originated traffic to remote pods must be sourced from the local
+    # management-port IP, not the node underlay IP: primary-UDN pods only
+    # route cluster subnets on their default-network interface, so they
+    # cannot reply to underlay node IPs (e.g. the open-default-ports
+    # hostNetwork e2e coverage).
+    local mp0_ipv4 mp0_ipv6 src_ipv4 src_ipv6
+    mp0_ipv4=$($OCI_BIN exec "$local_node" ip -4 -o addr show ovn-k8s-mp0 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n 1 || true)
+    mp0_ipv6=$($OCI_BIN exec "$local_node" ip -6 -o addr show ovn-k8s-mp0 scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n 1 || true)
+    src_ipv4=""
+    src_ipv6=""
+    [ -n "$mp0_ipv4" ] && src_ipv4="src $mp0_ipv4"
+    [ -n "$mp0_ipv6" ] && src_ipv6="src $mp0_ipv6"
+
+    for remote_node in $nodes; do
+      if [ "$remote_node" == "$local_node" ]; then
+        continue
+      fi
+
+      local node_ips node_ipv4 node_ipv6 subnet_json subnets subnet
+      node_ips=$(kubectl get node "$remote_node" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+      node_ipv4=$(echo "$node_ips" | tr ' ' '\n' | grep -v ':' | head -n 1 || true)
+      node_ipv6=$(echo "$node_ips" | tr ' ' '\n' | grep ':' | head -n 1 || true)
+      subnet_json=$(kubectl get node "$remote_node" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
+      subnets=$(echo "$subnet_json" | jq -r '.default[]?')
+
+      for subnet in $subnets; do
+        if [[ "$subnet" == *:* ]]; then
+          if [ -z "$node_ipv6" ]; then
+            echo "Skipping IPv6 kind-node route on $local_node for $remote_node: no IPv6 InternalIP for $subnet"
+            continue
+          fi
+          echo "Adding IPv6 kind-node route on $local_node for $remote_node: $subnet via $node_ipv6 $src_ipv6"
+          # shellcheck disable=SC2086
+          $OCI_BIN exec "$local_node" ip -6 route replace "$subnet" via "$node_ipv6" dev breth0 $src_ipv6
+        else
+          if [ -z "$node_ipv4" ]; then
+            echo "Skipping IPv4 kind-node route on $local_node for $remote_node: no IPv4 InternalIP for $subnet"
+            continue
+          fi
+          echo "Adding IPv4 kind-node route on $local_node for $remote_node: $subnet via $node_ipv4 $src_ipv4"
+          # shellcheck disable=SC2086
+          $OCI_BIN exec "$local_node" ip route replace "$subnet" via "$node_ipv4" dev breth0 $src_ipv4
+        fi
+        configured_routes=$((configured_routes + 1))
+      done
+    done
+
+    echo "Kind node routes on $local_node:"
+    $OCI_BIN exec "$local_node" ip route || true
+    $OCI_BIN exec "$local_node" ip -6 route || true
+  done
+
+  if [ "$configured_routes" -eq 0 ]; then
+    echo "error: no unmanaged no-overlay without RAs static pod-subnet routes were configured on kind nodes"
+    exit 1
+  fi
+}
+
+# Unmanaged no-overlay kind without RAs does not advertise pod subnets, so
+# routeimport has no BGP routes to mirror into OVN. Program equivalent remote
+# pod-subnet routes on each node GR for gateway-router-routed paths.
+configure_no_overlay_unmanaged_no_ra_gr_static_routes() {
+  if ! is_default_network_unmanaged_no_overlay_without_ra; then
+    return
+  fi
+
+  echo "Configuring static pod-subnet routes on OVN gateway routers for unmanaged no-overlay without RAs..."
+  local nodes
+  nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+  echo "Found nodes: $nodes"
+
+  local configured_routes=0
+  local local_node remote_node
+  for local_node in $nodes; do
+    local nb_pod gr output_port
+    nb_pod=$(kubectl -n ovn-kubernetes get pods -l app=ovnkube-node \
+      --field-selector "spec.nodeName=${local_node}" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [ -z "$nb_pod" ]; then
+      echo "error: failed to find ovnkube-node pod on node $local_node for unmanaged no-overlay without RAs gateway route setup"
+      exit 1
+    fi
+
+    gr="GR_${local_node}"
+    output_port="rtoe-${gr}"
+
+    for remote_node in $nodes; do
+      if [ "$remote_node" == "$local_node" ]; then
+        continue
+      fi
+
+      local node_ips node_ipv4 node_ipv6 subnet_json subnets subnet
+      node_ips=$(kubectl get node "$remote_node" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+      node_ipv4=$(echo "$node_ips" | tr ' ' '\n' | grep -v ':' | head -n 1 || true)
+      node_ipv6=$(echo "$node_ips" | tr ' ' '\n' | grep ':' | head -n 1 || true)
+      subnet_json=$(kubectl get node "$remote_node" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
+      subnets=$(echo "$subnet_json" | jq -r '.default[]?')
+
+      for subnet in $subnets; do
+        local next_hop
+        if [[ "$subnet" == *:* ]]; then
+          if [ -z "$node_ipv6" ]; then
+            echo "Skipping IPv6 gateway route for $remote_node: no IPv6 InternalIP for $subnet"
+            continue
+          fi
+          next_hop="$node_ipv6"
+        else
+          if [ -z "$node_ipv4" ]; then
+            echo "Skipping IPv4 gateway route for $remote_node: no IPv4 InternalIP for $subnet"
+            continue
+          fi
+          next_hop="$node_ipv4"
+        fi
+
+        echo "Adding OVN gateway route on $local_node ($gr) for $remote_node: $subnet via $next_hop"
+        kubectl -n ovn-kubernetes exec "$nb_pod" -c nb-ovsdb -- \
+          ovn-nbctl --if-exists lr-route-del "$gr" "$subnet"
+        kubectl -n ovn-kubernetes exec "$nb_pod" -c nb-ovsdb -- \
+          ovn-nbctl lr-route-add "$gr" "$subnet" "$next_hop" "$output_port"
+        configured_routes=$((configured_routes + 1))
+      done
+    done
+
+    echo "Gateway router routes on $local_node ($gr):"
+    kubectl -n ovn-kubernetes exec "$nb_pod" -c nb-ovsdb -- ovn-nbctl lr-route-list "$gr" || true
+  done
+
+  if [ "$configured_routes" -eq 0 ]; then
+    echo "error: no unmanaged no-overlay without RAs static pod-subnet routes were configured on OVN gateway routers"
+    exit 1
+  fi
+}
+
+configure_no_overlay_unmanaged_no_ra_static_routes() {
+  if ! is_default_network_unmanaged_no_overlay_without_ra; then
+    return
+  fi
+
+  configure_pod_subnet_routes_on_runner_host
+  configure_no_overlay_unmanaged_no_ra_frr_static_routes
+  configure_no_overlay_unmanaged_no_ra_node_static_routes
+  configure_no_overlay_unmanaged_no_ra_gr_static_routes
 }
 
 set_dnsnameresolver_images() {
@@ -1740,11 +1976,12 @@ deploy_bgp_external_server() {
     echo "FRR bgp network IPv6: ${bgp_network_frr_v6}"
     $OCI_BIN exec bgpserver ip -6 route replace default via "$bgp_network_frr_v6"
   fi
-  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ]; then
+  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ] || is_default_network_unmanaged_no_overlay_without_ra; then
     kind_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr)
     echo "FRR kind network IPv4: ${kind_network_frr_v4}"
     # If UDN isolation is in loose disabled, we need to set the default gateway for the nodes in the cluster
     # to the FRR router so that cross-UDN traffic can be routed back to the pods in the cluster in the loose mode.
+    # Unmanaged no-overlay without RAs uses the same default-gateway path for pod traffic.
     echo "Setting default gateway for nodes in the cluster to FRR router IPv4: ${kind_network_frr_v4}"
     set_nodes_default_gw "$kind_network_frr_v4"
     if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
@@ -2199,7 +2436,7 @@ delete() {
   if [ "$KIND_INSTALL_METALLB" == true ]; then
     destroy_metallb
   fi
-  if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
+  if needs_external_frr_router; then
     destroy_bgp
   fi
   timeout 5 kubectl --kubeconfig "${KUBECONFIG}" delete namespace ovn-kubernetes || true

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -687,6 +687,10 @@ if [ "$KIND_ADD_NODES" == true ]; then
   if [ "$OVN_UPLINK_BRIDGE" == true ]; then
     configure_kind_uplink_bridge
   fi
+  configure_no_overlay_unmanaged_no_ra_static_routes
+  if [ "${ADVERTISE_DEFAULT_NETWORK}" = true ]; then
+    configure_pod_subnet_routes_on_runner_host
+  fi
   exit 0
 fi
 
@@ -739,15 +743,15 @@ if [ "$OVN_ENABLE_DNSNAMERESOLVER" == true ]; then
     add_ocp_dnsnameresolver_to_coredns_config
     update_coredns_deployment_image
 fi
+if needs_external_frr_router; then
+  deploy_frr_external_container
+  deploy_bgp_external_server
+fi
 if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
   frr_port=0
   if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" == true ]; then
     # Enable bgp port listening on node, required for managed mode. FRR will listen on port 179 to receive BGP updates from other nodes.
     frr_port=179
-  elif [ "${DPU_MODE}" != "host" ]; then
-    # external FRR is required for unmanaged mode where the FRR-K8S speakers run.
-    deploy_frr_external_container
-    deploy_bgp_external_server
   fi
   if [ "${DPU_MODE}" == "host" ]; then
     install_frr_k8s_crds
@@ -813,6 +817,7 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ] && [ "${DPU_MODE}" != "host" ]; th
     configure_frr_uplink_peers
   fi
 fi
+configure_no_overlay_unmanaged_no_ra_static_routes
 
 restart_dpu_sim_system_deployments_after_ovnk
 

--- a/docs/features/bgp-integration/no-overlay.md
+++ b/docs/features/bgp-integration/no-overlay.md
@@ -4,10 +4,10 @@
 
 No-overlay mode lets selected OVN-Kubernetes Layer 3 pod networks use direct
 underlay routing for inter-node pod east/west traffic instead of Geneve
-encapsulation. It uses the [Route Advertisements](route-advertisements.md)
-integration with FRR-k8s to advertise pod network routes through BGP, so the
-provider network or an OVN-Kubernetes managed internal BGP fabric can route
-traffic between pod subnets.
+encapsulation. It can use the [Route Advertisements](route-advertisements.md)
+integration with FRR-k8s to advertise pod network routes through BGP, or, for
+unmanaged routing, rely on external routing that is configured outside
+OVN-Kubernetes when no matching `RouteAdvertisements` object exists.
 
 No-overlay mode can be enabled for:
 
@@ -25,14 +25,18 @@ gateway mode.
 
 * A bare-metal deployment.
 * OVN-Kubernetes single-node zone interconnect mode.
-* The `route-advertisements` feature enabled in the OVN-Kubernetes
-  configuration.
-* [FRR-k8s](https://github.com/metallb/frr-k8s) deployed with FRR speakers
+* For BGP-backed no-overlay modes, the `route-advertisements` feature enabled in
+  the OVN-Kubernetes configuration.
+* For BGP-backed no-overlay modes,
+  [FRR-k8s](https://github.com/metallb/frr-k8s) deployed with FRR speakers
   running on every node.
-* For unmanaged routing, administrator-created `RouteAdvertisements` and
-  `FRRConfiguration` resources that exchange pod subnet routes. In managed
+* For BGP-backed unmanaged routing, administrator-created `RouteAdvertisements`
+  and `FRRConfiguration` resources that exchange pod subnet routes. In managed
   routing mode, OVN-Kubernetes creates these resources for the internal
   full-mesh BGP fabric.
+* For unmanaged routing without RouteAdvertisements, an external fabric that can
+  route pod traffic, and cluster-admin or third-party installed pod-subnet routes
+  in each node Linux routing table and OVN gateway router.
 
 Always check the dependencies on the [Requirements page](../requirements.md).
 
@@ -54,17 +58,25 @@ visible to existing network devices.
 
 ## Routing Modes
 
-No-overlay networks use one of two routing modes.
+No-overlay networks use one of these routing modes.
 
 * `managed`: OVN-Kubernetes creates the BGP resources for an internal full-mesh
   fabric. In this mode, each node advertises pod subnets to the default VRF on
   the other nodes. Use this only when nodes are directly connected at Layer 2.
   It is normally paired with SNAT enabled.
-* `unmanaged`: The cluster administrator creates the `FRRConfiguration` and
-  `RouteAdvertisements` resources. This is the right choice when an external
-  BGP route reflector, eBGP topology, VRF-Lite design, or another site-specific
-  routing design owns pod subnet distribution. This mode is normally used with
-  SNAT disabled.
+* BGP-backed `unmanaged`: The cluster administrator creates the
+  `FRRConfiguration` and `RouteAdvertisements` resources. This is the right
+  choice when an external BGP route reflector, eBGP topology, VRF-Lite design,
+  or another site-specific BGP design owns pod subnet distribution. This mode is
+  normally used with SNAT disabled.
+* `unmanaged` without RouteAdvertisements: For the default network or primary
+  Layer 3 CUDNs with unmanaged no-overlay routing, the cluster administrator can omit
+  `RouteAdvertisements` and configure the external fabric to route pod subnets
+  back to the nodes. This applies with either outbound SNAT setting.
+  OVN-Kubernetes does not create BGP resources or verify those external routes.
+  If one or more `RouteAdvertisements` objects select the network and advertise
+  `PodNetwork`, the network follows the existing no-overlay `RouteAdvertisements`
+  validation behavior.
 
 Managed routing currently supports only the `full-mesh` topology. For large
 clusters, prefer unmanaged routing with route reflectors or another scalable BGP
@@ -148,9 +160,10 @@ global:
   managedBGPFRRNamespace: frr-k8s-system
 ```
 
-### Unmanaged Routing
+### BGP-backed Unmanaged Routing
 
-Use unmanaged routing when the administrator owns the BGP configuration.
+Use BGP-backed unmanaged routing when the administrator owns the BGP
+configuration.
 
 ```ini
 [default]
@@ -161,10 +174,10 @@ outbound-snat = disabled
 routing = unmanaged
 ```
 
-In unmanaged mode, create an `FRRConfiguration` that peers with the routing
-infrastructure and accepts pod subnet routes. The values below are examples;
-adjust the AS numbers, neighbor address, and pod subnet prefixes for your
-deployment.
+In BGP-backed unmanaged mode, create an `FRRConfiguration` that peers with the
+routing infrastructure and accepts pod subnet routes. The values below are
+examples; adjust the AS numbers, neighbor address, and pod subnet prefixes for
+your deployment.
 
 ```yaml
 apiVersion: frrk8s.metallb.io/v1beta1
@@ -217,6 +230,35 @@ The default network no-overlay controller validates that at least one
 OVN-Kubernetes reports an event on the default network
 `NetworkAttachmentDefinition`.
 
+### Unmanaged Routing Without RouteAdvertisements
+
+Unmanaged no-overlay routing can run without a matching `RouteAdvertisements`
+object when the external fabric is configured outside OVN-Kubernetes to return
+pod subnet traffic to the node that owns each subnet. This example uses outbound
+SNAT enabled; `disabled` is also valid.
+
+```ini
+[default]
+transport = no-overlay
+
+[no-overlay]
+outbound-snat = enabled
+routing = unmanaged
+```
+
+In this mode, no `RouteAdvertisements` or `FRRConfiguration` object is required
+when no `RouteAdvertisements` object selects the default network and advertises
+`PodNetwork`. OVN-Kubernetes does not create BGP resources and does not verify
+external return routes. Each node gateway router installs routes for its local
+pod host subnet back into OVN and sends non-local pod subnet destinations to the
+external default next hop.
+
+If relevant `RouteAdvertisements` objects exist, the default network follows the
+existing no-overlay validation behavior: any accepted relevant
+`RouteAdvertisements` object is sufficient; if none are accepted,
+OVN-Kubernetes reports an event on the default network
+`NetworkAttachmentDefinition`.
+
 ## Enable no-overlay mode on a ClusterUserDefinedNetwork
 
 No-overlay CUDNs are configured in the `ClusterUserDefinedNetwork` API. Only
@@ -259,12 +301,12 @@ after the CUDN is created.
 
 To use managed routing for a CUDN, set `routing: Managed` and configure the
 global `[bgp-managed]` section shown in the default network managed-routing
-example. The CUDN still reports transport acceptance only after a
-`RouteAdvertisements` object advertises its pod routes and reaches
+example. BGP-backed CUDNs report transport acceptance only after a
+`RouteAdvertisements` object advertises their pod routes and reaches
 `Accepted=True`.
 
-Create a `RouteAdvertisements` object that selects the CUDN and advertises
-`PodNetwork` routes:
+For BGP-backed unmanaged routing, create a `RouteAdvertisements` object that
+selects the CUDN and advertises `PodNetwork` routes:
 
 ```yaml
 apiVersion: k8s.ovn.org/v1
@@ -290,7 +332,7 @@ For VRF-Lite designs, set `targetVRF: auto` or a specific VRF as described in
 the [Route Advertisements VRF-Lite workflow](route-advertisements.md#import-and-export-routes-to-a-cudn-over-the-network-vrf-vrf-lite).
 
 When the CUDN is reconciled, OVN-Kubernetes sets the `TransportAccepted` status
-condition:
+condition for the BGP-backed path:
 
 ```yaml
 status:
@@ -306,22 +348,52 @@ condition is set to `False` with a reason such as
 `NoOverlayRouteAdvertisementsIsMissing` or
 `NoOverlayRouteAdvertisementsNotAccepted`.
 
+For unmanaged routing without RouteAdvertisements, use unmanaged no-overlay on
+the CUDN and configure the external fabric to route pod subnet traffic to the
+owning nodes. Either outbound SNAT setting is valid:
+
+```yaml
+network:
+  topology: Layer3
+  layer3:
+    role: Primary
+    subnets:
+    - cidr: 10.10.0.0/16
+      hostSubnet: 24
+  transport: NoOverlay
+  noOverlay:
+    outboundSNAT: Enabled # or Disabled
+    routing: Unmanaged
+```
+
+In this mode, no `RouteAdvertisements` object is required. When no
+`RouteAdvertisements` object selects the CUDN and advertises `PodNetwork`, the
+`TransportAccepted` condition is set to `True` with reason
+`NoOverlayRouteAdvertisementsNotRequired`. If relevant `RouteAdvertisements`
+objects exist, the CUDN follows the existing no-overlay validation behavior:
+any accepted relevant `RouteAdvertisements` object sets
+`TransportAccepted=True` with reason `NoOverlayTransportAccepted`; if none are
+accepted, `TransportAccepted=False` is reported with reason
+`NoOverlayRouteAdvertisementsNotAccepted`.
+
 ## Operational Notes
 
 * The MTU for a no-overlay pod network can match the provider network MTU
   because there is no Geneve overhead. Do not set a pod MTU larger than the
   underlay can carry.
-* `RouteAdvertisements` with `PodNetwork` must select all nodes with
-  `nodeSelector: {}`. A network cannot be partly overlay and partly no-overlay.
+* For BGP-backed no-overlay networks, `RouteAdvertisements` with `PodNetwork`
+  must select all nodes with `nodeSelector: {}`. A network cannot be partly
+  overlay and partly no-overlay.
 * No-overlay CUDNs with overlapping pod subnets cannot be advertised into the
   same VRF. Use a VRF-Lite design when overlapping pod CIDRs are required.
-* East-west traffic depends on the BGP network. BGP speaker outages can impact
-  cluster pod networking.
+* East-west traffic depends on the external routing fabric. In BGP-backed modes,
+  BGP speaker outages can impact cluster pod networking.
 * No-overlay mode inherits the limitations of the Route Advertisements and BGP
   integration.
-* Network debugging includes both OVN-Kubernetes and the BGP routing
-  infrastructure. Check the `RouteAdvertisements` status before debugging data
-  plane paths.
+* Network debugging includes OVN-Kubernetes and the external routing
+  infrastructure. For BGP-backed paths, check the `RouteAdvertisements` status
+  before debugging data plane paths. For unmanaged networks without
+  RouteAdvertisements, check the external fabric return routes.
 
 ## Known Limitations
 
@@ -331,12 +403,15 @@ condition is set to `False` with a reason such as
   no-overlay transport are not supported.
 * Creating a no-overlay network manually with a `NetworkAttachmentDefinition` is
   not supported.
-* No-overlay mode does not rely on routes that administrators might add directly to
-  the underlay. Each no-overlay network must have at least one accepted
-  `RouteAdvertisements` object that advertises `PodNetwork` routes. In unmanaged
-  routing mode, administrators must create the matching `RouteAdvertisements`
-  and `FRRConfiguration` resources. In managed routing mode, OVN-Kubernetes
-  creates those resources for the internal BGP fabric.
+* Except for unmanaged networks with no relevant `RouteAdvertisements` object,
+  each no-overlay network must have at least one
+  accepted `RouteAdvertisements` object that advertises `PodNetwork` routes. In
+  BGP-backed unmanaged routing mode, administrators must create the matching
+  `RouteAdvertisements` and `FRRConfiguration` resources. In managed routing
+  mode, OVN-Kubernetes creates those resources for the internal BGP fabric.
+* OVN-Kubernetes does not validate return routes for unmanaged networks without
+  RouteAdvertisements. If the external fabric does not route a pod subnet back
+  to the owning node, return traffic fails.
 * Features that rely on OVN delivering pod-to-pod traffic through the overlay,
   such as IPsec, multicast, EgressIP, and EgressService, are not supported on
   no-overlay networks.

--- a/docs/okeps/okep-5259-no-overlay.md
+++ b/docs/okeps/okep-5259-no-overlay.md
@@ -31,6 +31,10 @@ See [terminology](https://ovn-kubernetes.io/okeps/okep-5193-user-defined-network
 * Support no-overlay mode for the cluster default network (CDN).
 * Support no-overlay mode for Primary layer-3 ClusterUserDefinedNetworks
   (CUDNs).
+* Support unmanaged no-overlay routing without matching RouteAdvertisements for
+  the cluster default network and primary layer-3 CUDNs, where
+  OVN-Kubernetes does not require or generate BGP resources, and the external
+  fabric is responsible for routing traffic back to node pod subnets.
 * The no-overlay mode is only supported for bare-metal clusters.
 * A cluster can have networks operating in overlay and no-overlay modes
   simultaneously.
@@ -136,6 +140,21 @@ As a cluster admin, I want to use no-overlay mode for intra-cluster traffic
 without advertising pod networks to the external network or depending on
 external BGP routers.
 
+### Story 4: Create a default network in unmanaged no-overlay mode without RouteAdvertisements
+
+As a cluster admin, I want to install the cluster with the default network in
+no-overlay mode and unmanaged routing when my external fabric already routes
+each node pod subnet back to the node that owns it. I do not want to enable
+RouteAdvertisements or create a dummy FRRConfiguration only to satisfy startup
+validation.
+
+### Story 5: Create a CUDN in unmanaged no-overlay mode without RouteAdvertisements
+
+As a cluster admin, I want to create a primary layer-3 CUDN with no-overlay
+transport and unmanaged routing when my external fabric already routes each pod
+subnet back to the node that owns it. I do not want to create a dummy
+FRRConfiguration or RouteAdvertisements object only to satisfy API validation.
+
 ## Proposed Solution
 
 This solution leverages the existing BGP feature to advertise each node's pod
@@ -143,6 +162,28 @@ subnet via the CNCF project [FRR-K8s](https://github.com/metallb/frr-k8s). FRR
 routers managed by FRR-k8s then propagate these routes throughout the provider
 network, enabling direct pod-to-pod traffic without an overlay. A single cluster
 can simultaneously have networks in both overlay and no-overlay modes.
+
+For the cluster default network, no-overlay can also be used without
+RouteAdvertisements at installation time when `[default] transport` is
+`no-overlay` and `[no-overlay] routing` is `unmanaged`, regardless of the
+`[no-overlay] outbound-snat` value. In that deployment, each node
+gateway router keeps routes for the node-local pod host subnet back toward the
+distributed router and sends non-local pod subnet destinations to the external
+default next hop. If one or more RouteAdvertisements objects select the default
+network and advertise `PodNetwork`, the default network follows the existing
+no-overlay `RouteAdvertisements` validation behavior.
+
+For primary layer-3 CUDNs, no-overlay can also be used without
+RouteAdvertisements when `spec.network.noOverlay.routing` is `Unmanaged`,
+regardless of the `spec.network.noOverlay.outboundSNAT` value. In that
+deployment, each node gateway router keeps routes for the node-local CUDN pod
+host subnet back toward the CUDN's distributed router and sends non-local pod
+subnet destinations to the external default next hop. The external fabric is
+responsible for return routing to pod IPs and OVN-Kubernetes does not verify
+that those external routes exist.
+If one or more RouteAdvertisements objects select the same CUDN and advertise
+`PodNetwork`, the CUDN follows the existing no-overlay `RouteAdvertisements`
+validation behavior.
 
 When no-overlay mode is enabled for a network:
 
@@ -171,10 +212,10 @@ the `[default]` section of the configuration file:
 * The `transport` flag accepts either `no-overlay` or
   `geneve`, defaulting to `geneve`. Setting it to `no-overlay` configures the
   default network to operate in no-overlay mode. More overlay transport
-  methods can be supported in the future. If
-  `transport=no-overlay` is set, but
+  methods can be supported in the future. If `transport=no-overlay` is set, but
   no `RouteAdvertisements` CR is configured for advertising the default network,
-  ovnkube-cluster-manager will emit an event and log an error message.
+  ovnkube-cluster-manager will emit an event and log an error message unless the
+  default network is configured with unmanaged routing.
 
 For the default network in no-overlay mode, the new flags `outbound-snat` and
 `routing` will be added to the `[no-overlay]` section of the configuration file:
@@ -274,10 +315,11 @@ We introduce new fields to the `spec.network` section of the
 ClusterUserDefinedNetwork (CUDN) CRD to control network transport technology:
 
 * **`transport`**: Specifies the transport technology used for the network.
-  * Supported values: `Geneve` or `NoOverlay`
-  * It's optional, if not specified, it will be treated as `Geneve`.
+  * Supported explicit values: `NoOverlay` or `EVPN`.
+  * It's optional. If not specified, OVN-Kubernetes uses the default OVN overlay
+    transport, such as Geneve.
   * More transport methods can be supported in the future.
-* **`noOverlayOptions`**: Contains configuration for no-overlay mode. This is
+* **`noOverlay`**: Contains configuration for no-overlay mode. This is
   required when `transport` is `NoOverlay`.
   * `outboundSNAT`: Defines the SNAT behavior for outbound traffic from pods.
     * Supported values: `Enabled` or `Disabled`. It is required when `transport`
@@ -302,9 +344,11 @@ ClusterUserDefinedNetwork (CUDN) CRD to control network transport technology:
     * `Unmanaged`: Users are responsible for managing the routing, including
       creating the RouteAdvertisements and FRRConfiguration CRs to advertise the
       pod subnets. It allows users to have more control over the BGP
-      configuration. One day if other routing protocols are integrated with
-      OVN-Kubernetes, users can use this option to manage the routing
-      themselves.
+      configuration. For CUDNs with unmanaged no-overlay routing, users may also
+      omit RouteAdvertisements entirely and rely on external return routing or
+      another external routing mechanism to return traffic to node pod subnets.
+      One day if other routing protocols are integrated with OVN-Kubernetes,
+      users can use this option to manage the routing themselves.
 
 The `spec` field of a ClusterUserDefinedNetwork CR is immutable. Therefore, the
 transport configuration cannot be changed after a ClusterUserDefinedNetwork CR is
@@ -317,7 +361,7 @@ type RoutingOption string
 
 const (
     TransportOptionNoOverlay  TransportOption = "NoOverlay"
-    TransportOptionGeneve     TransportOption = "Geneve"
+    TransportOptionEVPN       TransportOption = "EVPN"
 
     SNATEnabled  SNATOption = "Enabled"
     SNATDisabled SNATOption = "Disabled"
@@ -326,8 +370,8 @@ const (
     RoutingUnmanaged RoutingOption = "Unmanaged"
 )
 
-// NoOverlayOptions contains configuration options for networks operating in no-overlay mode.
-type NoOverlayOptions struct {
+// NoOverlayConfig contains configuration options for networks operating in no-overlay mode.
+type NoOverlayConfig struct {
     // OutboundSNAT defines the SNAT behavior for outbound traffic from pods.
     // +kubebuilder:validation:Enum=Enabled;Disabled
     // +required
@@ -341,17 +385,17 @@ type NoOverlayOptions struct {
 type NetworkSpec struct {
     ...
     // Transport describes the transport technology used for the network.
-    // Allowed values are "NoOverlay" and "Geneve".
+    // Allowed values are "NoOverlay" and "EVPN".
     // - "NoOverlay": The network operates in no-overlay mode.
-    // - "Geneve": The network uses Geneve overlay.
-    // Defaults to "Geneve" if not specified.
-    // +kubebuilder:validation:Enum=NoOverlay;Geneve
+    // - "EVPN": The network uses EVPN transport.
+    // When omitted, the network uses the default OVN overlay transport.
+    // +kubebuilder:validation:Enum=NoOverlay;EVPN
     // +optional
     Transport TransportOption `json:"transport,omitempty"`
-    // NoOverlayOptions contains configuration for no-overlay mode.
+    // NoOverlay contains configuration for no-overlay mode.
     // It is only allowed when Transport is "NoOverlay".
     // +optional
-    NoOverlayOptions *NoOverlayOptions `json:"noOverlayOptions,omitempty"`
+    NoOverlay *NoOverlayConfig `json:"noOverlay,omitempty"`
 }
 ```
 
@@ -364,8 +408,10 @@ accidentally, we will add the following CEL validation rules to the
       x-kubernetes-validations:
       - message: "transport 'NoOverlay' is only supported for Layer3 primary networks"
         rule: "!has(self.transport) || self.transport != 'NoOverlay' || (self.topology == 'Layer3' && has(self.layer3) && self.layer3.role == 'Primary')"
-      - message: "noOverlayOptions is required if and only if transport is 'NoOverlay'"
-        rule: "(has(self.transport) && self.transport == 'NoOverlay') == has(self.noOverlayOptions)"
+      - message: "spec.noOverlay is required when type transport is 'NoOverlay'"
+        rule: "!has(self.transport) || self.transport != 'NoOverlay' || has(self.noOverlay)"
+      - message: "spec.noOverlay is forbidden when transport type is not 'NoOverlay'"
+        rule: "(has(self.transport) && self.transport == 'NoOverlay') || !has(self.noOverlay)"
 ```
 
 A new status condition will be added to the CUDN CR to indicate whether the
@@ -383,23 +429,18 @@ Here is the definition of the new status condition:
   * `False`: The transport is not correctly configured.
   * `Unknown`: The status of the transport configuration is unknown.
   * This condition is only applicable when `spec.network.transport` is not set
-    to `Geneve`.
+    to the default overlay transport.
   * For a no-overlay CUDN, this condition is set to `True` when:
     * A RouteAdvertisements CR is created to advertise the pod subnets of
       the CUDN, and its status is `Accepted`.
+    * Or, for unmanaged no-overlay without RouteAdvertisements, no
+      RouteAdvertisements CR advertises the CUDN pod subnets and the CUDN is
+      configured with `transport: NoOverlay` and
+      `noOverlay.routing: Unmanaged`.
     * Otherwise, it will be set to `False` with an appropriate message.
 
-If the transport is not configured or configured as `Geneve`, the UDN controller
-shall set the `TransportAccepted` condition like this:
-
-```yaml
-status:
-  conditions:
-  - type: TransportAccepted
-    status: "True"
-    reason: "GeneveTransportAccepted"
-    message: "Geneve transport has been configured."
-```
+If the transport is not configured, the UDN controller does not set the
+`TransportAccepted` condition.
 
 If the transport is configured as `NoOverlay` and the RouteAdvertisements CR is
 created and its status is `Accepted`, the UDN controller shall set the
@@ -414,9 +455,23 @@ status:
     message: "Transport has been configured as 'no-overlay'."
 ```
 
-If no RouteAdvertisements CR is advertising the network, it shall update the
-CUDN status condition `TransportAccepted` to `False` with an appropriate
-message.
+If the transport is configured as `NoOverlay` with unmanaged routing, and no
+RouteAdvertisements CR selects the CUDN and advertises
+`PodNetwork`, the UDN controller accepts the CUDN without requiring a
+RouteAdvertisements CR:
+
+```yaml
+status:
+  conditions:
+  - type: TransportAccepted
+    status: "True"
+    reason: "NoOverlayRouteAdvertisementsNotRequired"
+    message: "Transport has been configured as no-overlay with unmanaged routing. RouteAdvertisements are not required; external routing is responsible for returning traffic to node pod subnets."
+```
+
+For other no-overlay CUDNs, if no RouteAdvertisements CR is advertising the
+network, it shall update the CUDN status condition `TransportAccepted` to
+`False` with an appropriate message.
 
 ```yaml
 status:
@@ -462,15 +517,15 @@ spec:
       - cidr: 10.10.0.0/16
         hostSubnet: 24
     transport: "NoOverlay"
-    noOverlayOptions:
-      outboundSNAT: "Disabled"
+    noOverlay:
+      outboundSNAT: "Enabled" # or "Disabled"
       routing: "Unmanaged"
 status:
   conditions:
   - type: TransportAccepted
     status: "True"
-    reason: "NoOverlayTransportAccepted"
-    message: "Transport has been configured as 'no-overlay'."
+    reason: "NoOverlayRouteAdvertisementsNotRequired"
+    message: "Transport has been configured as no-overlay with unmanaged routing. RouteAdvertisements are not required; external routing is responsible for returning traffic to node pod subnets."
 ```
 
 Or: if the routing is managed by OVN-Kubernetes:
@@ -495,7 +550,7 @@ spec:
       - cidr: 10.10.0.0/16
         hostSubnet: 24
     transport: "NoOverlay"
-    noOverlayOptions:
+    noOverlay:
       outboundSNAT: "Enabled"
       routing: "Managed"
 status:
@@ -944,6 +999,16 @@ external router instead of the node.
 
 #### Enable No-overlay Mode for the Default Network with Unmanaged Routing
 
+Unmanaged routing has two supported paths for the default network:
+
+* BGP-backed unmanaged routing, where the administrator creates
+  FRRConfiguration and RouteAdvertisements resources.
+* Unmanaged routing without RouteAdvertisements, where the external fabric can
+  route pod traffic, and the cluster admin or a third-party component installs
+  pod-subnet routes in each node Linux routing table and OVN gateway router.
+
+##### BGP-backed unmanaged routing
+
 1. The frr-k8s pods shall be deployed on each node.
 2. The cluster admin shall create a base FRRConfiguration CR that is used for
    generating the per-node FRRConfiguration instances by OVN-Kubernetes.
@@ -1021,6 +1086,42 @@ external router instead of the node.
 7. The BGP feature is responsible for exchanging BGP routes to remote pod
    subnets between nodes. Ultimately, these routes will be imported into the
    gateway router.
+
+##### Unmanaged routing without RouteAdvertisements
+
+1. The cluster admin ensures the external fabric can route pod traffic, and
+   installs the necessary pod-subnet routes in each node Linux routing table and
+   OVN gateway router, either directly or through a third-party component.
+   OVN-Kubernetes does not create or validate these external routes.
+
+2. The cluster admin enables no-overlay mode at installation time by running
+   ovn-kubernetes with the config file below. This mode does not require
+   RouteAdvertisements to be enabled, and either `outbound-snat` value is valid.
+
+    ```ini
+    [default]
+    transport = no-overlay
+
+    [no-overlay]
+    routing = unmanaged
+    outbound-snat = enabled
+    ```
+
+3. The default network controller in ovnkube-controller creates the OVN virtual
+   topology for the default network. Neither the transit switch nor static
+   routes to remote pod subnets are created.
+
+4. On each node gateway router, OVN-Kubernetes installs routes for the
+   node-local pod host subnet back toward the distributed router. It does not
+   install the broad cluster-CIDR route in this path, so destinations in
+   non-local pod subnets use the external default next hop.
+
+5. If the RouteAdvertisements feature is enabled and a RouteAdvertisements
+   object selects the default network and advertises `PodNetwork`, the default
+   network follows the existing no-overlay
+   validation behavior: any accepted relevant RouteAdvertisements object is
+   sufficient; if none are accepted, the default network no-overlay controller
+   reports a warning event.
 
 #### Enable No-overlay Mode for the Default Network with Managed Routing
 
@@ -1125,7 +1226,15 @@ external router instead of the node.
 
 #### Create a ClusterUserDefinedNetwork in No-overlay Mode with Unmanaged Routing
 
-Here is a configuration example:
+Unmanaged routing has two supported paths for CUDNs:
+
+* BGP-backed unmanaged routing, where the administrator creates
+  FRRConfiguration and RouteAdvertisements resources.
+* Unmanaged routing without RouteAdvertisements, where the administrator creates
+  only the CUDN, ensures the external fabric can route pod traffic, and installs
+  pod-subnet routes in each node Linux routing table and OVN gateway router.
+
+##### BGP-backed unmanaged routing
 
 1. The frr-k8s pods shall be deployed on each node.
 2. A cluster admin wants to enable no-overlay mode for the blue network by
@@ -1154,7 +1263,7 @@ Here is a configuration example:
           - cidr: 10.10.0.0/16
             hostSubnet: 24
         transport: "NoOverlay"
-        noOverlayOptions:
+        noOverlay:
           outboundSNAT: "Disabled"
           routing: "Unmanaged"
     ```
@@ -1240,6 +1349,63 @@ Here is a configuration example:
    subnets between nodes. Ultimately, these routes will be imported into the
    gateway router.
 
+##### Unmanaged routing without RouteAdvertisements
+
+1. The cluster admin ensures the external fabric can route pod traffic, and
+   installs the necessary CUDN pod-subnet routes in each node Linux routing
+   table and OVN gateway router, either directly or through a third-party
+   component. OVN-Kubernetes does not create or validate these external routes.
+
+2. The cluster admin creates the CUDN with no-overlay transport and unmanaged
+   routing.
+
+    ```yaml
+    apiVersion: k8s.ovn.org/v1
+    kind: ClusterUserDefinedNetwork
+    metadata:
+      name: blue
+      labels:
+        network: blue
+    spec:
+      namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: ["ns1", "ns2"]
+      network:
+        topology: Layer3
+        layer3:
+          role: Primary
+          mtu: 1500
+          subnets:
+          - cidr: 10.10.0.0/16
+            hostSubnet: 24
+        transport: "NoOverlay"
+        noOverlay:
+          outboundSNAT: "Enabled" # or "Disabled"
+          routing: "Unmanaged"
+    ```
+
+3. The UDN controller in ovnkube-cluster-manager accepts this CUDN without a
+   RouteAdvertisements object and sets `TransportAccepted=True` with reason
+   `NoOverlayRouteAdvertisementsNotRequired`.
+
+4. If the administrator creates one or more RouteAdvertisements objects that
+   select the CUDN and advertise `PodNetwork`, the CUDN follows the existing
+   no-overlay validation behavior: any accepted
+   relevant RouteAdvertisements object sets `TransportAccepted=True` with reason
+   `NoOverlayTransportAccepted`; if none are accepted,
+   `TransportAccepted=False` is reported with reason
+   `NoOverlayRouteAdvertisementsNotAccepted`.
+
+5. The UDN controller in ovnkube-controller creates the OVN virtual topology for
+   the UDN. Neither the transit switch nor static routes to remote pod subnets
+   are created. On each node gateway router, OVN-Kubernetes installs routes for
+   the node-local CUDN pod host subnet back toward the CUDN's distributed
+   router, but does not install the broad CUDN CIDR route that would capture
+   remote pod destinations. Return traffic depends on the external fabric
+   routes configured in step 1.
+
 #### Create a ClusterUserDefinedNetwork in No-overlay Mode with Managed Routing
 
 1. The frr-k8s pods shall be deployed on each node.
@@ -1284,7 +1450,7 @@ Here is a configuration example:
           - cidr: 10.10.0.0/16
             hostSubnet: 24
         transport: "NoOverlay"
-        noOverlayOptions:
+        noOverlay:
           outboundSNAT: "Enabled"
           routing: "Managed"
     ```
@@ -1524,8 +1690,28 @@ Not supported.
   * BGP VRF-lite with multiple CUDNs
   * test suite: conformance, control-plane
 * API Testing Details
+  * Config validation accepts the default network with `transport=no-overlay`
+    and `routing=unmanaged`, for either `outbound-snat` value, without requiring
+    the RouteAdvertisements feature, and still rejects no-overlay configurations
+    outside unmanaged routing when RouteAdvertisements are disabled.
+  * Gateway-router programming for unmanaged no-overlay without
+    RouteAdvertisements installs node-local host subnet routes back toward OVN
+    and does not install the broad network CIDR route that would capture remote
+    pod destinations.
   * ClusterUserDefinedNetwork CR reports expected status conditions
+  * A primary layer-3 CUDN with `transport: NoOverlay` and
+    `noOverlay.routing: Unmanaged` is accepted without RouteAdvertisements for
+    either `noOverlay.outboundSNAT` value.
+  * No-overlay CUDNs outside unmanaged routing still require an accepted
+    RouteAdvertisements object.
+  * An unmanaged no-overlay CUDN with relevant RouteAdvertisements
+    objects, none of which are accepted, reports `TransportAccepted=False` with
+    `NoOverlayRouteAdvertisementsNotAccepted`.
   * No-overlay mode cannot be enabled for UserDefinedNetworks
+  * Add an end-to-end or integration test that proves traffic works for the
+    unmanaged no-overlay default-network and CUDN paths without
+    RouteAdvertisements when the external return routes are supplied by the test
+    environment.
 * Scale Testing Details
   * The impact of the number of the imported BGP routes
 * Performance Testing Details
@@ -1541,14 +1727,17 @@ Not supported.
 
 ### Risks
 
-In the no-overlay mode, east-west traffic relies on the BGP network. Therefore,
-internal and external BGP speaker outages may impact cluster networking.
+In the no-overlay mode, east-west traffic relies on the external routing fabric.
+For BGP-backed deployments, internal and external BGP speaker outages may impact
+cluster networking. For unmanaged default-network and CUDN deployments without
+RouteAdvertisements, incorrect external return routes may impact cluster
+networking.
 
 The no-overlay mode inherits all limitations from the BGP integration feature.
 Consequently, multicast is not supported in no-overlay mode.
 
-As OVN is no longer delivering pod-to-pod traffic end-to-end, it will
-necessitate BGP knowledge for debugging.
+As OVN is no longer delivering pod-to-pod traffic end-to-end, debugging requires
+underlay routing knowledge, including BGP knowledge for BGP-backed deployments.
 
 ### Known Limitations
 
@@ -1577,6 +1766,11 @@ necessitate BGP knowledge for debugging.
   sessions for N nodes), leading to increased CPU and memory consumption on each
   node. For large-scale deployments, users should consider using the unmanaged
   routing mode with external route reflectors or other scalable BGP topologies.
+
+* In unmanaged default-network and CUDN paths without RouteAdvertisements,
+  OVN-Kubernetes accepts the network without RouteAdvertisements but does not
+  verify that the external fabric has correct return routes to each node pod
+  subnet. Missing or stale external routes will break return traffic.
 
 * Changing the transport type between Geneve and no-overlay for the cluster
   default network is not supported. Users must create a new cluster with the

--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -229,9 +229,14 @@ func NewClusterManager(
 				return nil, fmt.Errorf("failed to create managed BGP controller: %w", err)
 			}
 		}
-		if config.Default.Transport == types.NetworkTransportNoOverlay {
-			cm.noOverlayController = nooverlay.NewController(wf, recorder)
-		}
+	}
+
+	// create the no-overlay validation controller even when
+	// RouteAdvertisements are disabled, so that it can validate that routing
+	// is unmanaged, the only no-overlay mode that works without
+	// RouteAdvertisements
+	if config.Default.Transport == types.NetworkTransportNoOverlay {
+		cm.noOverlayController = nooverlay.NewController(wf, recorder)
 	}
 
 	if util.IsEVPNEnabled() {

--- a/go-controller/pkg/clustermanager/nooverlay/controller.go
+++ b/go-controller/pkg/clustermanager/nooverlay/controller.go
@@ -21,9 +21,9 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
-	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // validationErrorType represents different types of validation failures
@@ -32,6 +32,13 @@ type validationErrorType int
 const (
 	errTypeNotAccepted validationErrorType = iota
 	errTypeNoRouteAdvertise
+)
+
+type validationMode string
+
+const (
+	validationModeRouteAdvertisements   validationMode = "RouteAdvertisements"
+	validationModeNoRouteAdvertisements validationMode = "NoRouteAdvertisements"
 )
 
 // eventReason represents Kubernetes event reasons
@@ -58,19 +65,29 @@ func (e *validationError) Error() string {
 	return e.message
 }
 
+// validationState is the outcome of a validation run, used to avoid emitting
+// duplicate events: a mode when validation passed, an error text otherwise.
+type validationState struct {
+	mode    validationMode
+	errText string
+}
+
 // Controller validates no-overlay configuration with RouteAdvertisements.
 // It watches RouteAdvertisements CRs, triggering validation when relevant changes occur.
+// When RouteAdvertisements are disabled, it validates once: the only valid
+// no-overlay configuration without them is unmanaged routing.
 type Controller struct {
 	wf       *factory.WatchFactory
 	recorder record.EventRecorder
 
-	// raController watches RouteAdvertisements resources
+	// raController watches RouteAdvertisements resources; nil when
+	// RouteAdvertisements are disabled
 	raController controllerutil.Controller
 
 	// validationLock protects validation state
 	validationLock sync.Mutex
-	// lastValidationError tracks the last validation error to avoid spamming events
-	lastValidationError string
+	// lastValidationState tracks the last validation outcome to avoid spamming events
+	lastValidationState *validationState
 }
 
 // NewController creates a new no-overlay validation controller.
@@ -80,6 +97,10 @@ func NewController(wf *factory.WatchFactory, recorder record.EventRecorder) *Con
 	c := &Controller{
 		wf:       wf,
 		recorder: recorder,
+	}
+
+	if !util.IsRouteAdvertisementsEnabled() {
+		return c
 	}
 
 	// Create controller config with RouteAdvertisements informer
@@ -98,6 +119,13 @@ func NewController(wf *factory.WatchFactory, recorder record.EventRecorder) *Con
 
 // Start starts the no-overlay validation controller
 func (c *Controller) Start() error {
+	if c.raController == nil {
+		// RouteAdvertisements are disabled: the configuration is static, so a
+		// single validation is enough.
+		c.runValidation()
+		klog.Infof("no-overlay validation controller started without RouteAdvertisements")
+		return nil
+	}
 	// Start controller with initial validation after cache sync.
 	// This ensures the informer cache is populated before validation runs,
 	// preventing false errors from reading an empty cache.
@@ -113,7 +141,7 @@ func (c *Controller) Start() error {
 
 // Stop stops the no-overlay validation controller
 func (c *Controller) Stop() {
-	if c == nil {
+	if c == nil || c.raController == nil {
 		return
 	}
 
@@ -129,16 +157,6 @@ func (c *Controller) reconcileRA(key string) error {
 	return nil
 }
 
-// selectsDefaultNetwork returns true if the RouteAdvertisements selects the default network
-func selectsDefaultNetwork(ra *ratypes.RouteAdvertisements) bool {
-	for _, networkSelector := range ra.Spec.NetworkSelectors {
-		if networkSelector.NetworkSelectionType == apitypes.DefaultNetwork {
-			return true
-		}
-	}
-	return false
-}
-
 // raNeedsValidation checks if the RouteAdvertisements update requires validation
 func (c *Controller) raNeedsValidation(oldRA, newRA *ratypes.RouteAdvertisements) bool {
 	// If either object is nil, we need to validate, e.g., on deletion or addition
@@ -147,7 +165,7 @@ func (c *Controller) raNeedsValidation(oldRA, newRA *ratypes.RouteAdvertisements
 	}
 
 	// If the RA started or stopped advertising default network, validate
-	if selectsDefaultNetwork(oldRA) != selectsDefaultNetwork(newRA) {
+	if util.RASelectsDefaultNetwork(oldRA) != util.RASelectsDefaultNetwork(newRA) {
 		return true
 	}
 
@@ -170,66 +188,65 @@ func (c *Controller) runValidation() {
 	c.validationLock.Lock()
 	defer c.validationLock.Unlock()
 
-	err := c.validate()
-	currentError := ""
+	mode, err := c.validate()
+	currentState := validationState{mode: mode}
 	if err != nil {
-		currentError = err.Error()
+		currentState = validationState{errText: err.Error()}
 	}
 
-	// Only emit event if error state changed
-	if currentError != c.lastValidationError {
+	// Only emit an event if the validation outcome changed.
+	if c.lastValidationState == nil || *c.lastValidationState != currentState {
 		if err != nil {
 			klog.Errorf("No-overlay validation failed: %v", err)
 			c.emitValidationEvent(err)
 		} else {
-			klog.Infof("No-overlay validation passed: RouteAdvertisements configuration is now valid")
-			c.emitReadyEvent()
+			klog.Infof("No-overlay validation passed")
+			c.emitReadyEvent(mode)
 		}
-		c.lastValidationError = currentError
+		c.lastValidationState = &currentState
 	}
 }
 
-// validate checks if the no-overlay configuration is valid
-func (c *Controller) validate() error {
+// validate selects the active default-network no-overlay state: accepted RA,
+// unmanaged no-overlay without RAs, or invalid when matching RAs exist but none
+// are accepted.
+func (c *Controller) validate() (validationMode, error) {
+	if !util.IsRouteAdvertisementsEnabled() {
+		if config.IsDefaultNetworkUnmanagedNoOverlay() {
+			return validationModeNoRouteAdvertisements, nil
+		}
+		// not reachable with a validated config: config validation requires
+		// RouteAdvertisements for no-overlay unless routing is unmanaged
+		return "", fmt.Errorf("RouteAdvertisements are disabled: transport=no-overlay requires RouteAdvertisements unless routing is unmanaged")
+	}
+
 	// Get all RouteAdvertisements CRs
 	ras, err := c.wf.RouteAdvertisementsInformer().Lister().List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("failed to list RouteAdvertisements: %w", err)
+		return "", fmt.Errorf("failed to list RouteAdvertisements: %w", err)
 	}
 
-	// Track if we found RAs advertising default network that are not accepted
-	foundDefaultNetworkRA := false
+	// Track matching RAs that are not accepted. Accepted matches return early.
 	notAcceptedRANames := []string{}
 
-	// Check if any RouteAdvertisements CR is configured for the default network
 	for _, ra := range ras {
-		// Check if this RouteAdvertisements selects the default network
-		for _, networkSelector := range ra.Spec.NetworkSelectors {
-			if networkSelector.NetworkSelectionType == apitypes.DefaultNetwork {
-				// Found a RouteAdvertisements for default network
-				// Check if it advertises pod networks
-				if !slices.Contains(ra.Spec.Advertisements, ratypes.PodNetwork) {
-					continue
-				}
-
-				// We found at least one RA advertising default network
-				foundDefaultNetworkRA = true
-
-				if isRAAccepted(ra.Status.Conditions) {
-					// Valid configuration found
-					klog.V(5).Infof("Found valid RouteAdvertisements %q for default network with no-overlay transport", ra.Name)
-					return nil
-				} else {
-					klog.Warningf("RouteAdvertisements %q selects default network but status is not Accepted", ra.Name)
-					notAcceptedRANames = append(notAcceptedRANames, ra.Name)
-				}
-			}
+		if !util.RAAdvertisesDefaultNetwork(ra) {
+			continue
 		}
+
+		if isRAAccepted(ra.Status.Conditions) {
+			klog.V(5).Infof("Found valid RouteAdvertisements %q for default network with no-overlay transport", ra.Name)
+			return validationModeRouteAdvertisements, nil
+		}
+		klog.Warningf("RouteAdvertisements %q selects default network but status is not Accepted", ra.Name)
+		notAcceptedRANames = append(notAcceptedRANames, ra.Name)
 	}
 
-	// Return specific error based on what we found
-	if !foundDefaultNetworkRA {
-		return &validationError{
+	if len(notAcceptedRANames) == 0 {
+		if config.IsDefaultNetworkUnmanagedNoOverlay() {
+			return validationModeNoRouteAdvertisements, nil
+		}
+		return "", &validationError{
 			errorType: errTypeNoRouteAdvertise,
 			message:   "no RouteAdvertisements CR is advertising the default network pod networks",
 		}
@@ -238,7 +255,7 @@ func (c *Controller) validate() error {
 	// Found RAs advertising default network, but none are accepted
 	// Sort names to ensure deterministic error messages for event deduplication
 	slices.Sort(notAcceptedRANames)
-	return &validationError{
+	return "", &validationError{
 		errorType: errTypeNotAccepted,
 		message:   fmt.Sprintf("RouteAdvertisements CRs %q are advertising the default network pod networks but none have status Accepted=True", notAcceptedRANames),
 		raNames:   notAcceptedRANames,
@@ -284,11 +301,15 @@ func (c *Controller) emitValidationEvent(err error) {
 }
 
 // emitReadyEvent emits a Normal event when validation passes
-func (c *Controller) emitReadyEvent() {
+func (c *Controller) emitReadyEvent(mode validationMode) {
+	message := "No-overlay transport is properly configured with RouteAdvertisements CR advertising the default network pod networks with status Accepted=True"
+	if mode == validationModeNoRouteAdvertisements {
+		message = "No-overlay transport is configured with unmanaged routing and no RouteAdvertisements. Routes to pod subnets are not installed on nodes; external routing is responsible for returning traffic to node pod subnets."
+	}
 	c.emitEvent(
 		corev1.EventTypeNormal,
 		string(eventReasonConfigReady),
-		"No-overlay transport is properly configured with RouteAdvertisements CR advertising the default network pod networks with status Accepted=True",
+		message,
 	)
 }
 

--- a/go-controller/pkg/clustermanager/nooverlay/controller_test.go
+++ b/go-controller/pkg/clustermanager/nooverlay/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -69,6 +70,15 @@ func (tra testRA) RouteAdvertisements() *ratypes.RouteAdvertisements {
 	return ra
 }
 
+func startRouteAdvertisementsInformer(wf *factory.WatchFactory) chan struct{} {
+	stopCh := make(chan struct{})
+	go wf.RouteAdvertisementsInformer().Informer().Run(stopCh)
+	gomega.Eventually(func() bool {
+		return wf.RouteAdvertisementsInformer().Informer().HasSynced()
+	}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
+	return stopCh
+}
+
 var _ = ginkgo.Describe("No-Overlay Controller", func() {
 	var (
 		recorder *record.FakeRecorder
@@ -105,7 +115,7 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			gomega.Expect(controller.raController).NotTo(gomega.BeNil())
 		})
 
-		ginkgo.It("should have empty last validation error on creation", func() {
+		ginkgo.It("should have empty last validation state on creation", func() {
 			fakeClient := &util.OVNClusterManagerClientset{
 				KubeClient:                fake.NewSimpleClientset(),
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
@@ -117,7 +127,7 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			defer wf.Shutdown()
 
 			controller := NewController(wf, recorder)
-			gomega.Expect(controller.lastValidationError).To(gomega.BeEmpty())
+			gomega.Expect(controller.lastValidationState).To(gomega.BeNil())
 		})
 	})
 
@@ -155,17 +165,12 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
 
-			err = wf.Start()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
 
 			controller := NewController(wf, recorder)
 
-			// Give time for informers to sync
-			gomega.Eventually(func() bool {
-				return wf.RouteAdvertisementsInformer().Informer().HasSynced()
-			}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
-
-			err = controller.validate()
+			_, err = controller.validate()
 			if expectError {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				if expectErrorSubstring != "" {
@@ -238,6 +243,126 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			"",
 		),
 	)
+
+	ginkgo.Context("unmanaged no-overlay validation without RouteAdvertisements", func() {
+		ginkgo.BeforeEach(func() {
+			config.NoOverlay.OutboundSNAT = types.NoOverlaySNATEnabled
+			config.NoOverlay.Routing = config.NoOverlayRoutingUnmanaged
+		})
+
+		ginkgo.It("should pass when no RouteAdvertisements CR exists", func() {
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
+			controller := NewController(wf, recorder)
+
+			mode, err := controller.validate()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(mode).To(gomega.Equal(validationModeNoRouteAdvertisements))
+		})
+
+		ginkgo.It("should fail when a matching RouteAdvertisements CR exists but is not accepted", func() {
+			ra := testRA{
+				Name:           "test-ra",
+				SelectsDefault: true,
+				AdvertisePods:  true,
+				AcceptedStatus: ptr.To(metav1.ConditionFalse),
+			}
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
+			controller := NewController(wf, recorder)
+
+			raObj := ra.RouteAdvertisements()
+			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), raObj, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().UpdateStatus(context.Background(), raObj, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() bool {
+				raObj, getErr := wf.RouteAdvertisementsInformer().Lister().Get("test-ra")
+				if getErr != nil || raObj == nil {
+					return false
+				}
+				condition := meta.FindStatusCondition(raObj.Status.Conditions, conditionTypeAccepted)
+				return condition != nil && condition.Status == metav1.ConditionFalse
+			}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
+
+			_, err = controller.validate()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("but none have status Accepted=True"))
+		})
+
+		ginkgo.It("should pass and emit a ready event when RouteAdvertisements are disabled", func() {
+			config.OVNKubernetesFeature.EnableRouteAdvertisements = false
+
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			controller := NewController(wf, recorder)
+			gomega.Expect(controller.raController).To(gomega.BeNil())
+
+			mode, err := controller.validate()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(mode).To(gomega.Equal(validationModeNoRouteAdvertisements))
+
+			gomega.Expect(controller.Start()).To(gomega.Succeed())
+			defer controller.Stop()
+			var event string
+			gomega.Eventually(recorder.Events, 2*time.Second).Should(gomega.Receive(&event))
+			gomega.Expect(event).To(gomega.ContainSubstring("NoOverlayConfigurationReady"))
+			gomega.Expect(event).To(gomega.ContainSubstring("unmanaged routing and no RouteAdvertisements"))
+		})
+
+		ginkgo.It("should fail when RouteAdvertisements are disabled and routing is managed", func() {
+			config.OVNKubernetesFeature.EnableRouteAdvertisements = false
+			config.NoOverlay.Routing = config.NoOverlayRoutingManaged
+
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			controller := NewController(wf, recorder)
+
+			_, err = controller.validate()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("RouteAdvertisements are disabled"))
+		})
+	})
 
 	ginkgo.Context("RA needsValidation logic", func() {
 		var controller *Controller
@@ -366,7 +491,8 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
 
-			gomega.Expect(wf.Start()).To(gomega.Succeed())
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
 
 			controller := NewController(wf, localRecorder)
 
@@ -400,7 +526,8 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
 
-			gomega.Expect(wf.Start()).To(gomega.Succeed())
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
 
 			controller := NewController(wf, localRecorder)
 
@@ -426,7 +553,8 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
 
-			gomega.Expect(wf.Start()).To(gomega.Succeed())
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
 
 			controller := NewController(wf, localRecorder)
 
@@ -491,7 +619,8 @@ var _ = ginkgo.Describe("No-Overlay Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
 
-			gomega.Expect(wf.Start()).To(gomega.Succeed())
+			stopCh := startRouteAdvertisementsInformer(wf)
+			defer close(stopCh)
 
 			controller := NewController(wf, recorder)
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -1252,8 +1252,11 @@ func (c *Controller) ReconcileRouteAdvertisements(raName string) error {
 	ra, err := c.raLister.Get(raName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// RA not found (likely a delete event) - fall back to requeueing all no-overlay/EVPN CUDNs
-			// since we can't determine which CUDNs were selected by the deleted RA
+			// On RA deletion the object is gone, so its selectors are unavailable.
+			// Requeue all no-overlay/EVPN CUDNs because any of them may have depended on
+			// the deleted RA. For unmanaged no-overlay, this also lets a CUDN previously
+			// blocked by an unaccepted RA become accepted when no remaining RA selects it
+			// and advertises PodNetwork.
 			klog.V(4).InfoS("RouteAdvertisements not found, re-queueing all CUDNs with no-overlay or EVPN transport", "ra", raName)
 			for _, cudn := range cudns {
 				transport := cudn.Spec.Network.GetTransport()
@@ -1272,7 +1275,7 @@ func (c *Controller) ReconcileRouteAdvertisements(raName string) error {
 	for _, cudn := range cudns {
 		transport := cudn.Spec.Network.GetTransport()
 
-		// Only consider CUDNs with no-overlay or EVPN transport (both require RouteAdvertisements)
+		// Only consider CUDNs with no-overlay or EVPN transport.
 		if transport != userdefinednetworkv1.TransportOptionNoOverlay && transport != userdefinednetworkv1.TransportOptionEVPN {
 			continue
 		}

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -31,6 +31,7 @@ import (
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	rainformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/routeadvertisements/v1"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	udnclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
@@ -87,9 +88,20 @@ var _ = Describe("User Defined Network Controller", func() {
 
 		networkManager, err := networkmanager.NewForCluster(&networkmanager.FakeControllerManager{}, f, cs, nil, id.NewTunnelKeyAllocator("TunnelKeys"))
 		Expect(err).NotTo(HaveOccurred())
+
+		var vtepInformer vtepinformer.VTEPInformer
+		if util.IsEVPNEnabled() {
+			vtepInformer = f.VTEPInformer()
+		}
+
+		var raInformer rainformer.RouteAdvertisementsInformer
+		if util.IsRouteAdvertisementsEnabled() {
+			raInformer = f.RouteAdvertisementsInformer()
+		}
+
 		return New(cs.NetworkAttchDefClient, f.NADInformer(),
 			cs.UserDefinedNetworkClient, f.UserDefinedNetworkInformer(), f.ClusterUserDefinedNetworkInformer(),
-			renderNADStub, networkManager.Interface(), f.PodCoreInformer(), f.NamespaceInformer(), f.VTEPInformer(), f.RouteAdvertisementsInformer(), nil,
+			renderNADStub, networkManager.Interface(), f.PodCoreInformer(), f.NamespaceInformer(), vtepInformer, raInformer, nil,
 		)
 	}
 
@@ -110,9 +122,13 @@ var _ = Describe("User Defined Network Controller", func() {
 		if util.IsEVPNEnabled() {
 			vtepInformer = f.VTEPInformer()
 		}
+		var raInformer rainformer.RouteAdvertisementsInformer
+		if util.IsRouteAdvertisementsEnabled() {
+			raInformer = f.RouteAdvertisementsInformer()
+		}
 		return New(cs.NetworkAttchDefClient, f.NADInformer(),
 			cs.UserDefinedNetworkClient, f.UserDefinedNetworkInformer(), f.ClusterUserDefinedNetworkInformer(),
-			renderNADStub, nm.Interface(), f.PodCoreInformer(), f.NamespaceInformer(), vtepInformer, f.RouteAdvertisementsInformer(), nil,
+			renderNADStub, nm.Interface(), f.PodCoreInformer(), f.NamespaceInformer(), vtepInformer, raInformer, nil,
 		)
 	}
 
@@ -2417,6 +2433,14 @@ var _ = Describe("User Defined Network Controller", func() {
 		return cudn
 	}
 
+	configureUnmanagedNoOverlayCUDN := func(cudn *udnv1.ClusterUserDefinedNetwork, outboundSNAT udnv1.SNATOption) {
+		cudn.Spec.Network.Transport = udnv1.TransportOptionNoOverlay
+		cudn.Spec.Network.NoOverlay = &udnv1.NoOverlayConfig{
+			OutboundSNAT: outboundSNAT,
+			Routing:      udnv1.RoutingUnmanaged,
+		}
+	}
+
 	createAcceptedRA := func(name string, matchLabels map[string]string) {
 		ra := &ratypes.RouteAdvertisements{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -2513,6 +2537,57 @@ var _ = Describe("User Defined Network Controller", func() {
 			createNotAcceptedRA("test-ra", map[string]string{"app": "test"})
 			Expect(c.Run()).To(Succeed())
 			expectTransportCondition("test-cudn", metav1.ConditionFalse, ReasonNoOverlayRouteAdvertisementsNotAccepted, "RouteAdvertisements CR test-ra advertises the pod subnets, but its status is not accepted.")
+		})
+
+		DescribeTable("should accept unmanaged no-overlay without RouteAdvertisements",
+			func(outboundSNAT udnv1.SNATOption) {
+				cudn := newCUDNWithTransport("test-cudn", map[string]string{"app": "test"}, udnv1.TransportOptionNoOverlay)
+				configureUnmanagedNoOverlayCUDN(cudn, outboundSNAT)
+				c = newTestController(template.RenderNetAttachDefManifest, cudn)
+				Expect(c.Run()).To(Succeed())
+				expectTransportCondition("test-cudn", metav1.ConditionTrue, ReasonNoOverlayRouteAdvertisementsNotRequired, MessageNoOverlayRouteAdvertisementsNotRequired)
+			},
+			Entry("with outboundSNAT enabled", udnv1.SNATEnabled),
+			Entry("with outboundSNAT disabled", udnv1.SNATDisabled),
+		)
+
+		It("should accept unmanaged no-overlay when RouteAdvertisements feature is disabled", func() {
+			config.OVNKubernetesFeature.EnableRouteAdvertisements = false
+			cudn := newCUDNWithTransport("test-cudn", map[string]string{"app": "test"}, udnv1.TransportOptionNoOverlay)
+			configureUnmanagedNoOverlayCUDN(cudn, udnv1.SNATEnabled)
+			c = newTestController(template.RenderNetAttachDefManifest, cudn)
+			Expect(c.Run()).To(Succeed())
+			expectTransportCondition("test-cudn", metav1.ConditionTrue, ReasonNoOverlayRouteAdvertisementsNotRequired, MessageNoOverlayRouteAdvertisementsNotRequired)
+		})
+
+		It("should reject unmanaged no-overlay when RouteAdvertisements exists but is not accepted", func() {
+			cudn := newCUDNWithTransport("test-cudn", map[string]string{"app": "test"}, udnv1.TransportOptionNoOverlay)
+			configureUnmanagedNoOverlayCUDN(cudn, udnv1.SNATEnabled)
+			c = newTestController(template.RenderNetAttachDefManifest, cudn)
+			createNotAcceptedRA("test-ra", map[string]string{"app": "test"})
+			Expect(c.Run()).To(Succeed())
+			expectTransportCondition("test-cudn", metav1.ConditionFalse, "NoOverlayRouteAdvertisementsNotAccepted", "RouteAdvertisements CR test-ra advertises the pod subnets, but its status is not accepted.")
+		})
+
+		It("should accept unmanaged no-overlay when any relevant RouteAdvertisements is accepted", func() {
+			cudn := newCUDNWithTransport("test-cudn", map[string]string{"app": "test"}, udnv1.TransportOptionNoOverlay)
+			configureUnmanagedNoOverlayCUDN(cudn, udnv1.SNATEnabled)
+			c = newTestController(template.RenderNetAttachDefManifest, cudn)
+			createAcceptedRA("test-ra", map[string]string{"app": "test"})
+			createNotAcceptedRA("test-ra-bad", map[string]string{"app": "test"})
+			Expect(c.Run()).To(Succeed())
+			expectTransportCondition("test-cudn", metav1.ConditionTrue, "NoOverlayTransportAccepted", "Transport has been configured as 'no-overlay'.")
+		})
+
+		It("should still require RouteAdvertisements for no-overlay with managed routing and SNAT disabled", func() {
+			cudn := newCUDNWithTransport("test-cudn", map[string]string{"app": "test"}, udnv1.TransportOptionNoOverlay)
+			cudn.Spec.Network.NoOverlay = &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATDisabled,
+				Routing:      udnv1.RoutingManaged,
+			}
+			c = newTestController(template.RenderNetAttachDefManifest, cudn)
+			Expect(c.Run()).To(Succeed())
+			expectTransportCondition("test-cudn", metav1.ConditionFalse, "NoOverlayRouteAdvertisementsIsMissing", "No RouteAdvertisements CR is advertising the pod networks.")
 		})
 
 		It("should update status to True with EVPNTransportAccepted when RA is accepted", func() {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -217,6 +217,7 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, uplink
 		if noOverlayCfg != nil {
 			// Convert CRD SNATOption enum ("Enabled"/"Disabled") to internal format ("enabled"/"disabled")
 			netConfSpec.OutboundSNAT = strings.ToLower(string(noOverlayCfg.OutboundSNAT))
+			netConfSpec.NoOverlayRouting = noOverlayRoutingFromCRD(noOverlayCfg.Routing)
 		}
 	}
 
@@ -289,6 +290,9 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, uplink
 	if netConfSpec.OutboundSNAT != "" {
 		cniNetConf["outboundSNAT"] = netConfSpec.OutboundSNAT
 	}
+	if netConfSpec.NoOverlayRouting != "" {
+		cniNetConf["noOverlayRouting"] = netConfSpec.NoOverlayRouting
+	}
 	if netConfSpec.EVPN != nil {
 		cniNetConf["evpn"] = netConfSpec.EVPN
 	}
@@ -310,6 +314,17 @@ func transportFromCRD(crdTransport userdefinednetworkv1.TransportOption) string 
 		return types.NetworkTransportEVPN
 	default:
 		return "" // empty string means default OVN transport; kubebuilder prevents unknown values
+	}
+}
+
+func noOverlayRoutingFromCRD(crdRouting userdefinednetworkv1.RoutingOption) string {
+	switch crdRouting {
+	case userdefinednetworkv1.RoutingManaged:
+		return config.NoOverlayRoutingManaged
+	case userdefinednetworkv1.RoutingUnmanaged:
+		return config.NoOverlayRoutingUnmanaged
+	default:
+		return ""
 	}
 }
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
@@ -503,8 +503,39 @@ var _ = Describe("NetAttachDefTemplate", func() {
 				"topology": "layer3",
 				"joinSubnet": "100.65.0.0/16,fd99::/64",
 				"subnets": "192.168.100.0/16,2001:dbb::/60",
-				"mtu": 1500
-			}`,
+					"mtu": 1500
+				}`,
+		),
+		Entry("primary network, layer3 with no-overlay unmanaged routing",
+			udnv1.NetworkSpec{
+				Topology: udnv1.NetworkTopologyLayer3,
+				Layer3: &udnv1.Layer3Config{
+					Role: udnv1.NetworkRolePrimary,
+					Subnets: []udnv1.Layer3Subnet{
+						{CIDR: "192.168.100.0/16"},
+					},
+					MTU: 1500,
+				},
+				Transport: udnv1.TransportOptionNoOverlay,
+				NoOverlay: &udnv1.NoOverlayConfig{
+					OutboundSNAT: udnv1.SNATEnabled,
+					Routing:      udnv1.RoutingUnmanaged,
+				},
+			},
+			`{
+					"cniVersion": "1.1.0",
+					"type": "ovn-k8s-cni-overlay",
+					"name": "cluster_udn_test-net",
+					"netAttachDefName": "mynamespace/test-net",
+					"role": "primary",
+					"topology": "layer3",
+					"joinSubnet": "100.65.0.0/16,fd99::/64",
+					"subnets": "192.168.100.0/16",
+					"mtu": 1500,
+					"transport": "no-overlay",
+					"outboundSNAT": "enabled",
+					"noOverlayRouting": "unmanaged"
+				}`,
 		),
 		Entry("primary network, layer2",
 			udnv1.NetworkSpec{

--- a/go-controller/pkg/clustermanager/userdefinednetwork/transport_validation.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/transport_validation.go
@@ -33,7 +33,10 @@ const (
 	ReasonNoOverlayTransportAccepted              = "NoOverlayTransportAccepted"
 	ReasonNoOverlayRouteAdvertisementsIsMissing   = "NoOverlayRouteAdvertisementsIsMissing"
 	ReasonNoOverlayRouteAdvertisementsNotAccepted = "NoOverlayRouteAdvertisementsNotAccepted"
+	ReasonNoOverlayRouteAdvertisementsNotRequired = "NoOverlayRouteAdvertisementsNotRequired"
 	ReasonRouteAdvertisementsNotEnabled           = "RouteAdvertisementsNotEnabled"
+
+	MessageNoOverlayRouteAdvertisementsNotRequired = "Transport has been configured as no-overlay with unmanaged routing. RouteAdvertisements are not required; external routing is responsible for returning traffic to node pod subnets."
 )
 
 // setTransportStatusCondition validates the transport configuration for a CUDN and sets its TransportAccepted status condition.
@@ -44,6 +47,9 @@ const (
 // the error is surfaced as a TransportAccepted=False condition (VTEP or config issue).
 // For no-overlay and EVPN transports (when EVPN validation passes), it validates that a
 // RouteAdvertisements CR exists and is accepted.
+// No-overlay CUDNs with unmanaged routing can be accepted without
+// RouteAdvertisements only when no RouteAdvertisements object selects the CUDN
+// and advertises PodNetwork.
 //
 // This function only SETS the condition on the provided CUDN object; it does NOT apply status.
 // The actual status update is handled by updateClusterUDNStatus() to ensure a single status update.
@@ -90,12 +96,33 @@ func (c *Controller) setTransportStatusCondition(cudn *userdefinednetworkv1.Clus
 	return false, nil
 }
 
+// allowsNoOverlayWithoutRouteAdvertisements returns true for primary layer 3
+// no-overlay CUDNs that do not require RouteAdvertisements because routing is
+// unmanaged. In this mode, the external network is responsible for returning
+// traffic to node pod subnets.
+func allowsNoOverlayWithoutRouteAdvertisements(cudn *userdefinednetworkv1.ClusterUserDefinedNetwork) bool {
+	if cudn == nil {
+		return false
+	}
+	network := cudn.Spec.Network
+	noOverlay := network.NoOverlay
+	return network.GetTransport() == userdefinednetworkv1.TransportOptionNoOverlay &&
+		network.Topology == userdefinednetworkv1.NetworkTopologyLayer3 &&
+		network.Layer3 != nil &&
+		network.Layer3.Role == userdefinednetworkv1.NetworkRolePrimary &&
+		noOverlay != nil &&
+		noOverlay.Routing == userdefinednetworkv1.RoutingUnmanaged
+}
+
 // validateTransportWithRouteAdvertisements validates that a CUDN with no-overlay or EVPN transport has proper RouteAdvertisements configuration.
 // This function is used for both NoOverlay and EVPN transports as they both require RouteAdvertisements validation.
-// This function updates the cudn object status then reconcileCUDN() goes ahead and update the CR to reflect actual CUDN transport status.
+// This function updates the cudn object status then reconcileCUDN() goes ahead and updates the CR to reflect actual CUDN transport status.
 // Returns true if the TransportAccepted condition was updated (changed from previous value).
 func (c *Controller) validateTransportWithRouteAdvertisements(cudn *userdefinednetworkv1.ClusterUserDefinedNetwork, transport userdefinednetworkv1.TransportOption) (bool, error) {
 	if c.raLister == nil {
+		if allowsNoOverlayWithoutRouteAdvertisements(cudn) {
+			return c.setTransportCondition(cudn, metav1.ConditionTrue, ReasonNoOverlayRouteAdvertisementsNotRequired, MessageNoOverlayRouteAdvertisementsNotRequired), nil
+		}
 		// RouteAdvertisements feature not enabled
 		updated := c.setTransportCondition(cudn, metav1.ConditionFalse, ReasonRouteAdvertisementsNotEnabled,
 			fmt.Sprintf("RouteAdvertisements feature is not enabled but required for %s transport.", transport))
@@ -103,6 +130,7 @@ func (c *Controller) validateTransportWithRouteAdvertisements(cudn *userdefinedn
 	}
 
 	klog.V(5).Infof("Validating %s ClusterUserDefinedNetwork %q", transport, cudn.Name)
+	allowsNoRAAcceptance := allowsNoOverlayWithoutRouteAdvertisements(cudn)
 
 	// Get all RouteAdvertisements CRs
 	ras, err := c.raLister.List(labels.Everything())
@@ -164,7 +192,11 @@ func (c *Controller) validateTransportWithRouteAdvertisements(cudn *userdefinedn
 		updated = c.setTransportCondition(cudn, metav1.ConditionTrue, acceptedReason, acceptedMessage)
 	} else if !foundCUDNRA {
 		// No RouteAdvertisements CR advertising this CUDN
-		updated = c.setTransportCondition(cudn, metav1.ConditionFalse, missingReason, "No RouteAdvertisements CR is advertising the pod networks.")
+		if allowsNoRAAcceptance {
+			updated = c.setTransportCondition(cudn, metav1.ConditionTrue, ReasonNoOverlayRouteAdvertisementsNotRequired, MessageNoOverlayRouteAdvertisementsNotRequired)
+		} else {
+			updated = c.setTransportCondition(cudn, metav1.ConditionFalse, missingReason, "No RouteAdvertisements CR is advertising the pod networks.")
+		}
 	} else {
 		// Found RAs advertising this CUDN, but none are accepted
 		raNamesList := strings.Join(notAcceptedRANames, ", ")

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -95,6 +95,12 @@ type NetConf struct {
 	// Only valid when Transport is "no-overlay".
 	OutboundSNAT string `json:"outboundSNAT,omitempty"`
 
+	// NoOverlayRouting configures whether pod network routing is managed by
+	// OVN-Kubernetes or externally when using no-overlay transport.
+	// Valid values are "managed" and "unmanaged".
+	// Only valid when Transport is "no-overlay".
+	NoOverlayRouting string `json:"noOverlayRouting,omitempty"`
+
 	// EVPNConfig contains configuration for EVPN mode.
 	// Only valid when Transport is "evpn".
 	EVPN *EVPNConfig `json:"evpn,omitempty"`
@@ -151,6 +157,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		PhysicalNetworkName   string      `json:"physicalNetworkName,omitempty"`
 		Transport             string      `json:"transport,omitempty"`
 		OutboundSNAT          string      `json:"outboundSNAT,omitempty"`
+		NoOverlayRouting      string      `json:"noOverlayRouting,omitempty"`
 		EVPN                  *EVPNConfig `json:"evpn,omitempty"`
 		Uplink                string      `json:"uplink,omitempty"`
 		DeviceID              string      `json:"deviceID,omitempty"`
@@ -181,6 +188,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		PhysicalNetworkName:   n.PhysicalNetworkName,
 		Transport:             n.Transport,
 		OutboundSNAT:          n.OutboundSNAT,
+		NoOverlayRouting:      n.NoOverlayRouting,
 		EVPN:                  n.EVPN,
 		Uplink:                n.Uplink,
 		DeviceID:              n.DeviceID,

--- a/go-controller/pkg/cni/types/types_test.go
+++ b/go-controller/pkg/cni/types/types_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 )
 
-func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
+func TestNetConfMarshalJSONIncludesNoOverlayFields(t *testing.T) {
 	netConf := NetConf{
-		Transport:    "no-overlay",
-		OutboundSNAT: "enabled",
+		Transport:        "no-overlay",
+		OutboundSNAT:     "enabled",
+		NoOverlayRouting: "unmanaged",
 	}
 
 	rawNetConf, err := json.Marshal(netConf)
@@ -20,8 +21,9 @@ func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
 	}
 
 	var parsedNetConf struct {
-		Transport    string `json:"transport"`
-		OutboundSNAT string `json:"outboundSNAT"`
+		Transport        string `json:"transport"`
+		OutboundSNAT     string `json:"outboundSNAT"`
+		NoOverlayRouting string `json:"noOverlayRouting"`
 	}
 	if err := json.Unmarshal(rawNetConf, &parsedNetConf); err != nil {
 		t.Fatalf("failed to unmarshal NetConf: %v", err)
@@ -32,5 +34,8 @@ func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
 	}
 	if parsedNetConf.OutboundSNAT != netConf.OutboundSNAT {
 		t.Fatalf("expected outboundSNAT %q, got %q", netConf.OutboundSNAT, parsedNetConf.OutboundSNAT)
+	}
+	if parsedNetConf.NoOverlayRouting != netConf.NoOverlayRouting {
+		t.Fatalf("expected noOverlayRouting %q, got %q", netConf.NoOverlayRouting, parsedNetConf.NoOverlayRouting)
 	}
 }

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -2445,6 +2445,13 @@ func buildNoOverlayConfig(file *config) error {
 	return nil
 }
 
+// IsDefaultNetworkUnmanagedNoOverlay returns true when the default network
+// uses no-overlay transport with unmanaged routing.
+func IsDefaultNetworkUnmanagedNoOverlay() bool {
+	return Default.Transport == types.NetworkTransportNoOverlay &&
+		NoOverlay.Routing == NoOverlayRoutingUnmanaged
+}
+
 // validateNoOverlayConfig validates the no-overlay configuration
 func validateNoOverlayConfig() error {
 	// Validate transport option; empty string means default OVN overlay transport
@@ -2454,9 +2461,6 @@ func validateNoOverlayConfig() error {
 
 	// If transport is no-overlay, validate required no-overlay options
 	if Default.Transport == types.NetworkTransportNoOverlay {
-		if !OVNKubernetesFeature.EnableRouteAdvertisements {
-			return fmt.Errorf("enable-route-advertisements must be true when transport=%q", types.NetworkTransportNoOverlay)
-		}
 		if NoOverlay.OutboundSNAT == "" {
 			return fmt.Errorf("outbound-snat is required when transport=no-overlay")
 		}
@@ -2469,6 +2473,11 @@ func validateNoOverlayConfig() error {
 		}
 		if NoOverlay.Routing != NoOverlayRoutingManaged && NoOverlay.Routing != NoOverlayRoutingUnmanaged {
 			return fmt.Errorf("invalid routing %q: must be %q or %q", NoOverlay.Routing, NoOverlayRoutingManaged, NoOverlayRoutingUnmanaged)
+		}
+
+		if !OVNKubernetesFeature.EnableRouteAdvertisements && NoOverlay.Routing != NoOverlayRoutingUnmanaged {
+			return fmt.Errorf("enable-route-advertisements must be true when transport=%q unless routing=%q",
+				types.NetworkTransportNoOverlay, NoOverlayRoutingUnmanaged)
 		}
 
 		// If routing is managed, topology is required

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1960,6 +1960,31 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 			err := validateNoOverlayConfig()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
+
+		It("allows unmanaged no-overlay with RouteAdvertisements disabled", func() {
+			for _, outboundSNAT := range []string{types.NoOverlaySNATDisabled, types.NoOverlaySNATEnabled} {
+				OVNKubernetesFeature.EnableRouteAdvertisements = false
+				Default.Transport = types.NetworkTransportNoOverlay
+				NoOverlay.OutboundSNAT = outboundSNAT
+				NoOverlay.Routing = NoOverlayRoutingUnmanaged
+
+				err := validateNoOverlayConfig()
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		})
+
+		It("still requires RouteAdvertisements outside unmanaged no-overlay", func() {
+			OVNKubernetesFeature.EnableRouteAdvertisements = false
+			Default.Transport = types.NetworkTransportNoOverlay
+			NoOverlay.OutboundSNAT = types.NoOverlaySNATEnabled
+			NoOverlay.Routing = NoOverlayRoutingManaged
+			ManagedBGP.Topology = ManagedBGPTopologyFullMesh
+			ManagedBGP.FRRNamespace = "frr-k8s-system"
+
+			err := validateNoOverlayConfig()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("enable-route-advertisements must be true"))
+		})
 	})
 
 	Describe("BGP Configuration", func() {

--- a/go-controller/pkg/util/mocks/multinetwork/NetInfo.go
+++ b/go-controller/pkg/util/mocks/multinetwork/NetInfo.go
@@ -851,6 +851,24 @@ func (_m *NetInfo) OutboundSNAT() string {
 	return r0
 }
 
+// NoOverlayRouting provides a mock function with no fields
+func (_m *NetInfo) NoOverlayRouting() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NoOverlayRouting")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // PhysicalNetworkName provides a mock function with no fields
 func (_m *NetInfo) PhysicalNetworkName() string {
 	ret := _m.Called()

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -28,6 +28,8 @@ import (
 
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
 
@@ -1964,6 +1966,27 @@ func IsRouteAdvertisementsEnabled() bool {
 	// for now, we require multi-network to be enabled because we rely on NADs,
 	// even for the default network
 	return config.OVNKubernetesFeature.EnableMultiNetwork && config.OVNKubernetesFeature.EnableRouteAdvertisements
+}
+
+// RASelectsDefaultNetwork returns true when the RouteAdvertisements selects
+// the default network.
+func RASelectsDefaultNetwork(ra *ratypes.RouteAdvertisements) bool {
+	if ra == nil {
+		return false
+	}
+	for _, networkSelector := range ra.Spec.NetworkSelectors {
+		if networkSelector.NetworkSelectionType == apitypes.DefaultNetwork {
+			return true
+		}
+	}
+	return false
+}
+
+// RAAdvertisesDefaultNetwork returns true when the RouteAdvertisements
+// advertises the default network pod subnets, regardless of its status.
+func RAAdvertisesDefaultNetwork(ra *ratypes.RouteAdvertisements) bool {
+	return ra != nil && slices.Contains(ra.Spec.Advertisements, ratypes.PodNetwork) &&
+		RASelectsDefaultNetwork(ra)
 }
 
 func IsEVPNEnabled() bool {

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -63,6 +63,7 @@ type NetInfo interface {
 	PhysicalNetworkName() string
 	Transport() string
 	OutboundSNAT() string
+	NoOverlayRouting() string
 	EVPNVTEPName() string
 	EVPNMACVRFVNI() int32
 	EVPNMACVRFRouteTarget() string
@@ -689,6 +690,11 @@ func (nInfo *DefaultNetInfo) OutboundSNAT() string {
 	return config.NoOverlay.OutboundSNAT
 }
 
+// NoOverlayRouting returns the routing mode for the default network when using no-overlay transport.
+func (nInfo *DefaultNetInfo) NoOverlayRouting() string {
+	return config.NoOverlay.Routing
+}
+
 // EVPNVTEPName returns empty as EVPN is not supported on the default network
 func (nInfo *DefaultNetInfo) EVPNVTEPName() string {
 	return ""
@@ -761,10 +767,11 @@ type userDefinedNetInfo struct {
 	defaultGatewayIPs   []net.IP
 	managementIPs       []net.IP
 
-	transport    string
-	evpn         *ovncnitypes.EVPNConfig
-	outboundSNAT string
-	uplink       string
+	transport        string
+	evpn             *ovncnitypes.EVPNConfig
+	outboundSNAT     string
+	uplink           string
+	noOverlayRouting string
 }
 
 func (nInfo *userDefinedNetInfo) GetNetInfo() NetInfo {
@@ -919,6 +926,11 @@ func (nInfo *userDefinedNetInfo) Transport() string {
 // OutboundSNAT() string returns the outbound SNAT configuration for this network when using no-overlay transport.
 func (nInfo *userDefinedNetInfo) OutboundSNAT() string {
 	return nInfo.outboundSNAT
+}
+
+// NoOverlayRouting returns the routing mode for this network when using no-overlay transport.
+func (nInfo *userDefinedNetInfo) NoOverlayRouting() string {
+	return nInfo.noOverlayRouting
 }
 
 // EVPNVTEPName returns the name of the VTEP CR for EVPN
@@ -1125,6 +1137,9 @@ func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
 	if nInfo.OutboundSNAT() != other.OutboundSNAT() {
 		return false
 	}
+	if nInfo.NoOverlayRouting() != other.NoOverlayRouting() {
+		return false
+	}
 
 	lessCIDRNetworkEntry := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
 	if !cmp.Equal(nInfo.Subnets(), other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
@@ -1174,6 +1189,7 @@ func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 		evpn:                  nInfo.evpn,
 		outboundSNAT:          nInfo.outboundSNAT,
 		uplink:                nInfo.uplink,
+		noOverlayRouting:      nInfo.noOverlayRouting,
 	}
 	// copy mutables
 	c.mutableNetInfo.copyFrom(&nInfo.mutableNetInfo)
@@ -1191,15 +1207,16 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		return nil, err
 	}
 	ni := &userDefinedNetInfo{
-		netName:        netconf.Name,
-		primaryNetwork: netconf.Role == types.NetworkRolePrimary,
-		topology:       types.Layer3Topology,
-		joinSubnets:    joinSubnets,
-		mtu:            netconf.MTU,
-		transport:      netconf.Transport,
-		evpn:           netconf.EVPN,
-		outboundSNAT:   netconf.OutboundSNAT,
-		uplink:         netconf.Uplink,
+		netName:          netconf.Name,
+		primaryNetwork:   netconf.Role == types.NetworkRolePrimary,
+		topology:         types.Layer3Topology,
+		joinSubnets:      joinSubnets,
+		mtu:              netconf.MTU,
+		transport:        netconf.Transport,
+		evpn:             netconf.EVPN,
+		outboundSNAT:     netconf.OutboundSNAT,
+		uplink:           netconf.Uplink,
+		noOverlayRouting: netconf.NoOverlayRouting,
 		mutableNetInfo: mutableNetInfo{
 			id:      types.InvalidID,
 			nads:    sets.Set[string]{},
@@ -1278,6 +1295,7 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		transport:             netconf.Transport,
 		evpn:                  netconf.EVPN,
 		uplink:                netconf.Uplink,
+		noOverlayRouting:      netconf.NoOverlayRouting,
 		mutableNetInfo: mutableNetInfo{
 			id:      types.InvalidID,
 			nads:    sets.Set[string]{},
@@ -1633,6 +1651,19 @@ func ValidateNetConf(nadName string, netconf *ovncnitypes.NetConf) error {
 	}
 	if netconf.Uplink != "" && config.Gateway.Mode != config.GatewayModeShared {
 		return fmt.Errorf("uplink %q is supported only in shared gateway mode", netconf.Uplink)
+	}
+
+	if netconf.NoOverlayRouting != "" {
+		if netconf.Transport != types.NetworkTransportNoOverlay {
+			return fmt.Errorf("noOverlayRouting is only valid when transport is %q", types.NetworkTransportNoOverlay)
+		}
+		if netconf.NoOverlayRouting != config.NoOverlayRoutingManaged &&
+			netconf.NoOverlayRouting != config.NoOverlayRoutingUnmanaged {
+			return fmt.Errorf("invalid noOverlayRouting %q: must be one of %q", netconf.NoOverlayRouting, []string{
+				config.NoOverlayRoutingManaged,
+				config.NoOverlayRoutingUnmanaged,
+			})
+		}
 	}
 
 	if netconf.JoinSubnet != "" && netconf.Topology == types.LocalnetTopology {

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1877,6 +1877,69 @@ func TestValidateNetConfUplinkGatewayMode(t *testing.T) {
 	}
 }
 
+func TestValidateNetConfNoOverlayRouting(t *testing.T) {
+	tests := []struct {
+		name             string
+		transport        string
+		noOverlayRouting string
+		expectedError    string
+	}{
+		{
+			name:             "managed routing is accepted with no-overlay transport",
+			transport:        ovntypes.NetworkTransportNoOverlay,
+			noOverlayRouting: config.NoOverlayRoutingManaged,
+		},
+		{
+			name:             "unmanaged routing is accepted with no-overlay transport",
+			transport:        ovntypes.NetworkTransportNoOverlay,
+			noOverlayRouting: config.NoOverlayRoutingUnmanaged,
+		},
+		{
+			name:             "routing is rejected without no-overlay transport",
+			noOverlayRouting: config.NoOverlayRoutingUnmanaged,
+			expectedError:    `noOverlayRouting is only valid when transport is "no-overlay"`,
+		},
+		{
+			name:             "routing is rejected with EVPN transport",
+			transport:        ovntypes.NetworkTransportEVPN,
+			noOverlayRouting: config.NoOverlayRoutingUnmanaged,
+			expectedError:    `noOverlayRouting is only valid when transport is "no-overlay"`,
+		},
+		{
+			name:             "invalid routing is rejected with no-overlay transport",
+			transport:        ovntypes.NetworkTransportNoOverlay,
+			noOverlayRouting: "external",
+			expectedError:    `invalid noOverlayRouting "external"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			nadName := "namespace/network"
+			netconf := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: "network",
+				},
+				NADName:          nadName,
+				Topology:         ovntypes.Layer3Topology,
+				Transport:        test.transport,
+				NoOverlayRouting: test.noOverlayRouting,
+			}
+
+			err := ValidateNetConf(nadName, netconf)
+			if test.expectedError != "" {
+				g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(test.expectedError)))
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				netInfo, err := NewNetInfo(netconf)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(netInfo.NoOverlayRouting()).To(gomega.Equal(test.noOverlayRouting))
+			}
+		})
+	}
+}
+
 func TestNewNetInfo(t *testing.T) {
 	type testConfig struct {
 		desc          string

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"slices"
 	"time"
 
@@ -102,6 +103,7 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 				jig := e2eservice.NewTestJig(cs, namespace, "udn-service")
 
 				dynamicUDNEnabled := isDynamicUDNEnabled()
+				loadBalancerProviderEnabled := isLoadBalancerProviderEnabled()
 
 				By("Selecting 3 schedulable nodes")
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
@@ -138,9 +140,11 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 				})
 				framework.ExpectNoError(err)
 
-				By("Wait for UDN LoadBalancer Ingress to pop up")
-				udnService, err = jig.WaitForLoadBalancer(context.TODO(), 180*time.Second)
-				framework.ExpectNoError(err)
+				if loadBalancerProviderEnabled {
+					By("Wait for UDN LoadBalancer Ingress to pop up")
+					udnService, err = jig.WaitForLoadBalancer(context.TODO(), 180*time.Second)
+					framework.ExpectNoError(err)
+				}
 
 				By("Creating a UDN backend pod")
 				udnServerPod := e2epod.NewAgnhostPod(
@@ -169,7 +173,9 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				By("Connect to the UDN service cluster IP from the UDN client pod on the same node")
 				checkConnectionToClusterIPs(f, udnClientPod, udnService, udnServerPod.Name)
 				By("Connect to the UDN service nodePort on all 3 nodes from the UDN client pod")
-				checkConnectionToLoadBalancers(f, udnClientPod, udnService, udnServerPod.Name)
+				if loadBalancerProviderEnabled {
+					checkConnectionToLoadBalancers(f, udnClientPod, udnService, udnServerPod.Name)
+				}
 				checkConnectionToNodePort(f, udnClientPod, udnService, &nodes.Items[0], "endpoint node", udnServerPod.Name)
 				if !dynamicUDNEnabled {
 					checkConnectionToNodePort(f, udnClientPod, udnService, &nodes.Items[1], "other node", udnServerPod.Name)
@@ -182,7 +188,9 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 
 				By("Connect to the UDN service from the UDN client pod on a different node")
 				checkConnectionToClusterIPs(f, udnClientPod2, udnService, udnServerPod.Name)
-				checkConnectionToLoadBalancers(f, udnClientPod2, udnService, udnServerPod.Name)
+				if loadBalancerProviderEnabled {
+					checkConnectionToLoadBalancers(f, udnClientPod2, udnService, udnServerPod.Name)
+				}
 				checkConnectionToNodePort(f, udnClientPod2, udnService, &nodes.Items[1], "local node", udnServerPod.Name)
 				checkConnectionToNodePort(f, udnClientPod2, udnService, &nodes.Items[0], "server node", udnServerPod.Name)
 				if !dynamicUDNEnabled {
@@ -191,7 +199,7 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 
 				By("Connect to the UDN service from the UDN client external container")
 				externalContainer := infraapi.ExternalContainer{Name: "frr"}
-				if !dynamicUDNEnabled {
+				if loadBalancerProviderEnabled && !dynamicUDNEnabled {
 					checkConnectionToLoadBalancersFromExternalContainer(f, externalContainer, udnService, udnServerPod.Name)
 				}
 				checkConnectionToNodePortFromExternalContainer(externalContainer, udnService, &nodes.Items[0], "server node", udnServerPod.Name)
@@ -561,4 +569,8 @@ func filterLoadBalancerIngressByIPFamily(f *framework.Framework, service *v1.Ser
 		})
 	}
 	return lbIngressIPs
+}
+
+func isLoadBalancerProviderEnabled() bool {
+	return os.Getenv("KIND_INSTALL_METALLB") == "true"
 }

--- a/test/e2e/network_segmentation_utils.go
+++ b/test/e2e/network_segmentation_utils.go
@@ -27,9 +27,8 @@ func cudnGatewayRouterName(cudnName, nodeName string) string {
 	return types.GWRouterPrefix + util.GetUserDefinedNetworkPrefix(types.CUDNPrefix+cudnName) + nodeName
 }
 
-// cudnGRRoutesForNode returns the output of `ovn-nbctl lr-route-list` for
-// the CUDN gateway router of the given CUDN on the given node.
-func cudnGRRoutesForNode(k8sClient kubernetes.Interface, cudnName, nodeName string) (string, error) {
+// runOVNNbctlOnNode runs ovn-nbctl from the ovnkube-node pod on the given node.
+func runOVNNbctlOnNode(k8sClient kubernetes.Interface, nodeName string, args ...string) (string, error) {
 	ns := deploymentconfig.Get().OVNKubernetesNamespace()
 	nbPods, err := k8sClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app=ovnkube-node",
@@ -42,17 +41,24 @@ func cudnGRRoutesForNode(k8sClient kubernetes.Interface, cudnName, nodeName stri
 		return "", fmt.Errorf("no ovnkube-node pod found on node %s", nodeName)
 	}
 	nbPod := nbPods.Items[0]
-	if len(nbPod.Spec.Containers) == 0 {
-		return "", fmt.Errorf("no containers found in ovnkube-node pod %s on node %s", nbPod.Name, nodeName)
+	hasNBOVSDBContainer := false
+	for _, container := range nbPod.Spec.Containers {
+		if container.Name == "nb-ovsdb" {
+			hasNBOVSDBContainer = true
+			break
+		}
 	}
-	nbContainerName := nbPod.Spec.Containers[0].Name
-	if nbContainerName == "" {
-		return "", fmt.Errorf("first container has no name in ovnkube-node pod %s on node %s", nbPod.Name, nodeName)
+	if !hasNBOVSDBContainer {
+		return "", fmt.Errorf("ovnkube-node pod %s on node %s has no nb-ovsdb container", nbPod.Name, nodeName)
 	}
-	return e2ekubectl.RunKubectl(ns,
-		"exec", nbPod.Name, "-c", nbContainerName, "--",
-		"ovn-nbctl", "lr-route-list",
-		cudnGatewayRouterName(cudnName, nodeName))
+	kubectlArgs := append([]string{"exec", nbPod.Name, "-c", "nb-ovsdb", "--", "ovn-nbctl"}, args...)
+	return e2ekubectl.RunKubectl(ns, kubectlArgs...)
+}
+
+// cudnGRRoutesForNode returns the output of `ovn-nbctl lr-route-list` for
+// the CUDN gateway router of the given CUDN on the given node.
+func cudnGRRoutesForNode(k8sClient kubernetes.Interface, cudnName, nodeName string) (string, error) {
+	return runOVNNbctlOnNode(k8sClient, nodeName, "lr-route-list", cudnGatewayRouterName(cudnName, nodeName))
 }
 
 // podIPsForUserDefinedPrimaryNetwork returns the v4 or v6 IPs for a pod on the UDN

--- a/test/e2e/no_overlay.go
+++ b/test/e2e/no_overlay.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
-	"strings"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	rav1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
 	raclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -50,7 +51,7 @@ var _ = ginkgo.Describe("No-Overlay: Default network is enabled with no-overlay"
 	var serverService *corev1.Service
 	var nodes *corev1.NodeList
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.JustBeforeEach(func() {
 		var err error
 		ginkgo.By("Selecting nodes")
 		nodes, err = e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
@@ -198,6 +199,21 @@ var _ = ginkgo.Describe("No-Overlay: Default network is enabled with no-overlay"
 			checkConnectivityWithoutOverlay(serverPod.Status.PodIPs, serverService.Spec.ClusterIPs, tcpdumpPod, tcpdumpPod)
 
 			framework.Logf("Pod2pod and pod2service connectivity maintained after ovnkube-node pod restart - test passed!")
+		})
+	})
+
+	ginkgo.When("unmanaged routing is enabled without RouteAdvertisements", func() {
+		ginkgo.BeforeEach(func() {
+			enabled, err := isDefaultNetworkNoOverlayUnmanagedWithoutRouteAdvertisements()
+			framework.ExpectNoError(err, "Failed to check default network no-overlay unmanaged state")
+			if !enabled {
+				ginkgo.Skip("Test requires unmanaged no-overlay default network without RouteAdvertisements")
+			}
+		})
+
+		ginkgo.It("should maintain pod2pod connectivity without RouteAdvertisements", func() {
+			ginkgo.By("Testing pod2pod connectivity without default-network RouteAdvertisements")
+			checkConnectivityWithoutOverlay(serverPod.Status.PodIPs, nil, clientPod, tcpdumpPod)
 		})
 	})
 
@@ -391,6 +407,31 @@ func isManagedRoutingEnabled() bool {
 		return true
 	}
 	return false
+}
+
+func isDefaultNetworkNoOverlayUnmanagedWithoutRouteAdvertisements() (bool, error) {
+	if isManagedRoutingEnabled() {
+		return false, nil
+	}
+	hasDefaultNetworkRA, err := isAnyDefaultNetworkPodNetworkRouteAdvertisementsConfigured()
+	if err != nil {
+		return false, err
+	}
+	return !hasDefaultNetworkRA, nil
+}
+
+func isAnyDefaultNetworkPodNetworkRouteAdvertisementsConfigured() (bool, error) {
+	output, err := e2ekubectl.RunKubectl("default", "get", "routeadvertisements", "-o",
+		`go-template={{range .items}}{{range .spec.advertisements}}{{.}} {{end}}{{range .spec.networkSelectors}}{{.networkSelectionType}} {{end}}{{"\n"}}{{end}}`)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, string(rav1.PodNetwork)) && strings.Contains(line, string(apitypes.DefaultNetwork)) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // managedRouteAdvertisementName matches clustermanager/managedbgp.ManagedRouteAdvertisementName

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/util/podutils"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -4542,4 +4543,472 @@ func routeHasGateway(route kernelRoute, nextHop string) bool {
 		}
 	}
 	return false
+}
+
+var _ = ginkgo.Describe("Network Segmentation: unmanaged no-overlay CUDN without RouteAdvertisements", feature.NetworkSegmentation, feature.RouteAdvertisements, func() {
+	const unmanagedNoRALabel = "unmanaged-no-ra-no-overlay-e2e"
+
+	f := wrappedTestFramework("unmanaged-no-ra-no-overlay-cudn")
+	f.SkipNamespaceCreation = true
+
+	var (
+		namespace *corev1.Namespace
+		ictx      infraapi.Context
+		udnClient *udnclientset.Clientset
+		raClient  *raclientset.Clientset
+	)
+
+	newUnmanagedNoOverlayCUDN := func(name string) *udnv1.ClusterUserDefinedNetwork {
+		ginkgo.GinkgoHelper()
+		bgpAlloc, err := allocators.AllocateBGP(f, ictx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		cudnIPv4, cudnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
+		subnets := filterL3Subnets(f.ClientSet, []udnv1.Layer3Subnet{
+			{CIDR: udnv1.CIDR(cudnIPv4)},
+			{CIDR: udnv1.CIDR(cudnIPv6)},
+		})
+		gomega.Expect(subnets).NotTo(gomega.BeEmpty())
+		for i := range subnets {
+			if utilnet.IsIPv6CIDRString(string(subnets[i].CIDR)) {
+				subnets[i].HostSubnet = 64
+			} else {
+				subnets[i].HostSubnet = 24
+			}
+		}
+
+		return &udnv1.ClusterUserDefinedNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{unmanagedNoRALabel: name},
+			},
+			Spec: udnv1.ClusterUserDefinedNetworkSpec{
+				NamespaceSelector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "kubernetes.io/metadata.name",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{namespace.Name},
+				}}},
+				Network: udnv1.NetworkSpec{
+					Topology: udnv1.NetworkTopologyLayer3,
+					Layer3: &udnv1.Layer3Config{
+						Role:    udnv1.NetworkRolePrimary,
+						Subnets: subnets,
+					},
+					Transport: udnv1.TransportOptionNoOverlay,
+					NoOverlay: &udnv1.NoOverlayConfig{
+						OutboundSNAT: udnv1.SNATEnabled,
+						Routing:      udnv1.RoutingUnmanaged,
+					},
+				},
+			},
+		}
+	}
+
+	createUnmanagedNoOverlayCUDN := func(name string) *udnv1.ClusterUserDefinedNetwork {
+		ginkgo.GinkgoHelper()
+		cudn := newUnmanagedNoOverlayCUDN(name)
+		_, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudn, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			err := udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.Background(), name, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		})
+		return cudn
+	}
+
+	newNotAcceptedRA := func(name, cudnName string) *rav1.RouteAdvertisements {
+		return &rav1.RouteAdvertisements{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: rav1.RouteAdvertisementsSpec{
+				NetworkSelectors: apitypes.NetworkSelectors{{
+					NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+					ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+						NetworkSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{unmanagedNoRALabel: cudnName},
+						},
+					},
+				}},
+				NodeSelector: metav1.LabelSelector{},
+				FRRConfigurationSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{unmanagedNoRALabel: "missing"},
+				},
+				Advertisements: []rav1.AdvertisementType{
+					rav1.PodNetwork,
+				},
+			},
+		}
+	}
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		ictx = infraprovider.Get().NewTestContext()
+		namespace, err = f.CreateNamespace(context.Background(), f.BaseName, map[string]string{
+			"e2e-framework":           f.BaseName,
+			RequiredUDNNamespaceLabel: "",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		f.Namespace = namespace
+
+		udnClient, err = udnclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		raClient, err = raclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("accepts an unmanaged no-overlay CUDN without RouteAdvertisements", func() {
+		cudnName := randomNetworkMetaName()
+		createUnmanagedNoOverlayCUDN(cudnName)
+
+		gomega.Eventually(clusterUserDefinedNetworkTransportAcceptedFunc(
+			f.DynamicClient,
+			cudnName,
+			metav1.ConditionTrue,
+			"NoOverlayRouteAdvertisementsNotRequired",
+		), 30*time.Second, time.Second).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("maintains cross-node pod-to-pod connectivity without RouteAdvertisements", func() {
+		if infraprovider.Get().Name() != "kind" {
+			e2eskipper.Skipf("test programs kind-specific static underlay routes")
+		}
+
+		cudnName := randomNetworkMetaName()
+		cudn := createUnmanagedNoOverlayCUDN(cudnName)
+
+		gomega.Eventually(clusterUserDefinedNetworkTransportAcceptedFunc(
+			f.DynamicClient,
+			cudnName,
+			metav1.ConditionTrue,
+			"NoOverlayRouteAdvertisementsNotRequired",
+		), 30*time.Second, time.Second).Should(gomega.Succeed())
+		gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), time.Minute, time.Second).Should(gomega.Succeed())
+
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(nodes.Items).To(gomega.HaveLen(2), "test requires at least two schedulable nodes")
+		configureCUDNNoOverlayUnderlay(f.ClientSet, cudn, nodes.Items)
+
+		serverPodSpec := e2epod.NewAgnhostPod(namespace.Name, "server-pod", nil, nil, []corev1.ContainerPort{{ContainerPort: netexecPort}}, "netexec")
+		serverPodSpec.Spec.NodeName = nodes.Items[0].Name
+		clientPodSpec := e2epod.NewAgnhostPod(namespace.Name, "client-pod", nil, nil, nil)
+		clientPodSpec.Spec.NodeName = nodes.Items[1].Name
+
+		serverPod := e2epod.PodClientNS(f, namespace.Name).CreateSync(context.Background(), serverPodSpec)
+		clientPod := e2epod.PodClientNS(f, namespace.Name).CreateSync(context.Background(), clientPodSpec)
+
+		attachmentName := namespacedName(namespace.Name, cudnName)
+		serverIPs, err := getPodAnnotationIPsForAttachment(f.ClientSet, namespace.Name, serverPod.Name, attachmentName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(serverIPs).NotTo(gomega.BeEmpty())
+
+		for _, serverIPNet := range serverIPs {
+			serverIP := serverIPNet.IP.String()
+			clientIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+				f.ClientSet,
+				namespace.Name,
+				clientPod.Name,
+				attachmentName,
+				utilnet.IPFamilyOfString(serverIP),
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s/clientip", net.JoinHostPort(serverIP, strconv.Itoa(netexecPort)))
+			framework.Logf("Testing unmanaged no-overlay CUDN pod-to-pod traffic with command %q", cmd)
+			stdout, err := e2epodoutput.RunHostCmdWithRetries(
+				clientPod.Namespace,
+				clientPod.Name,
+				cmd,
+				framework.Poll,
+				60*time.Second,
+			)
+			framework.ExpectNoError(err, "testing unmanaged no-overlay CUDN pod-to-pod traffic failed")
+
+			sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to parse client address from output %q", stdout)
+			gomega.Expect(sourceIP).To(gomega.Equal(clientIP))
+		}
+	})
+
+	ginkgo.It("requires matching RouteAdvertisements to be accepted when one is configured", func() {
+		cudnName := randomNetworkMetaName()
+		createUnmanagedNoOverlayCUDN(cudnName)
+
+		gomega.Eventually(clusterUserDefinedNetworkTransportAcceptedFunc(
+			f.DynamicClient,
+			cudnName,
+			metav1.ConditionTrue,
+			"NoOverlayRouteAdvertisementsNotRequired",
+		), 30*time.Second, time.Second).Should(gomega.Succeed())
+
+		raName := cudnName + "-ra"
+		_, err := raClient.K8sV1().RouteAdvertisements().Create(context.Background(), newNotAcceptedRA(raName, cudnName), metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			err := raClient.K8sV1().RouteAdvertisements().Delete(context.Background(), raName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		})
+
+		gomega.Eventually(routeAdvertisementsAcceptedConditionFunc(
+			*raClient,
+			raName,
+			metav1.ConditionFalse,
+		), 30*time.Second, time.Second).Should(gomega.Succeed())
+		gomega.Eventually(clusterUserDefinedNetworkTransportAcceptedFunc(
+			f.DynamicClient,
+			cudnName,
+			metav1.ConditionFalse,
+			"NoOverlayRouteAdvertisementsNotAccepted",
+		), 30*time.Second, time.Second).Should(gomega.Succeed())
+
+		gomega.Expect(raClient.K8sV1().RouteAdvertisements().Delete(context.Background(), raName, metav1.DeleteOptions{})).To(gomega.Succeed())
+		gomega.Eventually(clusterUserDefinedNetworkTransportAcceptedFunc(
+			f.DynamicClient,
+			cudnName,
+			metav1.ConditionTrue,
+			"NoOverlayRouteAdvertisementsNotRequired",
+		), time.Minute, time.Second).Should(gomega.Succeed())
+	})
+})
+
+func routeAdvertisementsAcceptedConditionFunc(c raclientset.Clientset, name string, expectedStatus metav1.ConditionStatus) func() error {
+	return func() error {
+		ra, err := c.K8sV1().RouteAdvertisements().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+		if condition == nil {
+			return fmt.Errorf("no Accepted condition found in RouteAdvertisements %q", name)
+		}
+		if condition.Status != expectedStatus {
+			return fmt.Errorf("expected RouteAdvertisements %q Accepted=%s, got %s: %s", name, expectedStatus, condition.Status, condition.Message)
+		}
+		return nil
+	}
+}
+
+func clusterUserDefinedNetworkTransportAcceptedFunc(client dynamic.Interface, name string, expectedStatus metav1.ConditionStatus, expectedReason string) func() error {
+	return func() error {
+		cudn, err := client.Resource(clusterUDNGVR).Get(context.Background(), name, metav1.GetOptions{}, "status")
+		if err != nil {
+			return err
+		}
+		conditions, err := getConditions(cudn)
+		if err != nil {
+			return err
+		}
+		condition := meta.FindStatusCondition(conditions, "TransportAccepted")
+		if condition == nil {
+			return fmt.Errorf("no TransportAccepted condition found in ClusterUserDefinedNetwork %q", name)
+		}
+		if condition.Status != expectedStatus || condition.Reason != expectedReason {
+			return fmt.Errorf("expected ClusterUserDefinedNetwork %q TransportAccepted=%s/%s, got %s/%s: %s",
+				name, expectedStatus, expectedReason, condition.Status, condition.Reason, condition.Message)
+		}
+		return nil
+	}
+}
+
+func nodeInternalIPForFamily(node corev1.Node, family utilnet.IPFamily) string {
+	ginkgo.GinkgoHelper()
+	protocol := corev1.IPv4Protocol
+	if family == utilnet.IPv6 {
+		protocol = corev1.IPv6Protocol
+	}
+	nodeIPs := e2enode.GetAddressesByTypeAndFamily(&node, corev1.NodeInternalIP, protocol)
+	gomega.Expect(nodeIPs).NotTo(gomega.BeEmpty(), "node %s must have an InternalIP for %s", node.Name, family)
+	return nodeIPs[0]
+}
+
+func nodeInternalIPForSubnet(node corev1.Node, subnet string) string {
+	ginkgo.GinkgoHelper()
+	family := utilnet.IPv4
+	if utilnet.IsIPv6CIDRString(subnet) {
+		family = utilnet.IPv6
+	}
+	return nodeInternalIPForFamily(node, family)
+}
+
+// configureKindNodeVRFRoute installs a route in a kind node's CUDN VRF routing table.
+func configureKindNodeVRFRoute(nodeName, vrfName, subnet, nextHop string) {
+	ginkgo.GinkgoHelper()
+	cmd := kindNodeVRFRouteCommand("replace", vrfName, subnet, nextHop)
+	delCmd := kindNodeVRFRouteCommand("del", vrfName, subnet, nextHop)
+
+	framework.Logf("Adding unmanaged no-overlay CUDN route on kind node %s VRF %s: %v", nodeName, vrfName, cmd)
+	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, cmd)
+	framework.ExpectNoError(err, "failed to add unmanaged no-overlay CUDN route on kind node %s VRF %s", nodeName, vrfName)
+	ginkgo.DeferCleanup(func() {
+		if _, err := infraprovider.Get().ExecK8NodeCommand(nodeName, delCmd); err != nil {
+			framework.Logf("Failed to delete unmanaged no-overlay CUDN route on kind node %s VRF %s: %v", nodeName, vrfName, err)
+		}
+	})
+}
+
+func kindNodeVRFRouteCommand(action, vrfName, subnet, nextHop string) []string {
+	cmd := []string{"ip"}
+	if utilnet.IsIPv6CIDRString(subnet) {
+		cmd = append(cmd, "-6")
+	}
+	return append(cmd,
+		"route", action,
+		"vrf", vrfName,
+		subnet,
+		"via", nextHop,
+		"dev", deploymentconfig.Get().ExternalBridgeName(),
+	)
+}
+
+// configureFRRRoute installs a route in the external FRR container.
+func configureFRRRoute(subnet, nextHop string) {
+	ginkgo.GinkgoHelper()
+	cmd := []string{"ip", "route", "replace", subnet, "via", nextHop}
+	delCmd := []string{"ip", "route", "del", subnet, "via", nextHop}
+	if utilnet.IsIPv6CIDRString(subnet) {
+		cmd = []string{"ip", "-6", "route", "replace", subnet, "via", nextHop}
+		delCmd = []string{"ip", "-6", "route", "del", subnet, "via", nextHop}
+	}
+	frr := infraapi.ExternalContainer{Name: routerContainerName}
+	framework.Logf("Adding unmanaged no-overlay CUDN route on external FRR: %v", cmd)
+	_, err := infraprovider.Get().ExecExternalContainerCommand(frr, cmd)
+	framework.ExpectNoError(err, "failed to add unmanaged no-overlay CUDN route on external FRR")
+	ginkgo.DeferCleanup(func() {
+		if _, err := infraprovider.Get().ExecExternalContainerCommand(frr, delCmd); err != nil {
+			framework.Logf("Failed to delete unmanaged no-overlay CUDN route on external FRR: %v", err)
+		}
+	})
+}
+
+// configureGatewayRouterRoute installs a static route on a CUDN gateway router.
+func configureGatewayRouterRoute(cs clientset.Interface, cudnName, nodeName, subnet, nextHop string) {
+	ginkgo.GinkgoHelper()
+	gwRouterName := cudnGatewayRouterName(cudnName, nodeName)
+	outputPort := types.GWRouterToExtSwitchPrefix + gwRouterName
+	framework.Logf("Adding unmanaged no-overlay CUDN route on gateway router %s: %s via %s output %s", gwRouterName, subnet, nextHop, outputPort)
+	_, err := runOVNNbctlOnNode(cs, nodeName, "--if-exists", "lr-route-del", gwRouterName, subnet)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	_, err = runOVNNbctlOnNode(cs, nodeName, "lr-route-add", gwRouterName, subnet, nextHop, outputPort)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.DeferCleanup(func() {
+		if _, err := runOVNNbctlOnNode(cs, nodeName, "--if-exists", "lr-route-del", gwRouterName, subnet); err != nil {
+			framework.Logf("Failed to delete unmanaged no-overlay CUDN route on gateway router %s: %v", gwRouterName, err)
+		}
+	})
+}
+
+// configureUDNVRFRule installs a host IP rule for traffic to a CUDN prefix.
+func configureUDNVRFRule(nodeName, vrfName, prefix string) {
+	ginkgo.GinkgoHelper()
+	ipCmd := "ip"
+	if utilnet.IsIPv6CIDRString(prefix) {
+		ipCmd = "ip -6"
+	}
+	cmd := []string{"bash", "-c", fmt.Sprintf(
+		`table=$(ip -d link show dev %q | sed -n 's/.*vrf table \([0-9][0-9]*\).*/\1/p'); test -n "$table"; %s rule del priority 2000 to %q lookup "$table" 2>/dev/null || true; %s rule add priority 2000 to %q lookup "$table"`,
+		vrfName, ipCmd, prefix, ipCmd, prefix,
+	)}
+	delCmd := []string{"bash", "-c", fmt.Sprintf(
+		`table=$(ip -d link show dev %q | sed -n 's/.*vrf table \([0-9][0-9]*\).*/\1/p'); test -z "$table" || %s rule del priority 2000 to %q lookup "$table" 2>/dev/null || true`,
+		vrfName, ipCmd, prefix,
+	)}
+	framework.Logf("Adding unmanaged no-overlay CUDN VRF rule on kind node %s: %v", nodeName, cmd)
+	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, cmd)
+	framework.ExpectNoError(err, "failed to add unmanaged no-overlay CUDN VRF rule on kind node %s", nodeName)
+	ginkgo.DeferCleanup(func() {
+		if _, err := infraprovider.Get().ExecK8NodeCommand(nodeName, delCmd); err != nil {
+			framework.Logf("Failed to delete unmanaged no-overlay CUDN VRF rule on kind node %s: %v", nodeName, err)
+		}
+	})
+}
+
+// cudnHostSubnetsByNode returns the CUDN host subnets assigned to each node.
+func cudnHostSubnetsByNode(cs clientset.Interface, cudnName string, nodes []corev1.Node) map[string][]*net.IPNet {
+	ginkgo.GinkgoHelper()
+	networkName := ovnutil.GenerateCUDNNetworkName(cudnName)
+	hostSubnetsByNode := map[string][]*net.IPNet{}
+	gomega.Eventually(func() error {
+		hostSubnetsByNode = map[string][]*net.IPNet{}
+		for _, node := range nodes {
+			updatedNode, err := cs.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			hostSubnets, err := ovnutil.ParseNodeHostSubnetAnnotation(updatedNode, networkName)
+			if err != nil {
+				return err
+			}
+			if len(hostSubnets) == 0 {
+				return fmt.Errorf("node %s has no host subnets for CUDN %s", node.Name, cudnName)
+			}
+			hostSubnetsByNode[node.Name] = hostSubnets
+		}
+		return nil
+	}, time.Minute, time.Second).Should(gomega.Succeed())
+	return hostSubnetsByNode
+}
+
+// configureCommonCUDNUnderlayRoutes installs external routes for all CUDN host subnets.
+func configureCommonCUDNUnderlayRoutes(nodes []corev1.Node, hostSubnetsByNode map[string][]*net.IPNet) {
+	ginkgo.GinkgoHelper()
+	for _, node := range nodes {
+		for _, subnet := range hostSubnetsByNode[node.Name] {
+			configureFRRRoute(subnet.String(), nodeInternalIPForSubnet(node, subnet.String()))
+		}
+	}
+}
+
+// configureLocalGatewayCUDNUnderlayRoutes installs node VRF routes for remote CUDN host subnets.
+func configureLocalGatewayCUDNUnderlayRoutes(cudnName string, nodes []corev1.Node, hostSubnetsByNode map[string][]*net.IPNet) {
+	ginkgo.GinkgoHelper()
+	for _, localNode := range nodes {
+		for _, remoteNode := range nodes {
+			if localNode.Name == remoteNode.Name {
+				continue
+			}
+			for _, remoteSubnet := range hostSubnetsByNode[remoteNode.Name] {
+				configureKindNodeVRFRoute(localNode.Name, cudnName, remoteSubnet.String(), nodeInternalIPForSubnet(remoteNode, remoteSubnet.String()))
+			}
+		}
+	}
+}
+
+// configureSharedGatewayCUDNUnderlayRoutes installs gateway-router routes for remote CUDN host subnets.
+func configureSharedGatewayCUDNUnderlayRoutes(cs clientset.Interface, cudnName string, nodes []corev1.Node, hostSubnetsByNode map[string][]*net.IPNet) {
+	ginkgo.GinkgoHelper()
+	for _, localNode := range nodes {
+		for _, remoteNode := range nodes {
+			if localNode.Name == remoteNode.Name {
+				continue
+			}
+			for _, remoteSubnet := range hostSubnetsByNode[remoteNode.Name] {
+				configureGatewayRouterRoute(cs, cudnName, localNode.Name, remoteSubnet.String(), nodeInternalIPForSubnet(remoteNode, remoteSubnet.String()))
+			}
+		}
+	}
+}
+
+// configureCUDNVRFRules installs host IP rules for all CUDN cluster subnets.
+func configureCUDNVRFRules(cudn *udnv1.ClusterUserDefinedNetwork, nodes []corev1.Node) {
+	ginkgo.GinkgoHelper()
+	for _, subnet := range cudn.Spec.Network.Layer3.Subnets {
+		for _, node := range nodes {
+			configureUDNVRFRule(node.Name, cudn.Name, string(subnet.CIDR))
+		}
+	}
+}
+
+// configureCUDNNoOverlayUnderlay installs routes and rules for CUDN no-overlay connectivity.
+func configureCUDNNoOverlayUnderlay(cs clientset.Interface, cudn *udnv1.ClusterUserDefinedNetwork, nodes []corev1.Node) {
+	ginkgo.GinkgoHelper()
+	hostSubnetsByNode := cudnHostSubnetsByNode(cs, cudn.Name, nodes)
+	configureCommonCUDNUnderlayRoutes(nodes, hostSubnetsByNode)
+	configureCUDNVRFRules(cudn, nodes)
+	if IsGatewayModeLocal(cs) {
+		configureLocalGatewayCUDNUnderlayRoutes(cudn.Name, nodes, hostSubnetsByNode)
+	} else {
+		configureSharedGatewayCUDNUnderlayRoutes(cs, cudn.Name, nodes, hostSubnetsByNode)
+	}
 }

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -58,6 +58,58 @@ require_label() {
   LABELED_TESTS+="$*"
 }
 
+skip_default_pod_network_underlay_incompatible_tests() {
+  # Some tests do not work when default pod-network traffic uses the underlay,
+  # either because the test configuration no longer makes sense or because of
+  # an existing functional gap. Call out cases individually.
+
+  # Pod reached from default network through secondary interface: asymmetric
+  # configuration that does not make sense in this mode.
+  # TODO: perhaps the secondary network attached pods should not be attached to default network
+  skip "Multi Homing A single pod with an OVN-K secondary network attached to a localnet network mapped to external primary interface bridge can be reached by a client pod in the default network on the same node"
+  skip "Multi Homing A single pod with an OVN-K secondary network attached to a localnet network mapped to external primary interface bridge can be reached by a client pod in the default network on a different node"
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ] && [ "$PLATFORM_IPV4_SUPPORT" == false ]; then
+    # Skip all Multi Homing tests in BGP IPv6 only mode
+    # TODO: The tests are doing weird static ipv4, ipv6, dualstack specific ginkgo entries instead of relying on
+    # cluster family type to make a dynamic determination. These tests need to be refactored to be family-friendly
+    # instead of assuming only single stack v4 or dualstack lanes exist.
+    # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5569
+    skip "Multi Homing"
+  fi
+  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == false ]; then
+    # Skip IPv6/dual-stack multihoming secondary network tests in IPv4-only clusters.
+    skip "Multi Homing.*L3 - routed - secondary network with IPv6 subnet"
+    skip "Multi Homing.*L3 - routed - secondary network with a dual stack configuration"
+  fi
+  # These tests require MetalLB, whose setup is not compatible with this default-network underlay mode.
+  # TODO: consolidate configuration
+  skip "Load Balancer Service Tests with MetalLB"
+  skip "EgressService"
+
+  # tests that specifically expect the node SNAT to happen
+  # TODO: expect the pod IP where it makes sense
+  skip "e2e egress firewall policy validation with external containers"
+  skip "e2e egress IP validation on network of type Cluster Default \[OVN network\] Using different methods to disable a node's availability for egress Should validate the egress IP functionality against remote hosts"
+  skip "e2e egress IP validation on network of type Cluster Default \[OVN network\] Should validate the egress IP SNAT functionality against host-networked pods"
+  skip "e2e egress IP validation on network of type Cluster Default Should validate egress IP logic when one pod is managed by more than one egressIP object"
+  skip "e2e egress IP validation on network of type Cluster Default Should re-assign egress IPs when node readiness / reachability goes down/up"
+  skip "Pod to external server PMTUD when a client ovnk pod targeting an external server is created when tests are run towards the agnhost echo server queries to the hostNetworked server pod on another node shall work for UDP"
+  skip "e2e egress IP validation on network of type Cluster Default Should handle EIP reassignment correctly on namespace and pod label updates, and EIP object updates"
+
+  # https://issues.redhat.com/browse/OCPBUGS-55028
+  skip "e2e egress IP validation on network of type Cluster Default \[secondary-host-eip\]"
+
+  # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5240
+  skip "e2e control plane test node readiness according to its defaults interface MTU size should get node not ready with a too small MTU"
+
+  # buggy tests that don't work in dual stack mode
+  skip "Service Hairpin SNAT Should ensure service hairpin traffic is NOT SNATed to hairpin masquerade IP; GR LB"
+  skip "Services when a nodePort service targeting a pod with hostNetwork:false is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for TCP"
+  skip "Services when a nodePort service targeting a pod with hostNetwork:true is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for TCP"
+  skip "Services when a nodePort service targeting a pod with hostNetwork:false is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for UDP"
+  skip "Services when a nodePort service targeting a pod with hostNetwork:true is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for UDP"
+}
+
 if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
   if  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
 	  # No support for these features in dual-stack yet
@@ -119,6 +171,10 @@ fi
 
 if [ "$OVN_NETWORK_QOS_ENABLE" != "true" ]; then
   skip "e2e NetworkQoS validation"
+fi
+
+if [ "$KIND_INSTALL_METALLB" != true ]; then
+  skip "Load Balancer Service Tests with MetalLB"
 fi
 
 # Only run Node IP/MAC address migration tests if they are explicitly requested
@@ -192,61 +248,13 @@ if [ "$DYNAMIC_UDN_ALLOCATION" == true ]; then
   skip "BGP: For BGP configured networks"
 fi
 
-if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ]; then
+if [ "$ADVERTISE_DEFAULT_NETWORK" = true ] || { [ "$ENABLE_NO_OVERLAY" == true ] && [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ]; }; then
+  skip_default_pod_network_underlay_incompatible_tests
+fi
+
+# Some lanes keep RouteAdvertisements enabled in the cluster while skipping RA-specific tests.
+if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ] || [ "$SKIP_ROUTE_ADVERTISEMENTS_TESTS" == true ]; then
   skip_label "Feature:RouteAdvertisements"
-else
-  if [ "$ADVERTISE_DEFAULT_NETWORK" = true ]; then
-    # Some test don't work when the default network is advertised, either because
-    # the configuration that the test excercises does not make sense for an advertised network, or
-    # there is some bug or functional gap
-    # call out case by case
-
-    # pod reached from default network through secondary interface, asymetric, configuration does not make sense
-    # TODO: perhaps the secondary network attached pods should not be attached to default network
-    skip "Multi Homing A single pod with an OVN-K secondary network attached to a localnet network mapped to external primary interface bridge can be reached by a client pod in the default network on the same node"
-    skip "Multi Homing A single pod with an OVN-K secondary network attached to a localnet network mapped to external primary interface bridge can be reached by a client pod in the default network on a different node"
-    if [ "$PLATFORM_IPV6_SUPPORT" == true ] && [ "$PLATFORM_IPV4_SUPPORT" == false ]; then
-      # Skip all Multi Homing tests in BGP IPv6 only mode
-      # TODO: The tests are doing weird static ipv4, ipv6, dualstack specific ginkgo entries instead of relying on
-      # cluster family type to make a dynamic determination. These tests need to be refactored to be family-friendly
-      # instead of assuming only single stack v4 or dualstack lanes exist.
-      # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5569
-      skip "Multi Homing"
-    fi
-    if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == false ]; then
-      # Skip IPv6/dual-stack multihoming secondary network tests in IPv4-only clusters.
-      skip "Multi Homing.*L3 - routed - secondary network with IPv6 subnet"
-      skip "Multi Homing.*L3 - routed - secondary network with a dual stack configuration"
-    fi
-    # these tests require metallb but the configuration we do for it is not compatible with the configuration we do to advertise the default network
-    # TODO: consolidate configuration
-    skip "Load Balancer Service Tests with MetalLB"
-    skip "EgressService"
-
-    # tests that specifically expect the node SNAT to happen
-    # TODO: expect the pod IP where it makes sense
-    skip "e2e egress firewall policy validation with external containers"
-    skip "e2e egress IP validation on network of type Cluster Default \[OVN network\] Using different methods to disable a node's availability for egress Should validate the egress IP functionality against remote hosts"
-    skip "e2e egress IP validation on network of type Cluster Default \[OVN network\] Should validate the egress IP SNAT functionality against host-networked pods"
-    skip "e2e egress IP validation on network of type Cluster Default Should validate egress IP logic when one pod is managed by more than one egressIP object"
-    skip "e2e egress IP validation on network of type Cluster Default Should re-assign egress IPs when node readiness / reachability goes down/up"
-    skip "Pod to external server PMTUD when a client ovnk pod targeting an external server is created when tests are run towards the agnhost echo server queries to the hostNetworked server pod on another node shall work for UDP"
-    skip "e2e egress IP validation on network of type Cluster Default Should handle EIP reassignment correctly on namespace and pod label updates, and EIP object updates"
-
-    # https://issues.redhat.com/browse/OCPBUGS-55028
-    skip "e2e egress IP validation on network of type Cluster Default \[secondary-host-eip\]"
-
-
-    # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5240
-    skip "e2e control plane test node readiness according to its defaults interface MTU size should get node not ready with a too small MTU"
-
-    # buggy tests that don't work in dual stack mode
-    skip "Service Hairpin SNAT Should ensure service hairpin traffic is NOT SNATed to hairpin masquerade IP; GR LB"
-    skip "Services when a nodePort service targeting a pod with hostNetwork:false is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for TCP"
-    skip "Services when a nodePort service targeting a pod with hostNetwork:true is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for TCP"
-    skip "Services when a nodePort service targeting a pod with hostNetwork:false is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for UDP"
-    skip "Services when a nodePort service targeting a pod with hostNetwork:true is created when tests are run towards the agnhost echo service queries to the nodePort service shall work for UDP"
-  fi
 fi
 
 # if we set PARALLEL=true, skip serial test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RA-less (RouteAdvertisements-free) unmanaged no‑overlay routing for default network and CUDNs; controllers can mark TransportAccepted with new RA‑less reason and host‑subnet gateway routing is supported.

* **Documentation**
  * Expanded no‑overlay docs and OKEP with RA‑less guidance, examples, prerequisites, and operational notes.

* **Tests**
  * Added/extended unit and e2e coverage for RA‑less validation, CUDN transport acceptance, controller events, and gateway routing.

* **Chores**
  * CI e2e matrix updated to include RA‑less scenarios; test deployment scripts and kind provisioning enhanced for RA‑less flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->