### PR TITLE
Fix duplicate gateway SNATs for no-overlay outbound SNAT

### DIFF
--- a/go-controller/pkg/kubevirt/dhcp.go
+++ b/go-controller/pkg/kubevirt/dhcp.go
@@ -6,7 +6,6 @@ package kubevirt
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -175,7 +174,7 @@ func composeDHCPOptions(controllerName string, vmKey ktypes.NamespacedName, dhcp
 	dhcpvOptionsDbObjectID := libovsdbops.NewDbObjectIDs(libovsdbops.VirtualMachineDHCPOptions, controllerName,
 		map[libovsdbops.ExternalIDKey]string{
 			libovsdbops.ObjectNameKey: vmKey.String(),
-			libovsdbops.CIDRKey:       strings.ReplaceAll(dhcpOptions.Cidr, ":", "."),
+			libovsdbops.CIDRKey:       libovsdbops.BuildCIDRKey(dhcpOptions.Cidr),
 		})
 	dhcpOptions.ExternalIDs = dhcpvOptionsDbObjectID.GetExternalIDs()
 	dhcpOptions.ExternalIDs[OvnZoneExternalIDKey] = OvnLocalZone

--- a/go-controller/pkg/libovsdb/ops/db_object_ids.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_ids.go
@@ -83,6 +83,12 @@ func ParseNamespaceNameKey(key string) (namespace, name string, err error) {
 	return s[0], s[1], nil
 }
 
+// BuildCIDRKey formats a CIDR for use as an ExternalIDKey value: IPv6 CIDRs
+// contain ":", which is the delimiter used to build the primary ID.
+func BuildCIDRKey(cidr string) string {
+	return strings.ReplaceAll(cidr, ":", ".")
+}
+
 // dbIDsMap is used to make sure the same ownerType is not defined twice for the same dbObjType to avoid conflicts.
 // It is filled in newObjectIDsType when registering new ObjectIDsType
 var dbIDsMap = map[dbObjType]map[ownerType]bool{}

--- a/go-controller/pkg/libovsdb/ops/db_object_ids_test.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_ids_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import "testing"
+
+func TestBuildCIDRKey(t *testing.T) {
+	tests := []struct {
+		name string
+		cidr string
+		want string
+	}{
+		{
+			name: "IPv4 CIDR is unchanged",
+			cidr: "10.244.0.0/16",
+			want: "10.244.0.0/16",
+		},
+		{
+			// IPv6 ":" must be replaced: it is the delimiter used to build the
+			// primary ID from external ID values.
+			name: "IPv6 CIDR colons are replaced with dots",
+			cidr: "fd01::/48",
+			want: "fd01../48",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildCIDRKey(tc.cidr); got != tc.want {
+				t.Fatalf("BuildCIDRKey(%q) = %q, want %q", tc.cidr, got, tc.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -50,6 +50,9 @@ const (
 	// UDNIsolationOwnerType means the object is needed to implement UserDefinedNetwork isolation
 	UDNIsolationOwnerType          ownerType = "UDNIsolation"
 	ClusterNetworkConnectOwnerType ownerType = "ClusterNetworkConnect"
+	// NoOverlayClusterSubnetSNATOwnerType is the cluster-subnet egress SNAT with
+	// no-overlay SNAT exemptions on a node's gateway router
+	NoOverlayClusterSubnetSNATOwnerType ownerType = "NoOverlayClusterSubnetSNAT"
 
 	// owner extra IDs, make sure to define only 1 ExternalIDKey for every string value
 	PriorityKey             ExternalIDKey = "priority"
@@ -395,6 +398,17 @@ var NATEgressIP = newObjectIDsType(nat, EgressIPOwnerType, []ExternalIDKey{
 	ObjectNameKey,
 	// the IP Family for this policy, ip4 or ip6 or ip(dualstack)
 	IPFamilyKey,
+})
+
+var NATNoOverlayClusterSubnetSNAT = newObjectIDsType(nat, NoOverlayClusterSubnetSNATOwnerType, []ExternalIDKey{
+	// the node whose gateway router holds this SNAT
+	ObjectNameKey,
+	// the SNATed cluster subnet
+	CIDRKey,
+	// the IP family of the cluster subnet, v4 or v6
+	IPFamilyKey,
+	// network name
+	NetworkKey,
 })
 
 var QoSEgressQoS = newObjectIDsType(qos, EgressQoSOwnerType, []ExternalIDKey{

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -1156,6 +1156,16 @@ func BuildDNATAndSNATWithMatch(
 //   - Compare LogicalIP if the Type in `searched` is SNAT.
 //   - Compare LogicalPort if it is set in `searched`.
 //   - Ensure that all ExternalIDs of `searched` exist and have the same value in `existing`.
+//   - Compare AllowedExtIPs if it is set in `searched`: callers create one SNAT
+//     per allowed destination set for the same logical IP, so AllowedExtIPs is
+//     what tells those rows apart.
+//
+// ExemptedExtIPs is intentionally not compared: a NAT with exemptions is the
+// only one for its logical IP, and its exemptions are mutable configuration
+// that reconciliation may need to update in place on the existing row.
+// Comparing ExemptedExtIPs would turn every such update into a new row, and
+// mirroring the one-SNAT-per-allowed-set pattern with exempted_ext_ips would
+// not work with this equivalence.
 func isEquivalentNAT(existing *nbdb.NAT, searched *nbdb.NAT) bool {
 	// Simple case: uuid was provided.
 	if searched.UUID != "" && existing.UUID == searched.UUID {
@@ -1192,11 +1202,6 @@ func isEquivalentNAT(existing *nbdb.NAT, searched *nbdb.NAT) bool {
 
 	if searched.AllowedExtIPs != nil &&
 		(existing.AllowedExtIPs == nil || *searched.AllowedExtIPs != *existing.AllowedExtIPs) {
-		return false
-	}
-
-	if searched.ExemptedExtIPs != nil &&
-		(existing.ExemptedExtIPs == nil || *searched.ExemptedExtIPs != *existing.ExemptedExtIPs) {
 		return false
 	}
 

--- a/go-controller/pkg/libovsdb/ops/router_test.go
+++ b/go-controller/pkg/libovsdb/ops/router_test.go
@@ -120,7 +120,7 @@ func TestBuildSNATWithAllowedExtIPs(t *testing.T) {
 	}
 }
 
-func TestEquivalentNATChecksProvidedExtIPAddressSets(t *testing.T) {
+func TestEquivalentNATChecksAllowedExtIPsButNotExemptedExtIPs(t *testing.T) {
 	externalIP := net.ParseIP("169.254.0.12")
 	_, logicalIP, err := net.ParseCIDR("100.128.0.0/24")
 	if err != nil {
@@ -137,6 +137,12 @@ func TestEquivalentNATChecksProvidedExtIPAddressSets(t *testing.T) {
 	broadSearch := BuildSNATWithMatch(&externalIP, logicalIP, "rtos-blue-node", externalIDs, "")
 	if !isEquivalentNAT(existing, broadSearch) {
 		t.Fatal("expected broad SNAT search without allowed_ext_ips to still match")
+	}
+
+	existing = BuildSNATWithExemptedExtIPs(&externalIP, logicalIP, "rtos-blue-node", externalIDs, "", "old-exempted-ext-ips-uuid")
+	searched = BuildSNATWithExemptedExtIPs(&externalIP, logicalIP, "rtos-blue-node", externalIDs, "", "new-exempted-ext-ips-uuid")
+	if !isEquivalentNAT(existing, searched) {
+		t.Fatal("expected SNATs with different exempted_ext_ips to match for update")
 	}
 }
 

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1789,12 +1789,14 @@ var _ = Describe("Node Operations", func() {
 	Context("on delete", func() {
 		It("deletes iptables rules with ExternalIP", func() {
 			app.Action = func(*cli.Context) error {
-				// Depending on the order of informer event processing the initial
-				// Service might be "added" once or twice.  Take that into account.
 				minNFakeCommands := nInitialFakeCommands + 1
+				// Depending on the order of informer event processing the initial
+				// Service might be "added" once or twice. Add one more command for
+				// the delete handler's OpenFlow sync.
+				maxNFakeCommands := nInitialFakeCommands + 2
 				fExec.AddRepeatedFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-ofctl show breth0",
-				}, minNFakeCommands)
+				}, maxNFakeCommands)
 
 				externalIP := "1.1.1.1"
 				service := *newService("service1", "namespace1", "10.129.0.2",

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -979,15 +979,11 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 	if !config.Gateway.DisableSNATMultipleGWs || gw.netInfo.IsPrimaryNetwork() {
 		var v4UUID, v6UUID string
 		var err error
-		if util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
+		snatExemptionNeeded := util.IsNoOverlaySNATExemptionNeeded(gw.netInfo)
+		controllerName := getNetworkControllerName(gw.netInfo.GetNetworkName())
+		if snatExemptionNeeded {
 			// Get the no-overlay SNAT exemption address set UUIDs
 			addressSetFactory := addressset.NewOvnAddressSetFactory(gw.nbClient, config.IPv4Mode, config.IPv6Mode)
-			// Use the correct controller name: default-network-controller for default network,
-			// <networkName>-network-controller for user-defined networks
-			controllerName := types.DefaultNetworkControllerName
-			if gw.netInfo.IsUserDefinedNetwork() {
-				controllerName = getNetworkControllerName(gw.netInfo.GetNetworkName())
-			}
 			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, controllerName)
 			if err != nil {
 				return fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
@@ -996,7 +992,7 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 
 		isNetworkAdvertised := gw.isRoutingAdvertised(nodeName)
 		var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
-		if isNetworkAdvertised && !util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
+		if isNetworkAdvertised && !snatExemptionNeeded {
 			clusterNodeIPsAddrSetDbIDs, err = gw.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
 			if err != nil {
 				return fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
@@ -1030,12 +1026,35 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 				exemptedExtIPs = v4UUID
 			}
 
-			nat = libovsdbops.BuildSNATWithExemptedExtIPs(&externalIP[0], entry, "", extIDs, snatMatch, exemptedExtIPs)
+			natExtIDs := extIDs
+			if snatExemptionNeeded {
+				// Mark the SNAT with DB IDs so that it can be told apart from
+				// cluster-subnet SNATs created without exemptions.
+				natExtIDs = getNoOverlayClusterSubnetSNATDbIDs(controllerName, gw.netInfo.GetNetworkName(), nodeName, entry).GetExternalIDs()
+				maps.Copy(natExtIDs, extIDs)
+			}
+
+			nat = libovsdbops.BuildSNATWithExemptedExtIPs(&externalIP[0], entry, "", natExtIDs, snatMatch, exemptedExtIPs)
 			nats = append(nats, nat)
 		}
-		err = libovsdbops.CreateOrUpdateNATs(gw.nbClient, gwRouter, nats...)
+		natOps, err := libovsdbops.CreateOrUpdateNATsOps(gw.nbClient, nil, gwRouter, nats...)
 		if err != nil {
-			return fmt.Errorf("failed to update SNAT rule for pod on router %s error: %v", gw.gwRouterName, err)
+			return fmt.Errorf("failed to build SNAT ops for pod on router %s error: %w", gw.gwRouterName, err)
+		}
+		if snatExemptionNeeded {
+			// A cluster-subnet SNAT without our DB IDs is not matched by the ops
+			// above and would keep SNATing exempted traffic: delete such stale
+			// rows in the same transaction, so the exempted SNAT never coexists
+			// with a stale twin. Stale rows are left behind by versions that
+			// predate the DB IDs or by a transport switch from overlay to
+			// no-overlay.
+			natOps, err = gw.deleteStaleNoOverlayClusterSNATsOps(natOps, gwRouter, controllerName, nats)
+			if err != nil {
+				return fmt.Errorf("failed to build stale no-overlay SNAT cleanup ops on router %s error: %w", gw.gwRouterName, err)
+			}
+		}
+		if _, err := libovsdbops.TransactAndCheck(gw.nbClient, natOps); err != nil {
+			return fmt.Errorf("failed to update SNAT rule for pod on router %s error: %w", gw.gwRouterName, err)
 		}
 	} else {
 		// ensure we do not have any leftover SNAT entries after an upgrade
@@ -1053,6 +1072,95 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 		return fmt.Errorf("failed to sync stale SNATs on node %s: %v", nodeName, err)
 	}
 	return nil
+}
+
+// getNoOverlayClusterSubnetSNATDbIDs returns the DB IDs identifying the SNAT
+// that a gateway router applies to a cluster subnet, with no-overlay SNAT
+// exemptions, on the network scoped by controllerName and networkName.
+func getNoOverlayClusterSubnetSNATDbIDs(controllerName, networkName, nodeName string, clusterSubnet *net.IPNet) *libovsdbops.DbObjectIDs {
+	// Use the same ip-family value ("ip4"/"ip6") as the other NAT owners so the
+	// rows can be looked up consistently.
+	ipFamily := string(IPFamilyValueV4)
+	if utilnet.IsIPv6CIDR(clusterSubnet) {
+		ipFamily = string(IPFamilyValueV6)
+	}
+	return libovsdbops.NewDbObjectIDs(libovsdbops.NATNoOverlayClusterSubnetSNAT, controllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: nodeName,
+			libovsdbops.CIDRKey:       libovsdbops.BuildCIDRKey(clusterSubnet.String()),
+			libovsdbops.IPFamilyKey:   ipFamily,
+			libovsdbops.NetworkKey:    networkName,
+		})
+}
+
+// deleteStaleNoOverlayClusterSNATsOps appends operations that delete stale
+// cluster-subnet SNATs from the gateway router. desiredNATs are the DB-ID-marked
+// SNATs that the router should have. A stale SNAT is either a marked row whose
+// DB IDs no longer match any desired SNAT, e.g. for a cluster subnet that was
+// removed, or an unmarked SNAT for the same logical IP as a desired SNAT, left
+// behind by a version that predates the DB IDs or by a default network
+// transport switch from overlay to no-overlay. Either would keep SNATing
+// traffic that must be exempted: deleting them in the same transaction that
+// creates or updates the desired SNATs guarantees the exempted SNAT never
+// coexists with a stale twin.
+func (gw *GatewayManager) deleteStaleNoOverlayClusterSNATsOps(ops []ovsdb.Operation, gwRouter *nbdb.LogicalRouter, controllerName string, desiredNATs []*nbdb.NAT) ([]ovsdb.Operation, error) {
+	// A desired row is identified by the primary ID of its DB IDs, which this
+	// function computes on its own: identifying it by row UUID would depend on
+	// CreateOrUpdateNATsOps having already resolved the row UUIDs into
+	// desiredNATs, that is, on how the enclosing transaction is built.
+	primaryIDKey := libovsdbops.PrimaryIDKey.String()
+	desiredPrimaryIDs := sets.Set[string]{}
+	for _, desiredNAT := range desiredNATs {
+		desiredPrimaryIDs.Insert(desiredNAT.ExternalIDs[primaryIDKey])
+	}
+
+	routerNATs, err := libovsdbops.GetRouterNATs(gw.nbClient, gwRouter)
+	if err != nil {
+		return ops, fmt.Errorf("unable to get NAT entries for router %+v: %w", gwRouter, err)
+	}
+
+	isMarkedClusterSubnetSNAT := libovsdbops.GetPredicate[*nbdb.NAT](
+		libovsdbops.NewDbObjectIDs(libovsdbops.NATNoOverlayClusterSubnetSNAT, controllerName, nil), nil)
+
+	staleNATUUIDs := sets.Set[string]{}
+	for _, routerNAT := range routerNATs {
+		if isMarkedClusterSubnetSNAT(routerNAT) {
+			// Keep the marked rows that are still desired.
+			if !desiredPrimaryIDs.Has(routerNAT.ExternalIDs[primaryIDKey]) {
+				staleNATUUIDs.Insert(routerNAT.UUID)
+			}
+			continue
+		}
+		// An unmarked SNAT for the same cluster subnet as a desired SNAT,
+		// created without exemptions before they were enabled on this network.
+		// The logical IP alone identifies it: the gateway router holds at most
+		// one cluster-subnet SNAT per subnet, so any twin, even one carrying a
+		// stale external IP, is stale.
+		for _, desiredNAT := range desiredNATs {
+			if routerNAT.Type == nbdb.NATTypeSNAT &&
+				routerNAT.LogicalIP == desiredNAT.LogicalIP &&
+				ptr.Equal(routerNAT.LogicalPort, desiredNAT.LogicalPort) {
+				staleNATUUIDs.Insert(routerNAT.UUID)
+				break
+			}
+		}
+	}
+
+	if staleNATUUIDs.Len() == 0 {
+		return ops, nil
+	}
+
+	// Delete by exact row UUID: a model-based delete falls back to NAT
+	// equivalence, which ignores exempted_ext_ips and matches external IDs as a
+	// subset, so an unmarked twin's model would also match its marked desired
+	// row and delete it.
+	ops, err = libovsdbops.DeleteNATsWithPredicateOps(gw.nbClient, ops, func(nat *nbdb.NAT) bool {
+		return staleNATUUIDs.Has(nat.UUID)
+	})
+	if err != nil {
+		return ops, fmt.Errorf("unable to build stale no-overlay SNAT cleanup operations for router %s: %w", gwRouter.Name, err)
+	}
+	return ops, nil
 }
 
 // gatewayInit creates a gateway router for the local chassis.

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -2260,6 +2260,283 @@ func extractExternalIPs(l3GatewayConfig *util.L3GatewayConfig) []net.IP {
 	return externalIPs
 }
 
+var _ = ginkgo.Describe("No-overlay cluster SNAT cleanup", func() {
+	var fakeOvn *FakeOVN
+
+	buildMarkedClusterSNAT := func(externalIP net.IP, clusterSubnet *net.IPNet, exemptedExtIPs, uuid string) *nbdb.NAT {
+		extIDs := getNoOverlayClusterSubnetSNATDbIDs(types.DefaultNetworkControllerName, types.DefaultNetworkName,
+			nodeName, clusterSubnet).GetExternalIDs()
+		nat := libovsdbops.BuildSNATWithExemptedExtIPs(&externalIP, clusterSubnet, "", extIDs, "", exemptedExtIPs)
+		nat.UUID = uuid
+		return nat
+	}
+
+	buildUnmarkedClusterSNAT := func(externalIP net.IP, clusterSubnet *net.IPNet, exemptedExtIPs, uuid string) *nbdb.NAT {
+		nat := libovsdbops.BuildSNATWithExemptedExtIPs(&externalIP, clusterSubnet, "", nil, "", exemptedExtIPs)
+		nat.UUID = uuid
+		return nat
+	}
+
+	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		config.Gateway.Mode = config.GatewayModeShared
+		config.Gateway.EphemeralPortRange = config.DefaultEphemeralPortRange
+		fakeOvn = NewFakeOVN(false)
+	})
+
+	ginkgo.AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	ginkgo.It("removes unmarked cluster subnet SNATs with missing or stale exemptions", func() {
+		externalIPv4 := net.ParseIP("172.18.0.5")
+		externalIPv6 := net.ParseIP("fd00::5")
+		clusterSubnetV4 := ovntest.MustParseIPNets("10.244.0.0/16")[0]
+		clusterSubnetV6 := ovntest.MustParseIPNets("fd01::/48")[0]
+		joinSubnet := ovntest.MustParseIPNets("100.64.0.2/32")[0]
+
+		plainSNATV4 := buildUnmarkedClusterSNAT(externalIPv4, clusterSubnetV4, "", "plain-snat-v4-UUID")
+		staleSNATV4 := buildUnmarkedClusterSNAT(externalIPv4, clusterSubnetV4, "stale-as-v4-UUID", "stale-snat-v4-UUID")
+		desiredSNATV4 := buildMarkedClusterSNAT(externalIPv4, clusterSubnetV4, "desired-as-v4-UUID", "desired-snat-v4-UUID")
+		plainSNATV6 := buildUnmarkedClusterSNAT(externalIPv6, clusterSubnetV6, "", "plain-snat-v6-UUID")
+		staleSNATV6 := buildUnmarkedClusterSNAT(externalIPv6, clusterSubnetV6, "stale-as-v6-UUID", "stale-snat-v6-UUID")
+		desiredSNATV6 := buildMarkedClusterSNAT(externalIPv6, clusterSubnetV6, "desired-as-v6-UUID", "desired-snat-v6-UUID")
+		joinSNAT := libovsdbops.BuildSNAT(&externalIPv4, joinSubnet, "", nil)
+		joinSNAT.UUID = "join-snat-UUID"
+		desiredAddressSetV4 := &nbdb.AddressSet{
+			UUID: "desired-as-v4-UUID",
+			Name: "desired-as-v4",
+		}
+		desiredAddressSetV6 := &nbdb.AddressSet{
+			UUID: "desired-as-v6-UUID",
+			Name: "desired-as-v6",
+		}
+		staleAddressSetV4 := &nbdb.AddressSet{
+			UUID: "stale-as-v4-UUID",
+			Name: "stale-as-v4",
+		}
+		staleAddressSetV6 := &nbdb.AddressSet{
+			UUID: "stale-as-v6-UUID",
+			Name: "stale-as-v6",
+		}
+
+		gwRouter := &nbdb.LogicalRouter{
+			UUID: "GR_" + nodeName + "-UUID",
+			Name: "GR_" + nodeName,
+			Nat: []string{
+				plainSNATV4.UUID, desiredSNATV4.UUID, staleSNATV4.UUID,
+				plainSNATV6.UUID, desiredSNATV6.UUID, staleSNATV6.UUID,
+				joinSNAT.UUID,
+			},
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				gwRouter,
+				plainSNATV4, desiredSNATV4, staleSNATV4,
+				plainSNATV6, desiredSNATV6, staleSNATV6,
+				joinSNAT,
+				desiredAddressSetV4, desiredAddressSetV6,
+				staleAddressSetV4, staleAddressSetV6,
+			},
+		})
+		asV4UUID := resolveDesiredClusterSNAT(fakeOvn, desiredSNATV4, desiredAddressSetV4.Name)
+		asV6UUID := resolveDesiredClusterSNAT(fakeOvn, desiredSNATV6, desiredAddressSetV6.Name)
+
+		gw := newGatewayManager(fakeOvn, nodeName)
+		err := transactClusterSNATSync(fakeOvn, gw, gwRouter, types.DefaultNetworkControllerName, []*nbdb.NAT{desiredSNATV4, desiredSNATV6})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		routerNATs, err := libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		remainingJoinSNATs := []*nbdb.NAT{}
+		for _, nat := range routerNATs {
+			if nat.LogicalIP == "100.64.0.2" {
+				remainingJoinSNATs = append(remainingJoinSNATs, nat)
+			}
+		}
+		expectRouterClusterSNATWithExemption(routerNATs, clusterSubnetV4.String(), asV4UUID)
+		expectRouterClusterSNATWithExemption(routerNATs, clusterSubnetV6.String(), asV6UUID)
+		gomega.Expect(remainingJoinSNATs).To(gomega.HaveLen(1))
+
+		clusterSNATsV4, err := libovsdbops.FindNATsWithPredicate(fakeOvn.nbClient, func(nat *nbdb.NAT) bool {
+			return nat.Type == nbdb.NATTypeSNAT &&
+				nat.ExternalIP == externalIPv4.String() &&
+				nat.LogicalIP == clusterSubnetV4.String()
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(clusterSNATsV4).To(gomega.HaveLen(1))
+		clusterSNATsV6, err := libovsdbops.FindNATsWithPredicate(fakeOvn.nbClient, func(nat *nbdb.NAT) bool {
+			return nat.Type == nbdb.NATTypeSNAT &&
+				nat.ExternalIP == externalIPv6.String() &&
+				nat.LogicalIP == clusterSubnetV6.String()
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(clusterSNATsV6).To(gomega.HaveLen(1))
+	})
+
+	ginkgo.It("removes marked cluster subnet SNATs that are no longer desired", func() {
+		externalIP := net.ParseIP("172.18.0.5")
+		clusterSubnet := ovntest.MustParseIPNets("10.244.0.0/16")[0]
+		oldClusterSubnet := ovntest.MustParseIPNets("10.128.0.0/16")[0]
+
+		desiredSNAT := buildMarkedClusterSNAT(externalIP, clusterSubnet, "desired-as-UUID", "desired-snat-UUID")
+		undesiredSNAT := buildMarkedClusterSNAT(externalIP, oldClusterSubnet, "desired-as-UUID", "undesired-snat-UUID")
+		desiredAddressSet := &nbdb.AddressSet{
+			UUID: "desired-as-UUID",
+			Name: "desired-as",
+		}
+
+		gwRouter := &nbdb.LogicalRouter{
+			UUID: "GR_" + nodeName + "-UUID",
+			Name: "GR_" + nodeName,
+			Nat:  []string{desiredSNAT.UUID, undesiredSNAT.UUID},
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{gwRouter, desiredSNAT, undesiredSNAT, desiredAddressSet},
+		})
+		resolveDesiredClusterSNAT(fakeOvn, desiredSNAT, desiredAddressSet.Name)
+
+		gw := newGatewayManager(fakeOvn, nodeName)
+		err := transactClusterSNATSync(fakeOvn, gw, gwRouter, types.DefaultNetworkControllerName, []*nbdb.NAT{desiredSNAT})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		routerNATs, err := libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(routerNATs).To(gomega.HaveLen(1))
+		gomega.Expect(routerNATs[0].UUID).To(gomega.Equal(desiredSNAT.UUID))
+		gomega.Expect(routerNATs[0].LogicalIP).To(gomega.Equal(clusterSubnet.String()))
+	})
+
+	ginkgo.It("only cleans up the given gateway router", func() {
+		externalIP := net.ParseIP("172.18.0.5")
+		clusterSubnet := ovntest.MustParseIPNets("10.244.0.0/16")[0]
+		desiredAddressSet := &nbdb.AddressSet{
+			UUID: "desired-as-UUID",
+			Name: "desired-as",
+		}
+		testData := []libovsdbtest.TestData{desiredAddressSet}
+		gwRouters := []*nbdb.LogicalRouter{}
+		desiredSNATs := map[string]*nbdb.NAT{}
+
+		for _, gwNodeName := range []string{"test-node-a", "test-node-b"} {
+			plainSNAT := buildUnmarkedClusterSNAT(externalIP, clusterSubnet, "", "plain-snat-"+gwNodeName+"-UUID")
+			desiredSNAT := buildMarkedClusterSNAT(externalIP, clusterSubnet, desiredAddressSet.UUID, "desired-snat-"+gwNodeName+"-UUID")
+			gwRouter := &nbdb.LogicalRouter{
+				UUID: "GR_" + gwNodeName + "-UUID",
+				Name: "GR_" + gwNodeName,
+				Nat:  []string{plainSNAT.UUID, desiredSNAT.UUID},
+			}
+			gwRouters = append(gwRouters, gwRouter)
+			desiredSNATs[gwRouter.Name] = desiredSNAT
+			testData = append(testData, gwRouter, plainSNAT, desiredSNAT)
+		}
+
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: testData})
+		// Both routers share the same exemption address set.
+		resolvedAS, err := libovsdbops.GetAddressSet(fakeOvn.nbClient, &nbdb.AddressSet{Name: desiredAddressSet.Name})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, gwRouter := range gwRouters {
+			resolveDesiredClusterSNAT(fakeOvn, desiredSNATs[gwRouter.Name], desiredAddressSet.Name)
+		}
+
+		gw := newGatewayManager(fakeOvn, nodeName)
+		err = transactClusterSNATSync(fakeOvn, gw, gwRouters[0], types.DefaultNetworkControllerName, []*nbdb.NAT{desiredSNATs[gwRouters[0].Name]})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// the first router is cleaned up, the second one is untouched
+		routerNATs, err := libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouters[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(routerNATs).To(gomega.HaveLen(1))
+		gomega.Expect(routerNATs[0].UUID).To(gomega.Equal(desiredSNATs[gwRouters[0].Name].UUID))
+		routerNATs, err = libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouters[1])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(routerNATs).To(gomega.HaveLen(2))
+
+		err = transactClusterSNATSync(fakeOvn, gw, gwRouters[1], types.DefaultNetworkControllerName, []*nbdb.NAT{desiredSNATs[gwRouters[1].Name]})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for _, gwRouter := range gwRouters {
+			routerNATs, err := libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouter)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(routerNATs).To(gomega.HaveLen(1))
+			gomega.Expect(routerNATs[0].ExemptedExtIPs).NotTo(gomega.BeNil())
+			gomega.Expect(*routerNATs[0].ExemptedExtIPs).To(gomega.Equal(resolvedAS.UUID))
+		}
+	})
+
+	ginkgo.It("replaces an unmarked cluster subnet SNAT and keeps the marked one on a second sync", func() {
+		externalIP := net.ParseIP("172.18.0.5")
+		clusterSubnet := ovntest.MustParseIPNets("10.244.0.0/16")[0]
+
+		plainSNAT := buildUnmarkedClusterSNAT(externalIP, clusterSubnet, "", "plain-snat-UUID")
+		desiredAddressSet := &nbdb.AddressSet{
+			UUID: "desired-as-UUID",
+			Name: "desired-as",
+		}
+		gwRouter := &nbdb.LogicalRouter{
+			UUID: "GR_" + nodeName + "-UUID",
+			Name: "GR_" + nodeName,
+			Nat:  []string{plainSNAT.UUID},
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{gwRouter, plainSNAT, desiredAddressSet},
+		})
+
+		gw := newGatewayManager(fakeOvn, nodeName)
+		syncOnce := func() string {
+			// updateGWRouterNAT builds the desired SNATs from scratch on every sync
+			desiredSNAT := buildMarkedClusterSNAT(externalIP, clusterSubnet, "", "")
+			asUUID := resolveDesiredClusterSNAT(fakeOvn, desiredSNAT, desiredAddressSet.Name)
+			err := transactClusterSNATSync(fakeOvn, gw, gwRouter, types.DefaultNetworkControllerName, []*nbdb.NAT{desiredSNAT})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			return asUUID
+		}
+
+		// on upgrade, the plain SNAT is replaced by a marked, exempted one
+		asUUID := syncOnce()
+		routerNATs, err := libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(routerNATs).To(gomega.HaveLen(1))
+		gomega.Expect(routerNATs[0].ExternalIDs).To(gomega.HaveKey(libovsdbops.PrimaryIDKey.String()))
+		expectRouterClusterSNATWithExemption(routerNATs, clusterSubnet.String(), asUUID)
+		markedUUID := routerNATs[0].UUID
+
+		// a steady-state second sync leaves the row untouched
+		syncOnce()
+		routerNATs, err = libovsdbops.GetRouterNATs(fakeOvn.nbClient, gwRouter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(routerNATs).To(gomega.HaveLen(1))
+		gomega.Expect(routerNATs[0].UUID).To(gomega.Equal(markedUUID))
+		expectRouterClusterSNATWithExemption(routerNATs, clusterSubnet.String(), asUUID)
+	})
+})
+
+// resolveDesiredClusterSNAT updates a placeholder desired SNAT to reference the
+// real UUID of the exemption address set in the test DB, and returns that UUID
+// so callers can assert on it.
+func resolveDesiredClusterSNAT(fakeOvn *FakeOVN, desiredSNAT *nbdb.NAT, addressSetName string) string {
+	as, err := libovsdbops.GetAddressSet(fakeOvn.nbClient, &nbdb.AddressSet{Name: addressSetName})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	desiredSNAT.ExemptedExtIPs = &as.UUID
+	return as.UUID
+}
+
+// transactClusterSNATSync builds and commits the cluster-subnet SNAT ops for a
+// single gateway router the same way updateGWRouterNAT does: create or update
+// the desired SNATs and delete the stale rows, all in one transaction.
+func transactClusterSNATSync(fakeOvn *FakeOVN, gw *GatewayManager, gwRouter *nbdb.LogicalRouter, controllerName string, desiredNATs []*nbdb.NAT) error {
+	ops, err := libovsdbops.CreateOrUpdateNATsOps(fakeOvn.nbClient, nil, gwRouter, desiredNATs...)
+	if err != nil {
+		return err
+	}
+	ops, err = gw.deleteStaleNoOverlayClusterSNATsOps(ops, gwRouter, controllerName, desiredNATs)
+	if err != nil {
+		return err
+	}
+	_, err = libovsdbops.TransactAndCheck(fakeOvn.nbClient, ops)
+	return err
+}
+
 var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 	var (
 		fakeOvn           *FakeOVN

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -2580,6 +2580,24 @@ var _ = ginkgo.Describe("AddPodSNATOps", func() {
 		gomega.Expect(foundNATOp).To(gomega.BeTrue(), "Should have NAT insert operation")
 	})
 
+	ginkgo.It("returns an error when the no-overlay exemption address set is missing", func() {
+		originalTransport := config.Default.Transport
+		defer func() { config.Default.Transport = originalTransport }()
+		config.Default.Transport = types.NetworkTransportNoOverlay
+
+		originalOutboundSNAT := config.NoOverlay.OutboundSNAT
+		defer func() { config.NoOverlay.OutboundSNAT = originalOutboundSNAT }()
+		config.NoOverlay.OutboundSNAT = types.NoOverlaySNATEnabled
+
+		originalGatewayMode := config.Gateway.Mode
+		defer func() { config.Gateway.Mode = originalGatewayMode }()
+		config.Gateway.Mode = config.GatewayModeShared
+
+		ops, err := controller.AddPodSNATOps(nodeName, ovntest.MustParseIPNets("10.128.1.5/24"))
+		gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("no-overlay SNAT exemption address set")))
+		gomega.Expect(ops).To(gomega.BeNil())
+	})
+
 	ginkgo.It("returns error when node is not found", func() {
 		podIPs := ovntest.MustParseIPNets("10.128.1.5/24")
 

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -776,8 +776,8 @@ func (oc *Layer3UserDefinedNetworkController) init() (err error) {
 	// This is needed for both local and shared gateway modes
 	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
 		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled {
-		if _, err := initNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
-			return fmt.Errorf("failed to initialize noOverlay SNAT exemption address set for network %s: %w", oc.GetNetworkName(), err)
+		if _, err := ensureNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+			return fmt.Errorf("failed to ensure noOverlay SNAT exemption address set for network %s: %w", oc.GetNetworkName(), err)
 		}
 	}
 

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -803,6 +803,34 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 	}
 
 	klog.Infof("Adding or Updating local node %q for network %q", node.Name, oc.GetNetworkName())
+
+	// Sync the no-overlay SNAT exemption address set before any SNAT that
+	// references it is created: addNode() adds the local-gateway egress SNAT
+	// and SyncGateway() the shared-gateway cluster-subnet SNAT. Stop and retry
+	// on failure, so that we never SNAT east-west traffic that must be exempted.
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+		(nSyncs.syncNode || nSyncs.syncGw) {
+		hostAddrs, err := util.GetNodeHostAddrs(node)
+		if err == nil {
+			err = syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, hostAddrs)
+		}
+		if err != nil {
+			if nSyncs.syncNode {
+				oc.addNodeFailed.Store(node.Name, true)
+				oc.nodeClusterRouterPortFailed.Store(node.Name, true)
+				oc.mgmtPortFailed.Store(node.Name, true)
+				oc.syncZoneICFailed.Store(node.Name, true)
+				oc.syncEIPNodeRerouteFailed.Store(node.Name, true)
+			}
+			oc.gatewaysFailed.Store(node.Name, true)
+			err = fmt.Errorf("nodeAdd: error syncing no-overlay SNAT exemption address set for node %q for network %s: %w",
+				node.Name, oc.GetNetworkName(), err)
+			oc.recordNodeErrorEvent(node, err)
+			return err
+		}
+	}
+
 	if nSyncs.syncNode {
 		if hostSubnets, err = oc.addNode(node); err != nil {
 			oc.addNodeFailed.Store(node.Name, true)
@@ -849,21 +877,6 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 	if nSyncs.syncNode { // do this only if it is a new node add
 		errors := oc.addAllPodsOnNode(node.Name)
 		errs = append(errs, errors...)
-	}
-
-	// Sync noOverlay SNAT exemption address set BEFORE gateway initialization
-	// This must happen before the gateway creates SNAT rules that reference the address set
-	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
-		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
-		(nSyncs.syncNode || nSyncs.syncGw) {
-		hostAddrs, err := util.GetNodeHostAddrs(node)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get host addresses for node %s: %w", node.Name, err))
-		} else {
-			if err := syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, hostAddrs); err != nil {
-				errs = append(errs, fmt.Errorf("failed to sync noOverlay SNAT exemption address set: %w", err))
-			}
-		}
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1414,6 +1414,92 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		Expect(app.Run([]string{app.Name})).To(Succeed())
 	})
 
+	// The exemption address set must be synced before any SNAT that references
+	// it is created; if the sync fails, no SNAT may be created at all.
+	It("does not create SNAT rules when the exemption address set cannot be synced", func() {
+		By("Setting up LOCAL gateway mode configuration")
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			netConf := cudnNetInfo.netconf()
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+			By("Corrupting the host-cidrs annotation so that the exemption address set sync fails")
+			testNode.Annotations[util.OVNNodeHostCIDRs] = "not-a-json-list"
+
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+
+			By("Initializing CUDN controller")
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group",
+			})
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			By("Starting node watch on L3 UDN controller")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+
+			By("Adding the node to trigger addUpdateLocalNodeEvent()")
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Expecting the node sync to fail and be deferred for retry")
+			Eventually(func() bool {
+				_, failed := fullL3UDNController.gatewaysFailed.Load(nodeName)
+				return failed
+			}).WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).Should(BeTrue())
+			Eventually(func() bool {
+				_, failed := fullL3UDNController.addNodeFailed.Load(nodeName)
+				return failed
+			}).WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).Should(BeTrue())
+
+			By("Expecting no SNAT to have been created")
+			Consistently(func() []*nbdb.NAT {
+				nats, err := libovsdbops.FindNATsWithPredicate(fakeOvn.nbClient, func(*nbdb.NAT) bool { return true })
+				Expect(err).NotTo(HaveOccurred())
+				return nats
+			}).WithTimeout(2 * time.Second).WithPolling(200 * time.Millisecond).Should(BeEmpty())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
 	// Test 2: Verify SNAT with exempted_ext_ips is created on GR_<node> in SHARED gateway mode
 	It("creates SNAT with exempted address set in shared gateway mode on gateway router", func() {
 		// Step 1: Set config.Gateway.Mode = config.GatewayModeShared

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -645,6 +645,28 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *corev1.Node, n
 		}
 	}
 
+	// Sync no-overlay SNAT exemption address set before gateway sync. Gateway
+	// NAT creation needs the address set UUID to avoid creating a plain SNAT
+	// that must be fixed by a later reconciliation.
+	if util.IsNoOverlaySNATExemptionNeeded(oc) && (nSyncs.syncNode || nSyncs.syncGw) {
+		var addressSetErr error
+		hostAddrs, err := util.GetNodeHostAddrs(node)
+		if err != nil {
+			addressSetErr = fmt.Errorf("failed to get host addresses for node %s: %w", node.Name, err)
+		} else if err := syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, hostAddrs); err != nil {
+			addressSetErr = fmt.Errorf("failed to sync no-overlay SNAT exemption address set for node %s: %w", node.Name, err)
+		}
+		if addressSetErr != nil {
+			errs = append(errs, addressSetErr)
+			if nSyncs.syncGw {
+				// don't sync the gateway without the address set; mark it failed
+				// so that gateway sync is retried on the next event
+				nSyncs.syncGw = false
+				oc.gatewaysFailed.Store(node.Name, true)
+			}
+		}
+	}
+
 	if nSyncs.syncGw {
 		err := oc.syncNodeGateway(node)
 		if err != nil {
@@ -692,21 +714,6 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *corev1.Node, n
 		} else if !chassisFailed {
 			// In no-overlay mode, if chassis handler succeeded, clear the failed state
 			oc.syncZoneICFailed.Delete(node.Name)
-		}
-	}
-
-	// Sync no-overlay SNAT exemption address set for no-overlay mode with outbound SNAT enabled in SGW mode.
-	// The address set contains cluster CIDRs + local zone node IPs and is used in SNAT
-	// exemption rules to prevent SNATing pod-to-pod and pod-to-local-node traffic.
-	// In LGW mode, nftables sets are used instead.
-	if util.IsNoOverlaySNATExemptionNeeded(oc) && (nSyncs.syncNode || nSyncs.syncGw) {
-		hostAddrs, err := util.GetNodeHostAddrs(node)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get host addresses for node %s: %w", node.Name, err))
-		} else {
-			if err := syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, hostAddrs); err != nil {
-				errs = append(errs, fmt.Errorf("failed to sync no-overlay SNAT exemption address set: %w", err))
-			}
 		}
 	}
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -41,6 +42,7 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/sbdb"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -441,6 +443,35 @@ func startDefaultNodeController(oc *DefaultNetworkController) {
 	})
 }
 
+func expectRecordedClusterSNATInsertWithExemption(recordingClient *libovsdbtest.RecordingClient, logicalIP, exemptedExtIP string) {
+	var clusterSNATInsertOps []ovsdb.Operation
+	for _, txn := range recordingClient.Transactions {
+		for _, op := range txn {
+			if op.Op == ovsdb.OperationInsert && op.Table == "NAT" &&
+				op.Row["type"] == nbdb.NATTypeSNAT && op.Row["logical_ip"] == logicalIP {
+				clusterSNATInsertOps = append(clusterSNATInsertOps, op)
+			}
+		}
+	}
+	gomega.Expect(clusterSNATInsertOps).To(gomega.HaveLen(1))
+	gomega.Expect(clusterSNATInsertOps[0].Row).To(gomega.HaveKey("exempted_ext_ips"))
+	exemptedExtIPs, ok := clusterSNATInsertOps[0].Row["exempted_ext_ips"].(ovsdb.OvsSet)
+	gomega.Expect(ok).To(gomega.BeTrue())
+	gomega.Expect(exemptedExtIPs.GoSet).To(gomega.ConsistOf(ovsdb.UUID{GoUUID: exemptedExtIP}))
+}
+
+func expectRouterClusterSNATWithExemption(routerNATs []*nbdb.NAT, logicalIP, exemptedExtIP string) {
+	var clusterSNATs []*nbdb.NAT
+	for _, nat := range routerNATs {
+		if nat.Type == nbdb.NATTypeSNAT && nat.LogicalIP == logicalIP {
+			clusterSNATs = append(clusterSNATs, nat)
+		}
+	}
+	gomega.Expect(clusterSNATs).To(gomega.HaveLen(1))
+	gomega.Expect(clusterSNATs[0].ExemptedExtIPs).NotTo(gomega.BeNil())
+	gomega.Expect(*clusterSNATs[0].ExemptedExtIPs).To(gomega.Equal(exemptedExtIP))
+}
+
 var _ = ginkgo.Describe("Default network controller operations", func() {
 	var (
 		app      *cli.App
@@ -763,6 +794,69 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		err := app.Run([]string{
 			app.Name,
 			"-cluster-subnets=" + clusterCIDR,
+			"--init-gateways",
+			"--nodeport",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("syncs dual-stack no-overlay SNAT exemption address set before gateway NATs", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			config.Default.Transport = types.NetworkTransportNoOverlay
+			config.NoOverlay.OutboundSNAT = types.NoOverlaySNATEnabled
+			oc.addressSetFactory = addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
+			oc.ovnClusterLRPToJoinIfAddrs, err = oc.getOVNClusterRouterPortToJoinSwitchIfAddrs()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// a no-overlay network is always advertised: create the global
+			// advertised-network isolation resources that node sync relies on
+			gomega.Expect(ConfigureAdvertisedNetworkIsolation(nbClient)).To(gomega.Succeed())
+
+			dualStackGatewayConfig := node1.gatewayConfig(config.GatewayModeLocal, uint(vlanID))
+			dualStackGatewayConfig.IPAddresses = ovntest.MustParseIPNets(node1.GatewayRouterIPMask, "fd99::2/64")
+			dualStackGatewayConfig.NextHops = ovntest.MustParseIPs(node1.GatewayRouterNextHop, "fd99::1")
+			gomega.Expect(util.SetL3GatewayConfig(nodeAnnotator, dualStackGatewayConfig)).To(gomega.Succeed())
+			gomega.Expect(util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet, "aef0:0:0:1::/64"))).To(gomega.Succeed())
+			gomega.Expect(util.SetNodeHostCIDRs(nodeAnnotator, sets.New(fmt.Sprintf("%s/24", node1.NodeIP), "fd99::2/64"))).To(gomega.Succeed())
+			gomega.Expect(nodeAnnotator.Run()).To(gomega.Succeed())
+
+			recordingClient := libovsdbtest.NewRecordingClient(nbClient)
+			oc.nbClient = recordingClient
+			node, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = oc.addUpdateLocalNodeEvent(node, &nodeSyncs{
+				syncNode:              true,
+				syncClusterRouterPort: true,
+				syncMgmtPort:          true,
+				syncGw:                true,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			as, err := getNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(as).NotTo(gomega.BeNil())
+			v4UUID, v6UUID := as.GetASUUID()
+			gomega.Expect(v4UUID).NotTo(gomega.BeEmpty())
+			gomega.Expect(v6UUID).NotTo(gomega.BeEmpty())
+
+			expectRecordedClusterSNATInsertWithExemption(recordingClient, clusterCIDR, v4UUID)
+			expectRecordedClusterSNATInsertWithExemption(recordingClient, clusterv6CIDR, v6UUID)
+
+			routerNATs, err := libovsdbops.GetRouterNATs(nbClient, &nbdb.LogicalRouter{Name: types.GWRouterPrefix + node1.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			expectRouterClusterSNATWithExemption(routerNATs, clusterCIDR, v4UUID)
+			expectRouterClusterSNATWithExemption(routerNATs, clusterv6CIDR, v6UUID)
+			_, failed := oc.gatewaysFailed.Load(testNode.Name)
+			gomega.Expect(failed).To(gomega.BeFalse())
+
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR + "," + clusterv6CIDR,
+			"-k8s-service-cidr=10.96.0.0/16,fd00:10:96::/112",
 			"--init-gateways",
 			"--nodeport",
 		})

--- a/go-controller/pkg/ovn/no_overlay_snat_exemption.go
+++ b/go-controller/pkg/ovn/no_overlay_snat_exemption.go
@@ -19,13 +19,8 @@ const (
 	asName = "no-overlay-snat-exemption"
 )
 
-// initNoOverlaySNATExemptionAddressSet creates the address set for SNAT exemption in no-overlay mode.
-func initNoOverlaySNATExemptionAddressSet(
-	addressSetFactory addressset.AddressSetFactory,
-	netInfo util.NetInfo,
-	controllerName string,
-) (addressset.AddressSet, error) {
-	dbIDs := libovsdbops.NewDbObjectIDs(
+func getNoOverlaySNATExemptionAddressSetDbIDs(netInfo util.NetInfo, controllerName string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(
 		libovsdbops.AddressSetNoOverlaySNATExemption,
 		controllerName,
 		map[libovsdbops.ExternalIDKey]string{
@@ -33,16 +28,26 @@ func initNoOverlaySNATExemptionAddressSet(
 			libovsdbops.NetworkKey:    netInfo.GetNetworkName(),
 		},
 	)
+}
 
-	// Create the address set with empty initial addresses
+// ensureNoOverlaySNATExemptionAddressSet ensures that the address set for SNAT exemption in
+// no-overlay mode exists for every enabled IP family.
+func ensureNoOverlaySNATExemptionAddressSet(
+	addressSetFactory addressset.AddressSetFactory,
+	netInfo util.NetInfo,
+	controllerName string,
+) (addressset.AddressSet, error) {
+	dbIDs := getNoOverlaySNATExemptionAddressSetDbIDs(netInfo, controllerName)
+
+	// Ensure the address set exists with empty initial addresses
 	// Addresses will be added during controller initialization
 	as, err := addressSetFactory.EnsureAddressSet(dbIDs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create no-overlay SNAT exemption address set for network %s: %w",
+		return nil, fmt.Errorf("failed to ensure no-overlay SNAT exemption address set for network %s: %w",
 			netInfo.GetNetworkName(), err)
 	}
 
-	klog.Infof("Initialized no-overlay SNAT exemption address set for network %s", netInfo.GetNetworkName())
+	klog.V(5).Infof("Ensured no-overlay SNAT exemption address set for network %s", netInfo.GetNetworkName())
 	return as, nil
 }
 
@@ -53,14 +58,7 @@ func getNoOverlaySNATExemptionAddressSet(
 	netInfo util.NetInfo,
 	controllerName string,
 ) (addressset.AddressSet, error) {
-	dbIDs := libovsdbops.NewDbObjectIDs(
-		libovsdbops.AddressSetNoOverlaySNATExemption,
-		controllerName,
-		map[libovsdbops.ExternalIDKey]string{
-			libovsdbops.ObjectNameKey: asName,
-			libovsdbops.NetworkKey:    netInfo.GetNetworkName(),
-		},
-	)
+	dbIDs := getNoOverlaySNATExemptionAddressSetDbIDs(netInfo, controllerName)
 
 	as, err := addressSetFactory.GetAddressSet(dbIDs)
 	if err != nil {
@@ -89,14 +87,7 @@ func cleanupNoOverlaySNATExemptionAddressSet(
 		return fmt.Errorf("failed to cleanup no-overlay SNAT exemption address set: address set factory is nil")
 	}
 
-	dbIDs := libovsdbops.NewDbObjectIDs(
-		libovsdbops.AddressSetNoOverlaySNATExemption,
-		controllerName,
-		map[libovsdbops.ExternalIDKey]string{
-			libovsdbops.ObjectNameKey: asName,
-			libovsdbops.NetworkKey:    netInfo.GetNetworkName(),
-		},
-	)
+	dbIDs := getNoOverlaySNATExemptionAddressSetDbIDs(netInfo, controllerName)
 
 	if err := addressSetFactory.DestroyAddressSet(dbIDs); err != nil {
 		return fmt.Errorf("failed to cleanup no-overlay SNAT exemption address set for network %s: %w",
@@ -126,10 +117,17 @@ func syncNoOverlaySNATExemptionAddressSet(
 	if err != nil {
 		return err
 	}
-	if as == nil {
-		// Address set doesn't exist yet - create it first
-		if as, err = initNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName); err != nil {
-			return fmt.Errorf("failed to create no-overlay SNAT exemption address set: %w", err)
+	addressSetNeedsEnsure := as == nil
+	if as != nil {
+		v4UUID, v6UUID := as.GetASUUID()
+		ipv4Mode, ipv6Mode := netInfo.IPMode()
+		addressSetNeedsEnsure = (ipv4Mode && v4UUID == "") || (ipv6Mode && v6UUID == "")
+	}
+	if addressSetNeedsEnsure {
+		// EnsureAddressSet also creates a family that was enabled after the
+		// address set was first created, for example during a dual-stack upgrade.
+		if as, err = ensureNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName); err != nil {
+			return fmt.Errorf("failed to ensure no-overlay SNAT exemption address set: %w", err)
 		}
 	}
 
@@ -168,7 +166,9 @@ func syncNoOverlaySNATExemptionAddressSet(
 }
 
 // getNoOverlaySNATExemptionAsUUID returns the hashed address set UUIDs for IPv4 and IPv6.
-// These hash names are used to reference the address set in SNAT rules.
+// These hash names are used to reference the address set in SNAT rules. The address set
+// is synced before gateway sync, so every enabled IP family must have a UUID: return an
+// error otherwise so that no SNAT is ever created without exemptions.
 func getNoOverlaySNATExemptionAsUUID(
 	addressSetFactory addressset.AddressSetFactory,
 	netInfo util.NetInfo,
@@ -178,10 +178,16 @@ func getNoOverlaySNATExemptionAsUUID(
 	if err != nil {
 		return "", "", err
 	}
-	if as == nil {
-		return "", "", nil
+	var v4UUID, v6UUID string
+	if as != nil {
+		v4UUID, v6UUID = as.GetASUUID()
 	}
-
-	v4UUID, v6UUID := as.GetASUUID()
+	ipv4Mode, ipv6Mode := netInfo.IPMode()
+	if ipv4Mode && v4UUID == "" {
+		return "", "", fmt.Errorf("no-overlay SNAT exemption address set for network %s has no IPv4 UUID", netInfo.GetNetworkName())
+	}
+	if ipv6Mode && v6UUID == "" {
+		return "", "", fmt.Errorf("no-overlay SNAT exemption address set for network %s has no IPv6 UUID", netInfo.GetNetworkName())
+	}
 	return v4UUID, v6UUID, nil
 }

--- a/go-controller/pkg/ovn/no_overlay_snat_exemption_test.go
+++ b/go-controller/pkg/ovn/no_overlay_snat_exemption_test.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("No-Overlay SNAT Exemption Address Set", func() {
 				{CIDR: cidr, HostSubnetLength: 24},
 			}
 
-			_, err = initNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
+			_, err = ensureNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
@@ -110,6 +110,40 @@ var _ = ginkgo.Describe("No-Overlay SNAT Exemption Address Set", func() {
 			gomega.Expect(secondIPv6).To(gomega.Equal(firstIPv6))
 		})
 
+		ginkgo.It("creates a missing address-set family during a dual-stack upgrade", func() {
+			as, err := getNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			originalV4UUID, originalV6UUID := as.GetASUUID()
+			gomega.Expect(originalV4UUID).NotTo(gomega.BeEmpty())
+			gomega.Expect(originalV6UUID).To(gomega.BeEmpty())
+
+			_, ipv6CIDR, err := net.ParseCIDR("fd00:10:128::/48")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			netInfo.subnets = append(netInfo.subnets, config.CIDRNetworkEntry{
+				CIDR:             ipv6CIDR,
+				HostSubnetLength: 64,
+			})
+			netInfo.ipMode = &[2]bool{true, true}
+			dualStackFactory := addressset.NewOvnAddressSetFactory(fakeOvn.nbClient, true, true)
+			nodeIPs := []string{"192.168.1.10", "fd00::10"}
+
+			err = syncNoOverlaySNATExemptionAddressSet(dualStackFactory, netInfo, controllerName, nodeIPs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			as, err = getNoOverlaySNATExemptionAddressSet(dualStackFactory, netInfo, controllerName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			v4UUID, v6UUID := as.GetASUUID()
+			gomega.Expect(v4UUID).To(gomega.Equal(originalV4UUID))
+			gomega.Expect(v6UUID).NotTo(gomega.BeEmpty())
+
+			ipv4Addrs, ipv6Addrs := as.GetAddresses()
+			gomega.Expect(ipv4Addrs).To(gomega.ConsistOf("10.128.0.0/14", "192.168.1.10"))
+			gomega.Expect(ipv6Addrs).To(gomega.ConsistOf("fd00:10:128::/48", "fd00::10"))
+
+			_, _, err = getNoOverlaySNATExemptionAsUUID(dualStackFactory, netInfo, controllerName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("updates node IPs when they change", func() {
 			// First sync with initial node IPs
 			initialNodeIPs := []string{"192.168.1.10"}
@@ -160,7 +194,7 @@ var _ = ginkgo.Describe("No-Overlay SNAT Exemption Address Set", func() {
 
 	ginkgo.Context("cleanupNoOverlaySNATExemptionAddressSet", func() {
 		ginkgo.It("removes the address set", func() {
-			_, err := initNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
+			_, err := ensureNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Verify address set exists before cleanup
@@ -200,7 +234,7 @@ var _ = ginkgo.Describe("No-Overlay SNAT Exemption Address Set", func() {
 
 	ginkgo.Context("getNoOverlaySNATExemptionAsUUID", func() {
 		ginkgo.It("returns UUIDs for IPv4 and IPv6 address sets when it exists", func() {
-			_, err := initNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
+			_, err := ensureNoOverlaySNATExemptionAddressSet(addressSetFactory, netInfo, controllerName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(addressSetFactory, netInfo, controllerName)
@@ -216,10 +250,26 @@ var _ = ginkgo.Describe("No-Overlay SNAT Exemption Address Set", func() {
 			}
 		})
 
-		ginkgo.It("returns empty strings when it doesn't exist", func() {
-			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(addressSetFactory, netInfo, controllerName)
+		ginkgo.It("returns an error when it doesn't exist", func() {
+			_, _, err := getNoOverlaySNATExemptionAsUUID(addressSetFactory, netInfo, controllerName)
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("no-overlay SNAT exemption address set")))
+		})
+
+		ginkgo.It("does not require the missing family for a single-stack network on a dual-stack cluster", func() {
+			// A dual-stack cluster with an IPv4-only network: the network's
+			// address set only ever holds the IPv4 family, so the missing IPv6
+			// UUID must not be treated as an error.
+			config.IPv4Mode = true
+			config.IPv6Mode = true
+			netInfo.ipMode = &[2]bool{true, false}
+			singleStackFactory := addressset.NewOvnAddressSetFactory(fakeOvn.nbClient, true, false)
+
+			_, err := ensureNoOverlaySNATExemptionAddressSet(singleStackFactory, netInfo, controllerName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(v4UUID).To(gomega.BeEmpty())
+
+			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(singleStackFactory, netInfo, controllerName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(v4UUID).NotTo(gomega.BeEmpty())
 			gomega.Expect(v6UUID).To(gomega.BeEmpty())
 		})
 	})

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -87,10 +87,20 @@ type testNetInfo struct {
 	outboundSNAT string
 	subnets      []config.CIDRNetworkEntry
 	transport    string
+	// ipMode, when set, overrides IPMode() as {IPv4, IPv6}; otherwise the
+	// embedded NetInfo's IPMode() is used.
+	ipMode *[2]bool
 }
 
 func (ni *testNetInfo) TopologyType() string {
 	return ni.topology
+}
+
+func (ni *testNetInfo) IPMode() (bool, bool) {
+	if ni.ipMode != nil {
+		return ni.ipMode[0], ni.ipMode[1]
+	}
+	return ni.NetInfo.IPMode()
 }
 
 func (ni *testNetInfo) Subnets() []config.CIDRNetworkEntry {

--- a/go-controller/pkg/testing/libovsdb/recording_client.go
+++ b/go-controller/pkg/testing/libovsdb/recording_client.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package libovsdb
+
+import (
+	"context"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+)
+
+// RecordingClient wraps a libovsdb client and records the operations of every
+// transaction it forwards, so tests can assert on what was written to the DB.
+type RecordingClient struct {
+	libovsdbclient.Client
+	// Transactions holds a copy of the ops of each Transact call, in order.
+	Transactions [][]ovsdb.Operation
+}
+
+// NewRecordingClient returns a RecordingClient wrapping the given client.
+func NewRecordingClient(client libovsdbclient.Client) *RecordingClient {
+	return &RecordingClient{Client: client}
+}
+
+// Transact records the operations and forwards them to the wrapped client.
+func (c *RecordingClient) Transact(ctx context.Context, ops ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	c.Transactions = append(c.Transactions, append([]ovsdb.Operation(nil), ops...))
+	return c.Client.Transact(ctx, ops...)
+}


### PR DESCRIPTION
When we start ovn-kubernetes with the default network on no-overlay mode + outboundSNAT enabled, we need to exempt pod traffic from being SNATed to the node IP in the gateway router and we do that through the `extempted_ext_ips` field in the NAT object we attach to the gateway router for the default network.

Now, in `addUpdateLocalNodeEvent` (pkg/ovn/master.go) [we create this SNAT](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/3ddc00fe9cac61cf66881a1bfc5fb8f84ed07926/go-controller/pkg/ovn/master.go#L649) /before/ we create [the address set for the exempted pod subnet](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/3ddc00fe9cac61cf66881a1bfc5fb8f84ed07926/go-controller/pkg/ovn/master.go#L698-L711). This means that at the first node reconciliation,  `addUpdateLocalNodeEvent`  implements `outboundSNAT=disabled` and only at the next reconciliation it'll create the right SNAT object, since it finds the address set, thus implementing the desired `outboundSNAT=enabled`.

This was always the case, but a previous commit of mine (https://github.com/ovn-kubernetes/ovn-kubernetes/commit/122ab5c235ad42a361f8d35cf7a16925584baf11) made the problem surface because I added the check for `AllowedExtIPs` in `isEquivalentNAT` (go-controller/pkg/libovsdb/ops/router.go). 

This means that the first NAT that gets created, without `exempted_ext_ips`, is not replaced by the final one, with `exempted_ext_ips` and remains in nbdb:

```
sh-5.3# ovn-nbctl --column match,external_ip,logical_ip,options,exempted_ext_ips list nat
match               : ""
external_ip         : "172.18.0.5"
logical_ip          : "100.64.0.2"
options             : {stateless="false"}
exempted_ext_ips    : []

match               : ""
external_ip         : "172.18.0.5"
logical_ip          : "10.244.0.0/16"
options             : {stateless="false"}
exempted_ext_ips    : []            # <------------- stale NAT, not supposed to be here in the first place

match               : ""
external_ip         : "172.18.0.5"
logical_ip          : "10.244.0.0/16"
options             : {stateless="false"}
exempted_ext_ips    : a62607ed-616d-4c11-b707-753a891aa474

```

Let's fix that as follows:
- `libovsdb: ignore exempted_ext_ips when matching NATs`:  let's not consider `exempted_ext_ips` as an identifier but as part of the mutable NAT configuration, so reconciliation must update it in place. 
- `ovn: sync no-overlay SNAT exemptions before gateway NATs`: sync the exemption address set before node gateway sync, so the first reconciliation already builds the SNAT with `exempted_ext_ips`; on failure, defer gateway sync for retry.
- `ovn: fail SNAT creation when exemption address set is missing`: error out instead of silently creating a SNAT without exemptions
- `ovn: mark no-overlay cluster SNATs with DB IDs, clean up stale ones`: identify these SNATs by DB IDs instead of interpreting NAT fields; on every gateway sync, delete by UUID any stale duplicate (pre-DB-ID rows or leftovers from an overlay-to-no-overlay transition)
