### PR TITLE
Fix panic when deploymentconfig accessed during test initialization

### DIFF
--- a/test/e2e/deploymentconfig/config.go
+++ b/test/e2e/deploymentconfig/config.go
@@ -21,3 +21,11 @@ func Get() api.DeploymentConfig {
 	}
 	return deploymentConfig
 }
+
+// TryGet returns the deployment config and true if set, nil and false otherwise.
+func TryGet() (api.DeploymentConfig, bool) {
+	if deploymentConfig == nil {
+		return nil, false
+	}
+	return deploymentConfig, true
+}

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -44,7 +44,8 @@ func joinStrings(vals ...string) string {
 }
 
 func primaryLayer3MultiCIDRs() string {
-	if deploymentconfig.Get().IsConfigurationEnabled(deploymentconfigapi.L3UDNMultiSubnetConfig) {
+	dc, ok := deploymentconfig.TryGet()
+	if ok && dc.IsConfigurationEnabled(deploymentconfigapi.L3UDNMultiSubnetConfig) {
 		return joinStrings(primaryLayer3MultiIPv4CIDRs(), primaryLayer3MultiIPv6CIDRs())
 	}
 	// Backward compatible: single subnet per IP family


### PR DESCRIPTION
Adds TryGet() following the project's (value, bool) pattern for optional Get methods. Use it in primaryLayer3MultiCIDRs() which is called when ginkgo evaluates table Entry parameters at package initialization time.

Without this, the code panics with 'deployment config type not set' when the test tree is constructed before tests actually run.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
