### PR TITLE
Fix stale status.conditions[] cleanup for AdminNetworkPolicy/BaselineAdminNetworkPolicy

### DIFF
--- a/go-controller/pkg/clustermanager/status_manager/admin_network_policy_manager.go
+++ b/go-controller/pkg/clustermanager/status_manager/admin_network_policy_manager.go
@@ -125,14 +125,14 @@ func (m *anpZoneDeleteCleanupManager) doStartupCleanup(currentZones sets.Set[str
 	staleZones := sets.New[string]()
 	for _, anp := range existingANPs {
 		for _, mf := range anp.ManagedFields {
-			if mf.Subresource == "status" && !currentZones.Has(mf.Manager) && isEmptyStatusManagedField(mf) {
+			if mf.Subresource == "status" && !currentZones.Has(mf.Manager) {
 				staleZones.Insert(mf.Manager)
 			}
 		}
 	}
 	for _, banp := range existingBANPs {
 		for _, mf := range banp.ManagedFields {
-			if mf.Subresource == "status" && !currentZones.Has(mf.Manager) && isEmptyStatusManagedField(mf) {
+			if mf.Subresource == "status" && !currentZones.Has(mf.Manager) {
 				staleZones.Insert(mf.Manager)
 			}
 		}

--- a/go-controller/pkg/clustermanager/status_manager/status_manager.go
+++ b/go-controller/pkg/clustermanager/status_manager/status_manager.go
@@ -4,7 +4,6 @@
 package status_manager
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sync"
@@ -109,39 +108,6 @@ func (m *typedStatusManager[T]) Stop() {
 	controller.Stop(m.objController)
 }
 
-// isEmptyStatusManagedField checks if a managedField entry is managing only an empty status field.
-// This is the signature left by previous code that called ApplyStatus with an empty status.
-// Example: fieldsV1: {"f:status":{}}
-func isEmptyStatusManagedField(mf metav1.ManagedFieldsEntry) bool {
-	if mf.FieldsV1 == nil || mf.Subresource != "status" {
-		return false
-	}
-
-	// Parse the fieldsV1 JSON to check if it's just {"f:status":{}}
-	var fields map[string]interface{}
-	if err := json.Unmarshal(mf.FieldsV1.Raw, &fields); err != nil {
-		return false
-	}
-
-	// Check if it only has one "f:status" key
-	if len(fields) != 1 {
-		return false
-	}
-
-	statusField, ok := fields["f:status"]
-	if !ok {
-		return false
-	}
-
-	// Check if "f:status" is empty
-	statusMap, ok := statusField.(map[string]interface{})
-	if !ok {
-		return false
-	}
-	// Empty status: {} or contains only empty nested fields
-	return len(statusMap) == 0
-}
-
 // doStartupCleanup performs a one-time cleanup of stale managedFields for all objects.
 // This handles the upgrade scenario where previous code left stale managedFields.
 // Returns an error if any cleanup operations failed.
@@ -157,10 +123,14 @@ func (m *typedStatusManager[T]) doStartupCleanup(zones sets.Set[string]) error {
 	for _, obj := range objects {
 		managedFields := m.resource.getManagedFields(obj)
 
-		// Check for stale empty-status managedFields
+		// Check for stale status managedFields
 		for _, mf := range managedFields {
-			if !zones.Has(mf.Manager) && isEmptyStatusManagedField(mf) {
-				klog.V(5).Infof("StatusManager %s: cleaning up stale empty-status managedField for manager: %s", m.name, mf.Manager)
+			// Skip cluster-manager (global aggregator)
+			if mf.Manager == clusterManagerName {
+				continue
+			}
+			if !zones.Has(mf.Manager) && mf.Subresource == "status" {
+				klog.V(5).Infof("StatusManager %s: cleaning up stale status managedField for manager: %s", m.name, mf.Manager)
 				applyAsZoneController := &metav1.ApplyOptions{
 					Force:        true,
 					FieldManager: mf.Manager,

--- a/go-controller/pkg/clustermanager/status_manager/status_manager.go
+++ b/go-controller/pkg/clustermanager/status_manager/status_manager.go
@@ -4,7 +4,6 @@
 package status_manager
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sync"
@@ -109,39 +108,6 @@ func (m *typedStatusManager[T]) Stop() {
 	controller.Stop(m.objController)
 }
 
-// isEmptyStatusManagedField checks if a managedField entry is managing only an empty status field.
-// This is the signature left by previous code that called ApplyStatus with an empty status.
-// Example: fieldsV1: {"f:status":{}}
-func isEmptyStatusManagedField(mf metav1.ManagedFieldsEntry) bool {
-	if mf.FieldsV1 == nil || mf.Subresource != "status" {
-		return false
-	}
-
-	// Parse the fieldsV1 JSON to check if it's just {"f:status":{}}
-	var fields map[string]interface{}
-	if err := json.Unmarshal(mf.FieldsV1.GetRawBytes(), &fields); err != nil {
-		return false
-	}
-
-	// Check if it only has one "f:status" key
-	if len(fields) != 1 {
-		return false
-	}
-
-	statusField, ok := fields["f:status"]
-	if !ok {
-		return false
-	}
-
-	// Check if "f:status" is empty
-	statusMap, ok := statusField.(map[string]interface{})
-	if !ok {
-		return false
-	}
-	// Empty status: {} or contains only empty nested fields
-	return len(statusMap) == 0
-}
-
 // doStartupCleanup performs a one-time cleanup of stale managedFields for all objects.
 // This handles the upgrade scenario where previous code left stale managedFields.
 // Returns an error if any cleanup operations failed.
@@ -157,10 +123,14 @@ func (m *typedStatusManager[T]) doStartupCleanup(zones sets.Set[string]) error {
 	for _, obj := range objects {
 		managedFields := m.resource.getManagedFields(obj)
 
-		// Check for stale empty-status managedFields
+		// Check for stale status managedFields
 		for _, mf := range managedFields {
-			if !zones.Has(mf.Manager) && isEmptyStatusManagedField(mf) {
-				klog.V(5).Infof("StatusManager %s: cleaning up stale empty-status managedField for manager: %s", m.name, mf.Manager)
+			// Skip cluster-manager (global aggregator)
+			if mf.Manager == clusterManagerName {
+				continue
+			}
+			if !zones.Has(mf.Manager) && mf.Subresource == "status" {
+				klog.V(5).Infof("StatusManager %s: cleaning up stale status managedField for manager: %s", m.name, mf.Manager)
 				applyAsZoneController := &metav1.ApplyOptions{
 					Force:        true,
 					FieldManager: mf.Manager,

--- a/go-controller/pkg/clustermanager/status_manager/status_manager_test.go
+++ b/go-controller/pkg/clustermanager/status_manager/status_manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
 	egressfirewallapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
+	egressfirewallapply "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/applyconfiguration/egressfirewall/v1"
 	egressfirewallfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressqosapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1"
 	networkqosapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
@@ -557,8 +558,8 @@ var _ = Describe("Cluster Manager Status Manager", func() {
 			},
 		}
 		egressFirewall.ManagedFields = []metav1.ManagedFieldsEntry{
-			{Manager: "zone1", Subresource: "status", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone1: zone1: EgressFirewall Rules applied\"":{}}}}`)}},
-			{Manager: "zone2", Subresource: "status", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone2: zone2: EgressFirewall Rules applied\"":{}}}}`)}},
+			{Manager: "zone1", Operation: metav1.ManagedFieldsOperationApply, Subresource: "status", APIVersion: "k8s.ovn.org/v1", FieldsType: "FieldsV1", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone1: zone1: EgressFirewall Rules applied\"":{}}}}`)}},
+			{Manager: "zone2", Operation: metav1.ManagedFieldsOperationApply, Subresource: "status", APIVersion: "k8s.ovn.org/v1", FieldsType: "FieldsV1", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone2: zone2: EgressFirewall Rules applied\"":{}}}}`)}},
 		}
 
 		// Set up a reactor to intercept cleanup patches and track which zones are cleaned
@@ -632,12 +633,12 @@ var _ = Describe("Cluster Manager Status Manager", func() {
 		}
 		egressFirewall.ManagedFields = []metav1.ManagedFieldsEntry{
 			// Valid managedFields with actual message content nested inside
-			{Manager: "zone1", Subresource: "status", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone1: EgressFirewall Rules applied\"":{}}}}`)}},
-			{Manager: "zone2", Subresource: "status", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone2: EgressFirewall Rules applied\"":{}}}}`)}},
+			{Manager: "zone1", Operation: metav1.ManagedFieldsOperationApply, Subresource: "status", APIVersion: "k8s.ovn.org/v1", FieldsType: "FieldsV1", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone1: EgressFirewall Rules applied\"":{}}}}`)}},
+			{Manager: "zone2", Operation: metav1.ManagedFieldsOperationApply, Subresource: "status", APIVersion: "k8s.ovn.org/v1", FieldsType: "FieldsV1", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:messages":{"v:\"zone2: EgressFirewall Rules applied\"":{}}}}`)}},
 			// Stale managedField with empty status (left by buggy code when zone was deleted)
-			{Manager: "zone3-deleted", Subresource: "status", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{}}`)}},
+			{Manager: "zone3-deleted", Operation: metav1.ManagedFieldsOperationApply, Subresource: "status", APIVersion: "k8s.ovn.org/v1", FieldsType: "FieldsV1", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{}}`)}},
 			// Legitimate cluster-manager managedField with its own nested structure
-			{Manager: "cluster-manager", Subresource: "status", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:status":{}}}`)}},
+			{Manager: "cluster-manager", Operation: metav1.ManagedFieldsOperationApply, Subresource: "status", APIVersion: "k8s.ovn.org/v1", FieldsType: "FieldsV1", FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:status":{"f:status":{}}}`)}},
 		}
 
 		var cleanupCalled atomic.Uint32
@@ -774,6 +775,63 @@ var _ = Describe("Cluster Manager Status Manager", func() {
 		}, fakeClient)
 		checkNQStatusEventually(networkQoS, false, false, fakeClient)
 
+	})
+
+	It("cleans up stale zone managedFields during startup", func() {
+		config.OVNKubernetesFeature.EnableEgressFirewall = true
+		namespace1 := util.NewNamespace(namespace1Name)
+		egressFirewall := newEgressFirewall(namespace1.Name)
+		zones := sets.New("zone1", "zone2")
+
+		objects := []runtime.Object{namespace1, egressFirewall}
+		for _, zone := range zones.UnsortedList() {
+			objects = append(objects, getNode(zone))
+		}
+		fakeClient = util.GetOVNClientset(objects...).GetClusterManagerClientset()
+		efClient := fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(namespace1.Name)
+
+		ctx := context.TODO()
+		applyZoneMessage := func(zone, message string) {
+			applyObj := egressfirewallapply.EgressFirewall(egressFirewall.Name, egressFirewall.Namespace).
+				WithStatus(egressfirewallapply.EgressFirewallStatus().WithMessages(message))
+			_, err := efClient.ApplyStatus(ctx, applyObj, metav1.ApplyOptions{FieldManager: zone, Force: true})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		zone1Msg := types.GetZoneStatus("zone1", "OK")
+		zone2Msg := types.GetZoneStatus("zone2", "OK")
+		zone3Msg := types.GetZoneStatus("zone3", "OK")
+		applyZoneMessage("zone1", zone1Msg)
+		applyZoneMessage("zone2", zone2Msg)
+		// zone3 is not a current zone (no matching node), so it is stale and must be cleaned up.
+		applyZoneMessage("zone3", zone3Msg)
+
+		var err error
+		wf, err = factory.NewClusterManagerWatchFactory(fakeClient)
+		Expect(err).NotTo(HaveOccurred())
+		statusManager = NewStatusManager(wf, fakeClient, networkmanager.Default().Interface())
+		Expect(wf.Start()).NotTo(HaveOccurred())
+		Expect(statusManager.Start()).NotTo(HaveOccurred())
+
+		// The stale zone3 managedField and message must be removed, while zone1 and
+		// zone2 (their managedFields and messages) must be preserved.
+		Eventually(func() bool {
+			ef, err := efClient.Get(ctx, egressFirewall.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+
+			managers := sets.New[string]()
+			for _, mf := range ef.ManagedFields {
+				managers.Insert(mf.Manager)
+			}
+			if managers.Has("zone3") || !managers.Has("zone1") || !managers.Has("zone2") {
+				return false
+			}
+
+			gotMessages := sets.New(ef.Status.Messages...)
+			return !gotMessages.Has(zone3Msg) && gotMessages.Has(zone1Msg) && gotMessages.Has(zone2Msg)
+		}, 5).Should(BeTrue(), "stale zone3 managedField and message should be removed; zone1/zone2 preserved")
 	})
 
 })

--- a/go-controller/pkg/util/fake_client.go
+++ b/go-controller/pkg/util/fake_client.go
@@ -119,7 +119,7 @@ func GetOVNClientset(objects ...runtime.Object) *OVNClientset {
 		KubeClient:                fake.NewSimpleClientset(v1Objects...),
 		ANPClient:                 anpfake.NewSimpleClientset(anpObjects...),
 		EgressIPClient:            egressipfake.NewSimpleClientset(egressIPObjects...),
-		EgressFirewallClient:      egressfirewallfake.NewSimpleClientset(egressFirewallObjects...),
+		EgressFirewallClient:      egressfirewallfake.NewClientset(egressFirewallObjects...),
 		CloudNetworkClient:        cloudservicefake.NewSimpleClientset(cloudObjects...),
 		EgressQoSClient:           egressqosfake.NewSimpleClientset(egressQoSObjects...),
 		NetworkAttchDefClient:     nadClient,


### PR DESCRIPTION
## Problem

  When nodes are deleted while \`ovnkube-control-plane\` pods are down, stale \`Ready-In-Zone-<nodename>\` entries accumulate in the \`status.conditions[]\` array of AdminNetworkPolicy (ANP) and BaselineAdminNetworkPolicy (BANP) resources. These stale entries are never cleaned up, even after the controller restarts.
   
   **Root Cause:** 
   The ANP/BANP status manager uses zone-based reconciliation where each zone (controller instance) manages its own status condition via Server-Side Apply (SSA). When a node is deleted while all controllers are down:
   1. No controller is running to detect the node deletion event
   2. The stale \`Ready-In-Zone-<nodename>\` condition remains in the status
   3. On controller restart, the new leader only reconciles current zones - it doesn't check for conditions referencing deleted zones

   ## Solution
   
   removing the isEmptyStatusManagedField check so startup cleanup runs for all managers not in currentZones. That works for the real bug, since SSA via removeZoneStatusFromAllANPs() already clears that zone’s status.

 ## Implementation Details

   **Files Modified:*

 1. admin_network_policy_manager.go 
    - Removed && isEmptyStatusManagedField(mf) check
    - Now cleans up ALL stale zone managedFields, not just empty ones
  2. status_manager.go 
    - Removed && isEmptyStatusManagedField(mf) check
    - Added explicit && mf.Subresource == "status" check for consistency
    - Updated log message and comment
  
  **Test Scenarios:**
   1. **Node deletion during controller downtime**: Simulates the exact bug scenario
      - Create ANP/BANP
      - Delete node while ovnkube-control-plane is scaled to 0
      - Verify stale status entry is cleaned on controller restart

   2. **Controller restart without node deletion**: Ensures cleanup doesn't remove valid entries
      - Create ANP/BANP
      - Restart controller without deleting nodes
      - Verify all status entries remain intact


