### PR TITLE
helm: drop NET_ADMIN from nb/sb-ovsdb; fix e2e accordingly

### DIFF
--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -44,10 +44,6 @@ spec:
         image: {{ include "getDPUImage" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.global.dpuImage.pullPolicy }}
         command: ["/root/ovnkube.sh", "local-nb-ovsdb"]
-        securityContext:
-          runAsUser: 0
-          capabilities:
-            add: ["NET_ADMIN"]
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
@@ -109,10 +105,6 @@ spec:
         image: {{ include "getDPUImage" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.global.dpuImage.pullPolicy }}
         command: ["/root/ovnkube.sh", "local-sb-ovsdb"]
-        securityContext:
-          runAsUser: 0
-          capabilities:
-            add: ["NET_ADMIN"]
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -44,10 +44,6 @@ spec:
         image: {{ include "getImage" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
         command: ["/root/ovnkube.sh", "local-nb-ovsdb"]
-        securityContext:
-          runAsUser: 0
-          capabilities:
-            add: ["NET_ADMIN"]
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
@@ -122,10 +118,6 @@ spec:
         image: {{ include "getImage" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
         command: ["/root/ovnkube.sh", "local-sb-ovsdb"]
-        securityContext:
-          runAsUser: 0
-          capabilities:
-            add: ["NET_ADMIN"]
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch

--- a/test/e2e/multihoming_external_router_utils.go
+++ b/test/e2e/multihoming_external_router_utils.go
@@ -326,9 +326,19 @@ func newPodExecutionContext(cmdBuilder routeCommandBuilder, pod v1.Pod) (*podExe
 		return nil, fmt.Errorf("failed to get target nodes for pod %s: %w", pod.Name, err)
 	}
 
+	// Pick the container that can actually run the command:
+	//   - Host-routing commands ("ip route ...") need NET_ADMIN, getNodeContainerName()
+	//     returns the right ovnkube-controller container name.
+	//   - OVN logical-router commands ("ovn-nbctl ...") must run in the container that
+	//     owns the NB DB unix socket, which is "nb-ovsdb".
+	containerName := "nb-ovsdb"
+	if _, isHostRoutingCommand := cmdBuilder.(hostRoutingTableCommandBuilder); isHostRoutingCommand {
+		containerName = getNodeContainerName()
+	}
+
 	return &podExecutionContext{
 		pod:           pod,
-		containerName: pod.Spec.Containers[0].Name,
+		containerName: containerName,
 		targetNodes:   targetNodes,
 		cmdBuilder:    cmdBuilder,
 	}, nil

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -682,8 +682,11 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 			extraCIDR = extraIP + "/128"
 		}
 
+		// The default first container (nb-ovsdb) dropped NET_ADMIN. Run "ip addr ..."
+		// inside the ovnkube-node pod's container that has NET_ADMIN.
+		nodeContainer := getNodeContainerName()
 		cmd := fmt.Sprintf(`ip -br addr; ip addr del %s dev lo; ip addr add %s dev lo; ip -br addr`, extraCIDR, extraCIDR)
-		_, err = e2epodoutput.RunHostCmdWithRetries(clientPod.Namespace, clientPod.Name, cmd, framework.Poll, 30*time.Second)
+		_, err = RunHostCmdInContainerWithRetries(clientPod.Namespace, clientPod.Name, nodeContainer, cmd, framework.Poll, 30*time.Second)
 		framework.ExpectNoError(err)
 		cleanupFn = func() {
 			// initial pod used for host command may be deleted at this point, refetch
@@ -695,7 +698,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 			gomega.Expect(pods.Items).To(gomega.HaveLen(1))
 			clientPod := &pods.Items[0]
 			cmd := fmt.Sprintf(`ip addr del %s dev lo || true`, extraCIDR)
-			_, _ = e2epodoutput.RunHostCmdWithRetries(clientPod.Namespace, clientPod.Name, cmd, framework.Poll, 30*time.Second)
+			_, _ = RunHostCmdInContainerWithRetries(clientPod.Namespace, clientPod.Name, nodeContainer, cmd, framework.Poll, 30*time.Second)
 		}
 
 		ginkgo.By("Starting a UDP server listening on the additional IP")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1280,6 +1280,33 @@ func getNodeContainerName() string {
 	return "ovnkube-controller"
 }
 
+// RunHostCmdInContainer runs cmd in a specific pod container via kubectl exec,
+// like the k8s e2e framework's e2epodoutput.RunHostCmd but with --container.
+// The framework helper omits -c, so kubectl uses the pod's first container.
+// Use this when that container lacks what the command needs (e.g. NET_ADMIN
+// after nb-ovsdb dropped it in IC mode).
+func RunHostCmdInContainer(ns, name, container, cmd string) (string, error) {
+	return e2ekubectl.RunKubectl(ns, "exec", name, "--container", container, "--", "/bin/sh", "-x", "-c", cmd)
+}
+
+// RunHostCmdInContainerWithRetries retries RunHostCmdInContainer until success
+// or timeout, like e2epodoutput.RunHostCmdWithRetries.
+func RunHostCmdInContainerWithRetries(ns, name, container, cmd string, interval, timeout time.Duration) (string, error) {
+	var output string
+	pollErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		out, err := RunHostCmdInContainer(ns, name, container, cmd)
+		if err != nil {
+			return false, nil
+		}
+		output = out
+		return true, nil
+	})
+	if pollErr != nil {
+		return "", fmt.Errorf("RunHostCmdInContainerWithRetries timed out after %v: %w", timeout, pollErr)
+	}
+	return output, nil
+}
+
 // getNodeZone returns the node's zone
 func getNodeZone(node *v1.Node) (string, error) {
 	nodeZone, ok := node.Annotations[ovnNodeZoneNameAnnotation]


### PR DESCRIPTION
nb-ovsdb / sb-ovsdb only run ovsdb-server, which doesn't need NET_ADMIN or root. Drop the securityContext from both DB containers in the ovnkube-single-node-zone and ovnkube-single-node-zone-dpu charts.

Update e2e to route NET_ADMIN-requiring host commands at getNodeContainerName() instead of pod.Spec.Containers[0] (nb-ovsdb).


Co-authored-by: Cursor

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->