### PR TITLE
Fixes UDN Egress HW Offload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,8 @@ jobs:
   build-base:
     name: Build-base
     runs-on: ubuntu-24.04
+    env:
+      OVN_UPGRADE_FROM_REF: release-1.3
     steps:
     # Create a cache for the built base image
     - name: Restore base image cache
@@ -97,8 +99,8 @@ jobs:
             exit 0
         fi
 
-        if docker pull ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:${{ github.base_ref || github.ref_name }}; then
-            docker tag ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:${{ github.base_ref || github.ref_name }} ovn-daemonset-fedora:dev
+        if docker pull ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:${{ env.OVN_UPGRADE_FROM_REF }}; then
+            docker tag ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-fedora:${{ env.OVN_UPGRADE_FROM_REF }} ovn-daemonset-fedora:dev
 
             echo "BASE_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -108,7 +110,7 @@ jobs:
       if: steps.is_base_image_build_needed.outputs.BASE_IMAGE_RESTORED != 'true' && success()
       uses: actions/checkout@v6
       with:
-        ref: ${{ github.base_ref || github.ref_name }}
+        ref: ${{ env.OVN_UPGRADE_FROM_REF }}
 
     - name: Set up Go
       if: steps.is_base_image_build_needed.outputs.BASE_IMAGE_RESTORED != 'true' && success()
@@ -321,6 +323,9 @@ jobs:
       OVN_HYBRID_OVERLAY_ENABLE: "false"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "false"
+      OVN_UPGRADE_FROM_REF: release-1.3
+      ENABLE_MULTI_NET: "${{ matrix.gateway-mode == 'shared' }}"
+      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.gateway-mode == 'shared' }}"
       # TODO(koolzz): deprecate once infra is switched completely to kind-helm.sh
       USE_HELM: "true"
     steps:
@@ -328,7 +333,7 @@ jobs:
     - name: Check out code into the Go module directory - from Base branch
       uses: actions/checkout@v6
       with:
-          ref: ${{ github.base_ref || github.ref_name }}
+          ref: ${{ env.OVN_UPGRADE_FROM_REF }}
 
     - name: Set up Go
       uses: actions/setup-go@v6

--- a/docs/design/service-traffic-policy.md
+++ b/docs/design/service-traffic-policy.md
@@ -491,13 +491,11 @@ back to the node IP. The UDN gateway router load balancer uses `lb_force_snat_ip
 the packet can already have the node IP as source when it leaves the gateway router toward the
 physical bridge.
 
-The physical bridge still commits that packet through the default conntrack zone with
-`nat(src=<node-ip>)`. This lets conntrack detect overlapping source ports and reassign them in the
-same zone used for underlay egress, instead of bypassing NAT because the source IP already equals
-the node IP.
+The physical bridge still commits that packet through the default conntrack
+zone with all-zero SNAT, avoiding a second explicit node-IP SNAT.
 
 ```
-table=0, priority=99,ip,in_port="patch-breth0_<udn>",dl_src=<bridge-mac>,nw_src=<node-ip> actions=ct(commit,zone=64000,nat(src=<node-ip>),exec(set_field:<udn-ct-mark>->ct_mark)),output:<physical-port>
+table=0, priority=99,ip,in_port="patch-breth0_<udn>",dl_src=<bridge-mac>,nw_src=<node-ip> actions=ct(commit,zone=64000,nat(src=0.0.0.0),exec(set_field:<udn-ct-mark>->ct_mark)),output:<physical-port>
 table=0, priority=100,ip,in_port="patch-breth0_<udn>",dl_src=<bridge-mac>,nw_src=<udn-gr-masq-ip> actions=ct(commit,zone=64000,nat(src=<node-ip>),exec(set_field:<udn-ct-mark>->ct_mark)),output:<physical-port>
 ```
 

--- a/docs/design/udn-shared-gateway-egress-snat.md
+++ b/docs/design/udn-shared-gateway-egress-snat.md
@@ -1,0 +1,98 @@
+# UDN Shared Gateway Egress SNAT
+
+## Problem
+
+Primary user defined networks in shared gateway mode need egress traffic to
+leave the node with the Kubernetes node IP. The original UDN datapath did this
+with two source NAT operations:
+
+```text
+pod IP -> UDN gateway-router masquerade IP -> node IP
+```
+
+The first NAT is performed by the UDN gateway router. The second NAT is
+performed on the shared gateway bridge in conntrack zone 64000 before the
+packet exits the node.
+
+This works functionally, but it creates a datapath that is difficult for some
+hardware offload implementations to offload because the same connection is
+committed with source NAT in both the UDN gateway-router conntrack zone and
+the shared gateway bridge conntrack zone.
+
+## Design
+
+For new UDN egress connections in shared gateway mode, the UDN gateway router
+SNATs directly to the node IP:
+
+```text
+pod IP -> node IP
+```
+
+The shared gateway bridge still commits the connection in zone 64000 with the
+UDN conntrack mark, but it uses all-zero SNAT instead of a second explicit
+node-IP source NAT:
+
+```text
+ct(commit,zone=64000,nat(src=0.0.0.0),exec(set_field:<udn mark>->ct_mark))
+```
+
+This keeps the reverse-path zone 64000 state without applying another explicit
+node-IP translation.
+
+## Upgrade Compatibility
+
+Existing connections can be using the old gateway-router NAT entry:
+
+```text
+external_ip=<UDN gateway-router masquerade IP>
+logical_ip=<UDN subnet>
+```
+
+Those connections need the old row to remain present because OVN generates the
+unSNAT path from the NAT row external IP. If the row is replaced in place with
+the node IP, replies to the old masquerade IP can no longer be unSNATed.
+
+To avoid that disruption, ovnkube keeps the legacy row and adds a second,
+versioned row for new traffic:
+
+```text
+external_ip=<node IP>
+logical_ip=<UDN subnet>
+external_ids:k8s.ovn.org/udn-egress-snat-version=v2
+```
+
+Rows without the version external ID are treated as v1. The v2 row has a
+higher NAT priority and a non-empty NAT match. OVN only uses NAT priority when
+`NAT.match` is set, so unconditioned UDN subnet SNATs use a family match
+(`ip4` or `ip6`) on the v2 row.
+
+During upgrade:
+
+1. Old connections continue to use the v1 masquerade-IP NAT state.
+2. Reply traffic to the old masquerade IP still has a matching unSNAT flow.
+3. New connections match the higher-priority v2 node-IP NAT row.
+4. The bridge supports both source addresses:
+   - masquerade IP uses the legacy `nat(src=<node IP>)` bridge flow.
+   - node IP uses the v2 all-zero SNAT bridge flow.
+
+## Cleanup
+
+The v1 row is intentionally not deleted by this migration. It is required for
+existing long-lived connections and is harmless once those connections age out
+because the v2 row has higher priority for new traffic.
+
+Future cleanup can remove unversioned UDN egress SNAT rows after a release
+boundary where all nodes are known to have drained old conntrack state.
+
+## Test Coverage
+
+Unit coverage verifies:
+
+- shared gateway UDN gateway routers contain both v1 and v2 subnet SNAT rows.
+- the v2 row is tagged with the SNAT version external ID.
+- the v2 row has a non-empty match and higher priority.
+- the shared gateway bridge node-IP path uses all-zero SNAT in zone 64000.
+
+E2E upgrade coverage should keep a UDN pod and an active egress connection
+alive across an ovnkube-node restart or rollout, then verify that the old pod
+can still reach the external target after the new v2 SNAT row is installed.

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -737,19 +737,18 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
-				// table0, for SGW UDN no-overlay networks, handle cross-node traffic
+				// table0, for SGW UDN networks, handle traffic
 				// that has already been SNATed to node IP by the gateway router.
-				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+				if !netConfig.IsDefaultNetwork() && config.Gateway.Mode == config.GatewayModeShared {
 					// Commit to conntrack and send directly to the physical port.
-					// SNAT to the node IP may already have happened on the UDN GW
-					// router because lb_force_snat_ip=router_ip. SNAT to the same
-					// node IP again here so zone 64000 can resolve source-port collisions.
+					// SNAT to the node IP already happened on the UDN GW router.
+					// Use all-zero SNAT so zone 64000 has a NAT action without
+					// applying a second explicit node-IP SNAT.
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, nw_src=%s, "+
-							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+							"actions=ct(commit, zone=%d, nat(src=0.0.0.0), exec(set_field:%s->ct_mark)), output:%s",
 							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV4,
 							physicalIP.IP, config.Default.ConntrackZone,
-							physicalIP.IP,
 							netConfig.MasqCTMark, ofPortPhys))
 				}
 
@@ -794,7 +793,10 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, false)...)
 					}
 				} else {
-					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
+					// For UDN legacy egress, keep the SNAT from masquerade IP
+					// to node IP. Existing upgraded connections may still use
+					// this v1 path, while new v2 traffic matches the node-IP
+					// all-zero SNAT flow above.
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
 							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
@@ -854,19 +856,18 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
-				// table0, for SGW UDN no-overlay networks, handle cross-node traffic
+				// table0, for SGW UDN networks, handle traffic
 				// that has already been SNATed to node IP by the gateway router.
-				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+				if !netConfig.IsDefaultNetwork() && config.Gateway.Mode == config.GatewayModeShared {
 					// Commit to conntrack and send directly to the physical port.
-					// SNAT to the node IP may already have happened on the UDN GW
-					// router because lb_force_snat_ip=router_ip. SNAT to the same
-					// node IP again here so zone 64000 can resolve source-port collisions.
+					// SNAT to the node IP already happened on the UDN GW router.
+					// Use all-zero SNAT so zone 64000 has a NAT action without
+					// applying a second explicit node-IP SNAT.
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
-							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+							"actions=ct(commit, zone=%d, nat(src=::), exec(set_field:%s->ct_mark)), output:%s",
 							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV6,
 							protoPrefixV6, physicalIP.IP, config.Default.ConntrackZone,
-							physicalIP.IP,
 							netConfig.MasqCTMark, ofPortPhys))
 				}
 
@@ -911,7 +912,10 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, true)...)
 					}
 				} else {
-					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
+					// For UDN legacy egress, keep the SNAT from masquerade IP
+					// to node IP. Existing upgraded connections may still use
+					// this v1 path, while new v2 traffic matches the node-IP
+					// all-zero SNAT flow above.
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
 							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
 
-func TestSharedNoOverlayNodeIPFlowUsesNATInDefaultConntrackZone(t *testing.T) {
+func TestSharedUDNEgressFlowsSupportLegacyAndV2SNAT(t *testing.T) {
 	if err := config.PrepareTestConfig(); err != nil {
 		t.Fatalf("failed to prepare test config: %v", err)
 	}
@@ -47,7 +47,6 @@ func TestSharedNoOverlayNodeIPFlowUsesNATInDefaultConntrackZone(t *testing.T) {
 				OfPortPatch: "patch-breth0_bluenet",
 				MasqCTMark:  "0x4",
 				PktMark:     "0x3",
-				Transport:   types.NetworkTransportNoOverlay,
 				V4MasqIPs: &udngenerator.MasqueradeIPs{
 					GatewayRouter:  v4GatewayMasqIP,
 					ManagementPort: v4ManagementMasqIP,
@@ -66,14 +65,22 @@ func TestSharedNoOverlayNodeIPFlowUsesNATInDefaultConntrackZone(t *testing.T) {
 	}
 
 	expectedIPv4 := fmt.Sprintf("cookie=%s, priority=99, in_port=patch-breth0_bluenet, dl_src=%s, ip, nw_src=172.18.0.3, "+
-		"actions=ct(commit, zone=%d, nat(src=172.18.0.3), exec(set_field:0x4->ct_mark)), output:eth0",
+		"actions=ct(commit, zone=%d, nat(src=0.0.0.0), exec(set_field:0x4->ct_mark)), output:eth0",
 		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Default.ConntrackZone)
 	expectedIPv6 := fmt.Sprintf("cookie=%s, priority=99, in_port=patch-breth0_bluenet, dl_src=%s, ipv6, ipv6_src=fd00::3, "+
+		"actions=ct(commit, zone=%d, nat(src=::), exec(set_field:0x4->ct_mark)), output:eth0",
+		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Default.ConntrackZone)
+	expectedLegacyIPv4 := fmt.Sprintf("cookie=%s, priority=100, in_port=patch-breth0_bluenet, dl_src=%s, ip, ip_src=169.254.0.11, "+
+		"actions=ct(commit, zone=%d, nat(src=172.18.0.3), exec(set_field:0x4->ct_mark)), output:eth0",
+		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Default.ConntrackZone)
+	expectedLegacyIPv6 := fmt.Sprintf("cookie=%s, priority=100, in_port=patch-breth0_bluenet, dl_src=%s, ipv6, ipv6_src=fd69::11, "+
 		"actions=ct(commit, zone=%d, nat(src=fd00::3), exec(set_field:0x4->ct_mark)), output:eth0",
 		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Default.ConntrackZone)
 
 	expectFlow(t, flows, expectedIPv4)
 	expectFlow(t, flows, expectedIPv6)
+	expectFlow(t, flows, expectedLegacyIPv4)
+	expectFlow(t, flows, expectedLegacyIPv6)
 }
 
 func TestLocalNoOverlayServiceHairpinUsesUDNGatewayMasqueradeIP(t *testing.T) {

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -807,22 +807,37 @@ func (gw *GatewayManager) syncNATsForGRIPChange(gwConfig *GatewayConfig, oldExtI
 			continue
 		}
 
-		// check external ip changed
-		for _, externalIP := range gwConfig.externalIPs {
-			oldExternalIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6(externalIP), oldExtIPs)
-			if err != nil {
-				return fmt.Errorf("failed to update GW SNAT rule for pods on router %s error: %v", gw.gwRouterName, err)
+		if nat.ExternalIDs[types.UDNEgressSNATVersionExternalID] == types.UDNEgressSNATVersionV2 {
+			for _, externalIP := range gwConfig.udnEgressSNATIPs {
+				oldExternalIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6(externalIP), oldExtIPs)
+				if err != nil {
+					return fmt.Errorf("failed to update UDN egress SNAT v2 rule on router %s error: %v", gw.gwRouterName, err)
+				}
+				if externalIP.String() == oldExternalIP.String() {
+					continue
+				}
+				if nat.ExternalIP == oldExternalIP.String() {
+					natModified = true
+					nat.ExternalIP = externalIP.String()
+				}
 			}
-			if externalIP.String() == oldExternalIP.String() {
-				// no external ip change, skip
-				continue
+		} else if !gw.netInfo.IsUserDefinedNetwork() {
+			// check external ip changed
+			for _, externalIP := range gwConfig.externalIPs {
+				oldExternalIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6(externalIP), oldExtIPs)
+				if err != nil {
+					return fmt.Errorf("failed to update GW SNAT rule for pods on router %s error: %v", gw.gwRouterName, err)
+				}
+				if externalIP.String() == oldExternalIP.String() {
+					// no external ip change, skip
+					continue
+				}
+				if nat.ExternalIP == oldExternalIP.String() {
+					// needs to be updated
+					natModified = true
+					nat.ExternalIP = externalIP.String()
+				}
 			}
-			if nat.ExternalIP == oldExternalIP.String() {
-				// needs to be updated
-				natModified = true
-				nat.ExternalIP = externalIP.String()
-			}
-
 		}
 
 		// note, nat.LogicalIP may be a CIDR or IP, we don't care unless it's an IP
@@ -853,6 +868,18 @@ func (gw *GatewayManager) syncNATsForGRIPChange(gwConfig *GatewayConfig, oldExtI
 		}
 	}
 	return nil
+}
+
+const udnEgressSNATV2Priority = 100
+
+func udnEgressSNATV2Match(match string, ipFamily utilnet.IPFamily) string {
+	if match != "" {
+		return match
+	}
+	if ipFamily == utilnet.IPv6 {
+		return "ip6"
+	}
+	return "ip4"
 }
 
 func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayConfig, gwLRPIPs []net.IP, gwRouter *nbdb.LogicalRouter) error {
@@ -943,6 +970,26 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 
 			nat = libovsdbops.BuildSNATWithExemptedExtIPs(&externalIP[0], entry, "", extIDs, snatMatch, exemptedExtIPs)
 			nats = append(nats, nat)
+			if gw.netInfo.IsUserDefinedNetwork() && config.Gateway.Mode == config.GatewayModeShared &&
+				len(gwConfig.udnEgressSNATIPs) > 0 {
+				udnEgressSNATIP, err := util.MatchIPFamily(utilnet.IsIPv6CIDR(entry), gwConfig.udnEgressSNATIPs)
+				if err != nil {
+					return fmt.Errorf("failed to create UDN egress SNAT v2 rules for gateway router %s: %v",
+						gw.gwRouterName, err)
+				}
+				v2ExtIDs := maps.Clone(extIDs)
+				v2ExtIDs[types.UDNEgressSNATVersionExternalID] = types.UDNEgressSNATVersionV2
+				v2Nat := libovsdbops.BuildSNATWithExemptedExtIPs(
+					&udnEgressSNATIP[0],
+					entry,
+					"",
+					v2ExtIDs,
+					udnEgressSNATV2Match(snatMatch, ipFamily),
+					exemptedExtIPs,
+				)
+				v2Nat.Priority = udnEgressSNATV2Priority
+				nats = append(nats, v2Nat)
+			}
 		}
 		err = libovsdbops.CreateOrUpdateNATs(gw.nbClient, gwRouter, nats...)
 		if err != nil {

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1143,6 +1143,13 @@ func (oc *Layer2UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
 	}
 
+	var udnEgressSNATIPs []net.IP
+	if config.Gateway.Mode == config.GatewayModeShared {
+		for _, nodeIP := range l3GatewayConfig.IPAddresses {
+			udnEgressSNATIPs = append(udnEgressSNATIPs, nodeIP.IP)
+		}
+	}
+
 	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
 
 	// Always SNAT to the per network masquerade IP.
@@ -1176,6 +1183,7 @@ func (oc *Layer2UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 		gwRouterJoinCIDRs:          gwRouterJoinCIDRs,
 		hostAddrs:                  nil,
 		externalIPs:                externalIPs,
+		udnEgressSNATIPs:           udnEgressSNATIPs,
 		ovnClusterLRPToJoinIfAddrs: nil,
 	}, nil
 }

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -1155,6 +1155,13 @@ func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
 	}
 
+	var udnEgressSNATIPs []net.IP
+	if config.Gateway.Mode == config.GatewayModeShared {
+		for _, nodeIP := range l3GatewayConfig.IPAddresses {
+			udnEgressSNATIPs = append(udnEgressSNATIPs, nodeIP.IP)
+		}
+	}
+
 	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
 
 	// Always SNAT to the per network masquerade IP.
@@ -1198,6 +1205,7 @@ func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 		gwRouterJoinCIDRs:          gwRouterJoinCIDRs,
 		hostAddrs:                  hostAddrs,
 		externalIPs:                externalIPs,
+		udnEgressSNATIPs:           udnEgressSNATIPs,
 		ovnClusterLRPToJoinIfAddrs: oc.ovnClusterLRPToJoinIfAddrs,
 	}, nil
 }

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1852,6 +1852,7 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 	const (
 		nat1             = "abc-UUID"
 		nat2             = "cba-UUID"
+		nat3             = "bca-UUID"
 		staticRoute1     = "srA-UUID"
 		staticRoute2     = "srB-UUID"
 		staticRoute3     = "srC-UUID"
@@ -1874,6 +1875,9 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 	masqSubnet := config.Gateway.V4MasqueradeSubnet
 	var nat []string
 	nat = append(nat, nat1, nat2)
+	if config.Gateway.Mode == config.GatewayModeShared {
+		nat = append(nat, nat3)
+	}
 	expectedEntities := []libovsdbtest.TestData{
 		&nbdb.LogicalRouter{
 			Name:         gwRouterName,
@@ -1900,6 +1904,17 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 	}
 	expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
 	expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), netInfo.Subnets()[0].CIDR.String(), standardNonDefaultNetworkExtIDs(netInfo), udnSubnetMasqMatch))
+	if config.Gateway.Mode == config.GatewayModeShared {
+		udnEgressSNATV2ExtIDs := standardNonDefaultNetworkExtIDs(netInfo)
+		udnEgressSNATV2ExtIDs[types.UDNEgressSNATVersionExternalID] = types.UDNEgressSNATVersionV2
+		udnEgressSNATV2Match := udnSubnetMasqMatch
+		if udnEgressSNATV2Match == "" {
+			udnEgressSNATV2Match = "ip4"
+		}
+		udnEgressSNATV2 := newNATEntry(nat3, gwConfig.IPAddresses[0].IP.String(), netInfo.Subnets()[0].CIDR.String(), udnEgressSNATV2ExtIDs, udnEgressSNATV2Match)
+		udnEgressSNATV2.Priority = udnEgressSNATV2Priority
+		expectedEntities = append(expectedEntities, udnEgressSNATV2)
+	}
 	return expectedEntities
 }
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -45,6 +45,7 @@ type GatewayConfig struct {
 	gwRouterJoinCIDRs          []*net.IPNet
 	hostAddrs                  []string
 	externalIPs                []net.IP
+	udnEgressSNATIPs           []net.IP
 	ovnClusterLRPToJoinIfAddrs []*net.IPNet
 }
 

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -248,6 +248,10 @@ const (
 	LoadBalancerOwnerExternalID = OvnK8sPrefix + "/" + "owner"
 	// key for UDN enabled services routes
 	UDNEnabledServiceExternalID = OvnK8sPrefix + "/" + "udn-enabled-default-service"
+	// key for UDN egress SNAT version on OVN NAT rows
+	UDNEgressSNATVersionExternalID = OvnK8sPrefix + "/" + "udn-egress-snat-version"
+	// value for UDN egress SNAT rows that use the node IP on the gateway router
+	UDNEgressSNATVersionV2 = "v2"
 	// key for management port name, indicating the netdev link name associated with the given management port representor OVS interface
 	OvnManagementPortNameExternalID = OvnK8sPrefix + "/management-port-name"
 	// EVPNVTEPExternalID is the external-id key used to tag OVS ports with their EVPN VTEP name

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -14,7 +14,6 @@ import (
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
@@ -266,13 +265,6 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				checkConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[2], "other node", defaultServerPod.Name)
 				checkNoConnectionToClusterIPs(f, udnClientPod2, defaultService)
 
-				// Make sure that restarting OVNK after applying a UDN with an affected service won't result
-				// in OVNK in CLBO state https://issues.redhat.com/browse/OCPBUGS-41499
-				if netConfigParams.topology == "layer3" { // no need to run it for layer 2 as well
-					By("Restart ovnkube-node on one node and verify that the new ovnkube-node pod goes to the running state")
-					err = restartOVNKubeNodePod(cs, deploymentconfig.Get().OVNKubernetesNamespace(), clientNode)
-					Expect(err).NotTo(HaveOccurred())
-				}
 			},
 
 			Entry(

--- a/test/scripts/udn-upgrade-snat.sh
+++ b/test/scripts/udn-upgrade-snat.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+AGNHOST_IMAGE=${AGNHOST_IMAGE:-registry.k8s.io/e2e-test-images/agnhost:2.59}
+CLIENT_POD=${UDN_UPGRADE_SNAT_CLIENT_POD:-client}
+DEFAULT_NS=${UDN_UPGRADE_SNAT_DEFAULT_NS:-udn-snat-upgrade-default}
+NAD_NAME=${UDN_UPGRADE_SNAT_NAD:-tenant-upgrade}
+PING_LOG=${UDN_UPGRADE_SNAT_PING_LOG:-/tmp/udn-snat-upgrade-ping.log}
+PING_PID=${UDN_UPGRADE_SNAT_PING_PID:-/tmp/udn-snat-upgrade-ping.pid}
+SERVER_POD=${UDN_UPGRADE_SNAT_SERVER_POD:-backend}
+UDN_NS=${UDN_UPGRADE_SNAT_NS:-udn-snat-upgrade}
+
+enabled() {
+  [[ "${OVN_GATEWAY_MODE:-}" == "shared" ]] &&
+    [[ "${ENABLE_MULTI_NET:-}" == "true" ]] &&
+    [[ "${ENABLE_NETWORK_SEGMENTATION:-}" == "true" ]]
+}
+
+skip_if_disabled() {
+  if enabled; then
+    return
+  fi
+
+  echo "Skipping shared gateway UDN SNAT upgrade check"
+  exit 0
+}
+
+setup() {
+  skip_if_disabled
+
+  kubectl delete namespace "$UDN_NS" "$DEFAULT_NS" \
+    --ignore-not-found=true --wait=true
+
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${UDN_NS}
+  labels:
+    k8s.ovn.org/primary-user-defined-network: ""
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${DEFAULT_NS}
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ${NAD_NAME}
+  namespace: ${UDN_NS}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.0",
+      "name": "udn-snat-upgrade",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "layer3",
+      "subnets": "172.31.0.0/16/24",
+      "mtu": 1300,
+      "netAttachDefName": "${UDN_NS}/${NAD_NAME}",
+      "role": "primary"
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${SERVER_POD}
+  namespace: ${DEFAULT_NS}
+  labels:
+    app: udn-snat-upgrade-backend
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+  - name: agnhost
+    image: ${AGNHOST_IMAGE}
+    command: ["/agnhost"]
+    args: ["netexec", "--http-port=8080"]
+    ports:
+    - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: ${DEFAULT_NS}
+spec:
+  type: NodePort
+  selector:
+    app: udn-snat-upgrade-backend
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${CLIENT_POD}
+  namespace: ${UDN_NS}
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+  - name: agnhost
+    image: ${AGNHOST_IMAGE}
+    command: ["/agnhost"]
+    args: ["pause"]
+EOF
+
+  kubectl -n "$DEFAULT_NS" wait pod "$SERVER_POD" \
+    --for=condition=Ready --timeout=180s
+  kubectl -n "$UDN_NS" wait pod "$CLIENT_POD" \
+    --for=condition=Ready --timeout=240s
+
+  verify_connectivity "before upgrade"
+  start_persistent_ping
+}
+
+target_node_ip() {
+  local client_node
+  local node
+  local node_ip
+  local node_jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}'
+
+  client_node=$(kubectl -n "$UDN_NS" get pod "$CLIENT_POD" \
+    -o=jsonpath='{.spec.nodeName}')
+
+  while read -r node node_ip; do
+    if [[ "$node" != "$client_node" && -n "$node_ip" ]]; then
+      echo "$node_ip"
+      return
+    fi
+  done < <(kubectl get nodes -o=jsonpath="$node_jsonpath")
+
+  node_ip=$(kubectl get node "$client_node" \
+    -o=jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}'
+  )
+  if [[ -z "$node_ip" ]]; then
+    echo "failed to find node InternalIP" >&2
+    exit 1
+  fi
+  echo "$node_ip"
+}
+
+verify_connectivity() {
+  local phase=$1
+  local node_ip
+  local node_port
+  local output
+
+  node_ip=$(target_node_ip)
+  node_port=$(kubectl -n "$DEFAULT_NS" get service backend \
+    -o=jsonpath='{.spec.ports[0].nodePort}')
+
+  for _ in {1..30}; do
+    output=$(kubectl -n "$UDN_NS" exec "$CLIENT_POD" -- \
+      curl -g -q -s --max-time 2 \
+      "http://${node_ip}:${node_port}/hostname" 2>&1) || true
+    if [[ "$output" == "$SERVER_POD" ]]; then
+      echo "UDN SNAT upgrade connectivity succeeded ${phase}"
+      return
+    fi
+    sleep 2
+  done
+
+  echo "UDN SNAT upgrade connectivity failed ${phase}: ${output}"
+  exit 1
+}
+
+start_persistent_ping() {
+  local node_ip
+  local output
+
+  node_ip=$(target_node_ip)
+  kubectl -n "$UDN_NS" exec "$CLIENT_POD" -- /bin/sh -c \
+    "rm -f '$PING_LOG' '$PING_PID'; ping -n -i 1 '$node_ip' > '$PING_LOG' 2>&1 & echo \$! > '$PING_PID'"
+
+  for _ in {1..30}; do
+    output=$(kubectl -n "$UDN_NS" exec "$CLIENT_POD" -- \
+      /bin/sh -c "cat '$PING_LOG' 2>&1" || true)
+    if [[ "$output" == *"bytes from"* ]]; then
+      echo "UDN SNAT upgrade persistent ping started to ${node_ip}"
+      return
+    fi
+    sleep 1
+  done
+
+  echo "UDN SNAT upgrade persistent ping did not receive replies:"
+  echo "$output"
+  exit 1
+}
+
+verify_persistent_ping() {
+  local output
+
+  output=$(kubectl -n "$UDN_NS" exec "$CLIENT_POD" -- /bin/sh -c "
+    if [ -f '$PING_PID' ]; then
+      kill -INT \"\$(cat '$PING_PID')\" 2>/dev/null || true
+      sleep 1
+    fi
+    cat '$PING_LOG' 2>&1
+  " || true)
+
+  echo "$output"
+  if ! grep -Eq '(^|, )0(\.0+)?% packet loss(,|$)' <<< "$output"; then
+    echo "UDN SNAT upgrade persistent ping had packet loss"
+    exit 1
+  fi
+
+  echo "UDN SNAT upgrade persistent ping had no packet loss"
+}
+
+verify() {
+  skip_if_disabled
+
+  kubectl -n "$DEFAULT_NS" wait pod "$SERVER_POD" \
+    --for=condition=Ready --timeout=180s
+  kubectl -n "$UDN_NS" wait pod "$CLIENT_POD" \
+    --for=condition=Ready --timeout=240s
+
+  verify_persistent_ping
+  verify_connectivity "after upgrade"
+}
+
+cleanup() {
+  skip_if_disabled
+
+  kubectl delete namespace "$UDN_NS" "$DEFAULT_NS" \
+    --ignore-not-found=true --wait=false
+}
+
+case "${1:-}" in
+  setup)
+    setup
+    ;;
+  verify)
+    verify
+    ;;
+  cleanup)
+    cleanup
+    ;;
+  *)
+    echo "usage: $0 {setup|verify|cleanup}" >&2
+    exit 2
+    ;;
+esac

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -10,6 +10,8 @@ export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
+bash "${SCRIPT_DIR}/udn-upgrade-snat.sh" setup
+
 # Stash current replica counts and scale the controller Deployments to 0 so
 # their old pods exit before helm re-creates them with the new image.
 # DaemonSets are left to roll via their RollingUpdate strategy.
@@ -77,6 +79,9 @@ for ds in ovnkube-node ovnkube-single-node-zone; do
     kubectl -n ovn-kubernetes rollout status daemonset "$ds" --timeout=600s
   fi
 done
+
+bash "${SCRIPT_DIR}/udn-upgrade-snat.sh" verify
+bash "${SCRIPT_DIR}/udn-upgrade-snat.sh" cleanup
 
 # Remove the control-plane taint so e2e shard-conformance workloads can
 # schedule on the control-plane node (unchanged from the original script;


### PR DESCRIPTION
UDN egress traffic fails to be offloaded due to a double SNAT where the pod IP is first SNAT'ed to a masquerade IP in the OVN GR, and then to the node IP in zone 64000. The actions look like:

```
ct(zone=22,nat)
ct(commit,zone=27,nat(src=169.254.0.11:32768-60999,random))
ct(commit,zone=64000,mark=0x4/0xffffffff,nat(src=172.18.0.3))
```

CDN is not broken, because it only does a single SNAT IP change:

```
ct(zone=22,nat)
ct(commit,zone=23,nat(src=172.18.0.2:32768-60999,random)
ct(commit,zone=64000,mark=0x4/0xffffffff)
```

The proposed fix here is to perform the following actions for UDN:

```
ct(zone=22,nat)
ct(commit,zone=27,nat(src=172.18.0.3:32768-60999,random))
ct(commit,zone=64000,mark=0x4/0xffffffff,nat)
```

This avoids having to SNAT the IP twice, and still does an empty nat action in zone 64000 to ensure we handle collisions. The main collision concern is if 2 UDNs have the same subnet, and they both SNAT to the node IP in their respective GR (different CT zones), then we could get both of them SNAT'ed to the same source port. If this happens, and both clients are talking to the same destination (IP+port) it will result in a CT collision. So we have the extra nat to catch this case and modify the source port in case.

Unfortunately modifying actions for conntrack in different zones can causes traffic outage. Rather than introduce another flag into the code, I've tried to make the new flow backwards compatible. To do this the following is done:

1. Previous openflow is preserved in shared gw bridge for masq ->node IP SNAT. If the masq IP is seen on the UDN patch port, we still SNAT to node IP as before. This preserves previous NAT behavior for upgrade.
2. New flow is added (that already existed for no overlay mode), where if the packet from the UDN patch port is already node IP, just execute nat action.
3. For OVN, the previous SNAT for UDNs from pod IP -> masq IP is left intact to preserve previous pods.
4. Another OVN SNAT is added to the GR, with a higher priority so that newer pods/connections will SNAT to the node IP. nat.match has to be specified in order for priority to take effect, so a dummy nat.match == ipfamily is added to satisfy this requirement.

After this release, we will remove 1 and 3.

A new e2e test is added that upgrades from 1.3 release and then tests that a continuous ping does not drop packets during upgrade that follows the UDN egress path.

Fixes: #6422
Fixes: #6421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added v2 egress SNAT support for User Defined Networks in shared gateway mode, routing via node IP.
* **Improvements**
  * Updated shared-gateway UDN conntrack/SNAT behavior to use all-zero NAT addressing for new traffic while preserving legacy masquerade-IP SNAT for existing connections.
  * Improved upgrade behavior to maintain connectivity during rollouts.
* **Documentation**
  * Refreshed shared-gateway egress SNAT design details and upgrade compatibility notes.
* **Tests**
  * Extended SNAT upgrade and e2e verification coverage to validate v1/v2 behavior and restart/rollout resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->