### PR TITLE
RA controller shouldn't require subnets on nodes where a dynamic UDN is not allocated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -445,10 +445,11 @@ jobs:
         # Valid options are:
         # target: ["shard-conformance", "control-plane", "multi-homing", "node-ip-mac-migration",
         #          "external-gateway", "kv-live-migration", "network-segmentation",
-        #          "network-segmentation-dynamic", "bgp", "bgp-no-overlay", "bgp-loose-isolation",
+        #          "network-segmentation-dynamic", "bgp", "bgp-no-overlay", "bgp-no-overlay-dynamic", "bgp-loose-isolation",
         #          "evpn", "traffic-flow-test-only", "tools", "serial"]
         #         shard-conformance: hybrid-overlay = multicast-enable = emptylb-enable = false
         #         control-plane: hybrid-overlay = multicast-enable = emptylb-enable = true
+        #         targets ending in "-dynamic" run with dynamic UDN allocation enabled
         # ha: ["HA", "noHA"]
         # gateway-mode: ["local", "shared"]
         # ipfamily: ["ipv4", "ipv6", "dualstack"]
@@ -494,7 +495,7 @@ jobs:
           # restarting ovn-k pods (day-2 reconfiguration), which would disrupt any concurrently running test jobs.
           # Dedicated no-overlay jobs are therefore required to cover feature combinations that may interact with
           # no-overlay (e.g. BGP route advertisements, network-segmentation) where implementations are not strictly orthogonal.
-          - {"target": "bgp-no-overlay", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "snat-enabled"}
+          - {"target": "bgp-no-overlay-dynamic", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "snat-enabled"}
           - {"target": "bgp-no-overlay",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "true"}
           - {"target": "bgp-loose-isolation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "advertised-udn-isolation-mode": "loose"}
           - {"target": "evpn", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "evpn": "enable-evpn"}
@@ -533,7 +534,7 @@ jobs:
       PARALLEL: "${{ matrix.target != 'serial' }}"
       OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"
       MULTI_POD_SUBNET: true
-      DYNAMIC_UDN_ALLOCATION: "${{ matrix.target == 'network-segmentation-dynamic' }}"
+      DYNAMIC_UDN_ALLOCATION: "${{ endsWith(matrix.target, '-dynamic') }}"
       ENABLE_NO_OVERLAY: "${{ matrix.no-overlay != '' }}"
       ENABLE_NO_OVERLAY_OUTBOUND_SNAT: "${{ matrix.no-overlay == 'snat-enabled' || matrix.no-overlay == 'managed' }}"
       ENABLE_NO_OVERLAY_MANAGED_ROUTING: "${{ matrix.no-overlay == 'managed' }}"
@@ -689,7 +690,7 @@ jobs:
           make -C test control-plane WHAT="ClusterNetworkConnect"
         elif [ "${{ matrix.target }}" == "evpn" ]; then
           make -C test control-plane WHAT="EVPN"
-        elif [ "${{ matrix.target }}" == "bgp" ] || [ "${{ matrix.target }}" == "bgp-no-overlay" ] || [ "${{ matrix.target }}" == "bgp-loose-isolation" ]; then
+        elif [ "${{ matrix.target }}" == "bgp" ] || [ "${{ matrix.target }}" == "bgp-no-overlay" ] || [ "${{ matrix.target }}" == "bgp-no-overlay-dynamic" ] || [ "${{ matrix.target }}" == "bgp-loose-isolation" ]; then
           make -C test control-plane
         elif [ "${{ matrix.target }}" == "serial" ]; then
           # Run only Serial tests with ginkgo focus

--- a/docs/okeps/okep-5552-dynamic-udn-node-allocation.md
+++ b/docs/okeps/okep-5552-dynamic-udn-node-allocation.md
@@ -96,7 +96,8 @@ controller manager containers. The breakdown of how these will be modified is ou
 
 * Cluster Manager
   * UDN Controller — No change
-  * Route Advertisements Controller — No change
+  * Route Advertisements Controller — Modified to advertise networks only on nodes where they are active,
+reconciling on network activity changes, instead of requiring subnets on every selected node.
   * Egress Service Cluster — Doesn't support UDN
   * Endpoint Mirror Controller — No change
   * EgressIP Controller — No change

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -91,7 +91,16 @@ type Controller struct {
 	nsController   controllerutil.Controller
 
 	nm networkmanager.Interface
+	// networkRefReconcilerID identifies our registration with the network
+	// manager for network activity change notifications
+	networkRefReconcilerID uint64
 }
+
+// networkRefReconcilerFunc adapts a function to the
+// networkmanager.NetworkRefReconciler interface.
+type networkRefReconcilerFunc func(node, networkName string)
+
+func (f networkRefReconcilerFunc) Reconcile(node, networkName string) { f(node, networkName) }
 
 // NewController builds a controller that reconciles RouteAdvertisements
 func NewController(
@@ -199,6 +208,12 @@ func NewController(
 
 func (c *Controller) Start() error {
 	defer klog.Infof("Cluster manager routeadvertisements started")
+	// reconcile when a network goes active or inactive on a node: some of
+	// these changes, like a network going active again during the deletion
+	// grace period, update no object we watch
+	c.networkRefReconcilerID = c.nm.RegisterNetworkRefReconciler(networkRefReconcilerFunc(func(_, _ string) {
+		c.raController.ReconcileAll()
+	}))
 	return controllerutil.Start(
 		c.eipController,
 		c.frrController,
@@ -210,6 +225,7 @@ func (c *Controller) Start() error {
 }
 
 func (c *Controller) Stop() {
+	c.nm.DeRegisterNetworkRefReconciler(c.networkRefReconcilerID)
 	controllerutil.Stop(
 		c.eipController,
 		c.frrController,
@@ -716,7 +732,29 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 		selectedNetworks.hostSubnets = []string{}
 
 		// gather node specific information
+		nodeNetworks := make([]string, 0, len(selectedNetworks.networks))
 		for _, network := range selectedNetworks.networks {
+			if !c.nm.NodeHasNetwork(nodeName, network) {
+				// only advertise a network on nodes where it is active, that
+				// is, with pods or EgressIPs attached to it; NodeHasNetwork
+				// returns false only with dynamic UDN allocation enabled.
+				// The network manager notifies us when a network goes active
+				// or inactive on a node.
+				continue
+			}
+			if config.OVNKubernetesFeature.EnableDynamicUDNAllocation &&
+				selectedNetworks.networkTopology[network] == types.Layer2Topology &&
+				!c.nodeHasLayer2Allocation(nodeName, network) {
+				// without its tunnel ID allocated, the node cannot have
+				// rendered the layer2 network yet, so don't advertise it:
+				// unlike layer3, there are no per-node prefixes to otherwise
+				// wait for. The allocation is a node annotation update that
+				// triggers the advertising reconcile.
+				// TODO: replace with a per-node network status once
+				// available, to know when the network is actually rendered.
+				continue
+			}
+			nodeNetworks = append(nodeNetworks, network)
 			selectedNetworks.hostNetworkSubnets[network], err = getPrefixes(nodeName, network,
 				selectedNetworks.networkTopology[network], selectedNetworks.networkSubnets[network])
 			if err != nil {
@@ -750,18 +788,61 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 			}
 			if new == nil {
 				// if we got nil, we didn't match any VRF
+				if ra.Spec.TargetVRF == "auto" && frrConfigOnlyMatchesInactiveNetworks(frrConfig, selectedNetworks, nodeNetworks) {
+					// this FRRConfiguration only carries routers for VRFs of
+					// selected networks that are not active on this node:
+					// skip it for this node instead of failing, mirroring the
+					// per-network skip above.
+					continue
+				}
 				return nil, nil, fmt.Errorf("%w: FRRConfiguration %q selected for node %q has no VRF matching the RouteAdvertisements target VRF or any selected network",
 					errConfig, frrConfig.Name, nodeName)
 			}
 			generated = append(generated, new)
 		}
-		// check that we matched all the selected networks on 'auto'
-		if ra.Spec.TargetVRF == "auto" && !matchedNetworks.HasAll(selectedNetworks.networks...) {
+		// check that we matched all the networks selected for this node on 'auto'
+		if ra.Spec.TargetVRF == "auto" && !matchedNetworks.HasAll(nodeNetworks...) {
 			return nil, nil, fmt.Errorf("%w: selected FRRConfigurations for node %q don't match all selected networks with target VRF 'auto'", errConfig, nodeName)
 		}
 	}
 
 	return generated, nads, nil
+}
+
+// nodeHasLayer2Allocation reports whether the node has a gateway router LRP
+// tunnel ID allocated for the layer2 network.
+func (c *Controller) nodeHasLayer2Allocation(nodeName, network string) bool {
+	node, err := c.nodeLister.Get(nodeName)
+	if err != nil {
+		return false
+	}
+	return util.HasUDNLayer2NodeGRLRPTunnelID(node, network)
+}
+
+// frrConfigOnlyMatchesInactiveNetworks helps decide whether an
+// FRRConfiguration that matched no router for a node is a configuration
+// error. It is not an error if the FRRConfiguration is dedicated to selected
+// networks that are simply not active on the node: that is, its router
+// VRFs reference at least one selected network, and none of the referenced
+// networks are among the ones advertised on the node (nodeNetworks). Used
+// with target VRF 'auto' to skip such FRRConfigurations for the node.
+func frrConfigOnlyMatchesInactiveNetworks(frrConfig *frrtypes.FRRConfiguration, selected *selectedNetworks, nodeNetworks []string) bool {
+	advertised := sets.New(nodeNetworks...)
+	referencesSelected := false
+	for _, router := range frrConfig.Spec.BGP.Routers {
+		network := selected.networkVRFs[router.VRF]
+		if router.VRF == "" && slices.Contains(selected.networks, types.DefaultNetworkName) {
+			network = types.DefaultNetworkName
+		}
+		if network == "" {
+			continue
+		}
+		referencesSelected = true
+		if advertised.Has(network) {
+			return false
+		}
+	}
+	return referencesSelected
 }
 
 // generateFRRConfiguration generates a FRRConfiguration from a source for a
@@ -1621,6 +1702,9 @@ func nodeNeedsUpdate(oldObj, newObj *corev1.Node) bool {
 	return oldObj == nil || newObj == nil ||
 		!reflect.DeepEqual(oldObj.Labels, newObj.Labels) ||
 		util.NodeSubnetAnnotationChanged(oldObj, newObj) ||
+		// with dynamic UDN allocation, the tunnel ID allocation determines
+		// which nodes advertise a layer2 network
+		oldObj.Annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] != newObj.Annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] ||
 		oldObj.Annotations[util.OvnNodeIfAddr] != newObj.Annotations[util.OvnNodeIfAddr] ||
 		util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||
 		util.NodeChassisIDAnnotationChanged(oldObj, newObj) ||

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -143,6 +143,7 @@ type testNode struct {
 	Labels                    map[string]string
 	PrimaryAddressAnnotation  string
 	SubnetsAnnotation         string
+	TunnelIDsAnnotation       string
 	L3GatewayConfigAnnotation string
 	ChassisIDAnnotation       string
 	VTEPIPs                   map[string][]string
@@ -157,6 +158,9 @@ func (tn testNode) Node() *corev1.Node {
 	annotations := map[string]string{
 		"k8s.ovn.org/node-subnets": tn.SubnetsAnnotation,
 		util.OvnNodeIfAddr:         primaryAddressAnnotation,
+	}
+	if tn.TunnelIDsAnnotation != "" {
+		annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] = tn.TunnelIDsAnnotation
 	}
 	if tn.L3GatewayConfigAnnotation != "" {
 		annotations[util.OvnNodeL3GatewayConfig] = tn.L3GatewayConfigAnnotation
@@ -181,6 +185,24 @@ func (tn testNode) Node() *corev1.Node {
 			Labels:      tn.Labels,
 			Generation:  int64(tn.Generation),
 			Annotations: annotations,
+		},
+	}
+}
+
+type testPod struct {
+	Name      string
+	Namespace string
+	Node      string
+}
+
+func (tp testPod) Pod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tp.Name,
+			Namespace: tp.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: tp.Node,
 		},
 	}
 }
@@ -522,11 +544,13 @@ func TestController_reconcile(t *testing.T) {
 		nads                 []*testNAD
 		nodes                []*testNode
 		namespaces           []*testNamespace
+		pods                 []*testPod
 		eips                 []*testEIP
 		vteps                []*vtepv1.VTEP
 		reconcile            string
 		transport            string
 		gatewayMode          config.GatewayMode
+		dynamicUDN           bool
 		ipv6                 bool
 		wantErr              bool
 		expectAcceptedStatus metav1.ConditionStatus
@@ -2289,6 +2313,272 @@ exit
 			expectFRRConfigs:     []*testFRRConfig{},
 			expectNADAnnotations: map[string]map[string]string{"blue": {}},
 		},
+		{
+			name:       "with dynamic UDN allocation, ignores nodes where the selected network is not allocated and advertises dual-stack subnets where it is",
+			dynamicUDN: true,
+			ipv6:       true,
+			ra:         &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+							{ASN: 1, Address: "fd02::ffff:100:64"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "blue", Namespace: "blue", Network: util.GenerateCUDNNetworkName("blue"), Topology: "layer3", Subnet: "1.3.0.0/16,fd01:3::/48", Labels: map[string]string{"selected": "true"}},
+			},
+			namespaces: []*testNamespace{{Name: "blue"}},
+			pods:       []*testPod{{Name: "pod", Namespace: "blue", Node: "node"}},
+			nodes: []*testNode{
+				// "node" runs a pod attached to the network and has subnets
+				// allocated for it, "node2" does not and must not block the
+				// RouteAdvertisements from being accepted, not even with its
+				// stale empty subnet entry for the network
+				{Name: "node", SubnetsAnnotation: "{\"default\":[\"1.1.0.0/24\",\"fd01::/64\"], \"cluster_udn_blue\":[\"1.3.0.0/24\",\"fd01:3::/64\"]}"},
+				{Name: "node2", SubnetsAnnotation: "{\"default\":[\"1.1.1.0/24\",\"fd01:0:0:1::/64\"], \"cluster_udn_blue\":[]}"},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.3.0.0/24", "fd01:3::/64"}, Imports: []string{"blue"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.3.0.0/24"}},
+							{ASN: 1, Address: "fd02::ffff:100:64", Advertise: []string{"fd01:3::/64"}},
+						}},
+						{ASN: 1, VRF: "blue", Imports: []string{"default"}},
+					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name:       "with dynamic UDN allocation and 'auto' target VRF, only requires matching the networks allocated on each node",
+			dynamicUDN: true,
+			ra:         &testRA{Name: "ra", TargetVRF: "auto", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, VRF: "blue", Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+						{ASN: 1, VRF: "red", Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "blue", Namespace: "blue", Network: util.GenerateCUDNNetworkName("blue"), Topology: "layer3", Subnet: "1.3.0.0/16", Labels: map[string]string{"selected": "true"}},
+				{Name: "red", Namespace: "red", Network: util.GenerateCUDNNetworkName("red"), Topology: "layer3", Subnet: "1.2.0.0/16", Labels: map[string]string{"selected": "true"}},
+			},
+			namespaces: []*testNamespace{{Name: "blue"}, {Name: "red"}},
+			pods:       []*testPod{{Name: "pod", Namespace: "blue", Node: "node"}},
+			nodes: []*testNode{
+				// "node" is only active for network blue: with 'auto' target
+				// VRF, network red not matching any router VRF on it must not
+				// block the RouteAdvertisements from being accepted
+				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\", \"cluster_udn_blue\":\"1.3.0.0/24\"}"},
+				{Name: "node2", SubnetsAnnotation: "{\"default\":\"1.1.1.0/24\"}"},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, VRF: "blue", Prefixes: []string{"1.3.0.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.3.0.0/24"}},
+						}},
+					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}, "red": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name:       "with dynamic UDN allocation, withdraws a network from nodes where it is no longer active even if still allocated",
+			dynamicUDN: true,
+			ra:         &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "blue", Namespace: "blue", Network: util.GenerateCUDNNetworkName("blue"), Topology: "layer3", Subnet: "1.3.0.0/16", Labels: map[string]string{"selected": "true"}},
+			},
+			namespaces: []*testNamespace{{Name: "blue"}},
+			pods:       []*testPod{{Name: "pod", Namespace: "blue", Node: "node"}},
+			nodes: []*testNode{
+				// "node" runs a pod attached to the network; "node2" does not
+				// but still has a subnet allocated for it, as during the
+				// deletion grace period after its last workload left: only
+				// "node" must be advertised
+				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\", \"cluster_udn_blue\":\"1.3.0.0/24\"}"},
+				{Name: "node2", SubnetsAnnotation: "{\"default\":\"1.1.1.0/24\", \"cluster_udn_blue\":\"1.3.1.0/24\"}"},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.3.0.0/24"}, Imports: []string{"blue"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.3.0.0/24"}},
+						}},
+						{ASN: 1, VRF: "blue", Imports: []string{"default"}},
+					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name:       "with dynamic UDN allocation, advertises a layer2 network from nodes where it is active and its tunnel ID is allocated",
+			dynamicUDN: true,
+			ra:         &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "green", Namespace: "green", Network: util.GenerateCUDNNetworkName("green"), Topology: "layer2", Subnet: "1.4.0.0/16", Labels: map[string]string{"selected": "true"}},
+			},
+			namespaces: []*testNamespace{{Name: "green"}},
+			pods:       []*testPod{{Name: "pod", Namespace: "green", Node: "node"}},
+			nodes: []*testNode{
+				// layer2 networks have no per-node subnets: "node" runs a pod
+				// attached to the network and has its gateway router LRP
+				// tunnel ID allocated; "node2" still has a tunnel ID
+				// allocated but no workloads, and must not be advertised
+				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\"}", TunnelIDsAnnotation: "{\"cluster_udn_green\":\"5\"}"},
+				{Name: "node2", SubnetsAnnotation: "{\"default\":\"1.1.1.0/24\"}", TunnelIDsAnnotation: "{\"cluster_udn_green\":\"6\"}"},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.4.0.0/16"}, Imports: []string{"green"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.4.0.0/16"}},
+						}},
+						{ASN: 1, VRF: "green", Imports: []string{"default"}},
+					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"green": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name:       "with dynamic UDN allocation, does not advertise a layer2 network from an active node until its tunnel ID is allocated",
+			dynamicUDN: true,
+			ra:         &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "green", Namespace: "green", Network: util.GenerateCUDNNetworkName("green"), Topology: "layer2", Subnet: "1.4.0.0/16", Labels: map[string]string{"selected": "true"}},
+			},
+			namespaces: []*testNamespace{{Name: "green"}},
+			pods:       []*testPod{{Name: "pod", Namespace: "green", Node: "node"}},
+			nodes: []*testNode{
+				// "node" runs a pod attached to the network but has no tunnel
+				// ID allocated for it yet: it must not be advertised before
+				// the network is rendered on it, that is, once the tunnel ID
+				// allocation lands on the node annotations
+				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\"}"},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs:     []*testFRRConfig{},
+			expectNADAnnotations: map[string]map[string]string{"green": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name:       "with dynamic UDN allocation and 'auto' target VRF, skips FRRConfigurations that only match networks not allocated on the node",
+			dynamicUDN: true,
+			ra:         &testRA{Name: "ra", TargetVRF: "auto", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig-blue",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, VRF: "blue", Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+					},
+				},
+				{
+					Name:      "frrConfig-red",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, VRF: "red", Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "blue", Namespace: "blue", Network: util.GenerateCUDNNetworkName("blue"), Topology: "layer3", Subnet: "1.3.0.0/16", Labels: map[string]string{"selected": "true"}},
+				{Name: "red", Namespace: "red", Network: util.GenerateCUDNNetworkName("red"), Topology: "layer3", Subnet: "1.2.0.0/16", Labels: map[string]string{"selected": "true"}},
+			},
+			namespaces: []*testNamespace{{Name: "blue"}, {Name: "red"}},
+			pods:       []*testPod{{Name: "pod", Namespace: "blue", Node: "node"}},
+			nodes: []*testNode{
+				// "node" is only active for network blue: the source
+				// FRRConfiguration carrying only network red's VRF must be
+				// skipped for it instead of blocking the RouteAdvertisements
+				// from being accepted
+				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\", \"cluster_udn_blue\":\"1.3.0.0/24\"}"},
+				{Name: "node2", SubnetsAnnotation: "{\"default\":\"1.1.1.0/24\"}"},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig-blue/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, VRF: "blue", Prefixes: []string{"1.3.0.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.3.0.0/24"}},
+						}},
+					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}, "red": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2316,6 +2606,8 @@ exit
 			config.OVNKubernetesFeature.EnableRouteAdvertisements = true
 			config.OVNKubernetesFeature.EnableEgressIP = true
 			config.OVNKubernetesFeature.EnableEVPN = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = tt.dynamicUDN
+			config.OVNKubernetesFeature.EnableDynamicUDNAllocation = tt.dynamicUDN
 			// satisfy EVPN LGW restriction, otherwise no effect
 			config.Gateway.Mode = config.GatewayModeLocal
 			if tt.gatewayMode != "" {
@@ -2352,6 +2644,11 @@ exit
 
 			for _, namespace := range tt.namespaces {
 				_, err := fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace.Namespace(), metav1.CreateOptions{})
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+
+			for _, pod := range tt.pods {
+				_, err := fakeClientset.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod.Pod(), metav1.CreateOptions{})
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 
@@ -2492,6 +2789,136 @@ exit
 			}
 		})
 	}
+}
+
+// TestController_reconcileOnNetworkActivity verifies that the controller
+// reconciles on network activity changes notified by the network manager: a
+// network going active on a node that still has its subnet allocated, as
+// after a pod is recreated during the deletion grace period, updates no
+// object the controller watches.
+func TestController_reconcileOnNetworkActivity(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	frrNamespace := "frrNamespace"
+	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+		{
+			CIDR:             ovntest.MustParseIPNet("1.1.0.0/16"),
+			HostSubnetLength: 24,
+		},
+	}
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+	config.OVNKubernetesFeature.EnableEgressIP = true
+	config.OVNKubernetesFeature.EnableEVPN = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.Gateway.Mode = config.GatewayModeLocal
+
+	fakeClientset := util.GetOVNClientset().GetClusterManagerClientset()
+	addGenerateNameReactor[*frrfake.Clientset](fakeClientset.FRRClient)
+
+	ra := &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}}
+	_, err := fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), ra.RouteAdvertisements(), metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	frrConfig := &testFRRConfig{
+		Name:      "frrConfig",
+		Namespace: frrNamespace,
+		Routers: []*testRouter{
+			{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+				{ASN: 1, Address: "1.0.0.100"},
+			}},
+		},
+	}
+	_, err = fakeClientset.FRRClient.ApiV1beta1().FRRConfigurations(frrConfig.Namespace).Create(context.Background(), frrConfig.FRRConfiguration(), metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	nad := &testNAD{Name: "blue", Namespace: "blue", Network: util.GenerateCUDNNetworkName("blue"), Topology: "layer3", Subnet: "1.3.0.0/16", Labels: map[string]string{"selected": "true"}}
+	_, err = fakeClientset.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nad.Namespace).Create(context.Background(), nad.NAD(), metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// the node still has a subnet allocated for the network, as during the
+	// deletion grace period, but no workloads attached to it
+	node := &testNode{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\", \"cluster_udn_blue\":\"1.3.0.0/24\"}"}
+	_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node.Node(), metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	for _, namespace := range []string{"blue", config.Kubernetes.OVNConfigNamespace} {
+		_, err = fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
+	wf, err := factory.NewClusterManagerWatchFactory(fakeClientset)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	nm, err := networkmanager.NewForCluster(&networkmanager.FakeControllerManager{}, wf, fakeClientset, nil, id.NewTunnelKeyAllocator("TunnelKeys"))
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	c := NewController(nm.Interface(), wf, fakeClientset)
+
+	// prime the default network NAD
+	defaultNAD, err := util.EnsureDefaultNetworkNAD(c.nadLister, c.nadClient)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defaultNAD.Annotations = map[string]string{types.OvnNetworkNameAnnotation: types.DefaultNetworkName}
+	_, err = fakeClientset.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(defaultNAD.Namespace).Update(context.Background(), defaultNAD, metav1.UpdateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	err = wf.Start()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer wf.Shutdown()
+
+	cache.WaitForCacheSync(
+		context.Background().Done(),
+		wf.RouteAdvertisementsInformer().Informer().HasSynced,
+		wf.FRRConfigurationsInformer().Informer().HasSynced,
+		wf.NADInformer().Informer().HasSynced,
+		wf.NodeCoreInformer().Informer().HasSynced,
+		wf.EgressIPInformer().Informer().HasSynced,
+	)
+
+	// keep the network manager running so that pod events reach its trackers
+	err = nm.Start()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer nm.Stop()
+
+	err = c.Start()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer c.Stop()
+
+	t.Cleanup(func() { metrics.DeleteRouteAdvertisementCondition("ra") })
+
+	generatedFRRConfigs := func() []string {
+		frrConfigs, err := fakeClientset.FRRClient.ApiV1beta1().FRRConfigurations(frrNamespace).List(context.Background(), metav1.ListOptions{})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		var generated []string
+		for _, frrConfig := range frrConfigs.Items {
+			if key, ok := frrConfig.Annotations[types.OvnRouteAdvertisementsKey]; ok {
+				generated = append(generated, key)
+			}
+		}
+		return generated
+	}
+
+	// the network is not active on the node: nothing is advertised
+	raAccepted := func() bool {
+		ra, err := fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Get(context.Background(), "ra", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return meta.IsStatusConditionTrue(ra.Status.Conditions, "Accepted")
+	}
+	g.Eventually(raAccepted, 5*time.Second).Should(gomega.BeTrue())
+	g.Expect(generatedFRRConfigs()).To(gomega.BeEmpty())
+
+	// scheduling a pod on the node activates the network there without
+	// updating any object the controller watches: the network manager
+	// notification must trigger the reconcile that advertises the node
+	pod := &testPod{Name: "pod", Namespace: "blue", Node: "node"}
+	_, err = fakeClientset.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod.Pod(), metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	g.Eventually(generatedFRRConfigs, 5*time.Second).Should(gomega.ConsistOf("ra/frrConfig/node"))
 }
 
 func TestUpdates(t *testing.T) {

--- a/test/e2e/feature/features.go
+++ b/test/e2e/feature/features.go
@@ -29,9 +29,13 @@ var (
 	NoOverlay             = New("NoOverlay")
 	OVSCPUPin             = New("OVSCPUPin")
 	RouteAdvertisements   = New("RouteAdvertisements")
-	Unidle                = New("Unidle")
-	NetworkQos            = New("NetworkQos")
-	NetworkConnect        = New("NetworkConnect")
+	// RouteAdvertisementsDynamicUDN covers RouteAdvertisements behavior that
+	// is specific to dynamic UDN allocation; these tests require clusters
+	// with both route advertisements and dynamic UDN allocation enabled.
+	RouteAdvertisementsDynamicUDN = New("RouteAdvertisementsDynamicUDN")
+	Unidle                        = New("Unidle")
+	NetworkQos                    = New("NetworkQos")
+	NetworkConnect                = New("NetworkConnect")
 )
 
 func New(name string) ginkgo.Labels {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1431,6 +1431,9 @@ var _ = ginkgo.Describe("BGP: When an advertised CUDN network is dynamically all
 var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 	ginkgo.DescribeTableSubtree("between advertised networks", func(cudnATemplate, cudnBTemplate *udnv1.ClusterUserDefinedNetwork) {
 		const curlConnectionTimeoutCode = "28"
+		// match the whole phrase: a bare "7" is always contained in the curl
+		// error output, if only in the target address
+		const curlConnectionRefusedCode = "exit code 7"
 		const nodePortBackendLabel = "nodeport-backend"
 		const clientNodeBackend = "client-node"
 		const remoteNodeBackend = "remote-node"
@@ -1445,6 +1448,9 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 
 		// podNetB is in cudnB hosted on nodes[1], podNetDefault is in the default network hosted on nodes[1] - done in BeforeEach
 		var podNetB, podNetDefault *corev1.Pod
+		// nodesNetB are the nodes where cudnB is expected to exist: all of them,
+		// or just the node running its only pod with dynamic UDN allocation
+		var nodesNetB []corev1.Node
 		var svcNodePortNetA, svcNodePortNetAClientNodeBackend, svcNodePortNetARemoteNodeBackend, svcNodePortNetANodePortNodeBackend, svcNodePortNetB, svcNodePortNetDefault, svcNodePortETPLocalDefault, svcNodePortETPLocalNetA *corev1.Service
 		var cudnA, cudnB *udnv1.ClusterUserDefinedNetwork
 		var ra *rav1.RouteAdvertisements
@@ -1520,7 +1526,10 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 				gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnB.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
 
 				ginkgo.By("Selecting 3 schedulable nodes")
-				nodes, err = e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
+				// bound the node list: network pods are only scheduled on the
+				// first 3 nodes, and with dynamic UDN allocation the networks
+				// are only expected on the nodes that run their pods
+				nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
 				// create host networked pod
@@ -1719,18 +1728,36 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 					}
 				}
 
+				// With dynamic UDN allocation, networks only exist on nodes that
+				// run workloads attached to them: network A runs pods on every
+				// node while network B only runs a pod on nodes[1].
+				nodesNetB = nodes.Items
+				if isDynamicUDNEnabled() {
+					nodesNetB = []corev1.Node{nodes.Items[1]}
+				}
+
 				ginkgo.By("ensure routes from UDNs are learned by the external FRR router")
 				serverContainerIPs := getBGPServerContainerIPs(f)
 				for _, serverContainerIP := range serverContainerIPs {
 					for _, node := range nodes.Items {
 						if cudnA.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
 							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnA.Name)
-							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
 						} else {
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnATemplate.Spec.Network.Layer2.Subnets)
+						}
+					}
+					for _, node := range nodesNetB {
+						if cudnB.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
+							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
+						} else {
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnBTemplate.Spec.Network.Layer2.Subnets)
 						}
 					}
+				}
+
+				if isDynamicUDNEnabled() && cudnB.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
+					ginkgo.By("ensure nodes without workloads attached to network B get no subnet allocated for it")
+					expectNoUDNSubnetOnNodesExcept(nodes.Items, podNetB.Spec.NodeName, types.CUDNPrefix+cudnB.Name)
 				}
 			})
 
@@ -2185,15 +2212,29 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 						}
 						nodePort := svcNodePortNetB.Spec.Ports[0].NodePort
 						// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", curlConnectionTimeoutCode, true
+						expectedOut := curlConnectionTimeoutCode
+						if isDynamicUDNEnabled() && cudnBTemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
+							// network B is not active on the client's node: for L3
+							// networks the connection is rejected instead of timing
+							// out, for both IP families
+							expectedOut = curlConnectionRefusedCode
+						}
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", expectedOut, true
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in different UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 						clientPod := podsNetA[0]
 						// The service is backed by podNetB.
 						// We want to hit the nodeport on a different node from the client.
-						// client is on nodes[0]. Let's hit nodeport on nodes[2].
-						node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[2].Name, metav1.GetOptions{})
+						// client is on nodes[0]. Let's hit nodeport on nodes[2]. With
+						// dynamic UDN allocation the service is only reachable through
+						// nodes where network B is active, so use the backend's node
+						// nodes[1] instead, still different from the client's.
+						targetNodeName := nodes.Items[2].Name
+						if isDynamicUDNEnabled() {
+							targetNodeName = podNetB.Spec.NodeName
+						}
+						node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), targetNodeName, metav1.GetOptions{})
 						framework.ExpectNoError(err)
 						nodeIPv4, nodeIPv6 := getNodeAddresses(node)
 						nodeIP := nodeIPv4
@@ -2204,6 +2245,28 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 
 						// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+					}),
+				ginkgo.Entry("[ETP=Cluster] UDN pod to a nodeport service in a different UDN network via a node where that network is not active should not work",
+					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+						if !isDynamicUDNEnabled() {
+							e2eskipper.Skipf("Test requires dynamic UDN allocation: networks are active on every node otherwise")
+						}
+						// Documented limitation of dynamic UDN allocation (okep-5552):
+						// NodePort services with external traffic policy "Cluster" do
+						// not work when sending traffic to nodes where the backing
+						// network is not active. Network B is only active on nodes[1],
+						// so its nodeport service is not reachable through nodes[2].
+						clientPod := podsNetA[0]
+						node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[2].Name, metav1.GetOptions{})
+						framework.ExpectNoError(err)
+						nodeIPv4, nodeIPv6 := getNodeAddresses(node)
+						nodeIP := nodeIPv4
+						if ipFamily == utilnet.IPv6 {
+							nodeIP = nodeIPv6
+						}
+						nodePort := svcNodePortNetB.Spec.Ports[0].NodePort
+
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", true
 					}),
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in same UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -850,6 +850,14 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			clientPod, err = createPod(f, echoClientPodName, nodes.Items[1].Name, f.Namespace.Name, []string{"bash", "-c", "sleep infinity"}, nil)
 			framework.ExpectNoError(err)
 
+			// With dynamic UDN allocation, the network only exists on nodes
+			// that run workloads attached to it, which here is just the
+			// client pod's node: only expect it to be advertised.
+			advertisedNodes := nodes.Items
+			if isDynamicUDNEnabled() {
+				advertisedNodes = []corev1.Node{nodes.Items[1]}
+			}
+
 			// Create route advertisement
 			ginkgo.By("create router advertisement")
 			raClient, err := raclientset.NewForConfig(f.ClientConfig())
@@ -941,7 +949,7 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 
 			ginkgo.By("ensure CUDN pod subnet is advertised to the external FRR router")
 			for _, serverContainerIP := range serverContainerIPs {
-				for _, node := range nodes.Items {
+				for _, node := range advertisedNodes {
 					if cudnTemplate.Spec.Network.Layer3 != nil {
 						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cUDN.Name)
 					} else if cudnTemplate.Spec.Network.Layer2 != nil {
@@ -952,13 +960,19 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				}
 			}
 
+			if isDynamicUDNEnabled() && cudnTemplate.Spec.Network.Layer3 != nil {
+				ginkgo.By("ensure nodes without workloads attached to the network get no subnet allocated for it")
+				expectNoUDNSubnetOnNodesExcept(nodes.Items, clientPod.Spec.NodeName, types.CUDNPrefix+cUDN.Name)
+			}
+
 			layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
 			if layer2LocalGateway {
 				ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
 			} else {
 				ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
 			}
-			for _, node := range nodes.Items {
+			// the network topology only exists on the nodes it is allocated on
+			for _, node := range advertisedNodes {
 				nodeName := node.Name
 				for _, tc := range []struct {
 					cidr, nextHop string

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -694,6 +694,78 @@ func cudnLayer3SubnetsB() []udnv1.Layer3Subnet {
 	}}
 }
 
+// expectNoUDNSubnetOnNodesExcept asserts that, with dynamic UDN allocation,
+// no node other than activeNodeName gets a subnet allocated for the network.
+func expectNoUDNSubnetOnNodesExcept(nodes []corev1.Node, activeNodeName, netName string) {
+	ginkgo.GinkgoHelper()
+	gomega.Consistently(func() error {
+		for _, node := range nodes {
+			if node.Name == activeNodeName {
+				continue
+			}
+			if _, _, err := getNodePodCIDRs(node.Name, netName); err == nil {
+				return fmt.Errorf("node %s has a subnet allocated for network %s", node.Name, netName)
+			}
+		}
+		return nil
+	}, 10*time.Second, 2*time.Second).Should(gomega.Succeed())
+}
+
+// expectNodesNotAdvertisedInFRR asserts that the external FRR router has no
+// route within the network's subnets via any node other than activeNodeName.
+func expectNodesNotAdvertisedInFRR(nodes []corev1.Node, activeNodeName, v4CIDR, v6CIDR string) {
+	ginkgo.GinkgoHelper()
+	externalContainer := infraapi.ExternalContainer{Name: routerContainerName}
+	type familyCheck struct {
+		routeCmd []string
+		nextHop  func(corev1.Node) string
+	}
+	var checks []familyCheck
+	if v4CIDR != "" {
+		checks = append(checks, familyCheck{
+			routeCmd: []string{"ip", "route", "show", "root", v4CIDR},
+			nextHop: func(node corev1.Node) string {
+				ips := e2enode.GetAddressesByTypeAndFamily(&node, corev1.NodeInternalIP, corev1.IPv4Protocol)
+				if len(ips) == 0 {
+					return ""
+				}
+				return ips[0]
+			},
+		})
+	}
+	if v6CIDR != "" {
+		checks = append(checks, familyCheck{
+			routeCmd: []string{"ip", "-6", "route", "show", "root", v6CIDR},
+			nextHop: func(node corev1.Node) string {
+				// BGP uses the link-local address as the IPv6 nexthop
+				lla, err := GetNodeIPv6LinkLocalAddressForEth0(node.Name)
+				if err != nil {
+					return ""
+				}
+				return lla
+			},
+		})
+	}
+	gomega.Consistently(func() error {
+		for _, check := range checks {
+			routes, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, check.routeCmd)
+			if err != nil {
+				return fmt.Errorf("failed to get BGP routes from the external router: %w", err)
+			}
+			for _, node := range nodes {
+				if node.Name == activeNodeName {
+					continue
+				}
+				if nextHop := check.nextHop(node); nextHop != "" && strings.Contains(routes, nextHop) {
+					return fmt.Errorf("external router has a route within %q via node %s (%s): %s",
+						strings.Join(check.routeCmd, " "), node.Name, nextHop, routes)
+				}
+			}
+		}
+		return nil
+	}, 10*time.Second, 2*time.Second).Should(gomega.Succeed())
+}
+
 var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advertised", feature.RouteAdvertisements, func() {
 	var serverContainerIPs []string
 	var frrContainerIPv4, frrContainerIPv6 string
@@ -775,17 +847,8 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 
 			// Create client pod
 			ginkgo.By("Creating client pod")
-			podSpec := e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
-			podSpec.Spec.NodeName = nodes.Items[1].Name
-			for k := range podSpec.Spec.Containers {
-				if podSpec.Spec.Containers[k].Name == "agnhost-container" {
-					podSpec.Spec.Containers[k].Command = []string{
-						"sleep",
-						"infinity",
-					}
-				}
-			}
-			clientPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), podSpec)
+			clientPod, err = createPod(f, echoClientPodName, nodes.Items[1].Name, f.Namespace.Name, []string{"bash", "-c", "sleep infinity"}, nil)
+			framework.ExpectNoError(err)
 
 			// Create route advertisement
 			ginkgo.By("create router advertisement")
@@ -1185,6 +1248,170 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			},
 		),
 	)
+})
+
+// With dynamic UDN allocation, a network only exists on nodes that run
+// workloads attached to it and only those nodes get a subnet allocated for it.
+// A pod-network RouteAdvertisements selecting such a network must not wait for
+// subnets on the remaining nodes to reach the Accepted status, and must start
+// advertising a node as soon as the network is activated on it.
+var _ = ginkgo.Describe("BGP: When an advertised CUDN network is dynamically allocated", feature.RouteAdvertisementsDynamicUDN, func() {
+	var nodes *corev1.NodeList
+
+	f := wrappedTestFramework("dynamic-udn-route-advertisements")
+	f.SkipNamespaceCreation = true
+
+	ginkgo.BeforeEach(func() {
+		if !isDynamicUDNEnabled() {
+			ginkgo.Skip("test requires DYNAMIC_UDN_ALLOCATION=true")
+		}
+		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework":           f.BaseName,
+			RequiredUDNNamespaceLabel: "",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		f.Namespace = namespace
+
+		ginkgo.By("Selecting 3 schedulable nodes")
+		nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
+	})
+
+	ginkgo.It("is accepted when the network is allocated on a subset of the nodes only", func() {
+		ginkgo.By("create ClusterUserDefinedNetwork")
+		cudnTemplate := &udnv1.ClusterUserDefinedNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				// Keep generated CUDN names under the Linux 15-byte interface
+				// limit so the VRF name is unique instead of network ID based.
+				GenerateName: "bgp-dyn-",
+				Labels:       map[string]string{"bgp-dynamic-udn": ""},
+			},
+			Spec: udnv1.ClusterUserDefinedNetworkSpec{
+				NamespaceSelector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "kubernetes.io/metadata.name",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{f.Namespace.Name},
+				}}},
+				Network: udnv1.NetworkSpec{
+					Topology: udnv1.NetworkTopologyLayer3,
+					Layer3: &udnv1.Layer3Config{
+						Role: "Primary",
+						// use a dedicated range: other suites advertise their
+						// networks to the same external router and may run in
+						// parallel with this test
+						Subnets: []udnv1.Layer3Subnet{{
+							CIDR:       "106.106.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2016:100:200::0/60",
+							HostSubnet: 64,
+						}},
+					},
+				},
+			},
+		}
+		cudnTemplate.Spec.Network.Layer3.Subnets = filterL3Subnets(f.ClientSet, cudnTemplate.Spec.Network.Layer3.Subnets)
+		var v4CIDR, v6CIDR string
+		for _, subnet := range cudnTemplate.Spec.Network.Layer3.Subnets {
+			if utilnet.IsIPv6CIDRString(string(subnet.CIDR)) {
+				v6CIDR = string(subnet.CIDR)
+			} else {
+				v4CIDR = string(subnet.CIDR)
+			}
+		}
+		udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		cUDN, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudnTemplate, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), cUDN.Name, metav1.DeleteOptions{})
+		})
+		gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cUDN.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
+		netName := types.CUDNPrefix + cUDN.Name
+
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", f.Namespace.Name))
+			gomega.Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
+		})
+
+		activeNode := nodes.Items[0]
+		otherNode := nodes.Items[1]
+
+		ginkgo.By(fmt.Sprintf("Creating a pod attached to the network on node %s only", activeNode.Name))
+		_, err = createPod(f, "dynamic-udn-pod-1", activeNode.Name, f.Namespace.Name, []string{"bash", "-c", "sleep infinity"}, nil)
+		framework.ExpectNoError(err)
+
+		ginkgo.By(fmt.Sprintf("Node %s gets a subnet allocated for the network while the other nodes do not", activeNode.Name))
+		gomega.Eventually(func() error {
+			_, _, err := getNodePodCIDRs(activeNode.Name, netName)
+			return err
+		}, 30*time.Second, time.Second).Should(gomega.Succeed(),
+			"node %s must have a subnet allocated for network %s", activeNode.Name, netName)
+		expectNoUDNSubnetOnNodesExcept(nodes.Items, activeNode.Name, netName)
+
+		ginkgo.By("create route advertisement advertising the network")
+		raClient, err := raclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ra := &rav1.RouteAdvertisements{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bgp-dynamic-udn-ra",
+			},
+			Spec: rav1.RouteAdvertisementsSpec{
+				NetworkSelectors: apitypes.NetworkSelectors{
+					apitypes.NetworkSelector{
+						NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+						ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+							NetworkSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"bgp-dynamic-udn": ""},
+							},
+						},
+					},
+				},
+				NodeSelector:             metav1.LabelSelector{},
+				FRRConfigurationSelector: metav1.LabelSelector{},
+				Advertisements: []rav1.AdvertisementType{
+					rav1.PodNetwork,
+				},
+			},
+		}
+		ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() { raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), ra.Name, metav1.DeleteOptions{}) })
+
+		ginkgo.By("ensure the route advertisement is accepted although the network is not allocated on all nodes")
+		gomega.Eventually(routeAdvertisementsReadyFunc(*raClient, ra.Name), 30*time.Second, time.Second).Should(gomega.Succeed())
+
+		checkNodeAdvertisedInFRR := func(node corev1.Node) {
+			var podv4CIDR, podv6CIDR string
+			gomega.Eventually(func() error {
+				var err error
+				podv4CIDR, podv6CIDR, err = getNodePodCIDRs(node.Name, netName)
+				return err
+			}, 30*time.Second, time.Second).Should(gomega.Succeed(),
+				"node %s must have a subnet allocated for network %s", node.Name, netName)
+			if isIPv4Supported(f.ClientSet) && podv4CIDR != "" {
+				checkRouteInFRR(node, podv4CIDR, routerContainerName, false)
+			}
+			if isIPv6Supported(f.ClientSet) && podv6CIDR != "" {
+				checkRouteInFRR(node, podv6CIDR, routerContainerName, true)
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("ensure the network pod subnet of node %s is advertised to the external FRR router", activeNode.Name))
+		checkNodeAdvertisedInFRR(activeNode)
+
+		ginkgo.By("ensure nodes where the network is not allocated are not advertised to the external FRR router")
+		expectNodesNotAdvertisedInFRR(nodes.Items, activeNode.Name, v4CIDR, v6CIDR)
+
+		ginkgo.By(fmt.Sprintf("Creating a second pod on node %s activates the network on it and gets it advertised", otherNode.Name))
+		_, err = createPod(f, "dynamic-udn-pod-2", otherNode.Name, f.Namespace.Name, []string{"bash", "-c", "sleep infinity"}, nil)
+		framework.ExpectNoError(err)
+		checkNodeAdvertisedInFRR(otherNode)
+
+		gomega.Eventually(routeAdvertisementsReadyFunc(*raClient, ra.Name), 10*time.Second, time.Second).Should(gomega.Succeed(),
+			"the route advertisement must remain accepted")
+	})
 })
 
 var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -175,6 +175,19 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ] || [ "$DYNAMIC_UDN_ALLOCATION" != 
   skip_label "Feature:RouteAdvertisementsDynamicUDN"
 fi
 
+# With dynamic UDN allocation, networks only exist on nodes that run workloads
+# attached to them (okep-5552). Skip the RouteAdvertisements tests that have
+# not been adapted to that yet:
+# - the isolation tests expect the networks and their NodePort services to be
+#   reachable through every node, which does not hold for nodes where the
+#   network is not rendered (a documented limitation of dynamic UDN allocation)
+# - the VRF-Lite and EVPN tests (only supported in local gateway mode today)
+#   set up and expect per-network topology on every node
+if [ "$DYNAMIC_UDN_ALLOCATION" == true ]; then
+  skip "BGP: isolation between advertised networks"
+  skip "BGP: For BGP configured networks"
+fi
+
 if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ]; then
   skip_label "Feature:RouteAdvertisements"
 else

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -175,16 +175,13 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ] || [ "$DYNAMIC_UDN_ALLOCATION" != 
   skip_label "Feature:RouteAdvertisementsDynamicUDN"
 fi
 
-# With dynamic UDN allocation, networks only exist on nodes that run workloads
-# attached to them (okep-5552). Skip the RouteAdvertisements tests that have
-# not been adapted to that yet:
-# - the isolation tests expect the networks and their NodePort services to be
-#   reachable through every node, which does not hold for nodes where the
-#   network is not rendered (a documented limitation of dynamic UDN allocation)
-# - the VRF-Lite and EVPN tests (only supported in local gateway mode today)
-#   set up and expect per-network topology on every node
+# The "BGP: For BGP configured networks" tests (VRF-Lite and EVPN CUDNs) only
+# run in local gateway mode, while dynamic UDN allocation is only covered in
+# shared gateway mode lanes, so the two never overlap in CI. Skip them
+# explicitly on dynamic UDN clusters regardless: they set up and expect
+# per-network topology on every node, which does not hold with dynamic UDN
+# allocation (okep-5552).
 if [ "$DYNAMIC_UDN_ALLOCATION" == true ]; then
-  skip "BGP: isolation between advertised networks"
   skip "BGP: For BGP configured networks"
 fi
 

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -169,6 +169,12 @@ if [ "$ENABLE_NO_OVERLAY" != true ]; then
   skip_label "Feature:NoOverlay"
 fi
 
+# RouteAdvertisements tests over dynamically allocated UDNs require a cluster
+# with both route advertisements and dynamic UDN allocation enabled.
+if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ] || [ "$DYNAMIC_UDN_ALLOCATION" != true ]; then
+  skip_label "Feature:RouteAdvertisementsDynamicUDN"
+fi
+
 if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ]; then
   skip_label "Feature:RouteAdvertisements"
 else


### PR DESCRIPTION
Dynamic UDN allocation creates CUDN host subnets only on nodes that actively use the network. `RouteAdvertisements` for `PodNetwork` select all cluster nodes and currently require every selected Layer 3 network to have a host subnet on every node.

An inactive node without a CUDN subnet is therefore treated as a configuration error,  while it is the expected state for a dynamic UDN. The `RouteAdvertisement` remains `Not Accepted` while waiting for a subnet that the dynamic UDN would not allocate. Furthermore, creating a pod in this dynamic UDN will be stuck in `ContainerCreating`.

This change makes the RA controller take into account per-node dynamic UDNs while preserving missing-subnet errors for active and non-Dynamic networks.

Finally, to improve coverage for dynamic UDN, enable dynamic UDN in the existing unmanaged no-overlay shared-gw lane: `bgp-no-overlay` becomes `bgp-no-overlay-dynamic`.