### PR TITLE
Fixes OVS Pinning issues

### DIFF
--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -122,6 +122,11 @@ func Run(ctx context.Context, stopCh <-chan struct{}, podResCli podresourcesapi.
 			return
 
 		case <-ticker.C:
+			isFeatureEnabled, err = isFileNotEmpty(featureEnablerFile)
+			if err != nil {
+				klog.Warningf("Error while reading [%s]: %v", featureEnablerFile, err)
+				continue
+			}
 			if !isFeatureEnabled {
 				continue
 			}

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -235,14 +235,29 @@ func setProcessCPUAffinity(targetPIDStr string, set *cpuset.CPUSet) error {
 		return fmt.Errorf("can't get process (PID:%d) CPU affinity: %w", targetPID, err)
 	}
 
-	if desiredProcessCPUs == targetProcessCPUs {
-		klog.V(5).Infof("Process[%d] CPU affinity already matches desired process affinity %s", targetPID, printCPUSet(desiredProcessCPUs))
-		return nil
-	}
-
 	taskIDs, err := getThreadsOfProcess(targetPID)
 	if err != nil {
 		return fmt.Errorf("can't get tasks of PID(%d):%w", targetPID, err)
+	}
+
+	if desiredProcessCPUs == targetProcessCPUs {
+		allTasksMatch := true
+		for _, taskID := range taskIDs {
+			var taskCPUs unix.CPUSet
+			err = unix.SchedGetaffinity(taskID, &taskCPUs)
+			if err != nil {
+				klog.Warningf("Error while getting CPU affinity of task(%d) PID(%d): %v", taskID, targetPID, err)
+				continue
+			}
+			if taskCPUs != desiredProcessCPUs {
+				allTasksMatch = false
+				break
+			}
+		}
+		if allTasksMatch {
+			klog.V(5).Infof("Process[%d] and its tasks already match desired process affinity %s", targetPID, printCPUSet(desiredProcessCPUs))
+			return nil
+		}
 	}
 
 	klog.Infof("Setting CPU affinity of PID(%d) (ntasks=%d) to %s, was %s", targetPID, len(taskIDs), printCPUSet(desiredProcessCPUs), printCPUSet(targetProcessCPUs))


### PR DESCRIPTION
First bug:

Linux CPU affinity is tracked per thread, but setProcessCPUAffinity
returned early when the main process TID already matched the desired
CPU set. That could leave newly-created or lagging threads with a stale
affinity mask.
    
Check every task before taking the no-op path. If any task differs from
the desired CPU set, continue through the existing reconciliation path
and apply the affinity to all tasks.


Second bug:

The pinning loop cached the dynamic CPU affinity feature state from
fsnotify events. If a write or delete event was delayed or raced with a
ticker iteration, the loop could still apply CPU affinity after the
enabler file had been emptied or removed.

Fixes: #5152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-checks the CPU-affinity enablement state more frequently so changes take effect promptly.
  * When applying CPU pinning, verifies that all threads/tasks match the desired CPU set rather than relying solely on the process-level setting, avoiding missed or partial pinning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->