### PR TITLE
Add ovnkube-identity support for DPUs

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -975,10 +975,12 @@ ovnkube-identity() {
 
     # extra-allowed-user:
     #   ovnkube-cluster-manager service account - required for multi-homing
+    #   ovnkube-node-dpu service account - required for DPU access to the DPU-host cluster when identity is enabled
     exec /usr/bin/ovnkube-identity  --k8s-apiserver="${K8S_APISERVER}" \
     --webhook-cert-dir="/etc/webhook-cert" \
     ${ovnkube_enable_hybrid_overlay_flag} \
     --extra-allowed-user="system:serviceaccount:${ovn_kubernetes_namespace}:ovnkube-cluster-manager" \
+    --extra-allowed-user="system:serviceaccount:${ovn_kubernetes_namespace}:ovnkube-node-dpu" \
     --loglevel="${ovnkube_loglevel}"
 
     exit 9

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -987,10 +987,12 @@ ovnkube-identity() {
 
     # extra-allowed-user:
     #   ovnkube-cluster-manager service account - required for multi-homing
+    #   ovnkube-node-dpu service account - required for DPU access to the DPU-host cluster when identity is enabled
     exec /usr/bin/ovnkube-identity  --k8s-apiserver="${K8S_APISERVER}" \
     --webhook-cert-dir="/etc/webhook-cert" \
     ${ovnkube_enable_hybrid_overlay_flag} \
     --extra-allowed-user="system:serviceaccount:${ovn_kubernetes_namespace}:ovnkube-cluster-manager" \
+    --extra-allowed-user="system:serviceaccount:${ovn_kubernetes_namespace}:ovnkube-node-dpu" \
     --loglevel="${ovnkube_loglevel}"
 
     exit 9

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -297,12 +297,9 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	}()
 
 	if config.Kubernetes.BootstrapKubeconfig != "" {
-		// In the case of dpus K8S_NODE will be set to dpu host's name
-		var csrNodeName string
-		if config.IsModeDPU() {
-			csrNodeName = os.Getenv("K8S_NODE_DPU")
-		} else {
-			csrNodeName = os.Getenv("K8S_NODE")
+		csrNodeName := os.Getenv("K8S_NODE")
+		if csrNodeName == "" {
+			return fmt.Errorf("node identity (K8S_NODE) is not set")
 		}
 		if err := util.StartNodeCertificateManager(ctx.Context, ovnKubeStartWg, csrNodeName, &config.Kubernetes); err != nil {
 			return fmt.Errorf("failed to start the node certificate manager: %w", err)

--- a/go-controller/pkg/csrapprover/approver.go
+++ b/go-controller/pkg/csrapprover/approver.go
@@ -30,8 +30,15 @@ import (
 
 const (
 	ControllerName = "ovnkube-csr-approver-controller"
-	NamePrefix     = "system:ovn-node"
 	MaxDuration    = time.Hour * 24 * 365
+
+	// ovnkube-node running in dpu-host mode has its own acceptance condition
+	// and RBAC group, so it can be bound to a narrower ClusterRole and a
+	// restricted node-annotation allowlist than fullmode nodes.
+	NamePrefix           = "system:ovn-node"
+	NamePrefixDPUHost    = "system:ovn-node-dpu-host"
+	OVNNodesGroup        = "system:ovn-nodes"
+	OVNNodesDPUHostGroup = "system:ovn-nodes-dpu-host"
 )
 
 // CSRAcceptanceCondition specifies conditions which CSRs are approved by csrapprover.
@@ -77,7 +84,7 @@ func InitCSRAcceptanceConditions(fileName string) (conditions []CSRAcceptanceCon
 		}
 	}
 
-	conditions = append([]CSRAcceptanceCondition{DefaultCSRAcceptanceCondition}, conditions...)
+	conditions = append([]CSRAcceptanceCondition{DefaultCSRAcceptanceCondition, DPUHostCSRAcceptanceCondition}, conditions...)
 	// initialize Sets from slices
 	for i, v := range conditions {
 		conditions[i].groupsSet = sets.New[string](v.Groups...)
@@ -90,10 +97,20 @@ func InitCSRAcceptanceConditions(fileName string) (conditions []CSRAcceptanceCon
 var (
 	DefaultCSRAcceptanceCondition = CSRAcceptanceCondition{
 		CommonNamePrefix: NamePrefix,
-		Organizations:    []string{"system:ovn-nodes"},
-		Groups:           []string{"system:nodes", "system:ovn-nodes", "system:authenticated"},
+		Organizations:    []string{OVNNodesGroup},
+		Groups:           []string{"system:nodes", OVNNodesGroup, "system:authenticated"},
 		UserPrefixes:     []string{"system:node", NamePrefix},
 		Default:          true,
+	}
+	// DPUHostCSRAcceptanceCondition accepts CSRs from ovnkube-node running in dpu-host
+	// mode. It uses its own per-node common name prefix (system:ovn-node-dpu-host) and the
+	// dpu-host Organization/group, so the resulting identity is bound to the narrower
+	// ovnkube-node-dpu-host ClusterRole instead of ovnkube-node.
+	DPUHostCSRAcceptanceCondition = CSRAcceptanceCondition{
+		CommonNamePrefix: NamePrefixDPUHost,
+		Organizations:    []string{OVNNodesDPUHostGroup},
+		Groups:           []string{"system:nodes", OVNNodesDPUHostGroup, "system:authenticated"},
+		UserPrefixes:     []string{"system:node", NamePrefixDPUHost},
 	}
 	Usages = sets.New[certificatesv1.KeyUsage](
 		certificatesv1.UsageDigitalSignature,

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -904,8 +904,10 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	}
 	nc.nodeAddress = nodeAddr
 
-	if err := util.SetNodeZone(nodeAnnotator, sbZone); err != nil {
-		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
+	if config.IsModeDPUHost() || config.IsModeFull() {
+		if err := util.SetNodeZone(nodeAnnotator, sbZone); err != nil {
+			return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
+		}
 	}
 
 	// Set the node-encap-ips annotation with the configured encap IP.

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -37,7 +37,6 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeGatewayMtuSupport:          nil,
 	util.OvnNodeManagementPort:             nil,
 	util.OvnNodeDontSNATSubnets:            nil,
-	util.OVNNodePrimaryDPUHostAddr:         nil,
 	util.OvnNodeChassisID: func(v annotationChange, _ string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)
@@ -77,23 +76,79 @@ var hybridOverlayNodeAnnotationChecks = map[string]checkNodeAnnot{
 	hotypes.HybridOverlayDRIP:  nil,
 }
 
+// dpuHostNodeAnnotationChecks holds annotations allowed for ovnkube-node running in dpu-host
+// mode (identity system:ovn-node-dpu-host:<node>). These are
+// the host-side annotations. All other node annotations are written by the DPU via the ovnkube-node-dpu identity
+var dpuHostNodeAnnotationChecks = map[string]checkNodeAnnot{
+	util.OVNNodePrimaryDPUHostAddr: nil,
+	util.OVNNodeHostCIDRs:          nil,
+	util.OvnNodeMasqCIDR:           nil,
+	util.OvnNodeManagementPort:     nil,
+	// EgressIPs assigned to a secondary host (standard linux) interface are
+	// programmed by the node-side EgressIP controller running in dpu-host mode,
+	// since the interface lives in the host network namespace.
+	util.OVNNodeSecondaryHostEgressIPs: nil,
+	util.OvnNodeZoneName: func(v annotationChange, nodeName string) error {
+		if (v.action == added || v.action == changed) &&
+			(v.value == types.OvnDefaultZone || v.value == nodeName) {
+			return nil
+		}
+		return fmt.Errorf("%s can only be set to %s or %s, it cannot be removed", util.OvnNodeZoneName, types.OvnDefaultZone, nodeName)
+	},
+}
+
+// dpuNodeAnnotationChecks holds annotations allowed for ovnkube-node-dpu when updating
+// the DPU-host node belonging to it.
+var dpuNodeAnnotationChecks = map[string]checkNodeAnnot{
+	util.OVNNodeEncapIPs:        nil,
+	util.OvnNodeIfAddr:          nil,
+	util.OvnNodeL3GatewayConfig: nil,
+	// EgressIPs assigned to the default external OVS bridge interface are
+	// programmed by the DPU (canHandleBridgeEgressIP is gated to DPU/full mode),
+	// since that is where OVS runs.
+	util.OVNNodeBridgeEgressIPs: nil,
+	util.OvnNodeChassisID: func(v annotationChange, _ string) error {
+		if v.action == removed {
+			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)
+		}
+		if v.action == changed {
+			return fmt.Errorf("%s cannot be changed once set", util.OvnNodeChassisID)
+		}
+		return nil
+	},
+	util.OvnNodeGatewayMtuSupport: nil,
+}
+
 type NodeAdmission struct {
-	annotationChecks  map[string]checkNodeAnnot
-	annotationKeys    sets.Set[string]
-	extraAllowedUsers sets.Set[string]
+	annotationChecks        map[string]checkNodeAnnot
+	annotationKeys          sets.Set[string]
+	dpuAnnotationChecks     map[string]checkNodeAnnot
+	dpuAnnotationKeys       sets.Set[string]
+	dpuHostAnnotationChecks map[string]checkNodeAnnot
+	dpuHostAnnotationKeys   sets.Set[string]
+	extraAllowedUsers       sets.Set[string]
 }
 
 func NewNodeAdmissionWebhook(enableHybridOverlay bool, extraAllowedUsers ...string) *NodeAdmission {
 	checks := make(map[string]checkNodeAnnot)
 	maps.Copy(checks, commonNodeAnnotationChecks)
+	dpuChecks := make(map[string]checkNodeAnnot)
+	maps.Copy(dpuChecks, dpuNodeAnnotationChecks)
 	maps.Copy(checks, interconnectNodeAnnotationChecks)
+	maps.Copy(dpuChecks, interconnectNodeAnnotationChecks)
+	dpuHostChecks := make(map[string]checkNodeAnnot)
+	maps.Copy(dpuHostChecks, dpuHostNodeAnnotationChecks)
 	if enableHybridOverlay {
 		maps.Copy(checks, hybridOverlayNodeAnnotationChecks)
 	}
 	return &NodeAdmission{
-		annotationChecks:  checks,
-		annotationKeys:    sets.New[string](maps.Keys(checks)...),
-		extraAllowedUsers: sets.New[string](extraAllowedUsers...),
+		annotationChecks:        checks,
+		annotationKeys:          sets.New[string](maps.Keys(checks)...),
+		dpuAnnotationChecks:     dpuChecks,
+		dpuAnnotationKeys:       sets.New[string](maps.Keys(dpuChecks)...),
+		dpuHostAnnotationChecks: dpuHostChecks,
+		dpuHostAnnotationKeys:   sets.New[string](maps.Keys(dpuHostChecks)...),
+		extraAllowedUsers:       sets.New[string](extraAllowedUsers...),
 	}
 }
 
@@ -115,14 +170,41 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	if err != nil {
 		return nil, err
 	}
-	nodeName, isOVNKubeNode := ovnkubeNodeIdentity(req.UserInfo)
+	var isOVNKubeNode, isDPUHostNode, isDPUUser bool
+	var nodeName string
+	nodeName, isOVNKubeNode = ovnkubeNodeIdentity(req.UserInfo)
+	if !isOVNKubeNode {
+		nodeName, isDPUHostNode = dpuHostNodeIdentity(req.UserInfo)
+		if !isDPUHostNode {
+			isDPUUser = isDPUExtraAllowedUser(p.extraAllowedUsers, req.UserInfo.Username)
+		}
+	}
+	isNodeIdentity := isOVNKubeNode || isDPUHostNode
+
+	var effectiveKeys sets.Set[string]
+	var effectiveChecks map[string]checkNodeAnnot
+	identityDescription := "ovnkube-node on node"
+	switch {
+	case isDPUUser:
+		effectiveKeys = p.dpuAnnotationKeys
+		effectiveChecks = p.dpuAnnotationChecks
+		identityDescription = "ovnkube-node-dpu for node"
+		nodeName = newNode.Name
+	case isDPUHostNode:
+		effectiveKeys = p.dpuHostAnnotationKeys
+		effectiveChecks = p.dpuHostAnnotationChecks
+		identityDescription = "ovnkube-node on dpu-host node"
+	default:
+		effectiveKeys = p.annotationKeys
+		effectiveChecks = p.annotationChecks
+	}
 
 	changes := mapDiff(oldNode.Annotations, newNode.Annotations)
 	changedKeys := maps.Keys(changes)
 
-	if !isOVNKubeNode {
+	if !isNodeIdentity && !isDPUUser {
 		if !p.annotationKeys.HasAny(changedKeys...) {
-			// the user is not an ovnkube-node and hasn't changed any ovnkube-node annotations
+			// the user is not an ovnkube-node* and hasn't changed any ovnkube-node annotations
 			return nil, nil
 		}
 
@@ -134,12 +216,12 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 				p.annotationKeys.Intersection(sets.New[string](changedKeys...)).UnsortedList())
 		}
 
-		// The user is not ovnkube-node, in this case the nodeName comes from the object
+		// The user is not ovnkube-node*, in this case the nodeName comes from the object
 		nodeName = newNode.Name
 	}
 
 	for _, key := range changedKeys {
-		if check := p.annotationChecks[key]; check != nil {
+		if check := effectiveChecks[key]; check != nil {
 			if err := check(changes[key], nodeName); err != nil {
 				return nil, fmt.Errorf("user: %q is not allowed to set %s on node %q: %v", req.UserInfo.Username, key, newNode.Name, err)
 			}
@@ -147,20 +229,20 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	}
 
 	// All the checks beyond this point are ovnkube-node specific
-	// If the user is not ovnkube-node exit here
-	if !isOVNKubeNode {
+	// If the user is not ovnkube-node, ovnkube-node-dpu-host or ovnkube-node-dpu exit here
+	if !isNodeIdentity && !isDPUUser {
 		return nil, nil
 	}
 
-	if newNode.Name != nodeName {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to modify nodes %q annotations", nodeName, newNode.Name)
+	if isNodeIdentity && newNode.Name != nodeName {
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on node %q", identityDescription, nodeName, newNode.Name)
 	}
 
-	// ovnkube-node is not allowed to change annotations outside of it's scope
-	if !p.annotationKeys.HasAll(changedKeys...) {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations: %v",
+	// ovnkube-node / ovnkube-node-dpu-host / ovnkube-node-dpu is not allowed to change annotations outside of its scope
+	if !effectiveKeys.HasAll(changedKeys...) {
+		return nil, fmt.Errorf("%s: %q is not allowed to set the following annotations: %v", identityDescription,
 			nodeName,
-			sets.New[string](changedKeys...).Difference(p.annotationKeys).UnsortedList())
+			sets.New[string](changedKeys...).Difference(effectiveKeys).UnsortedList())
 	}
 
 	// Verify that nothing but the annotations changed.
@@ -190,7 +272,7 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	}
 	if !apiequality.Semantic.DeepEqual(oldNodeShallowCopy.ObjectMeta, newNodeShallowCopy.ObjectMeta) ||
 		!apiequality.Semantic.DeepEqual(oldNodeShallowCopy.Status, newNodeShallowCopy.Status) {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to modify anything other than annotations", nodeName)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify anything other than annotations", identityDescription, nodeName)
 	}
 
 	return nil, nil

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -37,7 +37,6 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeGatewayMtuSupport:          nil,
 	util.OvnNodeManagementPort:             nil,
 	util.OvnNodeDontSNATSubnets:            nil,
-	util.OVNNodePrimaryDPUHostAddr:         nil,
 	util.OvnNodeChassisID: func(v annotationChange, _ string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)
@@ -77,23 +76,79 @@ var hybridOverlayNodeAnnotationChecks = map[string]checkNodeAnnot{
 	hotypes.HybridOverlayDRIP:  nil,
 }
 
+// dpuHostNodeAnnotationChecks holds annotations allowed for ovnkube-node running in dpu-host
+// mode (identity system:ovn-node-dpu-host:<node>). These are
+// the host-side annotations. All other node annotations are written by the DPU via the ovnkube-node-dpu identity
+var dpuHostNodeAnnotationChecks = map[string]checkNodeAnnot{
+	util.OVNNodePrimaryDPUHostAddr: nil,
+	util.OVNNodeHostCIDRs:          nil,
+	util.OvnNodeMasqCIDR:           nil,
+	util.OvnNodeManagementPort:     nil,
+	// EgressIPs assigned to a secondary host (standard linux) interface are
+	// programmed by the node-side EgressIP controller running in dpu-host mode,
+	// since the interface lives in the host network namespace.
+	util.OVNNodeSecondaryHostEgressIPs: nil,
+	util.OvnNodeZoneName: func(v annotationChange, nodeName string) error {
+		if (v.action == added || v.action == changed) &&
+			(v.value == types.OvnDefaultZone || v.value == nodeName) {
+			return nil
+		}
+		return fmt.Errorf("%s can only be set to %s or %s, it cannot be removed", util.OvnNodeZoneName, types.OvnDefaultZone, nodeName)
+	},
+}
+
+// dpuNodeAnnotationChecks holds annotations allowed for ovnkube-node-dpu when updating
+// the DPU-host node belonging to it.
+var dpuNodeAnnotationChecks = map[string]checkNodeAnnot{
+	util.OVNNodeEncapIPs:        nil,
+	util.OvnNodeIfAddr:          nil,
+	util.OvnNodeL3GatewayConfig: nil,
+	// EgressIPs assigned to the default external OVS bridge interface are
+	// programmed by the DPU (canHandleBridgeEgressIP is gated to DPU/full mode),
+	// since that is where OVS runs.
+	util.OVNNodeBridgeEgressIPs: nil,
+	util.OvnNodeChassisID: func(v annotationChange, _ string) error {
+		if v.action == removed {
+			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)
+		}
+		if v.action == changed {
+			return fmt.Errorf("%s cannot be changed once set", util.OvnNodeChassisID)
+		}
+		return nil
+	},
+	util.OvnNodeGatewayMtuSupport: nil,
+}
+
 type NodeAdmission struct {
-	annotationChecks  map[string]checkNodeAnnot
-	annotationKeys    sets.Set[string]
-	extraAllowedUsers sets.Set[string]
+	annotationChecks        map[string]checkNodeAnnot
+	annotationKeys          sets.Set[string]
+	dpuAnnotationChecks     map[string]checkNodeAnnot
+	dpuAnnotationKeys       sets.Set[string]
+	dpuHostAnnotationChecks map[string]checkNodeAnnot
+	dpuHostAnnotationKeys   sets.Set[string]
+	extraAllowedUsers       sets.Set[string]
 }
 
 func NewNodeAdmissionWebhook(enableHybridOverlay bool, extraAllowedUsers ...string) *NodeAdmission {
 	checks := make(map[string]checkNodeAnnot)
 	maps.Copy(checks, commonNodeAnnotationChecks)
+	dpuChecks := make(map[string]checkNodeAnnot)
+	maps.Copy(dpuChecks, dpuNodeAnnotationChecks)
 	maps.Copy(checks, interconnectNodeAnnotationChecks)
+	maps.Copy(dpuChecks, interconnectNodeAnnotationChecks)
+	dpuHostChecks := make(map[string]checkNodeAnnot)
+	maps.Copy(dpuHostChecks, dpuHostNodeAnnotationChecks)
 	if enableHybridOverlay {
 		maps.Copy(checks, hybridOverlayNodeAnnotationChecks)
 	}
 	return &NodeAdmission{
-		annotationChecks:  checks,
-		annotationKeys:    sets.New[string](slices.Collect(maps.Keys(checks))...),
-		extraAllowedUsers: sets.New[string](extraAllowedUsers...),
+		annotationChecks:        checks,
+		annotationKeys:          sets.New[string](slices.Collect(maps.Keys(checks))...),
+		dpuAnnotationChecks:     dpuChecks,
+		dpuAnnotationKeys:       sets.New[string](slices.Collect(maps.Keys(dpuChecks))...),
+		dpuHostAnnotationChecks: dpuHostChecks,
+		dpuHostAnnotationKeys:   sets.New[string](slices.Collect(maps.Keys(dpuHostChecks))...),
+		extraAllowedUsers:       sets.New[string](extraAllowedUsers...),
 	}
 }
 
@@ -115,14 +170,41 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	if err != nil {
 		return nil, err
 	}
-	nodeName, isOVNKubeNode := ovnkubeNodeIdentity(req.UserInfo)
+	var isOVNKubeNode, isDPUHostNode, isDPUUser bool
+	var nodeName string
+	nodeName, isOVNKubeNode = ovnkubeNodeIdentity(req.UserInfo)
+	if !isOVNKubeNode {
+		nodeName, isDPUHostNode = dpuHostNodeIdentity(req.UserInfo)
+		if !isDPUHostNode {
+			isDPUUser = isDPUExtraAllowedUser(p.extraAllowedUsers, req.UserInfo.Username)
+		}
+	}
+	isNodeIdentity := isOVNKubeNode || isDPUHostNode
+
+	var effectiveKeys sets.Set[string]
+	var effectiveChecks map[string]checkNodeAnnot
+	identityDescription := "ovnkube-node on node"
+	switch {
+	case isDPUUser:
+		effectiveKeys = p.dpuAnnotationKeys
+		effectiveChecks = p.dpuAnnotationChecks
+		identityDescription = "ovnkube-node-dpu for node"
+		nodeName = newNode.Name
+	case isDPUHostNode:
+		effectiveKeys = p.dpuHostAnnotationKeys
+		effectiveChecks = p.dpuHostAnnotationChecks
+		identityDescription = "ovnkube-node on dpu-host node"
+	default:
+		effectiveKeys = p.annotationKeys
+		effectiveChecks = p.annotationChecks
+	}
 
 	changes := mapDiff(oldNode.Annotations, newNode.Annotations)
 	changedKeys := slices.Collect(maps.Keys(changes))
 
-	if !isOVNKubeNode {
+	if !isNodeIdentity && !isDPUUser {
 		if !p.annotationKeys.HasAny(changedKeys...) {
-			// the user is not an ovnkube-node and hasn't changed any ovnkube-node annotations
+			// the user is not an ovnkube-node* and hasn't changed any ovnkube-node annotations
 			return nil, nil
 		}
 
@@ -134,12 +216,12 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 				p.annotationKeys.Intersection(sets.New[string](changedKeys...)).UnsortedList())
 		}
 
-		// The user is not ovnkube-node, in this case the nodeName comes from the object
+		// The user is not ovnkube-node*, in this case the nodeName comes from the object
 		nodeName = newNode.Name
 	}
 
 	for _, key := range changedKeys {
-		if check := p.annotationChecks[key]; check != nil {
+		if check := effectiveChecks[key]; check != nil {
 			if err := check(changes[key], nodeName); err != nil {
 				return nil, fmt.Errorf("user: %q is not allowed to set %s on node %q: %v", req.UserInfo.Username, key, newNode.Name, err)
 			}
@@ -147,20 +229,20 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	}
 
 	// All the checks beyond this point are ovnkube-node specific
-	// If the user is not ovnkube-node exit here
-	if !isOVNKubeNode {
+	// If the user is not ovnkube-node, ovnkube-node-dpu-host or ovnkube-node-dpu exit here
+	if !isNodeIdentity && !isDPUUser {
 		return nil, nil
 	}
 
-	if newNode.Name != nodeName {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to modify nodes %q annotations", nodeName, newNode.Name)
+	if isNodeIdentity && newNode.Name != nodeName {
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on node %q", identityDescription, nodeName, newNode.Name)
 	}
 
-	// ovnkube-node is not allowed to change annotations outside of it's scope
-	if !p.annotationKeys.HasAll(changedKeys...) {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations: %v",
+	// ovnkube-node / ovnkube-node-dpu-host / ovnkube-node-dpu is not allowed to change annotations outside of its scope
+	if !effectiveKeys.HasAll(changedKeys...) {
+		return nil, fmt.Errorf("%s: %q is not allowed to set the following annotations: %v", identityDescription,
 			nodeName,
-			sets.New[string](changedKeys...).Difference(p.annotationKeys).UnsortedList())
+			sets.New[string](changedKeys...).Difference(effectiveKeys).UnsortedList())
 	}
 
 	// Verify that nothing but the annotations changed.
@@ -190,7 +272,7 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	}
 	if !apiequality.Semantic.DeepEqual(oldNodeShallowCopy.ObjectMeta, newNodeShallowCopy.ObjectMeta) ||
 		!apiequality.Semantic.DeepEqual(oldNodeShallowCopy.Status, newNodeShallowCopy.Status) {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to modify anything other than annotations", nodeName)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify anything other than annotations", identityDescription, nodeName)
 	}
 
 	return nil, nil

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -47,8 +47,17 @@ func TestNewNodeAdmissionWebhook(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewNodeAdmissionWebhook(tt.enableHybridOverlay); !got.annotationKeys.HasAll(tt.expectedKeys...) {
+			got := NewNodeAdmissionWebhook(tt.enableHybridOverlay)
+			if !got.annotationKeys.HasAll(tt.expectedKeys...) {
 				t.Errorf("NewNodeAdmissionWebhook() = %v, want %v", got.annotationKeys, tt.expectedKeys)
+			}
+			// webhook must always have the DPU-allowed node annotation keys
+			if !got.dpuAnnotationKeys.HasAll(maps.Keys(dpuNodeAnnotationChecks)...) {
+				t.Errorf("NewNodeAdmissionWebhook() dpuAnnotationKeys = %v, want all of %v", got.dpuAnnotationKeys, maps.Keys(dpuNodeAnnotationChecks))
+			}
+			// webhook must always have the DPUHost-allowed node annotation keys
+			if !got.dpuHostAnnotationKeys.HasAll(maps.Keys(dpuHostNodeAnnotationChecks)...) {
+				t.Errorf("NewNodeAdmissionWebhook() dpuHostAnnotationKeys = %v, want all of %v", got.dpuHostAnnotationKeys, maps.Keys(dpuHostNodeAnnotationChecks))
 			}
 		})
 	}
@@ -145,7 +154,7 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 					Annotations: map[string]string{util.OVNNodeHostCIDRs: "new"},
 				},
 			},
-			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify nodes %q annotations", nodeName+"_rougeOne", nodeName),
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify annotations on node %q", nodeName+"_rougeOne", nodeName),
 		},
 		{
 			name: "ovnkube-node cannot modify annotations that do not belong to it",
@@ -399,6 +408,148 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 		})
 	}
 }
+func TestNodeAdmission_ValidateUpdateExtraUsers(t *testing.T) {
+	extraUser := "system:serviceaccount:ovn-kubernetes:ovnkube-node-dpu"
+	adm := NewNodeAdmissionWebhook(false, extraUser)
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		oldObj      *corev1.Node
+		newObj      *corev1.Node
+		expectedErr error
+	}{
+		{
+			name: "ovnkube-node-dpu can add annotation on its host node",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: extraUser,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dpu-host",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dpu-host",
+					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"},
+				},
+			},
+		},
+		{
+			name: "ovnkube-node-dpu cannot set annotations not in DPU allowed set",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: extraUser,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "192.168.1.0/24"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node-dpu for node: %q is not allowed to set the following annotations: %v", nodeName, []string{util.OVNNodeHostCIDRs}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
+			if err != tt.expectedErr && (err == nil || tt.expectedErr == nil || err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+		})
+	}
+}
+func TestNodeAdmission_ValidateUpdateDPUHost(t *testing.T) {
+	adm := NewNodeAdmissionWebhook(false)
+	// dpu-host is identified by its own per-node username prefix
+	// (system:ovn-node-dpu-host:<node>).
+	dpuHostUser := authenticationv1.UserInfo{
+		Username: fmt.Sprintf("%s:%s", csrapprover.NamePrefixDPUHost, nodeName),
+		Groups:   []string{"system:nodes", csrapprover.OVNNodesDPUHostGroup, "system:authenticated"},
+	}
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		oldObj      *corev1.Node
+		newObj      *corev1.Node
+		expectedErr error
+	}{
+		{
+			name: "dpu-host can set its host-side annotations",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						util.OVNNodePrimaryDPUHostAddr: "10.0.0.1/24",
+						util.OVNNodeHostCIDRs:          "[\"10.0.0.1/24\"]",
+						util.OvnNodeMasqCIDR:           "masq",
+						util.OvnNodeManagementPort:     "mgmt",
+					},
+				},
+			},
+		},
+		{
+			name: "dpu-host cannot set annotations owned by the DPU (e.g. chassis-id)",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node on dpu-host node: %q is not allowed to set the following annotations: %v", nodeName, []string{util.OvnNodeChassisID}),
+		},
+		{
+			name: "dpu-host cannot modify annotations on a different node",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName + "_other",
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "old"},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName + "_other",
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "new"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node on dpu-host node: %q is not allowed to modify annotations on node %q", nodeName, nodeName+"_other"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
+			if err != tt.expectedErr && (err == nil || tt.expectedErr == nil || err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+		})
+	}
+}
+
 func TestNodeAdmission_ValidateUpdateHybridOverlay(t *testing.T) {
 	adm := NewNodeAdmissionWebhook(true)
 	tests := []struct {

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -47,8 +47,19 @@ func TestNewNodeAdmissionWebhook(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewNodeAdmissionWebhook(tt.enableHybridOverlay); !got.annotationKeys.HasAll(tt.expectedKeys...) {
+			got := NewNodeAdmissionWebhook(tt.enableHybridOverlay)
+			if !got.annotationKeys.HasAll(tt.expectedKeys...) {
 				t.Errorf("NewNodeAdmissionWebhook() = %v, want %v", got.annotationKeys, tt.expectedKeys)
+			}
+			// webhook must always have the DPU-allowed node annotation keys
+			dpuKeys := slices.Collect(maps.Keys(dpuNodeAnnotationChecks))
+			if !got.dpuAnnotationKeys.HasAll(dpuKeys...) {
+				t.Errorf("NewNodeAdmissionWebhook() dpuAnnotationKeys = %v, want all of %v", got.dpuAnnotationKeys, dpuKeys)
+			}
+			// webhook must always have the DPUHost-allowed node annotation keys
+			dpuHostKeys := slices.Collect(maps.Keys(dpuHostNodeAnnotationChecks))
+			if !got.dpuHostAnnotationKeys.HasAll(dpuHostKeys...) {
+				t.Errorf("NewNodeAdmissionWebhook() dpuHostAnnotationKeys = %v, want all of %v", got.dpuHostAnnotationKeys, dpuHostKeys)
 			}
 		})
 	}
@@ -145,7 +156,7 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 					Annotations: map[string]string{util.OVNNodeHostCIDRs: "new"},
 				},
 			},
-			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify nodes %q annotations", nodeName+"_rougeOne", nodeName),
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify annotations on node %q", nodeName+"_rougeOne", nodeName),
 		},
 		{
 			name: "ovnkube-node cannot modify annotations that do not belong to it",
@@ -399,6 +410,148 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 		})
 	}
 }
+func TestNodeAdmission_ValidateUpdateExtraUsers(t *testing.T) {
+	extraUser := "system:serviceaccount:ovn-kubernetes:ovnkube-node-dpu"
+	adm := NewNodeAdmissionWebhook(false, extraUser)
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		oldObj      *corev1.Node
+		newObj      *corev1.Node
+		expectedErr error
+	}{
+		{
+			name: "ovnkube-node-dpu can add annotation on its host node",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: extraUser,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dpu-host",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dpu-host",
+					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"},
+				},
+			},
+		},
+		{
+			name: "ovnkube-node-dpu cannot set annotations not in DPU allowed set",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: extraUser,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "192.168.1.0/24"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node-dpu for node: %q is not allowed to set the following annotations: %v", nodeName, []string{util.OVNNodeHostCIDRs}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
+			if err != tt.expectedErr && (err == nil || tt.expectedErr == nil || err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+		})
+	}
+}
+func TestNodeAdmission_ValidateUpdateDPUHost(t *testing.T) {
+	adm := NewNodeAdmissionWebhook(false)
+	// dpu-host is identified by its own per-node username prefix
+	// (system:ovn-node-dpu-host:<node>).
+	dpuHostUser := authenticationv1.UserInfo{
+		Username: fmt.Sprintf("%s:%s", csrapprover.NamePrefixDPUHost, nodeName),
+		Groups:   []string{"system:nodes", csrapprover.OVNNodesDPUHostGroup, "system:authenticated"},
+	}
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		oldObj      *corev1.Node
+		newObj      *corev1.Node
+		expectedErr error
+	}{
+		{
+			name: "dpu-host can set its host-side annotations",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						util.OVNNodePrimaryDPUHostAddr: "10.0.0.1/24",
+						util.OVNNodeHostCIDRs:          "[\"10.0.0.1/24\"]",
+						util.OvnNodeMasqCIDR:           "masq",
+						util.OvnNodeManagementPort:     "mgmt",
+					},
+				},
+			},
+		},
+		{
+			name: "dpu-host cannot set annotations owned by the DPU (e.g. chassis-id)",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node on dpu-host node: %q is not allowed to set the following annotations: %v", nodeName, []string{util.OvnNodeChassisID}),
+		},
+		{
+			name: "dpu-host cannot modify annotations on a different node",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName + "_other",
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "old"},
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName + "_other",
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "new"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node on dpu-host node: %q is not allowed to modify annotations on node %q", nodeName, nodeName+"_other"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := adm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
+			if err != tt.expectedErr && (err == nil || tt.expectedErr == nil || err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+		})
+	}
+}
+
 func TestNodeAdmission_ValidateUpdateHybridOverlay(t *testing.T) {
 	adm := NewNodeAdmissionWebhook(true)
 	tests := []struct {

--- a/go-controller/pkg/ovnwebhook/podadmission.go
+++ b/go-controller/pkg/ovnwebhook/podadmission.go
@@ -25,43 +25,61 @@ import (
 // checkPodAnnot defines additional checks for the allowed annotations
 type checkPodAnnot func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error
 
-// interconnectPodAnnotations holds annotations allowed for ovnkube-node:<nodeName> users.
-var interconnectPodAnnotations = map[string]checkPodAnnot{
-	types.OvnPodAnnotationName: func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error {
-		// Ignore kubevirt pods with live migration, the IP can cross node-subnet boundaries
-		if kubevirt.IsPodLiveMigratable(pod) {
+// ovnPodAnnotationCheck validates changes to the ovn pod-networks annotation. It is shared by the
+// full-mode and DPU allowlists.
+var ovnPodAnnotationCheck checkPodAnnot = func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error {
+	// Ignore kubevirt pods with live migration, the IP can cross node-subnet boundaries
+	if kubevirt.IsPodLiveMigratable(pod) {
+		return nil
+	}
+
+	if pod.Spec.HostNetwork {
+		return fmt.Errorf("the annotation is not allowed on host networked pods")
+	}
+
+	podAnnot, err := util.UnmarshalPodAnnotation(map[string]string{types.OvnPodAnnotationName: v.value}, types.DefaultNetworkName)
+	if err != nil {
+		if util.IsAnnotationNotSetError(err) {
 			return nil
 		}
+		return err
+	}
+	node, err := nodeLister.Get(nodeName)
+	if err != nil {
+		return fmt.Errorf("could not get info on node %s from client: %w", nodeName, err)
+	}
 
-		if pod.Spec.HostNetwork {
-			return fmt.Errorf("the annotation is not allowed on host networked pods")
+	subnets, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
+	if err != nil {
+		return err
+	}
+	for _, ip := range podAnnot.IPs {
+		if !util.IsContainedInAnyCIDR(ip, subnets...) {
+			return fmt.Errorf("%s does not belong to %s node", ip, nodeName)
 		}
+	}
+	return nil
+}
 
-		podAnnot, err := util.UnmarshalPodAnnotation(map[string]string{types.OvnPodAnnotationName: v.value}, types.DefaultNetworkName)
-		if err != nil {
-			if util.IsAnnotationNotSetError(err) {
-				return nil
-			}
-			return err
-		}
-		node, err := nodeLister.Get(nodeName)
-		if err != nil {
-			return fmt.Errorf("could not get info on node %s from client: %w", nodeName, err)
-		}
+// interconnectPodAnnotations holds annotations allowed for full-mode ovnkube-node:<nodeName>
+// and ovnkube-node-dpu identities.
+var interconnectPodAnnotations = map[string]checkPodAnnot{
+	types.OvnPodAnnotationName: ovnPodAnnotationCheck,
+}
 
-		subnets, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
-		if err != nil {
-			return err
-		}
-		for _, ip := range podAnnot.IPs {
-			if !util.IsContainedInAnyCIDR(ip, subnets...) {
-				return fmt.Errorf("%s does not belong to %s node", ip, nodeName)
-			}
-		}
-		return nil
-	},
+// dpuPodAnnotations holds annotations allowed for the ovnkube-node-dpu identity. It is a superset
+// of interconnectPodAnnotations and the DPU connection-status annotations to be set on the dpu-host
+var dpuPodAnnotations = map[string]checkPodAnnot{
+	types.OvnPodAnnotationName:    ovnPodAnnotationCheck,
+	util.DPUConnectionStatusAnnot: nil,
+}
+
+// dpuHostPodAnnotations holds pod annotations allowed for ovnkube-node running in dpu-host
+// mode (identity system:ovn-node-dpu-host:<node>). dpu-host only requests VF plumbing from
+// the DPU, so it only sets the connection-details annotation; the connection-status and the
+// pod-networks annotation are written by the DPU and the ovnkube-cluster-manager.
+var dpuHostPodAnnotations = map[string]checkPodAnnot{
 	util.DPUConnectionDetailsAnnot: nil,
-	util.DPUConnectionStatusAnnot:  nil,
 }
 
 // PodAdmissionConditionOptions specifies additional validate admission for pod.
@@ -98,20 +116,35 @@ func InitPodAdmissionConditionOptions(fileName string) (podAdmissions []PodAdmis
 }
 
 type PodAdmission struct {
-	nodeLister        listers.NodeLister
-	annotations       map[string]checkPodAnnot
-	annotationKeys    sets.Set[string]
+	nodeLister            listers.NodeLister
+	annotations           map[string]checkPodAnnot
+	annotationKeys        sets.Set[string]
+	dpuAnnotations        map[string]checkPodAnnot
+	dpuAnnotationKeys     sets.Set[string]
+	dpuHostAnnotations    map[string]checkPodAnnot
+	dpuHostAnnotationKeys sets.Set[string]
+	// allAnnotationKeys is the union of every guarded annotation across all identities. It is used
+	// to decide whether a non ovnkube-node* user touched any annotation that requires ownership checks.
+	allAnnotationKeys sets.Set[string]
 	extraAllowedUsers sets.Set[string]
 	podAdmissions     []PodAdmissionConditionOption
 }
 
 func NewPodAdmissionWebhook(nodeLister listers.NodeLister, podAdmissions []PodAdmissionConditionOption, extraAllowedUsers ...string) *PodAdmission {
+	allAnnotationKeys := sets.New[string](maps.Keys(interconnectPodAnnotations)...)
+	allAnnotationKeys.Insert(maps.Keys(dpuPodAnnotations)...)
+	allAnnotationKeys.Insert(maps.Keys(dpuHostPodAnnotations)...)
 	return &PodAdmission{
-		nodeLister:        nodeLister,
-		annotations:       interconnectPodAnnotations,
-		annotationKeys:    sets.New[string](maps.Keys(interconnectPodAnnotations)...),
-		extraAllowedUsers: sets.New[string](extraAllowedUsers...),
-		podAdmissions:     podAdmissions,
+		nodeLister:            nodeLister,
+		annotations:           interconnectPodAnnotations,
+		annotationKeys:        sets.New[string](maps.Keys(interconnectPodAnnotations)...),
+		dpuAnnotations:        dpuPodAnnotations,
+		dpuAnnotationKeys:     sets.New[string](maps.Keys(dpuPodAnnotations)...),
+		dpuHostAnnotations:    dpuHostPodAnnotations,
+		dpuHostAnnotationKeys: sets.New[string](maps.Keys(dpuHostPodAnnotations)...),
+		allAnnotationKeys:     allAnnotationKeys,
+		extraAllowedUsers:     sets.New[string](extraAllowedUsers...),
+		podAdmissions:         podAdmissions,
 	}
 }
 
@@ -134,6 +167,29 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 		return nil, err
 	}
 	isOVNKubeNode, podAdmission, nodeName := checkNodeIdentity(p.podAdmissions, req.UserInfo)
+	var isDPUHostNode, isDPUUser bool
+	if !isOVNKubeNode {
+		var dpuHostNodeName string
+		if dpuHostNodeName, isDPUHostNode = dpuHostNodeIdentity(req.UserInfo); isDPUHostNode {
+			nodeName = dpuHostNodeName
+		} else if isDPUUser = isDPUExtraAllowedUser(p.extraAllowedUsers, req.UserInfo.Username); isDPUUser {
+			nodeName = newPod.Spec.NodeName
+		}
+	}
+
+	// effective allowlist: full-mode nodes use the interconnect set (pod-networks only),
+	// the DPU SA additionally may set the DPU connection status annotation, and dpu-host is
+	// restricted to DPU connection details annotation.
+	effectiveAnnotations := p.annotations
+	effectiveKeys := p.annotationKeys
+	if isDPUUser {
+		effectiveAnnotations = p.dpuAnnotations
+		effectiveKeys = p.dpuAnnotationKeys
+	}
+	if isDPUHostNode {
+		effectiveAnnotations = p.dpuHostAnnotations
+		effectiveKeys = p.dpuHostAnnotationKeys
+	}
 
 	changes := mapDiff(oldPod.Annotations, newPod.Annotations)
 	changedKeys := maps.Keys(changes)
@@ -146,9 +202,10 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 		}
 	}
 
-	if !isOVNKubeNode {
-		if !p.annotationKeys.HasAny(changedKeys...) {
-			// the user is not an ovnkube-node and hasn't changed any ovnkube-node annotations
+	if !isOVNKubeNode && !isDPUUser && !isDPUHostNode && podAdmission == nil {
+		guardedChangedKeys := p.allAnnotationKeys.Intersection(sets.New[string](changedKeys...))
+		if len(guardedChangedKeys) == 0 {
+			// the user is not an ovnkube-node and hasn't changed any guarded annotations
 			return nil, nil
 		}
 
@@ -156,7 +213,15 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 			return nil, fmt.Errorf("user %q is not allowed to set the following annotations on pod: %q: %v",
 				req.UserInfo.Username,
 				newPod.Name,
-				p.annotationKeys.Intersection(sets.New[string](changedKeys...)).UnsortedList())
+				guardedChangedKeys.UnsortedList())
+		}
+		// A generic extra-allowed user (e.g. ovnkube-cluster-manager) is only trusted with the
+		// default allowlist; the DPU-only annotations are reserved for the dedicated DPU identities.
+		if !p.annotationKeys.HasAll(guardedChangedKeys.UnsortedList()...) {
+			return nil, fmt.Errorf("user %q is not allowed to set the following annotations on pod: %q: %v",
+				req.UserInfo.Username,
+				newPod.Name,
+				guardedChangedKeys.Difference(p.annotationKeys).UnsortedList())
 		}
 
 		// The user is not ovnkube-node, in this case the nodeName comes from the object
@@ -164,35 +229,39 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 	}
 
 	for _, key := range changedKeys {
-		if check := p.annotations[key]; check != nil {
+		if check := effectiveAnnotations[key]; check != nil {
 			if err := check(p.nodeLister, changes[key], newPod, nodeName); err != nil {
 				return nil, fmt.Errorf("user: %q is not allowed to set %s on pod %q: %v", req.UserInfo.Username, key, newPod.Name, err)
 			}
 		}
 	}
 
-	// if there is no matched acceptanceCondition as well as ovnkube-node, then skip following check
-	if !isOVNKubeNode && podAdmission == nil {
+	// if there is no matched acceptanceCondition as well as ovnkube-node* identities, then skip following check
+	if !isOVNKubeNode && !isDPUUser && !isDPUHostNode && podAdmission == nil {
 		return nil, nil
 	}
 
-	prefixName := "ovnkube-node"
-	if podAdmission != nil {
-		prefixName = podAdmission.CommonNamePrefix
+	identityDescription := "ovnkube-node on node"
+	if isDPUUser {
+		identityDescription = "ovnkube-node-dpu"
+	} else if isDPUHostNode {
+		identityDescription = "ovnkube-node on dpu-host node"
+	} else if podAdmission != nil {
+		identityDescription = podAdmission.CommonNamePrefix + " on node"
 	}
 
 	if oldPod.Spec.NodeName != nodeName {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to modify pods %q annotations", prefixName, nodeName, oldPod.Name)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on pod %q", identityDescription, nodeName, oldPod.Name)
 	}
 	if newPod.Spec.NodeName != nodeName {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to modify pods %q annotations", prefixName, nodeName, newPod.Name)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on pod %q", identityDescription, nodeName, newPod.Name)
 	}
 
-	// ovnkube-node is not allowed to change annotations outside of it's scope
-	if isOVNKubeNode && !p.annotationKeys.HasAll(changedKeys...) {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to set the following annotations on pod: %q: %v",
-			prefixName, nodeName, newPod.Name,
-			sets.New[string](changedKeys...).Difference(p.annotationKeys).UnsortedList())
+	// ovnkube-node / ovnkube-node-dpu / dpu-host is not allowed to change annotations outside of its scope
+	if (isOVNKubeNode || isDPUUser || isDPUHostNode) && !effectiveKeys.HasAll(changedKeys...) {
+		return nil, fmt.Errorf("%s: %q is not allowed to set the following annotations on pod: %q: %v",
+			identityDescription, nodeName, newPod.Name,
+			sets.New[string](changedKeys...).Difference(effectiveKeys).UnsortedList())
 	}
 
 	// Verify that nothing but the annotations changed.
@@ -206,7 +275,7 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 	newPodShallowCopy.ManagedFields = nil
 	if !apiequality.Semantic.DeepEqual(oldPodShallowCopy.ObjectMeta, newPodShallowCopy.ObjectMeta) ||
 		!apiequality.Semantic.DeepEqual(oldPodShallowCopy.Status, newPodShallowCopy.Status) {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to modify anything other than annotations", prefixName, nodeName)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify anything other than annotations", identityDescription, nodeName)
 	}
 
 	return nil, nil

--- a/go-controller/pkg/ovnwebhook/podadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/podadmission_test.go
@@ -20,6 +20,7 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -139,7 +140,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
-			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify pods %q annotations", nodeName+"_rougeOne", podName),
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify annotations on pod %q", nodeName+"_rougeOne", podName),
 		},
 		{
 			name: "ovnkube-node cannot modify pod annotations that do not belong to it",
@@ -280,7 +281,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "ovnkube-node can modify DPUConnectionDetailsAnnot annotation on a pod",
+			name: "full-mode ovnkube-node cannot modify DPUConnectionDetailsAnnot annotation on a pod",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        nodeName,
@@ -306,9 +307,10 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations on pod: %q: %v", nodeName, podName, []string{util.DPUConnectionDetailsAnnot}),
 		},
 		{
-			name: "ovnkube-node can modify DPUConnetionStatusAnnot annotation on a pod",
+			name: "full-mode ovnkube-node cannot modify DPUConnectionStatusAnnot annotation on a pod",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        nodeName,
@@ -334,6 +336,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations on pod: %q: %v", nodeName, podName, []string{util.DPUConnectionStatusAnnot}),
 		},
 		{
 			name: "ovnkube-node cannot modify anything other than pods annotations",
@@ -439,6 +442,144 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			})
 			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
 			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
+				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+		})
+	}
+}
+
+func TestPodAdmission_ValidateUpdateDPUExtraUser(t *testing.T) {
+	extraUser := "system:serviceaccount:ovn-kubernetes:ovnkube-node-dpu"
+	tests := []struct {
+		name        string
+		node        *corev1.Node
+		ctx         context.Context
+		oldObj      *corev1.Pod
+		newObj      *corev1.Pod
+		expectedErr error
+	}{
+		{
+			name: "ovnkube-node-dpu can set DPUConnectionStatusAnnot on pod",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{"k8s.ovn.org/node-subnets": `{"default":"192.168.0.0/24"}`},
+				},
+			},
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: extraUser,
+				}},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{util.DPUConnectionStatusAnnot: `{"default":{"Status":"Ready","Reason":""}}`},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			padm := NewPodAdmissionWebhook(&fakeNodeLister{
+				nodes: map[string]*corev1.Node{tt.node.Name: tt.node},
+			}, nil, extraUser)
+			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
+			if err != tt.expectedErr && err.Error() != tt.expectedErr.Error() {
+				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+		})
+	}
+}
+
+func TestPodAdmission_ValidateUpdateDPUHost(t *testing.T) {
+	dpuHostUser := authenticationv1.UserInfo{
+		Username: fmt.Sprintf("%s:%s", csrapprover.NamePrefixDPUHost, nodeName),
+		Groups:   []string{"system:nodes", csrapprover.OVNNodesDPUHostGroup, "system:authenticated"},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{"k8s.ovn.org/node-subnets": `{"default":"192.168.0.0/24"}`},
+		},
+	}
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		oldObj      *corev1.Pod
+		newObj      *corev1.Pod
+		expectedErr error
+	}{
+		{
+			name: "dpu-host can set DPUConnectionDetailsAnnot on its own node's pod",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: podName},
+				Spec:       corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{util.DPUConnectionDetailsAnnot: `{"default":{"pfId":"0","vfId":"0","sandboxId":"abc"}}`},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+		},
+		{
+			name: "dpu-host cannot set DPUConnectionStatusAnnot (written by the DPU)",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: podName},
+				Spec:       corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{util.DPUConnectionStatusAnnot: `{"default":{"Status":"Ready","Reason":""}}`},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node on dpu-host node: %q is not allowed to set the following annotations on pod: %q: %v", nodeName, podName, []string{util.DPUConnectionStatusAnnot}),
+		},
+		{
+			name: "dpu-host cannot modify pods on a different node",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: dpuHostUser},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: podName},
+				Spec:       corev1.PodSpec{NodeName: nodeName + "_other"},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{util.DPUConnectionDetailsAnnot: `{"default":{"pfId":"0","vfId":"0","sandboxId":"abc"}}`},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName + "_other"},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node on dpu-host node: %q is not allowed to modify annotations on pod %q", nodeName, podName),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			padm := NewPodAdmissionWebhook(&fakeNodeLister{
+				nodes: map[string]*corev1.Node{node.Name: node},
+			}, nil)
+			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
+			if err != tt.expectedErr && (err == nil || tt.expectedErr == nil || err.Error() != tt.expectedErr.Error()) {
 				t.Errorf("ValidateUpdate() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
 			}

--- a/go-controller/pkg/ovnwebhook/user.go
+++ b/go-controller/pkg/ovnwebhook/user.go
@@ -7,15 +7,37 @@ import (
 	"strings"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 )
 
+const (
+	// OvnKubeNodeDPUServiceAccountName is the service account DPU ovnkube-node processes use
+	// to access the DPU-host cluster.
+	OvnKubeNodeDPUServiceAccountName = "ovnkube-node-dpu"
+)
+
+// isOvnKubeNodeDPUUser reports whether username is the ovnkube-node-dpu service account.
+func isOvnKubeNodeDPUUser(username string) bool {
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		return false
+	}
+	namespaceAndSA := strings.TrimPrefix(username, prefix)
+	namespace, saName, ok := strings.Cut(namespaceAndSA, ":")
+	return ok && namespace != "" && saName == OvnKubeNodeDPUServiceAccountName
+}
+
+// isDPUExtraAllowedUser reports whether username is registered in extraAllowedUsers as the DPU SA.
+func isDPUExtraAllowedUser(extraAllowedUsers sets.Set[string], username string) bool {
+	return extraAllowedUsers.Has(username) && isOvnKubeNodeDPUUser(username)
+}
+
 // checkNodeIdentity retrieves user name from UserInfo, based on given podAdmissions.
 func checkNodeIdentity(podAdmissions []PodAdmissionConditionOption, user authenticationv1.UserInfo) (bool, *PodAdmissionConditionOption, string) {
-	// check ovn prefix
-	if strings.HasPrefix(user.Username, csrapprover.NamePrefix) {
-		return true, nil, strings.TrimPrefix(user.Username, csrapprover.NamePrefix+":")
+	if nodeName, ok := ovnkubeNodeIdentity(user); ok {
+		return true, nil, nodeName
 	}
 
 	// check prefix in podAdmissions
@@ -28,12 +50,23 @@ func checkNodeIdentity(podAdmissions []PodAdmissionConditionOption, user authent
 	return false, nil, ""
 }
 
+// ovnkubeNodeIdentity returns the node name and true if the user is an ovnkube-node identity
+// (system:ovn-node:<nodeName>) that is allowed to modify that node's annotations.
 func ovnkubeNodeIdentity(user authenticationv1.UserInfo) (string, bool) {
-	if !strings.HasPrefix(user.Username, csrapprover.NamePrefix) {
+	if !strings.HasPrefix(user.Username, csrapprover.NamePrefix+":") {
 		return "", false
 	}
-
-	// Trim prefix and the last colon
 	nodeName := strings.TrimPrefix(user.Username, csrapprover.NamePrefix+":")
+	return nodeName, true
+}
+
+// dpuHostNodeIdentity returns the node name and true if the user is an ovnkube-node identity
+// running in dpu-host mode (system:ovn-node-dpu-host:<nodeName>). dpu-host uses its own
+// per-node common name prefix so it gets a restricted node-annotation allowlist.
+func dpuHostNodeIdentity(user authenticationv1.UserInfo) (string, bool) {
+	if !strings.HasPrefix(user.Username, csrapprover.NamePrefixDPUHost+":") {
+		return "", false
+	}
+	nodeName := strings.TrimPrefix(user.Username, csrapprover.NamePrefixDPUHost+":")
 	return nodeName, true
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -139,9 +139,11 @@ type OVNClusterManagerClientset struct {
 }
 
 const (
-	certNamePrefix       = "ovnkube-client"
-	certCommonNamePrefix = "system:ovn-node"
-	certOrganization     = "system:ovn-nodes"
+	certNamePrefix              = "ovnkube-client"
+	certCommonNamePrefix        = "system:ovn-node"
+	certCommonNamePrefixDPUHost = "system:ovn-node-dpu-host"
+	certOrganization            = "system:ovn-nodes"
+	certOrganizationDPUHost     = "system:ovn-nodes-dpu-host"
 )
 
 var (
@@ -277,12 +279,13 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 }
 
 // StartNodeCertificateManager manages the creation and rotation of the node-specific client certificate.
-// When there is no existing certificate, it will use the BootstrapKubeconfig kubeconfig to create a CSR and it will
-// wait for the certificate before returning.
+// When there is no existing certificate, it will use the BootstrapKubeconfig kubeconfig to create a CSR
+// and wait for the certificate before returning.
 func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeName string, conf *config.KubernetesConfig) error {
 	if nodeName == "" {
 		return fmt.Errorf("the provided node name cannot be empty")
 	}
+
 	defaultKConfig, err := newKubernetesRestConfig(conf)
 	if err != nil {
 		return fmt.Errorf("unable to create kubernetes rest config, err: %v", err)
@@ -290,10 +293,14 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 	defaultKConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	defaultKConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
+	if conf.BootstrapKubeconfig == "" {
+		return fmt.Errorf("bootstrap kubeconfig is required for certificate manager")
+	}
 	bootstrapKConfig, err := clientcmd.BuildConfigFromFlags("", conf.BootstrapKubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to load bootstrap kubeconfig from %s, err: %v", conf.BootstrapKubeconfig, err)
 	}
+
 	// If we have a valid certificate, use that to fetch CSRs.
 	// Otherwise, use the bootstrap credentials.
 	// https://github.com/kubernetes/kubernetes/blob/068ee321bc7bfe1c2cefb87fb4d9e5deea84fbc8/cmd/kubelet/app/server.go#L953-L963
@@ -311,9 +318,18 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 	}
 
 	// The CSR approver only accepts CSRs created by system:ovn-node:nodeName and system:node:nodeName.
-	// If the node name in the existing ovn-node certificate is different from the current node name,
-	// remove the certificate so the CSR will be created using the bootstrap kubeconfig using system:node:nodeName user.
-	certCommonName := fmt.Sprintf("%s:%s", certCommonNamePrefix, nodeName)
+	// If the node name in the existing certificate is different from the current node name,
+	// remove the certificate so a new CSR will be created.
+	// dpu-host uses a distinct per-node common name (system:ovn-node-dpu-host:<node>) and
+	// Organization (system:ovn-nodes-dpu-host) so its identity is bound to a narrower
+	// ClusterRole and node-annotation allowlist than full-mode nodes (system:ovn-nodes).
+	cnPrefix := certCommonNamePrefix
+	certOrg := certOrganization
+	if config.IsModeDPUHost() {
+		cnPrefix = certCommonNamePrefixDPUHost
+		certOrg = certOrganizationDPUHost
+	}
+	certCommonName := fmt.Sprintf("%s:%s", cnPrefix, nodeName)
 	currentCertFromFile, err := certificateStore.Current()
 	if err == nil && currentCertFromFile.Leaf != nil {
 		if currentCertFromFile.Leaf.Subject.CommonName != certCommonName {
@@ -346,7 +362,7 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 		Template: &x509.CertificateRequest{
 			Subject: pkix.Name{
 				CommonName:   certCommonName,
-				Organization: []string{certOrganization},
+				Organization: []string{certOrg},
 			},
 		},
 		RequestedCertificateLifetime: &conf.CertDuration,

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -134,9 +134,11 @@ type OVNClusterManagerClientset struct {
 }
 
 const (
-	certNamePrefix       = "ovnkube-client"
-	certCommonNamePrefix = "system:ovn-node"
-	certOrganization     = "system:ovn-nodes"
+	certNamePrefix              = "ovnkube-client"
+	certCommonNamePrefix        = "system:ovn-node"
+	certCommonNamePrefixDPUHost = "system:ovn-node-dpu-host"
+	certOrganization            = "system:ovn-nodes"
+	certOrganizationDPUHost     = "system:ovn-nodes-dpu-host"
 )
 
 var (
@@ -269,12 +271,13 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 }
 
 // StartNodeCertificateManager manages the creation and rotation of the node-specific client certificate.
-// When there is no existing certificate, it will use the BootstrapKubeconfig kubeconfig to create a CSR and it will
-// wait for the certificate before returning.
+// When there is no existing certificate, it will use the BootstrapKubeconfig kubeconfig to create a CSR
+// and wait for the certificate before returning.
 func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeName string, conf *config.KubernetesConfig) error {
 	if nodeName == "" {
 		return fmt.Errorf("the provided node name cannot be empty")
 	}
+
 	defaultKConfig, err := newKubernetesRestConfig(conf)
 	if err != nil {
 		return fmt.Errorf("unable to create kubernetes rest config, err: %v", err)
@@ -282,10 +285,14 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 	defaultKConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	defaultKConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
+	if conf.BootstrapKubeconfig == "" {
+		return fmt.Errorf("bootstrap kubeconfig is required for certificate manager")
+	}
 	bootstrapKConfig, err := clientcmd.BuildConfigFromFlags("", conf.BootstrapKubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to load bootstrap kubeconfig from %s, err: %v", conf.BootstrapKubeconfig, err)
 	}
+
 	// If we have a valid certificate, use that to fetch CSRs.
 	// Otherwise, use the bootstrap credentials.
 	// https://github.com/kubernetes/kubernetes/blob/068ee321bc7bfe1c2cefb87fb4d9e5deea84fbc8/cmd/kubelet/app/server.go#L953-L963
@@ -303,9 +310,18 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 	}
 
 	// The CSR approver only accepts CSRs created by system:ovn-node:nodeName and system:node:nodeName.
-	// If the node name in the existing ovn-node certificate is different from the current node name,
-	// remove the certificate so the CSR will be created using the bootstrap kubeconfig using system:node:nodeName user.
-	certCommonName := fmt.Sprintf("%s:%s", certCommonNamePrefix, nodeName)
+	// If the node name in the existing certificate is different from the current node name,
+	// remove the certificate so a new CSR will be created.
+	// dpu-host uses a distinct per-node common name (system:ovn-node-dpu-host:<node>) and
+	// Organization (system:ovn-nodes-dpu-host) so its identity is bound to a narrower
+	// ClusterRole and node-annotation allowlist than full-mode nodes (system:ovn-nodes).
+	cnPrefix := certCommonNamePrefix
+	certOrg := certOrganization
+	if config.IsModeDPUHost() {
+		cnPrefix = certCommonNamePrefixDPUHost
+		certOrg = certOrganizationDPUHost
+	}
+	certCommonName := fmt.Sprintf("%s:%s", cnPrefix, nodeName)
 	currentCertFromFile, err := certificateStore.Current()
 	if err == nil && currentCertFromFile.Leaf != nil {
 		if currentCertFromFile.Leaf.Subject.CommonName != certCommonName {
@@ -338,7 +354,7 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 		Template: &x509.CertificateRequest{
 			Subject: pkix.Name{
 				CommonName:   certCommonName,
-				Organization: []string{certOrganization},
+				Organization: []string{certOrg},
 			},
 		},
 		RequestedCertificateLifetime: &conf.CertDuration,

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -31,7 +31,7 @@ spec:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
       priorityClassName: "system-cluster-critical"
-      serviceAccountName: ovnkube-node
+      serviceAccountName: ovnkube-node-dpu-host
       hostNetwork: true
       dnsPolicy: Default
       {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -32,7 +32,6 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
-      serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default
       {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu-host.yaml
@@ -1,0 +1,150 @@
+{{- $tags := (.Values.tags | default dict) }}
+{{- if eq (index $tags "ovnkube-node-dpu-host") true }}
+# ovnkube-node-dpu-host runs on DPU-host nodes (ovn-node in dpu-host mode). It creates and
+# monitors DPU health leases in ovn-kubernetes and is bound to the dedicated
+# ovnkube-node-dpu-host ClusterRole below, which grants only the API access the dpu-host
+# process actually needs which is a subset of ovnkube-node).
+# - When ovnkube-identity is disabled, the binding targets the ovnkube-node-dpu-host
+#   service account.
+# - When ovnkube-identity is enabled, dpu-host authenticates as
+#   system:ovn-node-dpu-host:<node> in the system:ovn-nodes-dpu-host group (distinct from the
+#   full-node system:ovn-node:<node> / system:ovn-nodes identity), and the binding targets
+#   that group.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-node-dpu-host
+    namespace: ovn-kubernetes
+
+---
+# Shared DPU health lease Role, referenced by both the dpu (ovnkube-node-dpu) and
+# dpu-host (ovnkube-node-dpu-host) lease RoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: ovnkube-node-dpu-leases
+    namespace: ovn-kubernetes
+rules:
+    - apiGroups: ["coordination.k8s.io"]
+      resources:
+          - leases
+      verbs: [ "get", "create", "update" ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-dpu-host-leases
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovnkube-node-dpu-leases
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes-dpu-host
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu-host
+      namespace: ovn-kubernetes
+    {{- end }}
+
+# Dedicated ClusterRole for dpu-host.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-dpu-host
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: [ "create", "patch", "update" ]
+    - apiGroups: [""]
+      resources:
+          - nodes/status
+          - pods/status
+      verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests
+      verbs:
+        - create
+        - get
+        - list
+        - watch
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableEgressIp" | ternary .Values.global.enableEgressIp false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressips
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableEgressService" | ternary .Values.global.enableEgressService false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressservices
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - adminpolicybasedexternalroutes
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+      verbs: [ "get", "list", "watch" ]
+    {{- if eq (hasKey .Values.global "enableNetworkSegmentation" | ternary .Values.global.enableNetworkSegmentation false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - userdefinednetworks
+          - clusteruserdefinednetworks
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    {{- if or (eq (hasKey .Values.global "enableRouteAdvertisements" | ternary .Values.global.enableRouteAdvertisements false) true) (eq (hasKey .Values.global "enableNoOverlayManagedRouting" | ternary .Values.global.enableNoOverlayManagedRouting false) true) }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - routeadvertisements
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+
+# dpu-host is bound to the narrow dpu-host ClusterRole below. When ovnkube-identity is
+# enabled the subject is the system:ovn-nodes-dpu-host group (dpu-host authenticates as
+# system:ovn-node-dpu-host:<node>); otherwise it is the ovnkube-node-dpu-host service account.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-dpu-host
+roleRef:
+    name: ovnkube-node-dpu-host
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes-dpu-host
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu-host
+      namespace: ovn-kubernetes
+    {{- end }}
+{{- end }}

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu-host.yaml
@@ -1,0 +1,161 @@
+{{- $tags := (.Values.tags | default dict) }}
+{{- if eq (index $tags "ovnkube-node-dpu-host") true }}
+# ovnkube-node-dpu-host runs on DPU-host nodes (ovn-node in dpu-host mode). It creates and
+# monitors DPU health leases in ovn-kubernetes and is bound to the dedicated
+# ovnkube-node-dpu-host ClusterRole below, which grants only the API access the dpu-host
+# process actually needs which is a subset of ovnkube-node).
+# - When ovnkube-identity is disabled, the binding targets the ovnkube-node-dpu-host
+#   service account.
+# - When ovnkube-identity is enabled, dpu-host authenticates as
+#   system:ovn-node-dpu-host:<node> in the system:ovn-nodes-dpu-host group (distinct from the
+#   full-node system:ovn-node:<node> / system:ovn-nodes identity), and the binding targets
+#   that group.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-node-dpu-host
+    namespace: ovn-kubernetes
+
+---
+# Shared DPU health lease Role, referenced by both the dpu (ovnkube-node-dpu) and
+# dpu-host (ovnkube-node-dpu-host) lease RoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: ovnkube-node-dpu-leases
+    namespace: ovn-kubernetes
+rules:
+    - apiGroups: ["coordination.k8s.io"]
+      resources:
+          - leases
+      verbs: [ "get", "create", "update" ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-dpu-host-leases
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovnkube-node-dpu-leases
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes-dpu-host
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu-host
+      namespace: ovn-kubernetes
+    {{- end }}
+
+# Dedicated ClusterRole for dpu-host.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-dpu-host
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: [ "create", "patch", "update" ]
+    - apiGroups: [""]
+      resources:
+          - nodes/status
+          - pods/status
+      verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests
+      verbs:
+        - create
+        - get
+        - list
+        - watch
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableEgressIp" | ternary .Values.global.enableEgressIp false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressips
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableEgressService" | ternary .Values.global.enableEgressService false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressservices
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - adminpolicybasedexternalroutes
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+      verbs: [ "get", "list", "watch" ]
+    {{- if eq (hasKey .Values.global "enableNetworkSegmentation" | ternary .Values.global.enableNetworkSegmentation false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - userdefinednetworks
+          - clusteruserdefinednetworks
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableUplink" | ternary .Values.global.enableUplink false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - uplinks
+          - uplinkstates
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - uplinkstates
+      verbs: [ "create", "delete", "patch", "update" ]
+    {{- end }}
+    {{- if or (eq (hasKey .Values.global "enableRouteAdvertisements" | ternary .Values.global.enableRouteAdvertisements false) true) (eq (hasKey .Values.global "enableNoOverlayManagedRouting" | ternary .Values.global.enableNoOverlayManagedRouting false) true) }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - routeadvertisements
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+
+# dpu-host is bound to the narrow dpu-host ClusterRole below. When ovnkube-identity is
+# enabled the subject is the system:ovn-nodes-dpu-host group (dpu-host authenticates as
+# system:ovn-node-dpu-host:<node>); otherwise it is the ovnkube-node-dpu-host service account.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-dpu-host
+roleRef:
+    name: ovnkube-node-dpu-host
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes-dpu-host
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu-host
+      namespace: ovn-kubernetes
+    {{- end }}
+{{- end }}

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu.yaml
@@ -1,0 +1,138 @@
+{{- $tags := (.Values.tags | default dict) }}
+{{- if eq (index $tags "ovnkube-node-dpu-host") true }}
+# ovnkube-node-dpu SA is used by nodes in DPU cluster to access the DPU-host cluster API.
+# DPU health lease Role (ovnkube-node-dpu-leases) is defined in rbac-ovnkube-node-dpu-host.yaml.
+# When ovnkube-identity is enabled, the admission webhook applies DPU-specific annotation whitelists for this SA.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-node-dpu
+    namespace: ovn-kubernetes
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ovnkube-node-dpu-token
+    namespace: ovn-kubernetes
+    annotations:
+        kubernetes.io/service-account.name: ovnkube-node-dpu
+type: kubernetes.io/service-account-token
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-dpu
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+          - endpoints
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["networking.k8s.io"]
+      resources:
+          - networkpolicies
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - ipamclaims
+          - multi-networkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: [ "k8s.cni.cncf.io" ]
+      resources:
+          - ipamclaims/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls/status
+          - adminpolicybasedexternalroutes/status
+          - egressqoses/status
+          - routeadvertisements/status
+          - networkqoses/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies/status
+          - baselineadminnetworkpolicies/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies
+          - baselineadminnetworkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls
+          - egressips
+          - egressqoses
+          - egressservices
+          - adminpolicybasedexternalroutes
+          - userdefinednetworks
+          - clusteruserdefinednetworks
+          - networkqoses
+          - clusternetworkconnects
+      verbs: [ "get", "list", "watch" ]
+    {{- if or (eq (hasKey .Values.global "enableRouteAdvertisements" | ternary .Values.global.enableRouteAdvertisements false) true) (eq (hasKey .Values.global "enableNoOverlayManagedRouting" | ternary .Values.global.enableNoOverlayManagedRouting false) true) }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - routeadvertisements
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: ["create", "patch", "update"]
+    - apiGroups: [""]
+      resources:
+          - pods/status
+          - nodes/status
+      verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false) true }}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-dpu
+roleRef:
+    name: ovnkube-node-dpu
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-dpu-leases
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovnkube-node-dpu-leases
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu
+      namespace: ovn-kubernetes
+{{- end }}

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node-dpu.yaml
@@ -1,0 +1,149 @@
+{{- $tags := (.Values.tags | default dict) }}
+{{- if eq (index $tags "ovnkube-node-dpu-host") true }}
+# ovnkube-node-dpu SA is used by nodes in DPU cluster to access the DPU-host cluster API.
+# DPU health lease Role (ovnkube-node-dpu-leases) is defined in rbac-ovnkube-node-dpu-host.yaml.
+# When ovnkube-identity is enabled, the admission webhook applies DPU-specific annotation whitelists for this SA.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-node-dpu
+    namespace: ovn-kubernetes
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ovnkube-node-dpu-token
+    namespace: ovn-kubernetes
+    annotations:
+        kubernetes.io/service-account.name: ovnkube-node-dpu
+type: kubernetes.io/service-account-token
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-dpu
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+          - endpoints
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["networking.k8s.io"]
+      resources:
+          - networkpolicies
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - ipamclaims
+          - multi-networkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: [ "k8s.cni.cncf.io" ]
+      resources:
+          - ipamclaims/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls/status
+          - adminpolicybasedexternalroutes/status
+          - egressqoses/status
+          - routeadvertisements/status
+          - networkqoses/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies/status
+          - baselineadminnetworkpolicies/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies
+          - baselineadminnetworkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls
+          - egressips
+          - egressqoses
+          - egressservices
+          - adminpolicybasedexternalroutes
+          - userdefinednetworks
+          - clusteruserdefinednetworks
+          - networkqoses
+          - clusternetworkconnects
+      verbs: [ "get", "list", "watch" ]
+    {{- if eq (hasKey .Values.global "enableUplink" | ternary .Values.global.enableUplink false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - uplinks
+          - uplinkstates
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - uplinkstates
+      verbs: [ "create", "delete", "patch", "update" ]
+    {{- end }}
+    {{- if or (eq (hasKey .Values.global "enableRouteAdvertisements" | ternary .Values.global.enableRouteAdvertisements false) true) (eq (hasKey .Values.global "enableNoOverlayManagedRouting" | ternary .Values.global.enableNoOverlayManagedRouting false) true) }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - routeadvertisements
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: ["create", "patch", "update"]
+    - apiGroups: [""]
+      resources:
+          - pods/status
+          - nodes/status
+      verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false) true }}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-dpu
+roleRef:
+    name: ovnkube-node-dpu
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-dpu-leases
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovnkube-node-dpu-leases
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node-dpu
+      namespace: ovn-kubernetes
+{{- end }}

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -1,3 +1,5 @@
+{{- $tags := (.Values.tags | default dict) }}
+{{- if ne (index $tags "ovnkube-single-node-zone-dpu") true }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,7 +7,8 @@ metadata:
     namespace: ovn-kubernetes
 
 # When ovn_enable_ovnkube_identity is true, an ovnkube-node process will identify as a user in a system:ovn-nodes group,
-# not the ovnkube-node serviceAccount
+# not the ovnkube-node serviceAccount.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -238,39 +241,4 @@ rules:
       verbs:
           - get
           - create
-
-{{- $tags := (.Values.tags | default dict) }}
-{{- if (index $tags "ovnkube-node-dpu-host") }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-    name: ovnkube-node-dpu-leases
-    namespace: ovn-kubernetes
-roleRef:
-    name: ovnkube-node-dpu-leases
-    kind: Role
-    apiGroup: rbac.authorization.k8s.io
-subjects:
-    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
-    - kind: Group
-      name: system:ovn-nodes
-      apiGroup: rbac.authorization.k8s.io
-    {{- else }}
-    - kind: ServiceAccount
-      name: ovnkube-node
-      namespace: ovn-kubernetes
-    {{- end }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-    name: ovnkube-node-dpu-leases
-    namespace: ovn-kubernetes
-rules:
-    - apiGroups: ["coordination.k8s.io"]
-      resources:
-          - leases
-      verbs: [ "get", "create", "update" ]
 {{- end }}

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -1,3 +1,5 @@
+{{- $tags := (.Values.tags | default dict) }}
+{{- if ne (index $tags "ovnkube-single-node-zone-dpu") true }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,7 +7,8 @@ metadata:
     namespace: ovn-kubernetes
 
 # When ovn_enable_ovnkube_identity is true, an ovnkube-node process will identify as a user in a system:ovn-nodes group,
-# not the ovnkube-node serviceAccount
+# not the ovnkube-node serviceAccount.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -232,39 +235,4 @@ rules:
       verbs:
           - get
           - create
-
-{{- $tags := (.Values.tags | default dict) }}
-{{- if (index $tags "ovnkube-node-dpu-host") }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-    name: ovnkube-node-dpu-leases
-    namespace: ovn-kubernetes
-roleRef:
-    name: ovnkube-node-dpu-leases
-    kind: Role
-    apiGroup: rbac.authorization.k8s.io
-subjects:
-    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
-    - kind: Group
-      name: system:ovn-nodes
-      apiGroup: rbac.authorization.k8s.io
-    {{- else }}
-    - kind: ServiceAccount
-      name: ovnkube-node
-      namespace: ovn-kubernetes
-    {{- end }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-    name: ovnkube-node-dpu-leases
-    namespace: ovn-kubernetes
-rules:
-    - apiGroups: ["coordination.k8s.io"]
-      resources:
-          - leases
-      verbs: [ "get", "create", "update" ]
 {{- end }}

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -8,6 +8,7 @@ tags:
   ovnkube-control-plane: false
   ovnkube-node-dpu-host: false
   ovnkube-single-node-zone: false
+  ovnkube-single-node-zone-dpu: true
 
 # -- Whether or not call `lookup` Helm function, set it to `true` if you want to run `helm dry-run/template/lint`
 skipCallToK8s: false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR adds support for using ovnkube-identity with DPU.

DPUs are in a different cluster than the DPU-host nodes and use ovnkube-node-dpu SA to access the DPU-Host cluster and annotate the DPU-Host nodes. This SA is added as extra-allowed-user. 
The ovnkube-identity feature is enabled only on the DPU-Host cluster, and the DPU-Host nodes uses the same CSR mechanism as the ovnkube-nodes. 
Created separate RBAC for DPU and DPU-Host nodes and separate allowed list of annotations for both when ovnkube-identity is enabled, since the annotations are shared by DPU/DPU-host. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DPU-host mode with dedicated service account and RBAC rendering guards.
  * Improved role-aware node and pod admission validation so only the correct annotations can be changed per mode and identity.

* **Bug Fixes**
  * Node zone annotation is now applied only in DPU-host/Full modes.
  * Node certificate bootstrapping now requires a node identity value to be set.

* **Tests**
  * Added/expanded admission control tests for DPU and DPU-host identities and scenarios.

* **Chores**
  * Updated Helm and RBAC templates for DPU/DPU-host deployments and simplified DaemonSet environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->