### PR TITLE
cni: skip conntrack flush for IPs owned by another pod

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -337,7 +337,7 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 		NetdevName:    netdevName,
 	}
 	if !config.UnprivilegedMode {
-		err := podRequestInterfaceOps.UnconfigureInterface(pr, podInterfaceInfo)
+		err := podRequestInterfaceOps.UnconfigureInterface(pr, podInterfaceInfo, clientset.podLister)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -488,7 +488,7 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 		NetdevName:    netdevName,
 	}
 	if !config.UnprivilegedMode {
-		err := podRequestInterfaceOps.UnconfigureInterface(pr, podInterfaceInfo)
+		err := podRequestInterfaceOps.UnconfigureInterface(pr, podInterfaceInfo, clientset.podLister, pod)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
@@ -54,7 +55,7 @@ func (stub *podRequestInterfaceOpsStub) ConfigureInterface(pr *PodRequest, _ cli
 	}
 	return nil, nil
 }
-func (stub *podRequestInterfaceOpsStub) UnconfigureInterface(_ *PodRequest, ifInfo *PodInterfaceInfo) error {
+func (stub *podRequestInterfaceOpsStub) UnconfigureInterface(_ *PodRequest, ifInfo *PodInterfaceInfo, _ corev1listers.PodLister) error {
 	stub.unconfiguredInterfaces = append(stub.unconfiguredInterfaces, ifInfo)
 	return nil
 }

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
@@ -59,7 +60,7 @@ func (stub *podRequestInterfaceOpsStub) ConfigureInterface(pr *PodRequest, _ cli
 	}
 	return nil, nil
 }
-func (stub *podRequestInterfaceOpsStub) UnconfigureInterface(_ *PodRequest, ifInfo *PodInterfaceInfo) error {
+func (stub *podRequestInterfaceOpsStub) UnconfigureInterface(_ *PodRequest, ifInfo *PodInterfaceInfo, _ corev1listers.PodLister, _ *corev1.Pod) error {
 	stub.unconfiguredInterfaces = append(stub.unconfiguredInterfaces, ifInfo)
 	return nil
 }

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -344,7 +344,10 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 			}
 		}
 
-		err = podRequestInterfaceOps.UnconfigureInterface(pr, response.PodIFInfo)
+		// The unprivileged CNI shim has no apiserver/pod-lister access, so the
+		// live-migration IP-preservation guard in deletePodConntrack cannot run
+		// here; pass a nil lister to keep the previous conntrack-flush behavior.
+		err = podRequestInterfaceOps.UnconfigureInterface(pr, response.PodIFInfo, nil)
 	}
 	return err
 }

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -344,7 +344,10 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 			}
 		}
 
-		err = podRequestInterfaceOps.UnconfigureInterface(pr, response.PodIFInfo)
+		// The unprivileged CNI shim has no apiserver/pod-lister access, so the
+		// live-migration IP-preservation guard in deletePodConntrack cannot run
+		// here; pass a nil lister to keep the previous conntrack-flush behavior.
+		err = podRequestInterfaceOps.UnconfigureInterface(pr, response.PodIFInfo, nil, nil)
 	}
 	return err
 }

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -23,11 +23,16 @@ import (
 	"github.com/safchain/ethtool"
 	"github.com/vishvananda/netlink"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -830,7 +835,7 @@ func ConfigureOVS(ctx context.Context, ovsClient client.Client, namespace, podNa
 
 type PodRequestInterfaceOps interface {
 	ConfigureInterface(pr *PodRequest, ovsClient client.Client, getter PodInfoGetter, ifInfo *PodInterfaceInfo) ([]*current.Interface, error)
-	UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo) error
+	UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo, podLister corev1listers.PodLister) error
 }
 
 type defaultPodRequestInterfaceOps struct{}
@@ -911,7 +916,7 @@ func (*defaultPodRequestInterfaceOps) ConfigureInterface(pr *PodRequest, ovsClie
 	return []*current.Interface{hostIface, contIface}, nil
 }
 
-func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo) error {
+func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo, podLister corev1listers.PodLister) error {
 	podDesc := fmt.Sprintf("for pod %s/%s NAD %s", pr.PodNamespace, pr.PodName, pr.nadName)
 	klog.V(5).Infof("Tear down interface (%+v) %s", *pr, podDesc)
 	if ifInfo.IsDPUHostMode {
@@ -1025,12 +1030,12 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 		if err != nil {
 			klog.Errorf("Failed to clearPodBandwidth sandbox %v %s: %v", pr.SandboxID, podDesc, err)
 		}
-		pr.deletePodConntrack()
+		pr.deletePodConntrack(podLister)
 	}
 	return nil
 }
 
-func (pr *PodRequest) deletePodConntrack() {
+func (pr *PodRequest) deletePodConntrack(podLister corev1listers.PodLister) {
 	if pr.CNIConf.PrevResult == nil {
 		return
 	}
@@ -1039,6 +1044,16 @@ func (pr *PodRequest) deletePodConntrack() {
 		klog.Warningf("Could not convert result to current version: %v", err)
 		return
 	}
+
+	// During KubeVirt live migration the VM IPs are preserved and move to the
+	// migration target pod running on another node. Flushing them on this
+	// pod's CNI DEL would tear down established connections (e.g. the
+	// north/south NodePort/SNAT ingress connection routed to the VM) that must
+	// survive the migration. Compute, once per DEL, the set of IPs still owned
+	// by another living pod of the VM and skip only those; genuinely released
+	// IPs (e.g. the source pod's default-network IP) are still flushed as
+	// before.
+	preservedIPs := pr.migrationPreservedIPs(podLister)
 
 	for _, ip := range result.IPs {
 		// Skip known non-sandbox interfaces
@@ -1049,12 +1064,91 @@ func (pr *PodRequest) deletePodConntrack() {
 				continue
 			}
 		}
+		if preservedIPs.Has(ip.Address.IP.String()) {
+			klog.V(5).Infof("Skipping conntrack flush for pod %s/%s IP %s: IP is preserved on another pod of the live-migrated VM",
+				pr.PodNamespace, pr.PodName, ip.Address.IP.String())
+			continue
+		}
 		_, err = util.DeleteConntrack(ip.Address.IP.String(), 0, "", netlink.ConntrackReplyAnyIP, nil)
 		if err != nil {
 			klog.Errorf("Failed to delete Conntrack Entry for %s: %v", ip.Address.IP.String(), err)
 			continue
 		}
 	}
+}
+
+// migrationPreservedIPs returns the set of IP addresses that are preserved on
+// another living pod of the same KubeVirt VM as the pod being torn down,
+// because of a live migration: the migration target pod when the source is
+// deleted, or the source pod when a failed migration target is deleted.
+// Only the IPs actually preserved across the migration are returned:
+// the cluster default network is skipped, since it allocates per-node subnets
+// and its IPs move with the pod, not with the VM; genuinely released IPs keep
+// being flushed.
+//
+// An empty set is returned (flush everything, the previous behavior) when:
+//   - podLister is nil (the unprivileged CNI shim has no apiserver access)
+//   - the pod is already gone from the informer or does not belong to a
+//     live-migratable VM
+//   - there is no live migration, or no other living pod of the VM owns IPs
+//
+// Note: the guard requires cluster-wide pod visibility, since the surviving
+// pod of a live migration always runs on a different node. The cniserver's
+// podLister is backed by factory.LocalPodInformer(), which today watches pods
+// on all nodes; if that informer is ever scoped down to node-local pods, this
+// guard would silently degrade to flushing everything (see the TODO on the
+// pod informer registration in pkg/factory/factory.go NewNodeWatchFactory).
+func (pr *PodRequest) migrationPreservedIPs(podLister corev1listers.PodLister) sets.Set[string] {
+	preservedIPs := sets.New[string]()
+	if podLister == nil {
+		return preservedIPs
+	}
+	pod, err := podLister.Pods(pr.PodNamespace).Get(pr.PodName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Warningf("Failed finding pod %s/%s: %v", pr.PodNamespace, pr.PodName, err)
+		}
+		// Pod is already gone or not visible; nothing preserved, flush.
+		return preservedIPs
+	}
+	status, err := kubevirt.DiscoverLiveMigrationStatus(podLister, pod)
+	if err != nil {
+		klog.Warningf("Failed to discover live migration status for pod %s/%s: %v", pr.PodNamespace, pr.PodName, err)
+		return preservedIPs
+	}
+	if status == nil {
+		return preservedIPs
+	}
+	for _, vmPod := range []*corev1.Pod{status.SourcePod, status.TargetPod} {
+		if vmPod == nil || vmPod.Name == pr.PodName || util.PodCompleted(vmPod) {
+			continue
+		}
+		podNetworks, err := util.UnmarshalPodAnnotationAllNetworks(vmPod.Annotations)
+		if err != nil {
+			klog.Warningf("Failed to unmarshal OVN pod annotation of live migration pod %s/%s: %v",
+				vmPod.Namespace, vmPod.Name, err)
+			continue
+		}
+		for nadName, podNetwork := range podNetworks {
+			// The cluster default network allocates per-node subnets, so its
+			// IPs are never preserved across a live migration: the surviving
+			// pod owns a different IP from its own node's subnet, and the
+			// deleted pod's default-network IP is genuinely released.
+			if nadName == types.DefaultNetworkName {
+				continue
+			}
+			for _, ipStr := range podNetwork.IPs {
+				ip, _, err := net.ParseCIDR(ipStr)
+				if err != nil {
+					klog.Warningf("Failed to parse IP %q from OVN pod annotation of live migration pod %s/%s: %v",
+						ipStr, vmPod.Namespace, vmPod.Name, err)
+					continue
+				}
+				preservedIPs.Insert(ip.String())
+			}
+		}
+	}
+	return preservedIPs
 }
 
 func (pr *PodRequest) deletePort(ifaceName, podNamespace, podName string) {

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -23,11 +23,15 @@ import (
 	"github.com/safchain/ethtool"
 	"github.com/vishvananda/netlink"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -830,7 +834,7 @@ func ConfigureOVS(ctx context.Context, ovsClient client.Client, namespace, podNa
 
 type PodRequestInterfaceOps interface {
 	ConfigureInterface(pr *PodRequest, ovsClient client.Client, getter PodInfoGetter, ifInfo *PodInterfaceInfo) ([]*current.Interface, error)
-	UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo) error
+	UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo, podLister corev1listers.PodLister, pod *corev1.Pod) error
 }
 
 type defaultPodRequestInterfaceOps struct{}
@@ -911,7 +915,7 @@ func (*defaultPodRequestInterfaceOps) ConfigureInterface(pr *PodRequest, ovsClie
 	return []*current.Interface{hostIface, contIface}, nil
 }
 
-func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo) error {
+func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInfo *PodInterfaceInfo, podLister corev1listers.PodLister, pod *corev1.Pod) error {
 	podDesc := fmt.Sprintf("for pod %s/%s NAD %s", pr.PodNamespace, pr.PodName, pr.nadName)
 	klog.V(5).Infof("Tear down interface (%+v) %s", *pr, podDesc)
 	if ifInfo.IsDPUHostMode {
@@ -1025,12 +1029,12 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 		if err != nil {
 			klog.Errorf("Failed to clearPodBandwidth sandbox %v %s: %v", pr.SandboxID, podDesc, err)
 		}
-		pr.deletePodConntrack()
+		pr.deletePodConntrack(podLister, pod)
 	}
 	return nil
 }
 
-func (pr *PodRequest) deletePodConntrack() {
+func (pr *PodRequest) deletePodConntrack(podLister corev1listers.PodLister, pod *corev1.Pod) {
 	if pr.CNIConf.PrevResult == nil {
 		return
 	}
@@ -1039,6 +1043,16 @@ func (pr *PodRequest) deletePodConntrack() {
 		klog.Warningf("Could not convert result to current version: %v", err)
 		return
 	}
+
+	// During KubeVirt live migration the VM IPs are preserved and move to the
+	// migration target pod running on another node. Flushing them on this
+	// pod's CNI DEL would tear down established connections (e.g. the
+	// north/south NodePort/SNAT ingress connection routed to the VM) that must
+	// survive the migration. Compute, once per DEL, the set of IPs still owned
+	// by another living pod of the VM and skip only those; genuinely released
+	// IPs (e.g. the source pod's default-network IP) are still flushed as
+	// before.
+	preservedIPs := pr.migrationPreservedIPs(podLister, pod)
 
 	for _, ip := range result.IPs {
 		// Skip known non-sandbox interfaces
@@ -1049,12 +1063,83 @@ func (pr *PodRequest) deletePodConntrack() {
 				continue
 			}
 		}
+		if preservedIPs.Has(ip.Address.IP.String()) {
+			klog.V(5).Infof("Skipping conntrack flush for pod %s/%s IP %s: IP is preserved on another pod of the live-migrated VM",
+				pr.PodNamespace, pr.PodName, ip.Address.IP.String())
+			continue
+		}
 		_, err = util.DeleteConntrack(ip.Address.IP.String(), 0, "", netlink.ConntrackReplyAnyIP, nil)
 		if err != nil {
 			klog.Errorf("Failed to delete Conntrack Entry for %s: %v", ip.Address.IP.String(), err)
 			continue
 		}
 	}
+}
+
+// migrationPreservedIPs returns the set of IP addresses that are preserved on
+// another living pod of the same KubeVirt VM as the pod being torn down,
+// because of a live migration: the migration target pod when the source is
+// deleted, or the source pod when a failed migration target is deleted.
+// Only the IPs actually preserved across the migration are returned:
+// the cluster default network is skipped, since it allocates per-node subnets
+// and its IPs move with the pod, not with the VM; genuinely released IPs keep
+// being flushed.
+//
+// An empty set is returned (flush everything, the previous behavior) when:
+//   - podLister or pod is nil (the unprivileged CNI shim has no apiserver
+//     access, or the pod is already gone)
+//   - the pod does not belong to a live-migratable VM
+//   - there is no live migration, or no other living pod of the VM owns IPs
+//
+// Note: podLister requires cluster-wide pod visibility, since the surviving
+// pod of a live migration always runs on a different node. The cniserver's
+// podLister is backed by factory.LocalPodInformer(), which today watches pods
+// on all nodes; if that informer is ever scoped down to node-local pods, this
+// function will return an empty set (see the TODO on the pod informer
+// registration in pkg/factory/factory.go NewNodeWatchFactory).
+func (pr *PodRequest) migrationPreservedIPs(podLister corev1listers.PodLister, pod *corev1.Pod) sets.Set[string] {
+	preservedIPs := sets.New[string]()
+	if podLister == nil || pod == nil || !kubevirt.IsPodLiveMigratable(pod) {
+		return preservedIPs
+	}
+	status, err := kubevirt.DiscoverLiveMigrationStatus(podLister, pod)
+	if err != nil {
+		klog.Warningf("Failed to discover live migration status for pod %s/%s: %v", pr.PodNamespace, pr.PodName, err)
+		return preservedIPs
+	}
+	if status == nil {
+		return preservedIPs
+	}
+	for _, vmPod := range []*corev1.Pod{status.SourcePod, status.TargetPod} {
+		if vmPod == nil || vmPod.Name == pr.PodName || util.PodCompleted(vmPod) {
+			continue
+		}
+		podNetworks, err := util.UnmarshalPodAnnotationAllNetworks(vmPod.Annotations)
+		if err != nil {
+			klog.Warningf("Failed to unmarshal OVN pod annotation of live migration pod %s/%s: %v",
+				vmPod.Namespace, vmPod.Name, err)
+			continue
+		}
+		for nadName, podNetwork := range podNetworks {
+			// The cluster default network allocates per-node subnets, so its
+			// IPs are never preserved across a live migration: the surviving
+			// pod owns a different IP from its own node's subnet, and the
+			// deleted pod's default-network IP is genuinely released.
+			if nadName == types.DefaultNetworkName {
+				continue
+			}
+			for _, ipStr := range podNetwork.IPs {
+				ip, _, err := net.ParseCIDR(ipStr)
+				if err != nil {
+					klog.Warningf("Failed to parse IP %q from OVN pod annotation of live migration pod %s/%s: %v",
+						ipStr, vmPod.Namespace, vmPod.Name, err)
+					continue
+				}
+				preservedIPs.Insert(ip.String())
+			}
+		}
+	}
+	return preservedIPs
 }
 
 func (pr *PodRequest) deletePort(ifaceName, podNamespace, podName string) {

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -20,9 +20,15 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	kexec "k8s.io/utils/exec"
 	"sigs.k8s.io/knftables"
 
@@ -1244,10 +1250,294 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 					}
 				}
 			}
-			tc.inpPodRequest.deletePodConntrack()
+			tc.inpPodRequest.deletePodConntrack(nil)
 			mockTypeResult.AssertExpectations(t)
 		})
 	}
+}
+
+func TestPodRequest_migrationPreservedIPs(t *testing.T) {
+	const (
+		ns      = "kv-live-migration-84"
+		vmName  = "vm1"
+		srcName = "virt-launcher-vm1-source"
+		tgtName = "virt-launcher-vm1-target"
+		udnNAD  = ns + "/net1"
+
+		// The default-network IPs are pod-specific: the cluster default
+		// network allocates per-node subnets, so they are never preserved
+		// across live migration and are released with their pod.
+		srcDefaultIPv4 = "10.244.1.4"
+		tgtDefaultIPv4 = "10.244.2.20"
+
+		// The (dual-stack) UDN IPs are common to source and target pods:
+		// they are preserved across live migration via the IPAMClaim.
+		commonUDNIPv4 = "10.100.200.5"
+		commonUDNIPv6 = "fd10:0:2b:f000::5"
+	)
+
+	var (
+		migrationTargetReadyAnnotation = map[string]string{
+			kubevirtv1.MigrationTargetReadyTimestamp: "2026-06-29T06:14:48Z",
+		}
+	)
+
+	// podNetworksAnnotation renders the OVN pod-networks annotation wire
+	// format for the given NAD key -> IPs (CIDR) mapping.
+	podNetworksAnnotation := func(networks map[string][]string) string {
+		podNetworks := map[string]map[string][]string{}
+		for nad, ips := range networks {
+			podNetworks[nad] = map[string][]string{"ip_addresses": ips}
+		}
+		raw, err := json.Marshal(podNetworks)
+		require.NoError(t, err)
+		return string(raw)
+	}
+
+	srcNetworks := map[string][]string{
+		"default": {srcDefaultIPv4 + "/24"},
+		udnNAD:    {commonUDNIPv4 + "/24", commonUDNIPv6 + "/64"},
+	}
+
+	tgtNetworks := map[string][]string{
+		"default": {tgtDefaultIPv4 + "/24"},
+		udnNAD:    {commonUDNIPv4 + "/24", commonUDNIPv6 + "/64"},
+	}
+
+	tgtNetworksIPv6Only := map[string][]string{
+		"default": {tgtDefaultIPv4 + "/24"},
+		udnNAD:    {commonUDNIPv6 + "/64"},
+	}
+
+	// virtPod builds a virt-launcher pod for vm1 with the given annotations,
+	// pod phase (defaulting to Running) and OVN pod-networks annotation (NAD key -> IPs in CIDR
+	// format). The target pod gets a later creation timestamp than the
+	// source, since DiscoverLiveMigrationStatus relies on creation time
+	// ordering to tell them apart.
+	virtPod := func(name string, anns map[string]string, phase corev1.PodPhase, networks map[string][]string) *corev1.Pod {
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		if phase == "" {
+			phase = corev1.PodRunning
+		}
+		anns[kubevirtv1.DomainAnnotation] = vmName
+		if networks != nil {
+			anns[ovntypes.OvnPodAnnotationName] = podNetworksAnnotation(networks)
+		}
+		creation := metav1.NewTime(time.Date(2026, 6, 29, 6, 0, 0, 0, time.UTC))
+		if name == tgtName {
+			creation = metav1.NewTime(creation.Add(time.Minute))
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         ns,
+				UID:               ktypes.UID(name),
+				CreationTimestamp: creation,
+				Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: vmName},
+				Annotations:       anns,
+			},
+		}
+		pod.Status.Phase = phase
+		return pod
+	}
+
+	nonVMPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: ktypes.UID(name)}}
+	}
+
+	newLister := func(pods ...*corev1.Pod) corev1listers.PodLister {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for _, p := range pods {
+			require.NoError(t, indexer.Add(p))
+		}
+		return corev1listers.NewPodLister(indexer)
+	}
+
+	tests := []struct {
+		desc     string
+		podName  string
+		lister   corev1listers.PodLister
+		expected sets.Set[string]
+	}{
+		{
+			desc:     "nil lister (unprivileged shim) -> nothing preserved, flush all",
+			lister:   nil,
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "pod not in lister -> nothing preserved, flush all",
+			lister:   newLister(virtPod(tgtName, migrationTargetReadyAnnotation, "", tgtNetworks)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "single VM pod, no migration -> nothing preserved, flush all",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "non-VM pod -> nothing preserved, flush all",
+			lister:   newLister(nonVMPod(srcName)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:   "migration in progress -> only the shared UDN IPs preserved (dual-stack), default-network IPs not preserved",
+			lister: newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, "", tgtNetworks)),
+			// Default-network IPs come from per-node subnets and move with
+			// the pod, not with the VM: the source one is genuinely released
+			// and the target one is excluded from the preserved set.
+			expected: sets.New(commonUDNIPv4, commonUDNIPv6),
+		},
+		{
+			desc:     "migration target ready -> shared UDN IPs preserved (dual-stack)",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, migrationTargetReadyAnnotation, "", tgtNetworks)),
+			expected: sets.New(commonUDNIPv4, commonUDNIPv6),
+		},
+		{
+			desc:     "migration in progress, IPv6-only UDN -> IPv6 preserved",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, "", tgtNetworksIPv6Only)),
+			expected: sets.New(commonUDNIPv6),
+		},
+		{
+			desc:     "migration in progress, target without OVN annotation -> nothing preserved, flush all",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, "", nil)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "migration failed (target completed, source living) -> nothing preserved, flush all",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, corev1.PodSucceeded, tgtNetworks)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:    "deleting the failed migration target -> shared UDN IPs preserved",
+			podName: tgtName,
+			lister:  newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, corev1.PodSucceeded, tgtNetworks)),
+			// The migration failed and the source pod keeps hosting the VM:
+			// its UDN established connections must not be broken. Its
+			// default-network IP is not at risk from the target's DEL (it
+			// lives on another node's subnet and cannot appear in the
+			// target's PrevResult), so it is not in the preserved set.
+			expected: sets.New(commonUDNIPv4, commonUDNIPv6),
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			podName := tc.podName
+			if podName == "" {
+				podName = srcName
+			}
+			pr := &PodRequest{
+				PodNamespace: ns,
+				PodName:      podName,
+				nadKey:       ovntypes.DefaultNetworkName,
+			}
+			require.Equal(t, tc.expected, pr.migrationPreservedIPs(tc.lister))
+		})
+	}
+}
+
+// TestPodRequest_deletePodConntrackLiveMigration asserts that deletePodConntrack
+// suppresses the conntrack flush exactly for the IPs preserved on the live
+// migration target pod, while still flushing the released ones.
+func TestPodRequest_deletePodConntrackLiveMigration(t *testing.T) {
+	const (
+		ns      = "kv-live-migration-84"
+		vmName  = "vm1"
+		srcName = "virt-launcher-vm1-source"
+		tgtName = "virt-launcher-vm1-target"
+		udnNAD  = ns + "/net1"
+	)
+	// The target pod gets a later creation timestamp than the source, since
+	// DiscoverLiveMigrationStatus relies on creation time ordering to tell
+	// them apart.
+	virtPod := func(name string, networks string) *corev1.Pod {
+		creation := metav1.NewTime(time.Date(2026, 6, 29, 6, 0, 0, 0, time.UTC))
+		if name == tgtName {
+			creation = metav1.NewTime(creation.Add(time.Minute))
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         ns,
+				UID:               ktypes.UID(name),
+				CreationTimestamp: creation,
+				Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: vmName},
+				Annotations: map[string]string{
+					kubevirtv1.DomainAnnotation:   vmName,
+					ovntypes.OvnPodAnnotationName: networks,
+				},
+			},
+		}
+	}
+	newLister := func(pods ...*corev1.Pod) corev1listers.PodLister {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for _, p := range pods {
+			require.NoError(t, indexer.Add(p))
+		}
+		return corev1listers.NewPodLister(indexer)
+	}
+	// The pod being torn down owns the released default-network IPv4 address
+	// plus the dual-stack UDN addresses preserved on the migration target.
+	newPodRequest := func(t *testing.T) *PodRequest {
+		t.Helper()
+		prevResult := &current.Result{
+			CNIVersion: "1.1.0",
+			Interfaces: []*current.Interface{{Name: "eth0", Sandbox: "blah"}, {Name: "ovn-udn1", Sandbox: "blah"}},
+			IPs: []*current.IPConfig{
+				{Interface: &[]int{0}[0], Address: *ovntest.MustParseIPNet("10.244.1.4/24")},
+				{Interface: &[]int{1}[0], Address: *ovntest.MustParseIPNet("10.100.200.5/24")},
+				{Interface: &[]int{1}[0], Address: *ovntest.MustParseIPNet("fd10:0:2b:f000::5/64")},
+			},
+		}
+		raw, err := json.Marshal(prevResult)
+		require.NoError(t, err)
+		parsedResult, err := current.NewResult(raw)
+		require.NoError(t, err)
+		return &PodRequest{
+			PodNamespace: ns,
+			PodName:      srcName,
+			nadKey:       ovntypes.DefaultNetworkName,
+			CNIConf: &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					PrevResult: parsedResult,
+				},
+			},
+		}
+	}
+	srcNetworks := `{"default":{"ip_addresses":["10.244.1.4/24"]},"` + udnNAD + `":{"ip_addresses":["10.100.200.5/24","fd10:0:2b:f000::5/64"]}}`
+	tgtNetworks := `{"default":{"ip_addresses":["10.244.2.20/24"]},"` + udnNAD + `":{"ip_addresses":["10.100.200.5/24","fd10:0:2b:f000::5/64"]}}`
+
+	t.Run("live migration in progress: flushes only the released IP, keeps the preserved dual-stack UDN IPs", func(t *testing.T) {
+		mockNetLinkOps := new(util_mocks.NetLinkOps)
+		util.SetNetLinkOpMockInst(mockNetLinkOps)
+		// Only the released default-network IPv4 address is flushed; no
+		// IPv6 flush at all since the only IPv6 address is preserved.
+		mockNetLinkOps.On("ConntrackDeleteFilters", netlink.ConntrackTableType(netlink.ConntrackTable), netlink.InetFamily(netlink.FAMILY_V4), mock.Anything).
+			Return(uint(1), nil).Once()
+
+		lister := newLister(virtPod(srcName, srcNetworks), virtPod(tgtName, tgtNetworks))
+		newPodRequest(t).deletePodConntrack(lister)
+
+		mockNetLinkOps.AssertExpectations(t)
+		mockNetLinkOps.AssertNumberOfCalls(t, "ConntrackDeleteFilters", 1)
+	})
+
+	t.Run("no other living VM pod: flushes all the IPs", func(t *testing.T) {
+		mockNetLinkOps := new(util_mocks.NetLinkOps)
+		util.SetNetLinkOpMockInst(mockNetLinkOps)
+		mockNetLinkOps.On("ConntrackDeleteFilters", netlink.ConntrackTableType(netlink.ConntrackTable), netlink.InetFamily(netlink.FAMILY_V4), mock.Anything).
+			Return(uint(1), nil).Twice()
+		mockNetLinkOps.On("ConntrackDeleteFilters", netlink.ConntrackTableType(netlink.ConntrackTable), netlink.InetFamily(netlink.FAMILY_V6), mock.Anything).
+			Return(uint(1), nil).Once()
+
+		lister := newLister(virtPod(srcName, srcNetworks))
+		newPodRequest(t).deletePodConntrack(lister)
+
+		mockNetLinkOps.AssertExpectations(t)
+		mockNetLinkOps.AssertNumberOfCalls(t, "ConntrackDeleteFilters", 3)
+	})
 }
 
 func TestConfigureOVS(t *testing.T) {

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -20,9 +20,15 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	kexec "k8s.io/utils/exec"
 	"sigs.k8s.io/knftables"
 
@@ -1244,10 +1250,300 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 					}
 				}
 			}
-			tc.inpPodRequest.deletePodConntrack()
+			tc.inpPodRequest.deletePodConntrack(nil, nil)
 			mockTypeResult.AssertExpectations(t)
 		})
 	}
+}
+
+func TestPodRequest_migrationPreservedIPs(t *testing.T) {
+	const (
+		ns      = "kv-live-migration-84"
+		vmName  = "vm1"
+		srcName = "virt-launcher-vm1-source"
+		tgtName = "virt-launcher-vm1-target"
+		udnNAD  = ns + "/net1"
+
+		// The default-network IPs are pod-specific: the cluster default
+		// network allocates per-node subnets, so they are never preserved
+		// across live migration and are released with their pod.
+		srcDefaultIPv4 = "10.244.1.4"
+		tgtDefaultIPv4 = "10.244.2.20"
+
+		// The (dual-stack) UDN IPs are common to source and target pods:
+		// they are preserved across live migration via the IPAMClaim.
+		commonUDNIPv4 = "10.100.200.5"
+		commonUDNIPv6 = "fd10:0:2b:f000::5"
+	)
+
+	var (
+		migrationTargetReadyAnnotation = map[string]string{
+			kubevirtv1.MigrationTargetReadyTimestamp: "2026-06-29T06:14:48Z",
+		}
+	)
+
+	// podNetworksAnnotation renders the OVN pod-networks annotation wire
+	// format for the given NAD key -> IPs (CIDR) mapping.
+	podNetworksAnnotation := func(networks map[string][]string) string {
+		podNetworks := map[string]map[string][]string{}
+		for nad, ips := range networks {
+			podNetworks[nad] = map[string][]string{"ip_addresses": ips}
+		}
+		raw, err := json.Marshal(podNetworks)
+		require.NoError(t, err)
+		return string(raw)
+	}
+
+	srcNetworks := map[string][]string{
+		"default": {srcDefaultIPv4 + "/24"},
+		udnNAD:    {commonUDNIPv4 + "/24", commonUDNIPv6 + "/64"},
+	}
+
+	tgtNetworks := map[string][]string{
+		"default": {tgtDefaultIPv4 + "/24"},
+		udnNAD:    {commonUDNIPv4 + "/24", commonUDNIPv6 + "/64"},
+	}
+
+	tgtNetworksIPv6Only := map[string][]string{
+		"default": {tgtDefaultIPv4 + "/24"},
+		udnNAD:    {commonUDNIPv6 + "/64"},
+	}
+
+	// virtPod builds a virt-launcher pod for vm1 with the given annotations,
+	// pod phase (defaulting to Running) and OVN pod-networks annotation (NAD key -> IPs in CIDR
+	// format). The target pod gets a later creation timestamp than the
+	// source, since DiscoverLiveMigrationStatus relies on creation time
+	// ordering to tell them apart.
+	virtPod := func(name string, anns map[string]string, phase corev1.PodPhase, networks map[string][]string) *corev1.Pod {
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		if phase == "" {
+			phase = corev1.PodRunning
+		}
+		anns[kubevirtv1.DomainAnnotation] = vmName
+		anns[kubevirtv1.AllowPodBridgeNetworkLiveMigrationAnnotation] = ""
+		if networks != nil {
+			anns[ovntypes.OvnPodAnnotationName] = podNetworksAnnotation(networks)
+		}
+		creation := metav1.NewTime(time.Date(2026, 6, 29, 6, 0, 0, 0, time.UTC))
+		if name == tgtName {
+			creation = metav1.NewTime(creation.Add(time.Minute))
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         ns,
+				UID:               ktypes.UID(name),
+				CreationTimestamp: creation,
+				Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: vmName},
+				Annotations:       anns,
+			},
+		}
+		pod.Status.Phase = phase
+		return pod
+	}
+
+	nonVMPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: ktypes.UID(name)}}
+	}
+
+	newLister := func(pods ...*corev1.Pod) corev1listers.PodLister {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for _, p := range pods {
+			require.NoError(t, indexer.Add(p))
+		}
+		return corev1listers.NewPodLister(indexer)
+	}
+
+	tests := []struct {
+		desc     string
+		podName  string
+		lister   corev1listers.PodLister
+		expected sets.Set[string]
+	}{
+		{
+			desc:     "nil lister (unprivileged shim) -> nothing preserved, flush all",
+			lister:   nil,
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "pod not in lister -> nothing preserved, flush all",
+			lister:   newLister(virtPod(tgtName, migrationTargetReadyAnnotation, "", tgtNetworks)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "single VM pod, no migration -> nothing preserved, flush all",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "non-VM pod -> nothing preserved, flush all",
+			lister:   newLister(nonVMPod(srcName)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:   "migration in progress -> only the shared UDN IPs preserved (dual-stack), default-network IPs not preserved",
+			lister: newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, "", tgtNetworks)),
+			// Default-network IPs come from per-node subnets and move with
+			// the pod, not with the VM: the source one is genuinely released
+			// and the target one is excluded from the preserved set.
+			expected: sets.New(commonUDNIPv4, commonUDNIPv6),
+		},
+		{
+			desc:     "migration target ready -> shared UDN IPs preserved (dual-stack)",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, migrationTargetReadyAnnotation, "", tgtNetworks)),
+			expected: sets.New(commonUDNIPv4, commonUDNIPv6),
+		},
+		{
+			desc:     "migration in progress, IPv6-only UDN -> IPv6 preserved",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, "", tgtNetworksIPv6Only)),
+			expected: sets.New(commonUDNIPv6),
+		},
+		{
+			desc:     "migration in progress, target without OVN annotation -> nothing preserved, flush all",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, "", nil)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:     "migration failed (target completed, source living) -> nothing preserved, flush all",
+			lister:   newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, corev1.PodSucceeded, tgtNetworks)),
+			expected: sets.New[string](),
+		},
+		{
+			desc:    "deleting the failed migration target -> shared UDN IPs preserved",
+			podName: tgtName,
+			lister:  newLister(virtPod(srcName, nil, "", srcNetworks), virtPod(tgtName, nil, corev1.PodSucceeded, tgtNetworks)),
+			// The migration failed and the source pod keeps hosting the VM:
+			// its UDN established connections must not be broken. Its
+			// default-network IP is not at risk from the target's DEL (it
+			// lives on another node's subnet and cannot appear in the
+			// target's PrevResult), so it is not in the preserved set.
+			expected: sets.New(commonUDNIPv4, commonUDNIPv6),
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			podName := tc.podName
+			if podName == "" {
+				podName = srcName
+			}
+			var pod *corev1.Pod
+			if tc.lister != nil {
+				pod, _ = tc.lister.Pods(ns).Get(podName)
+			}
+			pr := &PodRequest{
+				PodNamespace: ns,
+				PodName:      podName,
+				nadKey:       ovntypes.DefaultNetworkName,
+			}
+			require.Equal(t, tc.expected, pr.migrationPreservedIPs(tc.lister, pod))
+		})
+	}
+}
+
+// TestPodRequest_deletePodConntrackLiveMigration asserts that deletePodConntrack
+// suppresses the conntrack flush exactly for the IPs preserved on the live
+// migration target pod, while still flushing the released ones.
+func TestPodRequest_deletePodConntrackLiveMigration(t *testing.T) {
+	const (
+		ns      = "kv-live-migration-84"
+		vmName  = "vm1"
+		srcName = "virt-launcher-vm1-source"
+		tgtName = "virt-launcher-vm1-target"
+		udnNAD  = ns + "/net1"
+	)
+	// The target pod gets a later creation timestamp than the source, since
+	// DiscoverLiveMigrationStatus relies on creation time ordering to tell
+	// them apart.
+	virtPod := func(name string, networks string) *corev1.Pod {
+		creation := metav1.NewTime(time.Date(2026, 6, 29, 6, 0, 0, 0, time.UTC))
+		if name == tgtName {
+			creation = metav1.NewTime(creation.Add(time.Minute))
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         ns,
+				UID:               ktypes.UID(name),
+				CreationTimestamp: creation,
+				Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: vmName},
+				Annotations: map[string]string{
+					kubevirtv1.DomainAnnotation:                             vmName,
+					kubevirtv1.AllowPodBridgeNetworkLiveMigrationAnnotation: "",
+					ovntypes.OvnPodAnnotationName:                           networks,
+				},
+			},
+		}
+	}
+	newLister := func(pods ...*corev1.Pod) corev1listers.PodLister {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for _, p := range pods {
+			require.NoError(t, indexer.Add(p))
+		}
+		return corev1listers.NewPodLister(indexer)
+	}
+	// The pod being torn down owns the released default-network IPv4 address
+	// plus the dual-stack UDN addresses preserved on the migration target.
+	newPodRequest := func(t *testing.T) *PodRequest {
+		t.Helper()
+		prevResult := &current.Result{
+			CNIVersion: "1.1.0",
+			Interfaces: []*current.Interface{{Name: "eth0", Sandbox: "blah"}, {Name: "ovn-udn1", Sandbox: "blah"}},
+			IPs: []*current.IPConfig{
+				{Interface: &[]int{0}[0], Address: *ovntest.MustParseIPNet("10.244.1.4/24")},
+				{Interface: &[]int{1}[0], Address: *ovntest.MustParseIPNet("10.100.200.5/24")},
+				{Interface: &[]int{1}[0], Address: *ovntest.MustParseIPNet("fd10:0:2b:f000::5/64")},
+			},
+		}
+		raw, err := json.Marshal(prevResult)
+		require.NoError(t, err)
+		parsedResult, err := current.NewResult(raw)
+		require.NoError(t, err)
+		return &PodRequest{
+			PodNamespace: ns,
+			PodName:      srcName,
+			nadKey:       ovntypes.DefaultNetworkName,
+			CNIConf: &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					PrevResult: parsedResult,
+				},
+			},
+		}
+	}
+	srcNetworks := `{"default":{"ip_addresses":["10.244.1.4/24"]},"` + udnNAD + `":{"ip_addresses":["10.100.200.5/24","fd10:0:2b:f000::5/64"]}}`
+	tgtNetworks := `{"default":{"ip_addresses":["10.244.2.20/24"]},"` + udnNAD + `":{"ip_addresses":["10.100.200.5/24","fd10:0:2b:f000::5/64"]}}`
+
+	t.Run("live migration in progress: flushes only the released IP, keeps the preserved dual-stack UDN IPs", func(t *testing.T) {
+		mockNetLinkOps := new(util_mocks.NetLinkOps)
+		util.SetNetLinkOpMockInst(mockNetLinkOps)
+		// Only the released default-network IPv4 address is flushed; no
+		// IPv6 flush at all since the only IPv6 address is preserved.
+		mockNetLinkOps.On("ConntrackDeleteFilters", netlink.ConntrackTableType(netlink.ConntrackTable), netlink.InetFamily(netlink.FAMILY_V4), mock.Anything).
+			Return(uint(1), nil).Once()
+
+		lister := newLister(virtPod(srcName, srcNetworks), virtPod(tgtName, tgtNetworks))
+		newPodRequest(t).deletePodConntrack(lister, virtPod(srcName, srcNetworks))
+
+		mockNetLinkOps.AssertExpectations(t)
+		mockNetLinkOps.AssertNumberOfCalls(t, "ConntrackDeleteFilters", 1)
+	})
+
+	t.Run("no other living VM pod: flushes all the IPs", func(t *testing.T) {
+		mockNetLinkOps := new(util_mocks.NetLinkOps)
+		util.SetNetLinkOpMockInst(mockNetLinkOps)
+		mockNetLinkOps.On("ConntrackDeleteFilters", netlink.ConntrackTableType(netlink.ConntrackTable), netlink.InetFamily(netlink.FAMILY_V4), mock.Anything).
+			Return(uint(1), nil).Twice()
+		mockNetLinkOps.On("ConntrackDeleteFilters", netlink.ConntrackTableType(netlink.ConntrackTable), netlink.InetFamily(netlink.FAMILY_V6), mock.Anything).
+			Return(uint(1), nil).Once()
+
+		lister := newLister(virtPod(srcName, srcNetworks))
+		newPodRequest(t).deletePodConntrack(lister, virtPod(srcName, srcNetworks))
+
+		mockNetLinkOps.AssertExpectations(t)
+		mockNetLinkOps.AssertNumberOfCalls(t, "ConntrackDeleteFilters", 3)
+	})
 }
 
 func TestConfigureOVS(t *testing.T) {


### PR DESCRIPTION
## 📑 Description

This PR addresses one of the two mechanisms behind the KubeVirt live-migration ingress flake (#6581): established NodePort connections to a VM on a primary UDN break when the VM live migrates. Since it uses a NodePort service, the destination IP stays the same (the node IP) even when the VM moves to a different node, so the connection must survive the migration.

### Details

During KubeVirt live migration the VM IPs are preserved and move to the migration target pod, but the source pod's CNI `DEL` calls `deletePodConntrack()`, which flushes the conntrack entries for every IP in its previous CNI result — including entries of established connections that now belong to the target pod.

When the NodePort entry node is also the migration source node, this wipes the UDN gateway router's DNAT/SNAT conntrack entries of the in-flight ingress connection and the traffic black-holes (seen in CI as `iperf3` `0.00 Bytes` stalls).

This mechanism is now confirmed at the dataplane level (not just inferred from CI artifacts): reproducing the flake locally with a live-migration loop plus a 1Hz conntrack sampler and packet capture on the entry node shows, in the same second the source pod's CNI `DEL` runs, the client's conntrack entries in the gateway router snat/dnat zones dropping from the datapath and never being rebuilt for the stalled stream, while sibling streams that survive show freshly rebuilt entries (`BE_LIBERAL` flag, lost TCP window scaling) created by mid-stream conntrack pickup.

### The fix

Guard the flush per IP: skip only the IPs still owned by another living pod of the same VM (read once per DEL from its OVN pod annotation, all networks, dual-stack); genuinely released IPs — e.g. the source pod's default-network IP — are still flushed. The unprivileged CNI shim has no apiserver access, passes a nil lister and keeps the previous behavior.

### Scope

Partially addresses #6581: it fixes the conntrack-flush mechanism, which triggers when the NodePort entry node is the migration source. The same flake signature also occurs when the entry node is the migration target or a bystander — that is a different mechanism (established connections reset by the load balancer reject flows installed while the mirrored EndpointSlice is transiently empty during the migration handoff) which this PR intentionally does not touch and will be handled separately; details in #6581.

## Additional Information for reviewers

N/S

## ✅ Checks
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required

## How to verify it

Unit tests in `pkg/cni`; the existing KubeVirt live-migration `Primary/Layer2 ingress snat` e2e tests exercise the protected ingress connection across migration.
