### PR TITLE
Add kube-api-linter (KAL) CI job for CRD API type checks

### DIFF
--- a/.github/workflows/kube-api-linter.yml
+++ b/.github/workflows/kube-api-linter.yml
@@ -1,0 +1,47 @@
+name: kube-api-linter
+
+on:
+  pull_request:
+    branches: [ master, release-* ]
+    paths:
+      - 'go-controller/pkg/crd/**'
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kube-api-linter-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  api-lint:
+    name: Kube API Linter
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go-controller/go.mod'
+        cache: false
+
+    - name: Build custom golangci-lint with KAL
+      run: |
+        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0
+        cd go-controller
+        golangci-lint custom
+      env:
+        GOFLAGS: ""
+
+    - name: Run kube-api-linter
+      run: |
+        cd go-controller
+        ./bin/golangci-lint-kube-api-linter run \
+          --config .golangci-kal.yml \
+          --modules-download-mode=vendor \
+          --timeout=10m0s \
+          --verbose \
+          ./pkg/crd/...

--- a/go-controller/.custom-gcl.yml
+++ b/go-controller/.custom-gcl.yml
@@ -1,0 +1,6 @@
+version: v2.11.0
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+  - module: 'sigs.k8s.io/kube-api-linter'
+    version: 'v0.0.0-20260505141229-de8f85687fd2'

--- a/go-controller/.golangci-kal.yml
+++ b/go-controller/.golangci-kal.yml
@@ -1,0 +1,38 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - kubeapilinter
+  settings:
+    custom:
+      kubeapilinter:
+        type: "module"
+        description: >-
+          Kube API Linter checks CRD types against
+          Kubernetes API conventions and best practices.
+        settings:
+          linters:
+            enable:
+              - commentstart
+              - conditions
+              - integers
+              - jsontags
+              - optionalorrequired
+              - statussubresource
+            disable:
+              # nomaps is too strict for CRD projects
+              - nomaps
+              # nonpointerstructs is intended for native types
+              - nonpointerstructs
+          lintersConfig:
+            optionalOrRequired:
+              preferredOptionalMarker: "optional"
+              preferredRequiredMarker: "required"
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - third_party$
+run:
+  build-tags:
+    - tools


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Add a new CI workflow that runs the kubernetes-sigs/kube-api-linter against go-controller/pkg/crd/ types. The job only triggers on PRs that touch CRD files, keeping CI fast for unrelated changes.

Includes:
- .custom-gcl.yml to build a golangci-lint binary with the KAL plugin
- .golangci-kal.yml with KAL-specific linter configuration
- .github/workflows/kube-api-linter.yml CI workflow

See https://github.com/kubernetes-sigs/kube-api-linter


## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
