### PR TITLE
add node network connected subnet route to UDN VRF table

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_testutil.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_testutil.go
@@ -45,6 +45,13 @@ func TestBridgeConfigWithGatewayRepresentor(brName, gwIfaceRep string) *BridgeCo
 	return bridge
 }
 
+// SetIPs allows tests to configure bridge IP addresses for verifying VRF route computation
+func (b *BridgeConfiguration) SetIPs(ips []*net.IPNet) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	b.ips = ips
+}
+
 func (b *BridgeConfiguration) GetNetConfigLen() int {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -119,6 +119,9 @@ type UserDefinedNetworkGateway struct {
 	// gwInterfaceIndex holds the link index of the gateway interface for this network.
 	gwInterfaceIndex int
 
+	// nodeNetAddrs holds the gateway bridge (br-ex) IP addresses with subnet masks
+	nodeNetAddrs []*net.IPNet
+
 	// save BGP state at the start of reconciliation loop run to handle it consistently throughout the run
 	isNetworkAdvertisedToDefaultVRF bool
 	isNetworkAdvertised             bool
@@ -173,6 +176,15 @@ func NewUserDefinedNetworkGateway(netInfo util.NetInfo, node *corev1.Node, nodeL
 		gwInterfaceIndex = 0
 	}
 
+	// Retrieve gateway bridge IPs for programming node network connected subnet routes in the VRF table
+	var nodeNetAddrs []*net.IPNet
+	if gw.openflowManager != nil {
+		nodeNetAddrs = gw.openflowManager.defaultBridge.GetIPs()
+		if len(nodeNetAddrs) == 0 {
+			klog.V(4).Infof("No bridge IPs found for UDN gateway %s, node network connected subnet routes will not be programmed", netInfo.GetNetworkName())
+		}
+	}
+
 	return &UserDefinedNetworkGateway{
 		NetInfo:                 netInfo,
 		node:                    node,
@@ -193,6 +205,7 @@ func NewUserDefinedNetworkGateway(netInfo util.NetInfo, node *corev1.Node, nodeL
 		reconcile:               make(chan struct{}, 1),
 		gwInterfaceName:         gwInterfaceName,
 		gwInterfaceIndex:        gwInterfaceIndex,
+		nodeNetAddrs:            nodeNetAddrs,
 	}, nil
 }
 
@@ -821,6 +834,27 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 		return nil, fmt.Errorf("unable to add default route for network %s, err: %v", udng.GetNetworkName(), err)
 	}
 	retVal = append(retVal, defaultRoute...)
+
+	// Add node network connected subnet route: eg. 192.168.x.0/24 dev br-ex scope link src 192.168.x.5
+	// necessary for direct L2 forwarding to nodes on the same subnet without going through the default gateway
+	for _, nodeNetAddr := range udng.nodeNetAddrs {
+		if nodeNetAddr == nil || nodeNetAddr.IP == nil || nodeNetAddr.Mask == nil {
+			continue
+		}
+		// only add routes for configured IP families
+		isV6 := utilnet.IsIPv6(nodeNetAddr.IP)
+		if (!isV6 && !config.IPv4Mode) || (isV6 && !config.IPv6Mode) {
+			continue
+		}
+		nodeSubnet := nodeNetAddr.IP.Mask(nodeNetAddr.Mask)
+		retVal = append(retVal, netlink.Route{
+			LinkIndex: udng.gwInterfaceIndex,
+			Dst:       &net.IPNet{IP: nodeSubnet, Mask: nodeNetAddr.Mask},
+			Src:       nodeNetAddr.IP,
+			Table:     udng.vrfTableId,
+			Scope:     netlink.SCOPE_LINK,
+		})
+	}
 
 	// Route3: Add MasqueradeRoute for reply traffic route: 169.254.169.12 dev ovn-k8s-mpX mtu 1400
 	// necessary for reply traffic towards UDN CNI pods to go into OVN

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -609,8 +609,13 @@ func openflowManagerCheckPorts(ofMgr *openflowManager) {
 	Expect(checkPorts(ofMgr.ovsClient, netConfigs, uplink, ofPortPhys)).To(Succeed())
 }
 
-func getDummyOpenflowManager() *openflowManager {
+// getDummyOpenflowManager creates a test openflow manager. Optional bridgeIPs
+// can be passed to configure gateway bridge IPs for node network route tests.
+func getDummyOpenflowManager(bridgeIPs ...*net.IPNet) *openflowManager {
 	gwBridge := bridgeconfig.TestBridgeConfig("breth0")
+	if len(bridgeIPs) > 0 {
+		gwBridge.SetIPs(bridgeIPs)
+	}
 	ofm := &openflowManager{
 		defaultBridge: newOpenflowBridge(gwBridge),
 		uplinkBridges: map[string]*openflowBridge{},
@@ -2528,6 +2533,125 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+
+	// Verifies that node network connected subnet routes (e.g. 192.168.1.0/24 dev br-ex scope link src 192.168.1.10)
+	// are programmed in the VRF table when gateway bridge IPs are configured. These routes enable direct L2 forwarding
+	// to other nodes on the same subnet without routing through the default gateway.
+	ovntest.OnSupportedPlatformsIt("should add node network connected subnet routes to VRF table", func() {
+		config.Gateway.Interface = "eth0"
+		config.IPv4Mode = true
+		config.IPv6Mode = true
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet),
+				},
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16/24,ae70::/60/64", types.NetworkRolePrimary)
+		ovntest.AnnotateNADWithNetworkID(netID, nad)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			ofm := getDummyOpenflowManager(ovntest.MustParseIPNets(v4NodeIP, v6NodeIP)...)
+			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, node, nil, nil, vrf, nil, &gateway{openflowManager: ofm}, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			mplink, err := netlink.LinkByName(mgtPort)
+			Expect(err).NotTo(HaveOccurred())
+			bridgelink, err := netlink.LinkByName("breth0")
+			Expect(err).NotTo(HaveOccurred())
+			vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
+			udnGateway.vrfTableId = vrfTableId
+
+			routes, err := udnGateway.computeRoutesForUDN(mplink)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify node network connected subnet routes are present for both IPv4 and IPv6.
+			// Match by scope and destination to stay resilient to route ordering changes.
+			var v4Found, v6Found bool
+			for _, route := range routes {
+				if route.Scope == netlink.SCOPE_LINK && route.Dst != nil {
+					if route.Dst.String() == "192.168.1.0/24" {
+						Expect(route.LinkIndex).To(Equal(bridgelink.Attrs().Index))
+						Expect(route.Src.Equal(ovntest.MustParseIP("192.168.1.10"))).To(BeTrue())
+						Expect(route.Table).To(Equal(vrfTableId))
+						v4Found = true
+					}
+					if route.Dst.String() == "fc00:f853:ccd:e793::/64" {
+						Expect(route.LinkIndex).To(Equal(bridgelink.Attrs().Index))
+						Expect(route.Src.Equal(ovntest.MustParseIP("fc00:f853:ccd:e793::3"))).To(BeTrue())
+						Expect(route.Table).To(Equal(vrfTableId))
+						v6Found = true
+					}
+				}
+			}
+			Expect(v4Found).To(BeTrue(), "IPv4 node network connected subnet route not found")
+			Expect(v6Found).To(BeTrue(), "IPv6 node network connected subnet route not found")
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+
+	ovntest.OnSupportedPlatformsIt("should filter node subnet routes by IP family and tolerate nil bridge IPs", func() {
+		config.Gateway.Interface = "eth0"
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{
+			"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet),
+		}}}
+		for _, tc := range []struct {
+			ipv4, ipv6     bool
+			cidr           string
+			wantV4, wantV6 bool
+			injectNil      bool
+			desc           string
+		}{
+			{true, false, "100.128.0.0/16/24", true, false, false, "IPv4-only"},
+			{false, true, "ae70::/60/64", false, true, false, "IPv6-only"},
+			{true, true, "100.128.0.0/16/24,ae70::/60/64", true, true, true, "nil bridge IP tolerance"},
+		} {
+			config.IPv4Mode = tc.ipv4
+			config.IPv6Mode = tc.ipv6
+			nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+				types.Layer3Topology, tc.cidr, types.NetworkRolePrimary)
+			ovntest.AnnotateNADWithNetworkID(netID, nad)
+			netInfo, err := util.ParseNADInfo(nad)
+			Expect(err).NotTo(HaveOccurred())
+			err = testNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				ips := ovntest.MustParseIPNets(v4NodeIP, v6NodeIP)
+				if tc.injectNil {
+					ips = append(ips, nil)
+				}
+				ofm := getDummyOpenflowManager(ips...)
+				gw, err := NewUserDefinedNetworkGateway(netInfo, node, nil, nil, vrf, nil, &gateway{openflowManager: ofm}, nil, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				mp, err := netlink.LinkByName(mgtPort)
+				Expect(err).NotTo(HaveOccurred())
+				gw.vrfTableId = util.CalculateRouteTableID(mp.Attrs().Index)
+				routes, err := gw.computeRoutesForUDN(mp)
+				Expect(err).NotTo(HaveOccurred())
+				var v4, v6 bool
+				for _, r := range routes {
+					if r.Scope == netlink.SCOPE_LINK && r.Dst != nil {
+						switch r.Dst.String() {
+						case "192.168.1.0/24":
+							v4 = true
+						case "fc00:f853:ccd:e793::/64":
+							v6 = true
+						}
+					}
+				}
+				Expect(v4).To(Equal(tc.wantV4), tc.desc+": IPv4 scope-link route")
+				Expect(v6).To(Equal(tc.wantV6), tc.desc+": IPv6 scope-link route")
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+		}
 	})
 
 	ovntest.OnSupportedPlatformsIt("should set rp filter to loose mode for management port interface", func() {


### PR DESCRIPTION
## 📑 Description

Using OVN local gateway mode, the NATted traffic from UDN pods destined to nodes on the same L2 subnet was being routed through the default gateway instead of being forwarded directly via br-ex/breth0. This happened because the VRF table doesn not have a connected subnet route for the node network.

Add a scope-link route (e.g. 192.168.x.0/24 dev br-ex/breth0 scope link src 192.168.x.5) to the UDN VRF table so the kernel can resolve destinations on the local subnet via direct L2/ARP forwarding without an unnecessary hop through the gateway.

Fixes: https://issues.redhat.com/browse/OCPBUGS-78351

## Additional Information for reviewers

1. gateway_udn.go — The fix (3 changes)

  a) New struct field — Added nodeNetAddrs []*net.IPNet to UserDefinedNetworkGateway to store the gateway bridge (br-ex) IP addresses with their subnet masks.

  b) Populate in constructor — In NewUserDefinedNetworkGateway(), fetch the bridge IPs from openflowManager.defaultBridge.GetIPs() when available. Guarded by a nil check since
  openflowManager is nil in DPUHost mode.

  c) New route in computeRoutesForUDN() — After the default gateway route, added a loop that creates a scope-link connected subnet route for each bridge IP:

```go
  for _, nodeNetAddr := range udng.nodeNetAddrs {
      nodeSubnet := nodeNetAddr.IP.Mask(nodeNetAddr.Mask)
      retVal = append(retVal, netlink.Route{
          LinkIndex: udng.gwInterfaceIndex,
          Dst:       &net.IPNet{IP: nodeSubnet, Mask: nodeNetAddr.Mask},
          Src:       nodeNetAddr.IP,
          Table:     udng.vrfTableId,
          Scope:     netlink.SCOPE_LINK,
      })
  }
```

  This produces: 192.168.x.0/24 dev br-ex scope link src 192.168.x.5 in the VRF table.

  2. bridgeconfig/bridgeconfig_testutil.go — Test helper

  Added a SetIPs() method on BridgeConfiguration so tests can configure bridge IPs. Follows the same mutex pattern as the existing GetIPs().

  3. gateway_udn_test.go — Test coverage (2 changes)

  a) Updated getDummyOpenflowManager — Changed signature to variadic bridgeIPs ...*net.IPNet so tests can optionally pass bridge IPs. All 13 existing callers continue to work unchanged.

  b) New test case — "should add node network connected subnet routes to VRF table" verifies both IPv4 (192.168.1.0/24) and IPv6 (fc00:f853:ccd:e793::/64) connected subnet routes are present
  with correct Dst, Src, LinkIndex, Table, and Scope. Uses order-independent matching by looping over routes.


## ✅ Checks
Local Unit test succeeded and the following are the  Unit Test Results

```bash
  Test Suite: pkg/node/... (gateway_udn, bridgeconfig, vrfmanager, and related packages)
  Branch: udn-vrf-node-subnet-route

  Related computeRoutesForUDN tests — all PASSED:
    ✔ should compute correct routes for a user defined network
    ✔ should have default route when network is advertised on default VRF
    ✔ should omit default route when network is advertised on any other vrf than default
    ✔ should create a route import VRF in DPU mode
    ✔ should add node network connected subnet routes to VRF table   <----------  NEW TEST

  All suites:
    ✔ pkg/node             — 210 Passed | 0 Failed
    ✔ pkg/node/bridgeconfig —   2 Passed | 0 Failed
    ✔ pkg/node/controllers  —  43 Passed | 0 Failed
    ✔ pkg/node/controllers/egressip — 14 Passed | 0 Failed
    ✔ pkg/node/managementport — 51 Passed | 0 Failed
    ✔ pkg/node/netlinkdevicemanager — 206 Passed | 0 Failed
    ✔ pkg/node/routemanager — 20 Passed | 0 Failed
    ✔ pkg/node/util         —  4 Passed | 0 Failed
    ✔ pkg/node/vrfmanager   —  8 Passed | 0 Failed

  Total: 0 Failed | 0 Regressions
```

## How to verify it
- Local Unit test succeeded.
- In an OVN  kind cluster using the modified code in local gateway mode, validated that UDN traffic destined to node subnet, leaves via direct L2/ARP forwarding without an unnecessary hop through the gateway.
- Validated that scope-link route existed in the UDN vrf route table on node. 

### Before Fix

```bash
➜ ./kind.sh -mne -nse -gm local -wk 2 

➜ oc get nodes -o wide
NAME                STATUS   ROLES           AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION           CONTAINER-RUNTIME
ovn-control-plane   Ready    control-plane   13m   v1.35.0   172.18.0.4    <none>        Debian GNU/Linux 12 (bookworm)   7.0.10-101.fc43.x86_64   containerd://2.2.0
ovn-worker          Ready    worker          13m   v1.35.0   172.18.0.3    <none>        Debian GNU/Linux 12 (bookworm)   7.0.10-101.fc43.x86_64   containerd://2.2.0
ovn-worker2         Ready    worker          13m   v1.35.0   172.18.0.2    <none>        Debian GNU/Linux 12 (bookworm)   7.0.10-101.fc43.x86_64   containerd://2.2.0

➜ oc get po -o wide
NAME   READY   STATUS    RESTARTS   AGE     IP           NODE          NOMINATED NODE   READINESS GATES
pod1   1/1     Running   0          2m48s   10.244.2.3   ovn-worker    <none>           <none>
pod2   1/1     Running   0          2m41s   10.244.1.6   ovn-worker2   <none>           <none>

[root@pod1 /]# curl -v telnet://172.18.0.2:8888
*   Trying 172.18.0.2:8888...
* Connected to 172.18.0.2 (172.18.0.2) port 8888

root@ovn-worker:~# ip a s breth0
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 46:fe:5b:3d:21:dc brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.3/16 brd 172.18.255.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet 169.254.0.2/17 brd 169.254.127.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet6 fc00:f853:ccd:e793::3/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::44fe:5bff:fe3d:21dc/64 scope link 
       valid_lft forever preferred_lft forever

root@ovn-worker:~# ip vrf
Name              Table
-----------------------
mp1-udn-vrf       1009

root@ovn-worker:~# ip route show table 1009
default via 172.18.0.1 dev breth0 mtu 1400 
unreachable default metric 4278198272 
10.96.0.0/16 via 169.254.0.4 dev breth0 mtu 1400 
10.200.0.0/16 dev ovn-k8s-mp1 proto kernel scope link src 10.200.0.2 
local 10.200.0.2 dev ovn-k8s-mp1 proto kernel scope host src 10.200.0.2 
broadcast 10.200.255.255 dev ovn-k8s-mp1 proto kernel scope link src 10.200.0.2 
169.254.0.3 via 10.200.0.1 dev ovn-k8s-mp1 
169.254.0.12 dev ovn-k8s-mp1 mtu 1400 

// In the above 1009 route table there is no scope-link route for 172.18.0.0/0 network 
// 8a:af:c0:35:d2:c7 is the MAC address of node's default gateway 

// UDN POD traffic destined to 172.18.0.2.8888 is forwarded directly to the gateway MAC 8a:af:c0:35:d2:c7
root@ovn-worker:~# tcpdump -i eth0 -nnne port 8888
16:33:00.749256 46:fe:5b:3d:21:dc > 8a:af:c0:35:d2:c7, ethertype IPv4 (0x0800), length 74: 172.18.0.3.34622 > 172.18.0.2.8888: Flags [S], seq 1496132001, win 65280, options [mss 1360,sackOK,TS val 3344983273 ecr 0,nop,wscale 10], length 0
16:33:00.749787 8a:af:c0:35:d2:c7 > 46:fe:5b:3d:21:dc, ethertype IPv4 (0x0800), length 74: 172.18.0.2.8888 > 172.18.0.3.34622: Flags [S.], seq 1953367920, ack 1496132002, win 65160, options [mss 1460,sackOK,TS val 3938482833 ecr 3344983273,nop,wscale 10], length 0

// On node 2, UDN POD traffic is received via default gateway 172.18.0.1/8a:af:c0:35:d2:c7 
root@ovn-worker2:~# ip a s breth0
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 86:a5:6b:84:c8:5d brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.2/16 brd 172.18.255.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet 169.254.0.2/17 brd 169.254.127.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet6 fc00:f853:ccd:e793::2/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::84a5:6bff:fe84:c85d/64 scope link 
       valid_lft forever preferred_lft forever

root@ovn-worker2:~# tcpdump -i breth0 -nnne port 8888 
16:33:00.749574 8a:af:c0:35:d2:c7 > 86:a5:6b:84:c8:5d, ethertype IPv4 (0x0800), length 74: 172.18.0.1.34622 > 172.18.0.2.8888: Flags [S], seq 1496132001, win 65280, options [mss 1360,sackOK,TS val 3344983273 ecr 0,nop,wscale 10], length 0
16:33:00.749627 86:a5:6b:84:c8:5d > 8a:af:c0:35:d2:c7, ethertype IPv4 (0x0800), length 74: 172.18.0.2.8888 > 172.18.0.1.34622: Flags [S.], seq 1953367920, ack 1496132002, win 65160, options [mss 1460,sackOK,TS val 3938482833 ecr 3344983273,nop,wscale 10], length 0

// gateway mac 8a:af:c0:35:d2:c7
5: br-233e6d1b2036: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 8a:af:c0:35:d2:c7 brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.1/16 brd 172.18.255.255 scope global br-233e6d1b2036
       valid_lft forever preferred_lft forever
    inet6 fc00:f853:ccd:e793::1/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::88af:c0ff:fe35:d2c7/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
```


### After Fix

```bash
➜ ./kind.sh -mne -nse -gm local -wk 2 

➜ oc get nodes -o wide
NAME                STATUS   ROLES           AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                      
ovn-control-plane   Ready    control-plane   34m   v1.35.0   172.18.0.2    <none>        Debian GNU/Linux 12 (bookworm)
ovn-worker          Ready    worker          34m   v1.35.0   172.18.0.4    <none>        Debian GNU/Linux 12 (bookworm)
ovn-worker2         Ready    worker          33m   v1.35.0   172.18.0.3    <none>        Debian GNU/Linux 12 (bookworm)

➜ oc get po -o wide
NAME   READY   STATUS    RESTARTS   AGE   IP           NODE          NOMINATED NODE   READINESS GATES
pod1   1/1     Running   0          35s   10.244.1.3   ovn-worker    <none>           <none>
pod2   1/1     Running   0          30s   10.244.2.6   ovn-worker2   <none>           <none>

[root@pod1 /]# curl -v telnet://172.18.0.2:8888
*   Trying 172.18.0.2:8888...
* Connected to 172.18.0.2 (172.18.0.2) port 8888

root@ovn-worker:~# ip a s breth0
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether fa:a6:44:ec:1d:f6 brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.4/16 brd 172.18.255.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet 169.254.0.2/17 brd 169.254.127.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet6 fc00:f853:ccd:e793::4/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::f8a6:44ff:feec:1df6/64 scope link 
       valid_lft forever preferred_lft forever

root@ovn-worker:~# ip vrf
Name              Table
-----------------------
mp1-udn-vrf       1009

root@ovn-worker:~# ip route show table 1009
default via 172.18.0.1 dev breth0 mtu 1400 
unreachable default metric 4278198272 
10.96.0.0/16 via 169.254.0.4 dev breth0 mtu 1400 
10.200.0.0/16 dev ovn-k8s-mp1 proto kernel scope link src 10.200.0.2 
local 10.200.0.2 dev ovn-k8s-mp1 proto kernel scope host src 10.200.0.2 
broadcast 10.200.255.255 dev ovn-k8s-mp1 proto kernel scope link src 10.200.0.2 
169.254.0.3 via 10.200.0.1 dev ovn-k8s-mp1 
169.254.0.12 dev ovn-k8s-mp1 mtu 1400 
172.18.0.0/16 dev breth0 scope link src 172.18.0.4  <<<<<  Connected subnet route

// N/W packets are directly forwarded to destination system 
root@ovn-worker:~# tcpdump -i eth0 -nnne port 8888
17:56:04.384520 fa:a6:44:ec:1d:f6 > 8a:d5:fd:43:ec:e6, ethertype IPv4 (0x0800), length 74: 172.18.0.4.40238 > 172.18.0.3.8888: Flags [S], seq 3810489716, win 65280, options [mss 1360,sackOK,TS val 858594941 ecr 0,nop,wscale 10], length 0
17:56:04.384682 8a:d5:fd:43:ec:e6 > fa:a6:44:ec:1d:f6, ethertype IPv4 (0x0800), length 74: 172.18.0.3.8888 > 172.18.0.4.40238: Flags [S.], seq 4222349067, ack 3810489717, win 65160, options [mss 1460,sackOK,TS val 1218116599 ecr 858594941,nop,wscale 10], length 0

// Node2 receives traffic from node1's MAC and IP directly. 
root@ovn-worker2:~# ip a s breth0
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 8a:d5:fd:43:ec:e6 brd ff:ff:ff:ff:ff:ff
    inet 172.18.0.3/16 brd 172.18.255.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet 169.254.0.2/17 brd 169.254.127.255 scope global breth0
       valid_lft forever preferred_lft forever
    inet6 fc00:f853:ccd:e793::3/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::88d5:fdff:fe43:ece6/64 scope link 
       valid_lft forever preferred_lft forever

root@ovn-worker2:~# tcpdump -i breth0 -nnne port 8888
17:56:04.384580 fa:a6:44:ec:1d:f6 > 8a:d5:fd:43:ec:e6, ethertype IPv4 (0x0800), length 74: 172.18.0.4.40238 > 172.18.0.3.8888: Flags [S], seq 3810489716, win 65280, options [mss 1360,sackOK,TS val 858594941 ecr 0,nop,wscale 10], length 0
17:56:04.384617 8a:d5:fd:43:ec:e6 > fa:a6:44:ec:1d:f6, ethertype IPv4 (0x0800), length 74: 172.18.0.3.8888 > 172.18.0.4.40238: Flags [S.], seq 4222349067, ack 3810489717, win 65160, options [mss 1460,sackOK,TS val 1218116599 ecr 858594941,nop,wscale 10], length 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway now caches bridge IPs and programs routes for user-defined networks, enabling direct Layer‑2 forwarding to nodes on the same subnets.

* **Tests**
  * Added a test helper to configure bridge IPs and expanded tests to verify VRF routing for node-connected subnets (IPv4 and IPv6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->