### PR TITLE
iprulemanager: refactor to use map-based rule tracking and reduce reconciles

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -865,7 +865,7 @@ func (c *Controller) repairNode() error {
 	assignedIPRoutes := sets.New[string]()
 	assignedIPRouteStrToRoutes := make(map[string]netlink.Route)
 	assignedIPRules := sets.New[string]()
-	assignedIPRulesStrToRules := make(map[string]netlink.Rule)
+	assignedIPRulesStrToRules := make(map[string]iprulemanager.IPRule)
 	existingAddrsFromAnnot, err := c.getAnnotation()
 	if err != nil {
 		return fmt.Errorf("failed to get annotation: %v", err)
@@ -910,9 +910,10 @@ func (c *Controller) repairNode() error {
 		return fmt.Errorf("failed to list IP rules: %v", err)
 	}
 	for _, existingRule := range existingRules {
-		ruleStr := existingRule.String()
+		ipRule := iprulemanager.IPRuleFromNetlinkRule(&existingRule)
+		ruleStr := ipRule.String()
 		assignedIPRules.Insert(ruleStr)
-		assignedIPRulesStrToRules[ruleStr] = existingRule
+		assignedIPRulesStrToRules[ruleStr] = ipRule
 	}
 	expectedAddrs := sets.New[addrLink]()
 	expectedIPRoutes := sets.New[string]()
@@ -1267,11 +1268,11 @@ func (c *Controller) removeStaleIPRoutes(staleIPRoutes sets.Set[string], routeSt
 	return nil
 }
 
-func (c *Controller) removeStaleIPRules(staleIPRules sets.Set[string], ruleStrToNetlinkRule map[string]netlink.Rule) error {
+func (c *Controller) removeStaleIPRules(staleIPRules sets.Set[string], ruleStrToIPRule map[string]iprulemanager.IPRule) error {
 	for _, ipRule := range staleIPRules.UnsortedList() {
-		rule, ok := ruleStrToNetlinkRule[ipRule]
+		rule, ok := ruleStrToIPRule[ipRule]
 		if !ok {
-			return fmt.Errorf("expected to find route %q in map: %+v", ipRule, ruleStrToNetlinkRule)
+			return fmt.Errorf("expected to find rule %q in map: %+v", ipRule, ruleStrToIPRule)
 		}
 		if err := c.ruleManager.Delete(rule); err != nil {
 			return fmt.Errorf("failed to delete IP rule (%s): %v", rule.String(), err)
@@ -1455,21 +1456,19 @@ func isLinkUp(flags string) bool {
 
 // generateIPRules generates IP rules at a predefined priority for each pod IP with a custom routing table based
 // from the links 'ifindex'
-func generateIPRule(srcIP net.IP, isIPv6 bool, ifIndex int) netlink.Rule {
-	r := *netlink.NewRule()
-	r.Table = util.CalculateRouteTableID(ifIndex)
-	r.Priority = rulePriority
-	var ipFullMask string
+func generateIPRule(srcIP net.IP, isIPv6 bool, ifIndex int) iprulemanager.IPRule {
+	family := netlink.FAMILY_V4
 	if isIPv6 {
-		ipFullMask = fmt.Sprintf("%s/128", srcIP.String())
-		r.Family = netlink.FAMILY_V6
-	} else {
-		ipFullMask = fmt.Sprintf("%s/32", srcIP.String())
-		r.Family = netlink.FAMILY_V4
+		family = netlink.FAMILY_V6
 	}
-	_, ipNet, _ := net.ParseCIDR(ipFullMask)
-	r.Src = ipNet
-	return r
+	addr, _ := netip.AddrFromSlice(srcIP)
+	addr = addr.Unmap()
+	return iprulemanager.IPRule{
+		Table:    util.CalculateRouteTableID(ifIndex),
+		Priority: rulePriority,
+		Family:   family,
+		Src:      netip.PrefixFrom(addr, addr.BitLen()),
+	}
 }
 
 func filterRouteByLinkTable(linkIndex, tableID int) (*netlink.Route, uint64) {
@@ -1522,13 +1521,13 @@ func isValidIP(ipStr string) bool {
 	return len(ip) > 0
 }
 
-func getNodeIPFwMarkIPRule(ipFamily int) netlink.Rule {
-	r := netlink.NewRule()
-	r.Priority = ruleFwMarkPriority
-	r.Mark = types.EgressIPConnmarkMark
-	r.Table = 254 // main
-	r.Family = ipFamily
-	return *r
+func getNodeIPFwMarkIPRule(ipFamily int) iprulemanager.IPRule {
+	return iprulemanager.IPRule{
+		Priority: ruleFwMarkPriority,
+		Mark:     types.EgressIPConnmarkMark,
+		Table:    254, // main
+		Family:   ipFamily,
+	}
 }
 
 func isVRFSlaveDevice(link netlink.Link) bool {

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
+	"net/netip"
 	"runtime"
 	"strings"
 	"sync"
@@ -37,6 +38,7 @@ import (
 	egressipfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	ovnkube "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/linkmanager"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
@@ -51,7 +53,7 @@ type testPodConfig struct {
 	snatKey   string // pod IP (key in nftables SNAT map)
 	snatValue string // egress IP (value in nftables SNAT map)
 	ifName    string // interface name (second key element in nftables SNAT map)
-	ipRule    *netlink.Rule
+	ipRule    *iprulemanager.IPRule
 }
 
 // eipConfig contains all the information needed to validate an EIP. Max one EIP IP maybe configured for a given
@@ -520,13 +522,13 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 		}).WithTimeout(time.Second).Should(gomega.Succeed())
 		ginkgo.By("verify expected IP rules match what was found")
 		// verify the correct rules are present and also no rule entries we do not expect
-		expectedIPRules := make(map[string][]netlink.Rule, 0)
+		expectedIPRules := make(map[string][]iprulemanager.IPRule, 0)
 		for _, expectedEIPConfig := range expectedEIPConfigs {
 			if len(expectedEIPConfig.podConfigs) == 0 {
 				// no pod configs expected therefore no IP routes
 				continue
 			}
-			var expectedRules []netlink.Rule
+			var expectedRules []iprulemanager.IPRule
 			for _, status := range expectedEIPConfig.eIP.Status.Items {
 				if status.Node != node1Name {
 					continue
@@ -558,27 +560,24 @@ var _ = ginkgo.DescribeTable("EgressIP selectors",
 						if err != nil {
 							return err
 						}
-						temp := foundRules[:0]
+						var foundIPRules []iprulemanager.IPRule
 						for _, rule := range foundRules {
 							if rule.Priority == rulePriority {
-								temp = append(temp, rule)
+								foundIPRules = append(foundIPRules, iprulemanager.IPRuleFromNetlinkRule(&rule))
 							}
 						}
-						foundRules = temp
 						expectedRules := expectedIPRules[expectedEIPConfig.eIP.Name]
 						var found bool
 						for _, expectedRule := range expectedRules {
 							found = false
-							for _, foundRule := range foundRules {
-								if expectedRule.Src.IP.Equal(foundRule.Src.IP) {
-									if expectedRule.Table == foundRule.Table {
-										found = true
-										break
-									}
+							for _, foundRule := range foundIPRules {
+								if expectedRule == foundRule {
+									found = true
+									break
 								}
 							}
 							if !found {
-								return fmt.Errorf("failed to find rule %s", expectedRule)
+								return fmt.Errorf("failed to find rule %s", expectedRule.String())
 							}
 						}
 					}
@@ -1712,14 +1711,18 @@ func containsRoutes(routes1 []netlink.Route, routes2 []netlink.Route) bool {
 	return true
 }
 
-func getRule(podIP string, tableID int) *netlink.Rule {
-	ipNet, err := util.GetIPNetFullMask(podIP)
+func getRule(podIP string, tableID int) *iprulemanager.IPRule {
+	addr, err := netip.ParseAddr(podIP)
 	if err != nil {
-		panic(err.Error())
+		panic(fmt.Sprintf("invalid IP: %s", podIP))
 	}
-	return &netlink.Rule{
+	bits := 32
+	if addr.Is6() {
+		bits = 128
+	}
+	return &iprulemanager.IPRule{
 		Priority: rulePriority,
-		Src:      ipNet,
+		Src:      netip.PrefixFrom(addr, bits),
 		Table:    tableID,
 	}
 }

--- a/go-controller/pkg/node/controllers/egressip/pod.go
+++ b/go-controller/pkg/node/controllers/egressip/pod.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/vishvananda/netlink"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -18,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 )
 
 // podIPConfig holds pod specific info to implement egress IP for secondary host networks for a single pod IP. A pod may
@@ -28,7 +28,7 @@ type podIPConfig struct {
 	snatKey   string // pod IP used as key in nftables SNAT map
 	snatValue string // egress IP used as value in nftables SNAT map
 	ifName    string // output interface name used as part of the nftables SNAT map concatenated key
-	ipRule    netlink.Rule
+	ipRule    iprulemanager.IPRule
 }
 
 func newPodIPConfig() *podIPConfig {
@@ -42,10 +42,7 @@ func (pIC *podIPConfig) equal(pIC2 *podIPConfig) bool {
 	if pIC.snatKey != pIC2.snatKey || pIC.snatValue != pIC2.snatValue || pIC.ifName != pIC2.ifName {
 		return false
 	}
-	if pIC.ipRule.String() != pIC2.ipRule.String() {
-		return false
-	}
-	return true
+	return pIC.ipRule == pIC2.ipRule
 }
 
 // podIPConfigList holds a list of podIPConfig to configure EIP for a single pod and its IPs.

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"syscall"
 	"time"
 
@@ -1113,11 +1114,11 @@ func (udng *UserDefinedNetworkGateway) getV6MasqueradeIP() (*net.IPNet, error) {
 // 2000:	from all fwmark 0x1001 lookup 1007
 // 2000:	from all to 10.132.0.0/14 lookup 1007
 // 2000:	from all to 169.254.0.12 lookup 1007
-func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules() ([]netlink.Rule, []netlink.Rule, error) {
-	var addIPRules []netlink.Rule
-	var delIPRules []netlink.Rule
-	var masqIPRules []netlink.Rule
-	var subnetIPRules []netlink.Rule
+func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules() ([]iprulemanager.IPRule, []iprulemanager.IPRule, error) {
+	var addIPRules []iprulemanager.IPRule
+	var delIPRules []iprulemanager.IPRule
+	var masqIPRules []iprulemanager.IPRule
+	var subnetIPRules []iprulemanager.IPRule
 	masqIPv4, err := udng.getV4MasqueradeIP()
 	if err != nil {
 		return nil, nil, err
@@ -1158,39 +1159,47 @@ func (udng *UserDefinedNetworkGateway) constructUDNVRFIPRules() ([]netlink.Rule,
 	return addIPRules, delIPRules, nil
 }
 
-func generateIPRuleForPacketMark(mark uint, isIPv6 bool, vrfTableId uint) netlink.Rule {
-	r := *netlink.NewRule()
-	r.Table = int(vrfTableId)
-	r.Priority = UDNMasqueradeIPRulePriority
-	r.Family = netlink.FAMILY_V4
+func generateIPRuleForPacketMark(mark uint, isIPv6 bool, vrfTableId uint) iprulemanager.IPRule {
+	family := netlink.FAMILY_V4
 	if isIPv6 {
-		r.Family = netlink.FAMILY_V6
+		family = netlink.FAMILY_V6
 	}
-	r.Mark = uint32(mark)
-	return r
-}
-func generateIPRuleForMasqIP(masqIP net.IP, isIPv6 bool, vrfTableId uint) netlink.Rule {
-	r := *netlink.NewRule()
-	r.Table = int(vrfTableId)
-	r.Priority = UDNMasqueradeIPRulePriority
-	r.Family = netlink.FAMILY_V4
-	if isIPv6 {
-		r.Family = netlink.FAMILY_V6
+	return iprulemanager.IPRule{
+		Table:    int(vrfTableId),
+		Priority: UDNMasqueradeIPRulePriority,
+		Family:   family,
+		Mark:     uint32(mark),
 	}
-	r.Dst = util.GetIPNetFullMaskFromIP(masqIP)
-	return r
 }
 
-func generateIPRuleForUDNSubnet(udnIP *net.IPNet, isIPv6 bool, vrfTableId uint) netlink.Rule {
-	r := *netlink.NewRule()
-	r.Table = int(vrfTableId)
-	r.Priority = UDNMasqueradeIPRulePriority
-	r.Family = netlink.FAMILY_V4
+func generateIPRuleForMasqIP(masqIP net.IP, isIPv6 bool, vrfTableId uint) iprulemanager.IPRule {
+	family := netlink.FAMILY_V4
 	if isIPv6 {
-		r.Family = netlink.FAMILY_V6
+		family = netlink.FAMILY_V6
 	}
-	r.Dst = udnIP
-	return r
+	addr, _ := netip.AddrFromSlice(masqIP)
+	addr = addr.Unmap()
+	return iprulemanager.IPRule{
+		Table:    int(vrfTableId),
+		Priority: UDNMasqueradeIPRulePriority,
+		Family:   family,
+		Dst:      netip.PrefixFrom(addr, addr.BitLen()),
+	}
+}
+
+func generateIPRuleForUDNSubnet(udnIP *net.IPNet, isIPv6 bool, vrfTableId uint) iprulemanager.IPRule {
+	family := netlink.FAMILY_V4
+	if isIPv6 {
+		family = netlink.FAMILY_V6
+	}
+	addr, _ := netip.AddrFromSlice(udnIP.IP)
+	ones, _ := udnIP.Mask.Size()
+	return iprulemanager.IPRule{
+		Table:    int(vrfTableId),
+		Priority: UDNMasqueradeIPRulePriority,
+		Family:   family,
+		Dst:      netip.PrefixFrom(addr.Unmap(), ones),
+	}
 }
 
 func (udng *UserDefinedNetworkGateway) run() {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"sort"
 	"strings"
 	"sync"
@@ -2742,7 +2743,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 		family   int
 		table    int
 		mark     uint32
-		dst      net.IPNet
+		dst      netip.Prefix
 	}
 	type testConfig struct {
 		desc          string
@@ -2773,7 +2774,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      netip.MustParsePrefix("169.254.0.16/32"),
 				},
 			},
 			deleteRules: []testRule{
@@ -2781,7 +2782,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      netip.MustParsePrefix("100.128.0.0/16"),
 				},
 			},
 			v4mode: true,
@@ -2800,7 +2801,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      netip.MustParsePrefix("fd69::10/128"),
 				},
 			},
 			deleteRules: []testRule{
@@ -2808,7 +2809,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      netip.MustParsePrefix("ae70::/60"),
 				},
 			},
 			v6mode: true,
@@ -2833,13 +2834,13 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      netip.MustParsePrefix("169.254.0.16/32"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      netip.MustParsePrefix("fd69::10/128"),
 				},
 			},
 			deleteRules: []testRule{
@@ -2847,13 +2848,13 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      netip.MustParsePrefix("100.128.0.0/16"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      netip.MustParsePrefix("ae70::/60"),
 				},
 			},
 			v4mode: true,
@@ -2910,8 +2911,8 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))
 				g.Expect(rule.Family).To(Equal(test.expectedRules[i].family))
-				if rule.Dst != nil {
-					g.Expect(*rule.Dst).To(Equal(test.expectedRules[i].dst))
+				if rule.Dst.IsValid() {
+					g.Expect(rule.Dst).To(Equal(test.expectedRules[i].dst))
 				} else {
 					g.Expect(rule.Mark).To(Equal(test.expectedRules[i].mark))
 				}
@@ -2920,7 +2921,7 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 				g.Expect(rule.Priority).To(Equal(test.deleteRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.deleteRules[i].table))
 				g.Expect(rule.Family).To(Equal(test.deleteRules[i].family))
-				g.Expect(*rule.Dst).To(Equal(test.deleteRules[i].dst))
+				g.Expect(rule.Dst).To(Equal(test.deleteRules[i].dst))
 			}
 		})
 	}
@@ -2935,7 +2936,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 		family   int
 		table    int
 		mark     uint32
-		dst      net.IPNet
+		dst      netip.Prefix
 	}
 	type testConfig struct {
 		desc          string
@@ -2961,13 +2962,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      netip.MustParsePrefix("169.254.0.16/32"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      netip.MustParsePrefix("100.128.0.0/16"),
 				},
 			},
 			v4mode: true,
@@ -2986,13 +2987,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      netip.MustParsePrefix("fd69::10/128"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      netip.MustParsePrefix("ae70::/60"),
 				},
 			},
 			v6mode: true,
@@ -3017,25 +3018,25 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      netip.MustParsePrefix("169.254.0.16/32"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      netip.MustParsePrefix("fd69::10/128"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      netip.MustParsePrefix("100.128.0.0/16"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      netip.MustParsePrefix("ae70::/60"),
 				},
 			},
 			v4mode: true,
@@ -3096,8 +3097,8 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))
 				g.Expect(rule.Family).To(Equal(test.expectedRules[i].family))
-				if rule.Dst != nil {
-					g.Expect(*rule.Dst).To(Equal(test.expectedRules[i].dst))
+				if rule.Dst.IsValid() {
+					g.Expect(rule.Dst).To(Equal(test.expectedRules[i].dst))
 				} else {
 					g.Expect(rule.Mark).To(Equal(test.expectedRules[i].mark))
 				}
@@ -3106,7 +3107,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToDefaultVRF(t *testing.T) {
 				g.Expect(rule.Priority).To(Equal(test.deleteRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.deleteRules[i].table))
 				g.Expect(rule.Family).To(Equal(test.deleteRules[i].family))
-				g.Expect(*rule.Dst).To(Equal(test.deleteRules[i].dst))
+				g.Expect(rule.Dst).To(Equal(test.deleteRules[i].dst))
 			}
 		})
 	}
@@ -3121,7 +3122,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 		family   int
 		table    int
 		mark     uint32
-		dst      net.IPNet
+		dst      netip.Prefix
 	}
 	type testConfig struct {
 		desc          string
@@ -3147,7 +3148,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      netip.MustParsePrefix("169.254.0.16/32"),
 				},
 			},
 			deleteRules: []testRule{
@@ -3155,7 +3156,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1007,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      netip.MustParsePrefix("100.128.0.0/16"),
 				},
 			},
 			v4mode: true,
@@ -3174,7 +3175,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      netip.MustParsePrefix("fd69::10/128"),
 				},
 			},
 			deleteRules: []testRule{
@@ -3182,7 +3183,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1009,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      netip.MustParsePrefix("ae70::/60"),
 				},
 			},
 			v6mode: true,
@@ -3207,13 +3208,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("169.254.0.16")),
+					dst:      netip.MustParsePrefix("169.254.0.16/32"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
-					dst:      *util.GetIPNetFullMaskFromIP(ovntest.MustParseIP("fd69::10")),
+					dst:      netip.MustParsePrefix("fd69::10/128"),
 				},
 			},
 			deleteRules: []testRule{
@@ -3221,13 +3222,13 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V4,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("100.128.0.0/16"),
+					dst:      netip.MustParsePrefix("100.128.0.0/16"),
 				},
 				{
 					priority: UDNMasqueradeIPRulePriority,
 					family:   netlink.FAMILY_V6,
 					table:    1010,
-					dst:      *ovntest.MustParseIPNet("ae70::/60"),
+					dst:      netip.MustParsePrefix("ae70::/60"),
 				},
 			},
 			v4mode: true,
@@ -3290,8 +3291,8 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 				g.Expect(rule.Priority).To(Equal(test.expectedRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.expectedRules[i].table))
 				g.Expect(rule.Family).To(Equal(test.expectedRules[i].family))
-				if rule.Dst != nil {
-					g.Expect(*rule.Dst).To(Equal(test.expectedRules[i].dst))
+				if rule.Dst.IsValid() {
+					g.Expect(rule.Dst).To(Equal(test.expectedRules[i].dst))
 				} else {
 					g.Expect(rule.Mark).To(Equal(test.expectedRules[i].mark))
 				}
@@ -3300,7 +3301,7 @@ func TestConstructUDNVRFIPRulesPodNetworkAdvertisedToNonDefaultVRF(t *testing.T)
 				g.Expect(rule.Priority).To(Equal(test.deleteRules[i].priority))
 				g.Expect(rule.Table).To(Equal(test.deleteRules[i].table))
 				g.Expect(rule.Family).To(Equal(test.deleteRules[i].family))
-				g.Expect(*rule.Dst).To(Equal(test.deleteRules[i].dst))
+				g.Expect(rule.Dst).To(Equal(test.deleteRules[i].dst))
 			}
 		})
 	}

--- a/go-controller/pkg/node/iprulemanager/fake.go
+++ b/go-controller/pkg/node/iprulemanager/fake.go
@@ -6,8 +6,6 @@ package iprulemanager
 import (
 	"fmt"
 	"time"
-
-	"github.com/vishvananda/netlink"
 )
 
 type FakeControllerWithError struct {
@@ -15,13 +13,13 @@ type FakeControllerWithError struct {
 
 func (f *FakeControllerWithError) Run(_ <-chan struct{}, _ time.Duration) {
 }
-func (f *FakeControllerWithError) Add(_ netlink.Rule) error {
+func (f *FakeControllerWithError) Add(_ IPRule) error {
 	return nil
 }
-func (f *FakeControllerWithError) AddWithMetadata(_ netlink.Rule, _ string) error {
+func (f *FakeControllerWithError) AddWithMetadata(_ IPRule, _ string) error {
 	return nil
 }
-func (f *FakeControllerWithError) Delete(_ netlink.Rule) error {
+func (f *FakeControllerWithError) Delete(_ IPRule) error {
 	return nil
 }
 func (f *FakeControllerWithError) DeleteWithMetadata(_ string) error {

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -4,9 +4,11 @@
 package iprulemanager
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -73,16 +75,7 @@ func (rm *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 
 // Add ensures an IP rule is applied even if it is altered by something else, it will be restored
 func (rm *Controller) Add(rule netlink.Rule) error {
-	rm.mu.Lock()
-	defer rm.mu.Unlock()
-	// check if we are already managing this rule and if so, no-op
-	for _, existingRule := range rm.rules {
-		if areNetlinkRulesEqual(existingRule.rule, &rule) {
-			return nil
-		}
-	}
-	rm.rules = append(rm.rules, ipRule{rule: &rule}) // empty metadata
-	return rm.reconcile()
+	return rm.AddWithMetadata(rule, "")
 }
 
 // AddWithMetadata ensures an IP rule along with its metadata is applied even if it is altered by something else, it will be restored
@@ -96,7 +89,11 @@ func (rm *Controller) AddWithMetadata(rule netlink.Rule, metadata string) error 
 		}
 	}
 	rm.rules = append(rm.rules, ipRule{rule: &rule, metadata: metadata})
-	return rm.reconcile()
+	if err := netlink.RuleAdd(&rule); err != nil && !errors.Is(err, syscall.EEXIST) {
+		return err
+	}
+
+	return nil
 }
 
 // Delete stops managed an IP rule and ensures its deleted

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -4,9 +4,13 @@
 package iprulemanager
 
 import (
+	"errors"
 	"fmt"
+	"maps"
 	"net"
+	"net/netip"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -18,33 +22,108 @@ import (
 
 type Interface interface {
 	Run(stopCh <-chan struct{}, syncPeriod time.Duration)
-	Add(rule netlink.Rule) error
-	AddWithMetadata(rule netlink.Rule, metadata string) error
-	Delete(rule netlink.Rule) error
+	Add(rule IPRule) error
+	AddWithMetadata(rule IPRule, metadata string) error
+	Delete(rule IPRule) error
 	DeleteWithMetadata(metadata string) error
 	OwnPriority(priority int) error
 }
 
-type ipRule struct {
-	rule     *netlink.Rule
+// This struct should be updated whenever a new netlink.Rule field is used in the codebase.
+type IPRule struct {
+	Priority int
+	Table    int
+	Family   int
+	Mark     uint32
+	Src      netip.Prefix
+	Dst      netip.Prefix
+}
+
+type ruleState struct {
 	metadata string
 	delete   bool
 }
 
 type Controller struct {
 	mu    *sync.Mutex
-	rules []ipRule
+	rules map[IPRule]ruleState
 	// only explicit IP rules (via fn Add) are allowed when a priority is owned. Other IP rules will be removed.
 	ownPriorities map[int]bool
 	v4            bool
 	v6            bool
 }
 
+func (r IPRule) String() string {
+	s := fmt.Sprintf("priority:%d table:%d family:%d mark:0x%x", r.Priority, r.Table, r.Family, r.Mark)
+	if r.Src.IsValid() {
+		s += fmt.Sprintf(" src:%s", r.Src)
+	}
+	if r.Dst.IsValid() {
+		s += fmt.Sprintf(" dst:%s", r.Dst)
+	}
+	return s
+}
+
+// IPRuleFromNetlinkRule will extract relevant fields from a netlink rule.
+// This function does not copy a netlink rule one-to-one.
+// If additional fields are needed, they must be added to IPRule.
+func IPRuleFromNetlinkRule(r *netlink.Rule) IPRule {
+	return IPRule{
+		Priority: r.Priority,
+		Table:    r.Table,
+		Family:   r.Family,
+		Mark:     r.Mark,
+		Src:      ipNetToPrefix(r.Src),
+		Dst:      ipNetToPrefix(r.Dst),
+	}
+}
+
+func (r IPRule) toNetlinkRule() *netlink.Rule {
+	nl := netlink.NewRule()
+	nl.Priority = r.Priority
+	nl.Table = r.Table
+	nl.Family = r.Family
+	nl.Mark = r.Mark
+	nl.Src = prefixToIPNet(r.Src)
+	nl.Dst = prefixToIPNet(r.Dst)
+	return nl
+}
+
+func ipNetToPrefix(n *net.IPNet) netip.Prefix {
+	if n == nil {
+		return netip.Prefix{}
+	}
+	addr, ok := netip.AddrFromSlice(n.IP)
+	if !ok {
+		return netip.Prefix{}
+	}
+	ones, _ := n.Mask.Size()
+	return netip.PrefixFrom(addr.Unmap(), ones)
+}
+
+func prefixToIPNet(p netip.Prefix) *net.IPNet {
+	if !p.IsValid() {
+		return nil
+	}
+	addr := p.Addr()
+	var ipLen int
+	if addr.Is4() {
+		ipLen = net.IPv4len
+	} else {
+		ipLen = net.IPv6len
+	}
+	ip := addr.As16()
+	return &net.IPNet{
+		IP:   net.IP(ip[16-ipLen:]),
+		Mask: net.CIDRMask(p.Bits(), ipLen*8),
+	}
+}
+
 // NewController creates a new linux IP rule manager
 func NewController(v4, v6 bool) *Controller {
 	return &Controller{
 		mu:            &sync.Mutex{},
-		rules:         make([]ipRule, 0),
+		rules:         make(map[IPRule]ruleState),
 		ownPriorities: make(map[int]bool, 0),
 		v4:            v4,
 		v6:            v6,
@@ -72,48 +151,39 @@ func (rm *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 }
 
 // Add ensures an IP rule is applied even if it is altered by something else, it will be restored
-func (rm *Controller) Add(rule netlink.Rule) error {
-	rm.mu.Lock()
-	defer rm.mu.Unlock()
-	// check if we are already managing this rule and if so, no-op
-	for _, existingRule := range rm.rules {
-		if areNetlinkRulesEqual(existingRule.rule, &rule) {
-			return nil
-		}
-	}
-	rm.rules = append(rm.rules, ipRule{rule: &rule}) // empty metadata
-	return rm.reconcile()
+func (rm *Controller) Add(rule IPRule) error {
+	return rm.AddWithMetadata(rule, "")
 }
 
 // AddWithMetadata ensures an IP rule along with its metadata is applied even if it is altered by something else, it will be restored
-func (rm *Controller) AddWithMetadata(rule netlink.Rule, metadata string) error {
+func (rm *Controller) AddWithMetadata(rule IPRule, metadata string) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	// check if we are already managing this rule and if so, no-op
-	for _, existingRule := range rm.rules {
-		if areNetlinkRulesEqual(existingRule.rule, &rule) {
-			return nil
+
+	if _, ok := rm.rules[rule]; !ok {
+		if err := netlink.RuleAdd(rule.toNetlinkRule()); err != nil && !errors.Is(err, syscall.EEXIST) {
+			return fmt.Errorf("failed to add IP rule (%s): %w", rule.String(), err)
 		}
 	}
-	rm.rules = append(rm.rules, ipRule{rule: &rule, metadata: metadata})
-	return rm.reconcile()
+
+	rm.rules[rule] = ruleState{metadata: metadata, delete: false}
+
+	return nil
 }
 
 // Delete stops managed an IP rule and ensures its deleted
-func (rm *Controller) Delete(rule netlink.Rule) error {
+func (rm *Controller) Delete(rule IPRule) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	var reconcileNeeded bool
-	for i, r := range rm.rules {
-		if areNetlinkRulesEqual(r.rule, &rule) {
-			rm.rules[i].delete = true
-			reconcileNeeded = true
-			break
-		}
+	if _, ok := rm.rules[rule]; !ok {
+		return nil
 	}
-	if reconcileNeeded {
-		return rm.reconcile()
+
+	if err := netlink.RuleDel(rule.toNetlinkRule()); err != nil && !errors.Is(err, syscall.ENOENT) {
+		rm.rules[rule] = ruleState{metadata: rm.rules[rule].metadata, delete: true}
+		return fmt.Errorf("failed to delete IP rule (%s): %w", rule.String(), err)
 	}
+	delete(rm.rules, rule)
 	return nil
 }
 
@@ -124,17 +194,18 @@ func (rm *Controller) DeleteWithMetadata(metadata string) error {
 	}
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	var reconcileNeeded bool
-	for i, r := range rm.rules {
+	var errs []error
+	for rule, r := range rm.rules {
 		if r.metadata == metadata {
-			rm.rules[i].delete = true // marks all rules matching that metadata as ready for deletion
-			reconcileNeeded = true
+			if err := netlink.RuleDel(rule.toNetlinkRule()); err != nil && !errors.Is(err, syscall.ENOENT) {
+				rm.rules[rule] = ruleState{metadata: r.metadata, delete: true}
+				errs = append(errs, fmt.Errorf("failed to delete IP rule (%s): %w", rule.String(), err))
+			} else {
+				delete(rm.rules, rule)
+			}
 		}
 	}
-	if reconcileNeeded {
-		return rm.reconcile()
-	}
-	return nil
+	return utilerrors.Join(errs...)
 }
 
 // OwnPriority ensures any IP rules observed with priority 'priority' must be specified otherwise its removed
@@ -161,105 +232,44 @@ func (rm *Controller) reconcile() error {
 
 	rulesFound, err := netlink.RuleList(family)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list IP rules: %w", err)
 	}
-	var errors []error
-	rulesToKeep := make([]ipRule, 0)
-	for _, r := range rm.rules {
-		// delete IP rule by first checking if it exists and if so, delete it
-		if r.delete {
-			if found, foundRoute := isNetlinkRuleInSlice(rulesFound, r.rule); found {
-				if err = netlink.RuleDel(foundRoute); err != nil {
-					// retry later
-					rulesToKeep = append(rulesToKeep, r)
-					errors = append(errors, err)
+	var errs []error
+	rulesToKeep := make(map[IPRule]ruleState)
+	notInNetlink := make(map[IPRule]ruleState, len(rm.rules))
+	maps.Copy(notInNetlink, rm.rules)
+
+	for _, r := range rulesFound {
+		rule := IPRuleFromNetlinkRule(&r)
+		if state, ok := rm.rules[rule]; ok {
+			delete(notInNetlink, rule)
+			if state.delete {
+				if err = netlink.RuleDel(&r); err != nil {
+					rulesToKeep[rule] = state
+					errs = append(errs, fmt.Errorf("failed to delete IP rule (%s): %w", rule.String(), err))
 				}
+			} else {
+				rulesToKeep[rule] = state
 			}
-		} else {
-			// add IP rule by first checking if it exists and if not, add it
-			rulesToKeep = append(rulesToKeep, r)
-			if found, _ := isNetlinkRuleInSlice(rulesFound, r.rule); !found {
-				if err = netlink.RuleAdd(r.rule); err != nil {
-					errors = append(errors, err)
-				}
+		} else if _, ok := rm.ownPriorities[r.Priority]; ok {
+			klog.Infof("Rule manager: deleting stale IP rule (%s) found at priority %d", rule.String(), r.Priority)
+			if err = netlink.RuleDel(&r); err != nil {
+				errs = append(errs, fmt.Errorf("failed to delete stale IP rule (%s) found at priority %d: %w",
+					rule.String(), r.Priority, err))
 			}
 		}
 	}
 
-	var found bool
-	for priority := range rm.ownPriorities {
-		for _, ruleFound := range rulesFound {
-			if ruleFound.Priority != priority {
-				continue
-			}
-			found = false
-			for _, ruleWanted := range rm.rules {
-				if areNetlinkRulesEqual(ruleWanted.rule, &ruleFound) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				klog.Infof("Rule manager: deleting stale IP rule (%s) found at priority %d", ruleFound.String(), priority)
-				if err = netlink.RuleDel(&ruleFound); err != nil {
-					errors = append(errors, fmt.Errorf("failed to delete stale IP rule (%s) found at priority %d: %v",
-						ruleFound.String(), priority, err))
-				}
-			}
+	for rule, state := range notInNetlink {
+		if state.delete {
+			continue
+		}
+		rulesToKeep[rule] = state
+		if err = netlink.RuleAdd(rule.toNetlinkRule()); err != nil && !errors.Is(err, syscall.EEXIST) {
+			errs = append(errs, fmt.Errorf("failed to add IP rule (%s): %w", rule.String(), err))
 		}
 	}
 
 	rm.rules = rulesToKeep
-	return utilerrors.Join(errors...)
-}
-
-func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
-	if r1.Priority != r2.Priority {
-		return false
-	}
-	if r1.Table != r2.Table {
-		return false
-	}
-	if !areRuleFamiliesEqual(r1.Family, r2.Family) {
-		return false
-	}
-	if r1.Type != r2.Type {
-		return false
-	}
-	if r1.Mark != r2.Mark {
-		return false
-	}
-
-	return areIPNetsEqual(r1.Src, r2.Src) && areIPNetsEqual(r1.Dst, r2.Dst)
-}
-
-func areRuleFamiliesEqual(f1, f2 int) bool {
-	return f1 == f2 || f1 == netlink.FAMILY_ALL || f2 == netlink.FAMILY_ALL
-}
-
-func areIPNetsEqual(n1, n2 *net.IPNet) bool {
-	if n1 == nil && n2 == nil {
-		return true
-	}
-	if n1 == nil || n2 == nil {
-		return false
-	}
-
-	if !n1.IP.Equal(n2.IP) {
-		return false
-	}
-
-	n1ones, n1bits := n1.Mask.Size()
-	n2ones, n2bits := n2.Mask.Size()
-	return n1ones == n2ones && n1bits == n2bits
-}
-
-func isNetlinkRuleInSlice(rules []netlink.Rule, candidate *netlink.Rule) (bool, *netlink.Rule) {
-	for _, r := range rules {
-		r := r
-		if areNetlinkRulesEqual(&r, candidate) {
-			return true, &r
-		}
-	}
-	return false, netlink.NewRule()
+	return utilerrors.Join(errs...)
 }

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -6,6 +6,7 @@ package iprulemanager
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"sync"
 	"syscall"
@@ -35,18 +36,22 @@ type ipRule struct {
 
 type Controller struct {
 	mu    *sync.Mutex
-	rules []ipRule
+	rules map[string]ipRule
 	// only explicit IP rules (via fn Add) are allowed when a priority is owned. Other IP rules will be removed.
 	ownPriorities map[int]bool
 	v4            bool
 	v6            bool
 }
 
+func (rule ipRule) toString() string {
+	return fmt.Sprintf("%s family:%d mark:%d", rule.rule.String(), rule.rule.Family, rule.rule.Mark)
+}
+
 // NewController creates a new linux IP rule manager
 func NewController(v4, v6 bool) *Controller {
 	return &Controller{
 		mu:            &sync.Mutex{},
-		rules:         make([]ipRule, 0),
+		rules:         make(map[string]ipRule),
 		ownPriorities: make(map[int]bool, 0),
 		v4:            v4,
 		v6:            v6,
@@ -82,16 +87,16 @@ func (rm *Controller) Add(rule netlink.Rule) error {
 func (rm *Controller) AddWithMetadata(rule netlink.Rule, metadata string) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
+	addedRule := ipRule{rule: &rule, metadata: metadata, delete: false}
 	// check if we are already managing this rule and if so, no-op
-	for _, existingRule := range rm.rules {
-		if areNetlinkRulesEqual(existingRule.rule, &rule) {
-			return nil
-		}
+	if _, ok := rm.rules[addedRule.toString()]; ok {
+		return nil
 	}
-	rm.rules = append(rm.rules, ipRule{rule: &rule, metadata: metadata})
+
 	if err := netlink.RuleAdd(&rule); err != nil && !errors.Is(err, syscall.EEXIST) {
-		return err
+		return fmt.Errorf("failed to add IP rule (%s): %w", addedRule.toString(), err)
 	}
+	rm.rules[addedRule.toString()] = addedRule
 
 	return nil
 }
@@ -100,18 +105,13 @@ func (rm *Controller) AddWithMetadata(rule netlink.Rule, metadata string) error 
 func (rm *Controller) Delete(rule netlink.Rule) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	var reconcileNeeded bool
-	for i, r := range rm.rules {
-		if areNetlinkRulesEqual(r.rule, &rule) {
-			rm.rules[i].delete = true
-			reconcileNeeded = true
-			break
-		}
+	iprule := ipRule{rule: &rule, metadata: "", delete: true}
+	if _, ok := rm.rules[iprule.toString()]; !ok {
+		return nil
 	}
-	if reconcileNeeded {
-		return rm.reconcile()
-	}
-	return nil
+
+	rm.rules[iprule.toString()] = iprule
+	return rm.reconcile()
 }
 
 // DeleteWithMetadata stops managing all IP rules with the provided metadata and ensures they are all deleted
@@ -124,7 +124,9 @@ func (rm *Controller) DeleteWithMetadata(metadata string) error {
 	var reconcileNeeded bool
 	for i, r := range rm.rules {
 		if r.metadata == metadata {
-			rm.rules[i].delete = true // marks all rules matching that metadata as ready for deletion
+			updatedRule := rm.rules[i]
+			updatedRule.delete = true
+			rm.rules[i] = updatedRule
 			reconcileNeeded = true
 		}
 	}
@@ -158,50 +160,48 @@ func (rm *Controller) reconcile() error {
 
 	rulesFound, err := netlink.RuleList(family)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list IP rules: %w", err)
 	}
 	var errors []error
-	rulesToKeep := make([]ipRule, 0)
-	for _, r := range rm.rules {
-		// delete IP rule by first checking if it exists and if so, delete it
-		if r.delete {
-			if found, foundRoute := isNetlinkRuleInSlice(rulesFound, r.rule); found {
-				if err = netlink.RuleDel(foundRoute); err != nil {
+	rulesToKeep := make(map[string]ipRule, 0)
+	notInNetlink := make(map[string]ipRule, len(rm.rules))
+	maps.Copy(notInNetlink, rm.rules)
+
+	for _, r := range rulesFound {
+		key := ipRule{rule: &r, metadata: "", delete: false}.toString()
+		// check if rule is managed by OVN-K
+		if rule, ok := rm.rules[key]; ok {
+			// rule is present in Netlink
+			delete(notInNetlink, key)
+			if rule.delete {
+				if err = netlink.RuleDel(rule.rule); err != nil {
 					// retry later
-					rulesToKeep = append(rulesToKeep, r)
-					errors = append(errors, err)
+					rulesToKeep[key] = rule
+					errors = append(errors, fmt.Errorf("failed to delete IP rule (%s): %w", rule.toString(), err))
 				}
+			} else {
+				rulesToKeep[key] = rule
 			}
-		} else {
-			// add IP rule by first checking if it exists and if not, add it
-			rulesToKeep = append(rulesToKeep, r)
-			if found, _ := isNetlinkRuleInSlice(rulesFound, r.rule); !found {
-				if err = netlink.RuleAdd(r.rule); err != nil {
-					errors = append(errors, err)
-				}
+		} else if _, ok := rm.ownPriorities[r.Priority]; ok {
+			// if not managed, delete if priority is owned
+			klog.Infof("Rule manager: deleting stale IP rule (%s) found at priority %d", r.String(), r.Priority)
+			if err = netlink.RuleDel(&r); err != nil {
+				errors = append(errors, fmt.Errorf("failed to delete stale IP rule (%s) found at priority %d: %w",
+					r.String(), r.Priority, err))
 			}
 		}
 	}
 
-	var found bool
-	for priority := range rm.ownPriorities {
-		for _, ruleFound := range rulesFound {
-			if ruleFound.Priority != priority {
-				continue
-			}
-			found = false
-			for _, ruleWanted := range rm.rules {
-				if areNetlinkRulesEqual(ruleWanted.rule, &ruleFound) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				klog.Infof("Rule manager: deleting stale IP rule (%s) found at priority %d", ruleFound.String(), priority)
-				if err = netlink.RuleDel(&ruleFound); err != nil {
-					errors = append(errors, fmt.Errorf("failed to delete stale IP rule (%s) found at priority %d: %v",
-						ruleFound.String(), priority, err))
-				}
+	// add missing rules to Netlink
+	for _, r := range notInNetlink {
+		if r.delete {
+			continue
+		}
+
+		rulesToKeep[r.toString()] = r
+		if found, _ := isNetlinkRuleInSlice(rulesFound, r.rule); !found {
+			if err = netlink.RuleAdd(r.rule); err != nil {
+				errors = append(errors, fmt.Errorf("failed to add IP rule (%s): %w", r.toString(), err))
 			}
 		}
 	}

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
@@ -20,40 +20,32 @@ import (
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 )
 
-func TestAreNetlinkRulesEqualChecksFamily(t *testing.T) {
-	v4Rule := netlink.NewRule()
-	v4Rule.Priority = 2000
-	v4Rule.Table = 1020
-	v4Rule.Family = netlink.FAMILY_V4
-	v4Rule.Mark = 0x1003
+func TestIPRuleEquality(t *testing.T) {
+	v4Rule := IPRuleFromNetlinkRule(&netlink.Rule{
+		Priority: 2000,
+		Table:    1020,
+		Family:   netlink.FAMILY_V4,
+		Mark:     0x1003,
+	})
+	v6Rule := IPRuleFromNetlinkRule(&netlink.Rule{
+		Priority: 2000,
+		Table:    1020,
+		Family:   netlink.FAMILY_V6,
+		Mark:     0x1003,
+	})
 
-	v6Rule := netlink.NewRule()
-	v6Rule.Priority = v4Rule.Priority
-	v6Rule.Table = v4Rule.Table
-	v6Rule.Family = netlink.FAMILY_V6
-	v6Rule.Mark = v4Rule.Mark
-
-	if areNetlinkRulesEqual(v4Rule, v6Rule) {
+	if v4Rule == v6Rule {
 		t.Fatalf("expected IPv4 and IPv6 rules with the same mark/table to be different")
 	}
 }
 
-func TestAreNetlinkRulesEqualTreatsFamilyAllAsWildcard(t *testing.T) {
-	v4Rule := netlink.NewRule()
-	v4Rule.Priority = 2000
-	v4Rule.Table = 1020
-	v4Rule.Family = netlink.FAMILY_V4
-	v4Rule.Mark = 0x1003
-
-	anyFamilyRule := netlink.NewRule()
-	anyFamilyRule.Priority = v4Rule.Priority
-	anyFamilyRule.Table = v4Rule.Table
-	anyFamilyRule.Family = netlink.FAMILY_ALL
-	anyFamilyRule.Mark = v4Rule.Mark
-
-	if !areNetlinkRulesEqual(v4Rule, anyFamilyRule) {
-		t.Fatalf("expected FAMILY_ALL to match a specific rule family")
+func isRuleInSlice(rules []netlink.Rule, candidate IPRule) bool {
+	for _, r := range rules {
+		if IPRuleFromNetlinkRule(&r) == candidate {
+			return true
+		}
 	}
+	return false
 }
 
 // FIXME(mk) - Within GH VM, if I need to create a new NetNs. I see the following error:
@@ -72,6 +64,9 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 	ruleWithSrc.Priority = 3000
 	ruleWithSrc.Table = 254
 	ruleWithSrc.Src = testIPNet
+
+	ipRuleWithDst := IPRuleFromNetlinkRule(ruleWithDst)
+	ipRuleWithSrc := IPRuleFromNetlinkRule(ruleWithSrc)
 
 	defer ginkgo.GinkgoRecover()
 	if ovntest.NoRoot() {
@@ -111,7 +106,7 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		ginkgo.It("ensure rule exist", func() {
 			gomega.Expect(func() error {
 				return testNS.Do(func(ns.NetNS) error {
-					return c.Add(*ruleWithDst)
+					return c.Add(ipRuleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 
@@ -121,8 +116,8 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); !ok {
-						return fmt.Errorf("failed to find rule %q", ruleWithDst.String())
+					if !isRuleInSlice(rules, ipRuleWithDst) {
+						return fmt.Errorf("failed to find rule %q", ipRuleWithDst.String())
 					}
 					return nil
 				})
@@ -132,7 +127,7 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		ginkgo.It("ensure rule is restored if it is removed", func() {
 			gomega.Expect(func() error {
 				return testNS.Do(func(ns.NetNS) error {
-					return c.Add(*ruleWithDst)
+					return c.Add(ipRuleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 
@@ -142,8 +137,8 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); !ok {
-						return fmt.Errorf("failed to find rule %q", ruleWithDst.String())
+					if !isRuleInSlice(rules, ipRuleWithDst) {
+						return fmt.Errorf("failed to find rule %q", ipRuleWithDst.String())
 					}
 					return nil
 				})
@@ -160,8 +155,8 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); !ok {
-						return fmt.Errorf("failed to find rule %q", ruleWithDst.String())
+					if !isRuleInSlice(rules, ipRuleWithDst) {
+						return fmt.Errorf("failed to find rule %q", ipRuleWithDst.String())
 					}
 					return nil
 				})
@@ -171,12 +166,12 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		ginkgo.It("ensure multiple rules are restored if they're removed", func() {
 			gomega.Expect(func() error {
 				return testNS.Do(func(ns.NetNS) error {
-					return c.Add(*ruleWithDst)
+					return c.Add(ipRuleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 			gomega.Expect(func() error {
 				return testNS.Do(func(ns.NetNS) error {
-					return c.Add(*ruleWithSrc)
+					return c.Add(ipRuleWithSrc)
 				})
 			}()).Should(gomega.Succeed())
 
@@ -186,10 +181,10 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); !ok {
+					if !isRuleInSlice(rules, ipRuleWithDst) {
 						return fmt.Errorf("failed to find rule with dst")
 					}
-					if ok2, _ := isNetlinkRuleInSlice(rules, ruleWithSrc); !ok2 {
+					if !isRuleInSlice(rules, ipRuleWithSrc) {
 						return fmt.Errorf("failed to find rule with src")
 					}
 					return nil
@@ -207,8 +202,8 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); !ok {
-						return fmt.Errorf("failed to find rule %s", ruleWithDst.String())
+					if !isRuleInSlice(rules, ipRuleWithDst) {
+						return fmt.Errorf("failed to find rule %s", ipRuleWithDst.String())
 					}
 					return nil
 				})
@@ -225,8 +220,8 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithSrc); !ok {
-						return fmt.Errorf("failed to find rule %s", ruleWithSrc)
+					if !isRuleInSlice(rules, ipRuleWithSrc) {
+						return fmt.Errorf("failed to find rule %s", ipRuleWithSrc.String())
 					}
 					return nil
 				})
@@ -238,7 +233,7 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		ginkgo.It("doesn't fail when no rule to delete", func() {
 			gomega.Expect(func() error {
 				return testNS.Do(func(ns.NetNS) error {
-					return c.Delete(*ruleWithDst)
+					return c.Delete(ipRuleWithDst)
 				})
 			}()).Should(gomega.Succeed())
 		})
@@ -246,10 +241,10 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 		ginkgo.It("deletes a rule", func() {
 			gomega.Expect(func() error {
 				return testNS.Do(func(ns.NetNS) error {
-					if err := c.Add(*ruleWithDst); err != nil {
+					if err := c.Add(ipRuleWithDst); err != nil {
 						return err
 					}
-					if err := c.Delete(*ruleWithDst); err != nil {
+					if err := c.Delete(ipRuleWithDst); err != nil {
 						return err
 					}
 					return nil
@@ -262,8 +257,8 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 					if err != nil {
 						return err
 					}
-					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); ok {
-						return fmt.Errorf("expected rule (%s) to be deleted but it was found", ruleWithDst)
+					if isRuleInSlice(rules, ipRuleWithDst) {
+						return fmt.Errorf("expected rule (%s) to be deleted but it was found", ipRuleWithDst.String())
 					}
 					return nil
 				})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Each call to iprulemanager.reconcile() pulls all IP rules from Netlink then performs two loops -- An O(Managed Rule x Kernel Rule) and an O(OwnedPriorities x ManagedRule x Kernel Rule) loop, eating up significant CPU time. Additionally, each call to Add(), Delete(), etc. was triggering an unnecessary reconcile() call. 

Reworks the IP rule manager to replace netlink.Rule pointers and slice-based tracking with a comparable IPRule value type and map-based storage. Updates API functions to not call reconcile(), reducing overall netlink calls and processing time. The loops in reconcile() have been condensed to an O(Kernel Rules) and a O(Recently Added Rules x Managed Rules) loop. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
