### PR TITLE
Prevent NAD controller crash on incompatible network configs

### DIFF
--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -38,6 +38,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
+const nadKind = "NetworkAttachmentDefinition"
+
 // nadController handles namespaced scoped NAD events and
 // manages cluster scoped networks defined in those NADs. NADs are mostly
 // referenced from pods to give them access to the network. Different NADs can
@@ -327,6 +329,31 @@ func (c *nadController) NodeHasNetwork(node, networkName string) bool {
 	c.RLock()
 	defer c.RUnlock()
 	return c.nodeHasNetworkNoLock(node, networkName)
+}
+
+// sortNADsByAge sorts NADs by CreationTimestamp (oldest first), using
+// namespace/name as a tiebreaker for NADs created within the same second.
+func sortNADsByAge(nads []*nettypes.NetworkAttachmentDefinition) {
+	var errs []error
+	sort.Slice(nads, func(i, j int) bool {
+		ti := nads[i].CreationTimestamp.Time
+		tj := nads[j].CreationTimestamp.Time
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		ki, err := cache.MetaNamespaceKeyFunc(nads[i])
+		if err != nil {
+			errs = append(errs, err)
+		}
+		kj, err := cache.MetaNamespaceKeyFunc(nads[j])
+		if err != nil {
+			errs = append(errs, err)
+		}
+		return ki < kj
+	})
+	for _, err := range errs {
+		klog.Warningf("sortNADsByAge: failed to compute NAD key: %v", err)
+	}
 }
 
 func nadRequiresDynamicFiltering(nad *nettypes.NetworkAttachmentDefinition) bool {
@@ -931,6 +958,11 @@ func (c *nadController) syncAll() (err error) {
 		return fmt.Errorf("%s: failed to list NADs: %w", c.name, err)
 	}
 
+	// Sort NADs deterministically so that in case of conflicting NADs the
+	// oldest NAD always wins, preserving established networks across
+	// controller restarts.
+	sortNADsByAge(existingNADs)
+
 	syncNAD := func(nad *nettypes.NetworkAttachmentDefinition) error {
 		key, err := cache.MetaNamespaceKeyFunc(nad)
 		if err != nil {
@@ -1093,7 +1125,7 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 			}
 
 			if c.recorder != nil {
-				c.recorder.Eventf(&corev1.ObjectReference{Kind: nad.Kind, Namespace: nad.Namespace, Name: nad.Name}, corev1.EventTypeWarning,
+				c.recorder.Eventf(&corev1.ObjectReference{Kind: nadKind, Namespace: nad.Namespace, Name: nad.Name, UID: nad.UID}, corev1.EventTypeWarning,
 					"InvalidConfig", "Failed to parse network config: %v", err.Error())
 			}
 			klog.Errorf("%s: failed parsing NAD %s: %v", c.name, key, err)
@@ -1166,14 +1198,27 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 		oldNetwork = currentNetwork
 		ensureNetwork = util.NewMutableNetInfo(nadNetwork)
 	// the NAD refers to an existing incompatible network referred by other
-	// NADs, return error
+	// NADs, log error and skip the NAD
 	case oldNetwork == nil:
 		// the NAD refers to the same network as before but with different
 		// incompatible configuration, remove the NAD reference from the network
 		oldNetwork = currentNetwork
 		fallthrough
 	default:
-		err = fmt.Errorf("%s: NAD %s CNI config does not match that of network %s", c.name, key, nadNetworkName)
+		owningNADs := c.nadsByNetwork[nadNetworkName]
+		klog.Errorf("%s: NAD %s CNI config does not match that of network %s (established by %v)",
+			c.name, key, nadNetworkName, owningNADs.UnsortedList())
+		if c.recorder != nil && nad != nil {
+			c.recorder.Eventf(
+				&corev1.ObjectReference{Kind: nadKind, Namespace: nad.Namespace, Name: nad.Name, UID: nad.UID},
+				corev1.EventTypeWarning,
+				"InvalidConfig",
+				"CNI config does not match that of network %s (established by %v); "+
+					"ensure the NAD config is compatible or use a different network name "+
+					"(e.g. via physicalNetworkName). To re-sync after fixing the config, "+
+					"edit this NAD.", nadNetworkName, owningNADs.UnsortedList(),
+			)
+		}
 	}
 
 	// remove the NAD reference from the old network and delete the network if

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -331,31 +331,6 @@ func (c *nadController) NodeHasNetwork(node, networkName string) bool {
 	return c.nodeHasNetworkNoLock(node, networkName)
 }
 
-// sortNADsByAge sorts NADs by CreationTimestamp (oldest first), using
-// namespace/name as a tiebreaker for NADs created within the same second.
-func sortNADsByAge(nads []*nettypes.NetworkAttachmentDefinition) {
-	var errs []error
-	sort.Slice(nads, func(i, j int) bool {
-		ti := nads[i].CreationTimestamp.Time
-		tj := nads[j].CreationTimestamp.Time
-		if !ti.Equal(tj) {
-			return ti.Before(tj)
-		}
-		ki, err := cache.MetaNamespaceKeyFunc(nads[i])
-		if err != nil {
-			errs = append(errs, err)
-		}
-		kj, err := cache.MetaNamespaceKeyFunc(nads[j])
-		if err != nil {
-			errs = append(errs, err)
-		}
-		return ki < kj
-	})
-	for _, err := range errs {
-		klog.Warningf("sortNADsByAge: failed to compute NAD key: %v", err)
-	}
-}
-
 func nadRequiresDynamicFiltering(nad *nettypes.NetworkAttachmentDefinition) bool {
 	ownerRef := metav1.GetControllerOf(nad)
 	if ownerRef == nil {
@@ -1033,6 +1008,31 @@ func (c *nadController) syncAll() (err error) {
 	}
 
 	return nil
+}
+
+// sortNADsByAge sorts NADs by CreationTimestamp (oldest first), using
+// namespace/name as a tiebreaker for NADs created within the same second.
+func sortNADsByAge(nads []*nettypes.NetworkAttachmentDefinition) {
+	var errs []error
+	sort.Slice(nads, func(i, j int) bool {
+		ti := nads[i].CreationTimestamp.Time
+		tj := nads[j].CreationTimestamp.Time
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		ki, err := cache.MetaNamespaceKeyFunc(nads[i])
+		if err != nil {
+			errs = append(errs, err)
+		}
+		kj, err := cache.MetaNamespaceKeyFunc(nads[j])
+		if err != nil {
+			errs = append(errs, err)
+		}
+		return ki < kj
+	})
+	for _, err := range errs {
+		klog.Warningf("sortNADsByAge: failed to compute NAD key: %v", err)
+	}
 }
 
 func (c *nadController) sync(key string) error {

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/id"
@@ -567,9 +568,10 @@ func TestNADController(t *testing.T) {
 	}
 
 	type args struct {
-		nad     string
-		network *ovncnitypes.NetConf
-		wantErr bool
+		nad       string
+		network   *ovncnitypes.NetConf
+		wantErr   bool
+		wantEvent string
 	}
 	type expected struct {
 		network *ovncnitypes.NetConf
@@ -801,9 +803,10 @@ func TestNADController(t *testing.T) {
 					network: networkAPrimary,
 				},
 				{
-					nad:     "test/nad_2",
-					network: networkAIncompatible,
-					wantErr: true,
+					nad:       "test/nad_2",
+					network:   networkAIncompatible,
+					wantErr:   false,
+					wantEvent: "InvalidConfig",
 				},
 			},
 			expected: []expected{
@@ -844,9 +847,10 @@ func TestNADController(t *testing.T) {
 					network: networkASecondary,
 				},
 				{
-					nad:     "test/nad_1",
-					network: networkAIncompatible,
-					wantErr: true,
+					nad:       "test/nad_1",
+					network:   networkAIncompatible,
+					wantErr:   false,
+					wantEvent: "InvalidConfig",
 				},
 			},
 			expected: []expected{
@@ -888,6 +892,7 @@ func TestNADController(t *testing.T) {
 			fakeClient := util.GetOVNClientset().GetClusterManagerClientset()
 			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
+			fakeRecorder := record.NewFakeRecorder(10)
 			nadController := &nadController{
 				nads:                map[string]string{},
 				primaryNADs:         map[string]string{},
@@ -897,6 +902,7 @@ func TestNADController(t *testing.T) {
 				nadClient:           fakeClient.NetworkAttchDefClient,
 				nodeLister:          wf.NodeCoreInformer().Lister(),
 				namespaceLister:     &fakeNamespaceLister{},
+				recorder:            fakeRecorder,
 			}
 			err = nadController.networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -936,6 +942,9 @@ func TestNADController(t *testing.T) {
 					g.Expect(err).To(gomega.HaveOccurred())
 				} else {
 					g.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+				if args.wantEvent != "" {
+					g.Expect(fakeRecorder.Events).Should(gomega.Receive(gomega.ContainSubstring(args.wantEvent)))
 				}
 				syncTouchedNetworks(args.nad, prevNetwork)
 			}
@@ -1799,6 +1808,86 @@ func TestSyncAll(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSyncAllDeterministicOrdering(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	fakeClient := util.GetOVNClientset().GetClusterManagerClientset()
+	wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	tcm := &testControllerManager{
+		controllers: map[string]NetworkController{},
+	}
+
+	fakeRecorder := record.NewFakeRecorder(10)
+	controller, err := NewForCluster(tcm, wf, fakeClient, fakeRecorder, id.NewTunnelKeyAllocator("TunnelKeys"))
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	_, err = fakeClient.KubeClient.CoreV1().Namespaces().Create(context.TODO(),
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "test",
+				Labels: map[string]string{types.RequiredUDNNamespaceLabel: ""},
+			},
+		}, metav1.CreateOptions{},
+	)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	baseNetwork := &ovncnitypes.NetConf{
+		Topology: types.LocalnetTopology,
+		NetConf: cnitypes.NetConf{
+			Name: "vlan-trunk",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		MTU: 1400,
+	}
+
+	// NAD A: older, localnet without VLAN
+	networkNoVLAN := *baseNetwork
+	networkNoVLAN.NADName = "test/nad-no-vlan"
+	nadA, err := ovntesting.BuildNAD("nad-no-vlan", "test", &networkNoVLAN)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadA.CreationTimestamp = metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// NAD B: newer, localnet with VLAN 2106 (incompatible)
+	networkWithVLAN := *baseNetwork
+	networkWithVLAN.NADName = "test/nad-vlan-2106"
+	networkWithVLAN.VLANID = 2106
+	nadB, err := ovntesting.BuildNAD("nad-vlan-2106", "test", &networkWithVLAN)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadB.CreationTimestamp = metav1.NewTime(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	// Create NADs in reverse order (newer first) to ensure the sort is what
+	// determines the winner, not insertion order.
+	_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions("test").Create(
+		context.Background(), nadB, metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions("test").Create(
+		context.Background(), nadA, metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	g.Expect(wf.Start()).To(gomega.Succeed())
+	defer wf.Shutdown()
+
+	// syncAll should NOT crash — the older NAD (no VLAN) should win
+	g.Expect(controller.Start()).To(gomega.Succeed())
+	controller.Stop()
+
+	// The older NAD's network (no VLAN) should be established
+	g.Expect(tcm.valid).To(gomega.HaveLen(1))
+	g.Expect(tcm.valid[0].GetNetworkName()).To(gomega.Equal("vlan-trunk"))
+	expectedNetInfo, err := util.NewNetInfo(&networkNoVLAN)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(util.AreNetworksCompatible(tcm.valid[0], expectedNetInfo)).To(gomega.BeTrue())
+
+	// A Warning event should have been recorded for the rejected NAD
+	g.Expect(fakeRecorder.Events).Should(gomega.Receive(gomega.ContainSubstring("InvalidConfig")))
 }
 
 func TestResourceCleanup(t *testing.T) {

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -1845,31 +1845,28 @@ func TestSyncAllDeterministicOrdering(t *testing.T) {
 			Name: "vlan-trunk",
 			Type: "ovn-k8s-cni-overlay",
 		},
-		MTU: 1400,
 	}
 
-	// NAD A: older, localnet without VLAN
-	networkNoVLAN := *baseNetwork
-	networkNoVLAN.NADName = "test/nad-no-vlan"
-	nadA, err := ovntesting.BuildNAD("nad-no-vlan", "test", &networkNoVLAN)
+	olderNetworkNoVLAN := *baseNetwork
+	olderNetworkNoVLAN.NADName = "test/nad-no-vlan"
+	olderNAD, err := ovntesting.BuildNAD("nad-no-vlan", "test", &olderNetworkNoVLAN)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	nadA.CreationTimestamp = metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	olderNAD.CreationTimestamp = metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
-	// NAD B: newer, localnet with VLAN 2106 (incompatible)
-	networkWithVLAN := *baseNetwork
-	networkWithVLAN.NADName = "test/nad-vlan-2106"
-	networkWithVLAN.VLANID = 2106
-	nadB, err := ovntesting.BuildNAD("nad-vlan-2106", "test", &networkWithVLAN)
+	newerNetworkWithVLAN := *baseNetwork
+	newerNetworkWithVLAN.NADName = "test/nad-vlan-2106"
+	newerNetworkWithVLAN.VLANID = 2106
+	newerNAD, err := ovntesting.BuildNAD("nad-vlan-2106", "test", &newerNetworkWithVLAN)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	nadB.CreationTimestamp = metav1.NewTime(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+	newerNAD.CreationTimestamp = metav1.NewTime(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	// Create NADs in reverse order (newer first) to ensure the sort is what
 	// determines the winner, not insertion order.
 	_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions("test").Create(
-		context.Background(), nadB, metav1.CreateOptions{})
+		context.Background(), newerNAD, metav1.CreateOptions{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions("test").Create(
-		context.Background(), nadA, metav1.CreateOptions{})
+		context.Background(), olderNAD, metav1.CreateOptions{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	g.Expect(wf.Start()).To(gomega.Succeed())
@@ -1882,7 +1879,7 @@ func TestSyncAllDeterministicOrdering(t *testing.T) {
 	// The older NAD's network (no VLAN) should be established
 	g.Expect(tcm.valid).To(gomega.HaveLen(1))
 	g.Expect(tcm.valid[0].GetNetworkName()).To(gomega.Equal("vlan-trunk"))
-	expectedNetInfo, err := util.NewNetInfo(&networkNoVLAN)
+	expectedNetInfo, err := util.ParseNADInfo(olderNAD)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(util.AreNetworksCompatible(tcm.valid[0], expectedNetInfo)).To(gomega.BeTrue())
 


### PR DESCRIPTION
## 📑 Description

When two NADs reference the same network name with incompatible configurations
(e.g. different VLAN IDs), the NAD controller's `syncAll` returns a fatal error
during initial sync, crashing the ovnkube-control-plane into CrashLoopBackOff.

This PR changes the incompatible NAD handling from a hard error to a graceful
log + Kubernetes Warning event, following the existing precedent for
invalid/unparseable NAD configs. The conflicting NAD is removed from internal
caches while the controller stays alive.

## Additional Information for reviewers

The root cause is that the CNI config `name` field determines the network
identity inside ovn-kubernetes. When two NADs share the same `name` but have
different configs, `syncNAD` returns a hard error that is fatal during initial
sync but merely retried during runtime — creating an asymmetry where a user
misconfiguration causes a permanent crash loop only after controller restart.

Changes:
- **Graceful error handling** (`nad_controller.go:1207`): Replace `err = fmt.Errorf(...)` with `klog.Errorf` + Kubernetes Warning event. The conflicting NAD is cleaned from caches via the existing `ensureNetwork == nil` path.
- **Deterministic ordering** (`nad_controller.go:958`): Sort NADs by `CreationTimestamp` in `syncAll` so the oldest NAD always wins on conflict, making the behavior stable across restarts.
- **Event discoverability** (`nad_controller.go:1127,1213`): Fix `ObjectReference` in NAD events to use hardcoded `Kind` and include `UID` (informer-cached objects have empty TypeMeta), making events visible in `kubectl describe`.
- **Better error messages**: Include which NADs established the network in both the log and event message.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests cover the fix:
- Existing tests `"NAD added then incompatible NAD added"` and `"two NADs added then one updated to incompatible network"` — flipped from `wantErr: true` to `wantErr: false`, with `InvalidConfig` event assertions via `FakeRecorder`.
- New `TestSyncAllDeterministicOrdering` — creates two conflicting localnet NADs (same network name, different VLAN IDs) with distinct timestamps in reverse insertion order, verifies oldest wins after `syncAll` and Warning event is emitted.

Manual verification:
1. Create a bridge mapping for `vlan-trunk`
2. Create NAD A with `"name": "vlan-trunk"` (no VLAN)
3. Create NAD B with `"name": "vlan-trunk", "vlanID": 2106`
4. Restart ovnkube-control-plane → verify it stays running (no CrashLoopBackOff)
5. `kubectl get events --field-selector reason=InvalidConfig` → verify Warning event on NAD B
6. `kubectl describe net-attach-def vlan-2106-break` → verify event appears in output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Network Attachment Definitions with incompatible CNI configurations now generate **InvalidConfig** warning events instead of failing reconciliation, enabling smoother conflict resolution.

* **Features**
  * Network Attachment Definitions are reconciled in a deterministic **oldest-first** order during controller startup for consistent behavior across restarts.
  * Warning events now include more detailed object information to improve troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->