### PR TITLE
Prevent ARP fan-out to CUDN GRs for node IP

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -146,7 +146,7 @@ RUN INSTALL_PKGS=" \
     python3-pip python3-pyyaml bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
     libpcap hostname kubernetes-client util-linux \
     ovn ovn-central ovn-host python3-openvswitch tcpdump openvswitch-test python3-pyOpenSSL \
-    iptables nftables iproute iputils strace socat \
+    iptables nftables iproute iputils ndisc6 libndp strace socat \
     libreswan openvswitch-ipsec \
     " && \
     dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -16,7 +16,7 @@ FROM ubuntu:26.04
 USER root
 
 # Keep socat until ovn-kubernetes#6122 removes the e2e/runtime dependency on it.
-RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables socat
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables socat ndisc6 libndp-tools
 
 # Install OVS and OVN packages.
 RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host

--- a/dist/images/Dockerfile.ubuntu.arm64
+++ b/dist/images/Dockerfile.ubuntu.arm64
@@ -16,7 +16,7 @@ FROM ubuntu:26.04
 USER root
 
 # Keep socat until ovn-kubernetes#6122 removes the e2e/runtime dependency on it.
-RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables socat
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables socat ndisc6 libndp-tools
 
 # Install OVS and OVN packages.
 RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host

--- a/docs/design/bridge-flows.md
+++ b/docs/design/bridge-flows.md
@@ -1,0 +1,208 @@
+# External Bridge (breth0) OpenFlow Design
+
+## Introduction
+
+OVN-Kubernetes programs OpenFlow rules on the external bridge (`breth0`)
+to steer traffic between the physical network,
+OVN patch ports, and the kernel (LOCAL port or a PF/VF representor on DPU
+setups). This document describes the flow tables, their responsibilities,
+and the design decisions behind notable flow sets.
+
+For service-specific traffic flows, see
+[Host-to-NodePort Hairpin Traffic](host-to-node-port-hairpin-trafficflow.md)
+and [Service Traffic Policy](service-traffic-policy.md).
+
+## The Shared Bridge
+
+The external bridge (`breth0`) is common to both shared gateway and local
+gateway modes. During node setup, ovnkube-node creates an OVS bridge named
+`br<iface>` (e.g. `eth0` → `breth0`), moves the primary NIC into it as
+an uplink port, and migrates the NIC's IP addresses and routes onto the
+bridge. The host's physical IP and MAC are then shared between the kernel
+and OVN — each Gateway Router's (GR) external port uses the same MAC as
+`breth0`.
+
+The key difference between gateway modes is what happens *after* traffic
+leaves OVN:
+
+- **Shared gateway** — traffic stays within the OVS datapath and exits
+  directly via `breth0`.
+- **Local gateway** — traffic exits OVN to the host kernel via the
+  management port (`ovn-k8s-mp0`), then the host routes it out.
+
+The OpenFlow rules on `breth0` described below apply to both modes unless
+noted otherwise.
+
+## Layer 2 Behavior
+
+By default, `breth0` table 0 forwards packets using standard L2 switching
+behavior via the `priority=0, actions=NORMAL` rule. Two higher-priority
+rules handle traffic destined to the shared bridge MAC:
+
+- **Priority 10 (fan-out)** — When a packet arrives with
+  `dl_dst=<bridgeMAC>`, it is replicated to every OVN patch port (default
+  network + all Cluster User Defined Network (CUDN) GRs) and also sent
+  to NORMAL for LOCAL delivery.
+  This ensures all OVN networks can process traffic destined to the node.
+
+  ```text
+  priority=10, table=0, dl_dst=<bridgeMAC>,
+      actions=output:<patch-default>,output:<patch-udn1>,...,NORMAL
+  ```
+
+- **Priority 10 / 9 (OVN egress validation)** — For each patch port, a
+  rule verifies that traffic coming from OVN has `dl_src=<bridgeMAC>`. A
+  companion priority 9 rule drops traffic from patch ports with incorrect
+  source MAC. These don't conflict with the fan-out rule: the egress validation
+  rules match `in_port=<patch-X>` (traffic originating from OVN), while
+  the fan-out rule matches `dl_dst=<bridgeMAC>` (traffic destined *to*
+  the node, typically arriving from the physical port).
+
+  ```text
+  priority=10, table=0, in_port=<patch-X>, dl_src=<bridgeMAC>, actions=output:NORMAL
+  priority=9,  table=0, in_port=<patch-X>, actions=drop
+  ```
+
+### ARP/NDP Behavior
+
+When CUDNs are enabled, each CUDN gateway
+router (GR) has an external interface that shares the node's physical IP.
+Without filtering, every GR replies to ARP/NDP requests for the node IP,
+creating a reply storm that floods the physical network with identical
+frames. Remote nodes passively learn redundant `MAC_Binding` entries,
+and `ovs-vswitchd` CPU scales linearly with the number of CUDNs. In
+testing, 70 CUDNs drove `ovs-vswitchd` CPU to ~400% with packet drops.
+
+#### No-Flood on CUDN Patch Ports
+
+CUDN GR patch ports have the `OFPPC_NO_FLOOD` OpenFlow port config flag
+set via `ovs-ofctl mod-port`. This prevents NORMAL's implicit flood
+action from reaching them, while still allowing explicit `output:<port>`
+actions to deliver traffic. The flag is initially set when the patch
+port is registered in `SetNetworkOfPatchPort()` and periodically
+re-applied by `SyncNoFlood()` during the OpenFlow sync loop (every
+~15 s), since `OFPPC_NO_FLOOD` is volatile — it is not persisted in
+OVSDB and is lost when `ovs-vswitchd` restarts or ports are re-created.
+
+#### Priority-12: Node IP ARP/NDP Filter
+
+Priority-12 flows intercept ARP requests and IPv6 Neighbor Solicitations
+for the node IP. They match `arp_tpa` / `nd_target` for the node IP
+without restricting `dl_dst` or `in_port`, so they catch broadcast,
+unicast, and multicast variants from any source. The action sends only
+to the default network patch port plus NORMAL:
+
+```text
+priority=12, table=0, arp, arp_op=1, arp_tpa=172.18.0.3,
+    actions=output:<default-patch>,NORMAL
+priority=12, table=0, icmp6, icmpv6_type=135, nd_target=fd00::3,
+    actions=output:<default-patch>,NORMAL
+```
+
+NORMAL performs FDB learning (recording the external source MAC on its
+ingress port) and delivers to LOCAL via broadcast flooding (since
+`dl_dst=ff:ff:ff:ff:ff:ff` for ARP, or solicited-node multicast for
+NS). Because CUDN ports are no-flood, NORMAL's flood does not reach
+them. Only the default GR replies — no storm.
+
+#### Priority-11: External Broadcast ARP/NA Forwarding
+
+With no-flood, broadcast ARP from external sources (e.g. a gateway router
+announcing a new MAC via GARP) would no longer reach CUDNs. Priority-11
+flows match broadcast ARP arriving on the physical port and explicitly
+forward to all GR patches so their MAC_Bindings stay current:
+
+```text
+priority=11, table=0, in_port=<phys>, dl_dst=ff:ff:ff:ff:ff:ff, arp,
+    actions=output:<default-patch>,output:<cudn1-patch>,...,NORMAL
+priority=11, table=0, in_port=<phys>, dl_dst=33:33:00:00:00:01, icmp6, icmpv6_type=136,
+    actions=output:<default-patch>,output:<cudn1-patch>,...,NORMAL
+```
+
+The IPv6 flow matches `dl_dst=33:33:00:00:00:01` — the Ethernet multicast
+MAC for IPv6 all-nodes (`ff02::1`). This restricts to unsolicited Neighbor
+Advertisements (the IPv6 equivalent of GARP) only. Neighbor Solicitations
+are intentionally **not** matched here — NS for the node IP is already
+handled by priority-12 (which targets `nd_target=<nodeIP>` specifically),
+and NS for masquerade IPs should never appear on the wire at all (see
+[masquerade-ips.md](masquerade-ips.md#kernel-static-neighbor-entries) for
+how kernel static neighbor entries prevent this).
+
+Unicast solicited NAs — i.e. an external host replying to a Neighbor
+Solicitation that the *node* sent — arrive with `dl_dst=bridgeMAC` and
+are handled by priority-50 (`dl_dst=bridgeMAC, ip6 → ct → table 1`),
+then delivered to CUDN patches via priority-14's explicit output actions.
+This is distinct from the GR's *outgoing* NA reply to an NS for the
+node IP: that exits OVN via the patch port and is handled by the
+priority-10 egress validation flow (`in_port=<patch>, dl_src=bridgeMAC
+→ NORMAL`), which sends it out the physical port.
+
+The `in_port=<phys>` match ensures only externally-originated broadcast
+is forwarded; OVN-originated traffic from patch ports is unaffected.
+Node-IP ARPs never fall here (caught at priority-12 first).
+
+#### Priority-0: Catch-All NORMAL
+
+All remaining traffic falls through to the default rule:
+
+```text
+priority=0, table=0, actions=NORMAL
+```
+
+Because CUDN patch ports have `no-flood`, NORMAL's flood does not reach
+them. When a CUDN sends an ARP for an external host (or any other
+broadcast/unknown-unicast), it hits priority-0, NORMAL performs an FDB
+lookup, and floods only to non-CUDN ports if the MAC is unknown. There
+is no cross-CUDN contamination through this path.
+
+#### Why All Three Layers Are Required
+
+The no-flood setting, priority-12, and priority-11 form a dependency chain
+where each compensates for the one below:
+
+1. **no-flood** prevents NORMAL from flooding to CUDNs → solves the storm.
+2. **Priority 11** is needed because no-flood also blocks legitimate
+   broadcast ARP (GARPs from external routers) → explicitly forwards
+   external broadcast to all GR patches so MAC bindings stay current.
+3. **Priority 12** is needed because priority 11 fans out ALL external
+   broadcast ARP, including node-IP ARP requests which would re-create
+   the storm → intercepts node-IP ARPs first and sends only to the
+   default patch.
+
+Removing any one breaks the design:
+
+- Without priority 12: node-IP ARPs hit priority 11 → storm returns.
+- Without priority 11: GARPs never reach CUDNs → stale MAC bindings.
+- Without no-flood: NORMAL floods everything to CUDNs → storm returns
+  (and priorities 11/12 become pointless).
+
+The priority-12 and priority-11 table-0 ARP/NDP flows above are generated by
+`arpFanoutFilterFlows()` in `go-controller/pkg/node/bridgeconfig/bridgeflows.go`.
+The priority-0 catch-all NORMAL rule is part of the base bridge configuration.
+
+#### Table-1: ICMPv6 FLOOD with CUDN Delivery
+
+Existing table-1 flows FLOOD ICMPv6 Router Advertisements (type 134) and
+Neighbor Advertisements (type 136) because they cannot create conntrack
+entries (kernel bug). Since FLOOD also respects no-flood, CUDN patches
+are prepended as explicit outputs:
+
+```text
+priority=14, table=1, icmp6, icmpv6_type=134,
+    actions=output:<cudn1-patch>,output:<cudn2-patch>,...,FLOOD
+priority=14, table=1, icmp6, icmpv6_type=136,
+    actions=output:<cudn1-patch>,output:<cudn2-patch>,...,FLOOD
+```
+
+When no CUDNs are configured, these remain plain `actions=FLOOD`.
+
+## Code Reference
+
+All flow generation lives in
+`go-controller/pkg/node/bridgeconfig/bridgeflows.go`. The two main entry
+points are:
+
+- `flowsForDefaultBridge()` — flows specific to the default bridge setup
+  (encap handling, egress, conntrack).
+- `commonFlows()` — flows shared across configurations (fan-out, ARP
+  filter, table 1/2/3/4/5 dispatch, UDN isolation).

--- a/docs/design/masquerade-ips.md
+++ b/docs/design/masquerade-ips.md
@@ -1,0 +1,259 @@
+# Masquerade IPs
+
+## Overview
+
+OVN-Kubernetes uses **masquerade IPs** — synthetic node-local addresses
+that must never appear on the physical network — as intermediate SNAT
+addresses on the external bridge (`breth0`). They serve two main
+purposes:
+
+1. **Network identification on the shared bridge.** Multiple CUDNs can
+   have **overlapping pod subnets** (e.g. two UDNs both using
+   `10.244.0.0/16`). They all share the same `breth0` and the same
+   node physical IP. When return traffic arrives at the node, OVS
+   cannot distinguish which network the packet belongs to by
+   destination IP alone because the pod subnets overlap. To solve
+   this, a **double-SNAT** is used:
+
+   - **Egress (pod → wire):** OVN's GR SNATs the pod source IP to the
+     UDN's unique masquerade IP (e.g. `169.254.0.11`). OVS on `breth0`
+     then SNATs the masquerade IP to the node's physical IP before
+     sending the packet on the wire. The masquerade IP is recorded in
+     conntrack alongside a per-network `ct_mark`:
+
+     ```text
+     priority=100, in_port=<cudn-patch>, dl_src=<bridgeMAC>, ip, ip_src=169.254.0.11,
+         actions=ct(commit, zone=<ctZone>, nat(src=<nodeIP>), exec(set_field:<ct_mark>->ct_mark)),
+                 output:<phys>
+     ```
+
+   - **Ingress (wire → pod):** OVS un-SNATs node IP → masquerade IP and
+     uses the `ct_mark` to identify the originating network, routing
+     the packet to the correct UDN patch port. OVN's GR then un-SNATs
+     masquerade IP → original pod IP.
+
+   The per-UDN masquerade IP is the piece that makes this work — it is
+   a unique, non-overlapping identifier for each network in conntrack.
+
+2. **Host-to-service traffic steering.** When the host kernel itself
+   accesses a Kubernetes Service, OVS SNATs the host's source IP to a
+   masquerade IP so the reply returns through OVS (where it can be
+   un-SNATted) instead of going directly to the host (which would
+   bypass conntrack state and break the connection). Similar masquerade
+   IPs handle service hairpin and `externalTrafficPolicy=Local`
+   scenarios.
+
+Masquerade IPs are **internal to each node** and should **never appear
+on the wire**. Traffic to/from these IPs is handled within the OVS
+datapath across multiple flow priorities and tables on `breth0`
+(priority-500 for specific masquerade IP matching, priority-100 for UDN
+egress SNAT, priority-50 for conntrack entry, and tables 1–5 for
+ct_mark-based dispatch). See [bridge-flows.md](bridge-flows.md) for the
+OpenFlow design.
+
+## Masquerade Subnet
+
+The masquerade subnet is configured via two ovnkube flags:
+
+| Flag | Default | Example for UDN-enabled clusters |
+|------|---------|----------------------------------|
+| `--gateway-v4-masquerade-subnet` | `169.254.169.0/29` (8 addresses) | `169.254.0.0/17` (32768 addresses) |
+| `--gateway-v6-masquerade-subnet` | `fd69::/125` (8 addresses) | `fd69::/112` (65536 addresses) |
+
+All masquerade IPs — both global (default network) and per-UDN — are
+allocated from this single subnet.
+
+The small default `/29` / `/125` contains only 8 addresses (offsets
+0–7), which is sufficient for clusters that only use the default
+network (6 of 8 slots used: the network address + 5 global IPs).
+Clusters with User Defined Networks (UDNs) **must** configure a larger
+subnet because the first per-UDN IP is at offset 11 — outside the
+default `/29`. Each UDN allocates 2 additional IPs. A `/17` (IPv4) or
+`/112` (IPv6) supports thousands of networks.
+
+The IPv4 range (`169.254.0.0/16`) is link-local space; the IPv6 range
+(`fd69::/112`) is within ULA space (`fd00::/8`), which *can* be routed
+within private networks. Neither range is inherently non-routable —
+they are intended strictly for node-local use and must not be advertised
+or routed off-node.
+
+## Address Layout Within the Subnet
+
+The subnet is divided into two regions: a **fixed global region**
+(offsets 0–5 allocated, 6–9 reserved) for the default network, and a
+**dynamic UDN region** (offset 11+) for per-network masquerade IPs.
+
+### Global Region (Offsets 0–9)
+
+Offsets 0–9 are reserved for global use. Offset 0 is the subnet network
+address and offsets 1–5 are currently allocated. Offsets 6–9 are
+reserved for future global IPs. Note: offsets 6–9 only exist when the
+subnet is larger than the default `/29` / `/125` (which contain only
+offsets 0–7).
+
+Using `169.254.0.0/17` as example:
+
+| Offset | IPv4 | IPv6 | Role | Code constant |
+|--------|------|------|------|---------------|
+| 0 | `169.254.0.0` | `fd69::` | Subnet network address (not usable) | — |
+| 1 | `169.254.0.1` | `fd69::1` | **OVN Masquerade** — GR SNAT source for default-network service traffic. The GR rewrites pod source IPs to this before forwarding to the service backend. | `V4OVNMasqueradeIP` |
+| 2 | `169.254.0.2` | `fd69::2` | **Host Masquerade** — host-to-service SNAT source. When the host itself accesses a ClusterIP service, OVS SNATs the host IP to this so the reply returns through OVS (not direct to the host, which would bypass un-SNAT). | `V4HostMasqueradeIP` |
+| 3 | `169.254.0.3` | `fd69::3` | **Host ETP=Local Masquerade** — `externalTrafficPolicy=Local` variant. Separate from .2 so that OVS can distinguish ETP=Local traffic and preserve the original client IP for the backend pod. | `V4HostETPLocalMasqueradeIP` |
+| 4 | `169.254.0.4` | `fd69::4` | **Dummy Next-Hop** — synthetic next-hop for masquerade routing. The host routing table has a route to the masquerade subnet via this next-hop. A static ARP/ND entry maps this IP to a synthetic MAC, ensuring packets reach OVS without real ARP resolution. | `V4DummyNextHopMasqueradeIP` |
+| 5 | `169.254.0.5` | `fd69::5` | **OVN Service Hairpin** — hairpin traffic SNAT source. When a pod sends traffic to a Service and the same pod is selected as backend, OVN SNATs to this IP to force the return path back through the load balancer. | `V4OVNServiceHairpinMasqueradeIP` |
+| 6–9 | — | — | Reserved for future global use | — |
+
+The global IPs are defined as fields in `MasqueradeIPsConfig`
+(`go-controller/pkg/config/config.go`) and sequentially allocated at
+startup by `config.AllocateV4MasqueradeIPs` /
+`config.AllocateV6MasqueradeIPs` in `go-controller/pkg/config/utils.go`.
+
+### UDN Region (Offset 11+)
+
+When network segmentation is enabled, each UDN gets its own pair of
+masquerade IPs computed from the network's integer ID. The allocation
+base constant is 10 (`userDefinedNetworkMasqueradeIPBase`), but the
+formula `base + networkID*2 - 1` means the first real allocation
+(networkID=1) starts at offset 11. Each network consumes 2 IPs:
+
+```text
+GatewayRouter  = subnet_base + 10 + (networkID × 2) - 1
+ManagementPort = subnet_base + 10 + (networkID × 2)
+```
+
+| Offset | networkID | IPv4 | IPv6 | Role |
+|--------|-----------|------|------|------|
+| 11 | 1 | `169.254.0.11` | `fd69::b` | UDN-1 Gateway Router masquerade |
+| 12 | 1 | `169.254.0.12` | `fd69::c` | UDN-1 Management Port masquerade |
+| 13 | 2 | `169.254.0.13` | `fd69::d` | UDN-2 Gateway Router masquerade |
+| 14 | 2 | `169.254.0.14` | `fd69::e` | UDN-2 Management Port masquerade |
+| ... | ... | ... | ... | ... |
+
+Each UDN's **Gateway Router** masquerade IP serves the same role as the
+global `V4OVNMasqueradeIP` (.1) but scoped to that network: the UDN's
+GR SNATs pod source IPs to this address for service traffic. The
+**Management Port** masquerade IP is used for management port traffic
+within the UDN.
+
+The gap between offset 5 (last used global IP) and offset 11 (first UDN
+IP) provides room for future global allocations without breaking
+existing UDN deployments.
+
+Per-UDN allocation is in `udn.AllocateV4MasqueradeIPs` /
+`udn.AllocateV6MasqueradeIPs` (`go-controller/pkg/generator/udn/masquerade_ips.go`).
+
+## Kernel Static Neighbor Entries
+
+### Why They Are Needed
+
+Masquerade IPs are handled entirely within the OVS datapath. Under
+normal operation, return service traffic arriving on the physical port
+is matched by OVS flows, un-SNATted via conntrack, and dispatched to the
+correct OVN patch port — the kernel is never involved.
+
+However, in **LGW + no-overlay (BGP) mode**, the kernel can become
+involved in the return path. Without static neighbor entries, the kernel
+has no way to resolve the L2 address for masquerade IPs and falls back
+to ARP/NDP — which should never happen for addresses that are internal
+to the node.
+
+A concrete example is cross-node NodePort traffic with CUDN pods in
+LGW + no-overlay (BGP) mode:
+
+```text
+ovn-control-plane                              ovn-worker2
+┌──────────────┐                           ┌──────────────┐
+│ CUDN pod A   │                           │              │
+│ (client)     │─── wire (node IPs) ─────▶│ NodePort svc │
+│              │                           │ (worker2 IP) │
+│ CUDN pod B   │◀── wire (node IPs) ──────│              │
+│ (backend)    │                           │              │
+└──────────────┘                           └──────────────┘
+```
+
+Detailed packet flow:
+
+```text
+FORWARD (SYN):
+  ovn-control-plane (CUDN pod A, src 2013:100:200::3) →
+    OVN cluster router SNAT (pod IP → mgmt-port masq IP fd69::c) →
+    exits to kernel via management port →
+    kernel nftables MASQUERADE (fd69::c → node IP) →
+    breth0 → eth0 → wire →
+  ovn-worker2 (NodePort on worker2's node IP) →
+    eth0 → breth0 → OVS → LOCAL →
+    kernel nftables DNAT (NodePort → ClusterIP) →
+    routes back out breth0 (UDN VRF cluster IP route) →
+    enters OVN via CUDN patch port →
+    GR DNAT (ClusterIP → pod B IP 2013:100:200::4) →
+    GR SNAT (src → GR masq IP fd69::b) →
+    exits OVN via CUDN patch port → breth0 →
+    OVS priority-100 SNAT (fd69::b → worker2 node IP) →
+    breth0 → eth0 → wire →
+  ovn-control-plane →
+    eth0 → breth0 → OVS → LOCAL → kernel → mgmt port → OVN → pod B
+
+RETURN (SYN-ACK):
+  ovn-control-plane (pod B responds) →
+    OVN → kernel → breth0 → eth0 → wire →
+  ovn-worker2 →
+    eth0 → breth0 → OVS → LOCAL (dst is worker2's IP) →
+    kernel conntrack un-SNAT (dst: worker2 IP → fd69::b) →
+    kernel forwards to fd69::b via breth0 →
+    ** NS for fd69::b — NOBODY ANSWERS — FAILED **
+```
+
+On the return path, the kernel on `ovn-worker2` receives the packet at
+LOCAL because it is addressed to worker2's node IP — this is the normal
+LGW flow, not a leak. Conntrack reverses the priority-100 SNAT
+(worker2 IP → `fd69::b`), and the kernel must then forward to
+`fd69::b` via `breth0`. To construct the L2 frame it needs the MAC for
+`fd69::b`, triggering neighbor discovery:
+
+- **IPv4**: the kernel broadcasts an ARP request
+  (`dl_dst=ff:ff:ff:ff:ff:ff`) from the LOCAL port. It falls through to
+  priority-0 `NORMAL`, which floods to all non-NO_FLOOD ports — the
+  physical port and the default network patch. The ARP leaks to the
+  wire, reaches a remote node whose CUDN GR owns the masquerade IP and
+  replies. So IPv4 happens to work accidentally, but masquerade IP ARPs
+  should never appear on the wire.
+- **IPv6**: the kernel sends a Neighbor Solicitation using
+  solicited-node multicast (`dl_dst=33:33:ff:00:00:0b`). This also
+  falls to `NORMAL` and floods to non-NO_FLOOD ports, leaking to the
+  wire. On the remote node the NS arrives on the physical port but
+  `NORMAL` there also skips NO_FLOOD ports (CUDN patches), so no CUDN
+  GR ever sees it. The neighbor entry enters `FAILED` state,
+  black-holing return traffic.
+
+Static neighbor entries eliminate both problems: the kernel never sends
+ARP/NS for masquerade IPs, keeping this traffic off the wire entirely.
+
+### The Fix: Permanent Neighbor Entries
+
+Rather than adding OpenFlow rules to forward NS to CUDN patches (which
+would be a workaround for traffic that shouldn't be on the wire in the
+first place), we add **permanent kernel neighbor entries** for each
+masquerade IP on `breth0`:
+
+```bash
+ip neigh add 169.254.0.11 lladdr 0a:58:a9:fe:00:0b dev breth0 nud permanent
+ip neigh add fd69::b      lladdr 0a:58:XX:XX:XX:XX dev breth0 nud permanent
+```
+
+The MAC is derived using `util.IPAddrToHWAddr()`, the same synthetic MAC
+scheme used by `addHostMACBindings()` for global masquerade IPs. With
+this entry present, the kernel never sends ARP/NS for the masquerade IP.
+If traffic does reach the kernel, it constructs the L2 frame immediately
+and sends it out via `breth0` (LOCAL port in OVS), where it is matched
+by OVS flows and handled correctly.
+
+### Global vs Per-UDN Neighbor Entries
+
+| Scope | IPs | Added by | Reconciled |
+|-------|-----|----------|------------|
+| Global (default network) | `V4OVNMasqueradeIP` + `V4DummyNextHopMasqueradeIP` (and v6 equivalents — 2 per family) | `addHostMACBindings()` in gateway init | Yes — `masqueradeReconciler` re-applies on link events |
+| Per-UDN | `V4MasqIPs.GatewayRouter`, `V6MasqIPs.GatewayRouter` | `addUDNMasqIPNeighbors()` in UDN `addNetwork()` | Not yet — only at network add time. On `ovnkube-node` restart, `addNetwork()` re-runs for every UDN and re-creates the entries. The only uncovered gap is `ovs-vswitchd` restart (which recreates the bridge interface and wipes kernel neighbors) while `ovnkube-node` stays running. Extending `masqueradeReconciler` to cover per-UDN entries is a follow-up. |
+
+Cleanup: per-UDN entries are removed by `delUDNMasqIPNeighbors()` when
+the network is deleted.
+

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -613,7 +613,61 @@ func (b *BridgeConfiguration) SetNetworkOfPatchPort(netName string) error {
 	if !found {
 		return fmt.Errorf("failed to find network %s configuration on bridge %s", netName, b.bridgeName)
 	}
-	return netConfig.setOfPatchPort()
+	if err := netConfig.setOfPatchPort(); err != nil {
+		return err
+	}
+
+	// Only set no-flood on bridges that also carry the default network.
+	// The ARP storm occurs because CUDNs share the node IP with the
+	// default GR on the same bridge.
+	if netName != types.DefaultNetworkName && util.IsNetworkSegmentationSupportEnabled() {
+		if _, isSharedBridge := b.netConfig[types.DefaultNetworkName]; isSharedBridge {
+			if err := util.SetPortNoFlood(b.bridgeName, netConfig.OfPortPatch); err != nil {
+				return fmt.Errorf("failed to set no-flood on port %s of bridge %s: %w",
+					netConfig.PatchPort, b.bridgeName, err)
+			}
+		}
+	}
+	return nil
+}
+
+// SyncNoFlood ensures OFPPC_NO_FLOOD is set on every non-default patch port
+// that shares the bridge with the default network. The flag is OpenFlow
+// port config (not OVSDB-persisted), so it must be reapplied after
+// ovs-vswitchd restarts or ports are re-created.
+//
+// To avoid running mod-port for every CUDN patch port on every sync
+// cycle, we first query dump-ports-desc once to learn which ports
+// already carry the flag and only touch ports that are missing it.
+func (b *BridgeConfiguration) SyncNoFlood() error {
+	if !util.IsNetworkSegmentationSupportEnabled() {
+		return nil
+	}
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if _, hasDefault := b.netConfig[types.DefaultNetworkName]; !hasDefault {
+		return nil
+	}
+
+	alreadyNoFlood, err := util.GetNoFloodPorts(b.bridgeName)
+	if err != nil {
+		return fmt.Errorf("failed to check no-flood state on bridge %s: %w", b.bridgeName, err)
+	}
+
+	for netName, netConfig := range b.netConfig {
+		if netName == types.DefaultNetworkName || netConfig.PatchPort == "" || netConfig.OfPortPatch == "" {
+			continue
+		}
+		if alreadyNoFlood[netConfig.OfPortPatch] {
+			continue
+		}
+		if err := util.SetPortNoFlood(b.bridgeName, netConfig.OfPortPatch); err != nil {
+			return fmt.Errorf("failed to set no-flood on port %s of bridge %s: %w",
+				netConfig.PatchPort, b.bridgeName, err)
+		}
+	}
+	return nil
 }
 
 func (b *BridgeConfiguration) GetInterfaceID() string {

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -818,6 +818,10 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=10, table=0, %s dl_dst=%s, actions=%s",
 				nodetypes.DefaultOpenFlowCookie, matchVLAN, bridgeMacAddress, actions))
+
+		if util.IsNetworkSegmentationSupportEnabled() {
+			dftFlows = append(dftFlows, b.arpFanoutFilterFlows(ofPortPhys, matchVLAN)...)
+		}
 	}
 
 	// table 0, check packets coming from OVN have the correct mac address. Low priority flows that are a catch all
@@ -1151,11 +1155,13 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		// has no default network configuration.
 		if config.IPv6Mode {
 			// REMOVEME(trozet) when https://bugzilla.kernel.org/show_bug.cgi?id=11797 is resolved
-			// must flood icmpv6 Route Advertisement and Neighbor Advertisement traffic as it fails to create a CT entry
+			// must flood icmpv6 Route Advertisement and Neighbor Advertisement traffic as it fails to create a CT entry.
+			// CUDN patches are no-flood so FLOOD alone won't reach them; prepend explicit outputs.
+			cudnActions := b.patchOutputActions(true)
 			for _, icmpType := range []int{types.RouteAdvertisementICMPType, types.NeighborAdvertisementICMPType} {
 				dftFlows = append(dftFlows,
-					fmt.Sprintf("cookie=%s, priority=14, table=1,icmp6,icmpv6_type=%d actions=FLOOD",
-						nodetypes.DefaultOpenFlowCookie, icmpType))
+					fmt.Sprintf("cookie=%s, priority=14, table=1,icmp6,icmpv6_type=%d actions=%sFLOOD",
+						nodetypes.DefaultOpenFlowCookie, icmpType, cudnActions))
 			}
 			if hasDefaultNetConfig {
 				// We send BFD traffic both on the host and in ovn
@@ -1294,6 +1300,118 @@ func (b *BridgeConfiguration) allowNodeIPGARPFlows(nodeIPs []net.IP) []string {
 
 	}
 	return flows
+}
+
+// arpFanoutFilterFlows prevents ARP requests and IPv6 Neighbor Solicitations
+// for local node IPs from reaching CUDN GR patch ports.
+//
+// The generic priority-10 fan-out rule replicates all unicast traffic destined
+// to the bridge MAC to every patch port. For broadcast ARP and IPv6 multicast
+// NS, the priority-0 NORMAL action floods to all ports. In both cases CUDN
+// GRs receive the request and reply for the node IP. Since all CUDN GRs share
+// the same node IP on their external interface, each one generates a reply
+// (ARP reply or NA). These duplicate replies flood the physical network and
+// cause remote nodes to passively learn redundant MAC_Bindings, driving
+// ovs-vswitchd CPU up.
+//
+// This function relies on CUDN patch ports being configured with OVS no-flood,
+// so that NORMAL's flood action never reaches them.
+//
+// Priority-12 flows intercept node-IP ARP/NDP and send only to the default
+// patch + NORMAL. NORMAL preserves FDB learning while no-flood excludes CUDNs.
+//
+// Priority-11 flows match external broadcast ARP (in_port=<phys>) and
+// explicitly forward to all GR patches so that external GARPs (e.g. gateway
+// MAC changes) still reach CUDNs for MAC_Binding updates. Node-IP ARPs are
+// caught at priority-12 first.
+//
+// Must be called with bridge.mutex held.
+func (b *BridgeConfiguration) arpFanoutFilterFlows(ofPortPhys, matchVLAN string) []string {
+	defaultNetConfig, found := b.netConfig[types.DefaultNetworkName]
+	if !found || defaultNetConfig.OfPortPatch == "" {
+		return nil
+	}
+
+	var flows []string
+
+	// Priority-12: ARP/NS for node IP → only default patch + NORMAL.
+	// NORMAL learns the external source MAC in the FDB and delivers to
+	// LOCAL (static FDB entry). No-flood on CUDN ports prevents them from
+	// receiving the packet via NORMAL's flood.
+	for _, ip := range b.ips {
+		if ip.IP.To4() != nil {
+			flows = append(flows,
+				fmt.Sprintf("cookie=%s, priority=12, table=0, %s arp, arp_op=1, arp_tpa=%s, "+
+					"actions=output:%s,NORMAL",
+					nodetypes.DefaultOpenFlowCookie, matchVLAN, ip.IP,
+					defaultNetConfig.OfPortPatch))
+		} else {
+			flows = append(flows,
+				fmt.Sprintf("cookie=%s, priority=12, table=0, %s icmp6, icmpv6_type=%d, nd_target=%s, "+
+					"actions=output:%s,NORMAL",
+					nodetypes.DefaultOpenFlowCookie, matchVLAN, types.NeighborSolicitationICMPType, ip.IP,
+					defaultNetConfig.OfPortPatch))
+		}
+	}
+
+	// Priority-11: external broadcast ARP (including GARPs) arriving on the
+	// physical port → explicitly forward to all GR patches so CUDNs can
+	// update MAC_Bindings when an external entity (e.g. gateway router)
+	// announces a new MAC. NORMAL handles FDB learning and delivery to
+	// LOCAL/physical. Without this, no-flood would prevent CUDNs from
+	// ever seeing external MAC announcements.
+	// The in_port match scopes to the physical port so that OVN-originated
+	// traffic from patch ports (already handled at priority 10 and above)
+	// is not affected.
+	// TODO: if localnet ports (VMs) are added to breth0, their GARPs
+	// won't reach CUDNs (blocked by no-flood). If localnet-to-CUDN
+	// communication is needed in the future, these flows should be
+	// extended to match additional in_ports.
+	// Only generated when CUDN patches exist (without them, NORMAL already
+	// floods to the default patch which is not no-flood).
+	allPatchActions := b.patchOutputActions(false)
+	if ofPortPhys != "" && b.hasCUDNPatchPorts() {
+		if config.IPv4Mode {
+			flows = append(flows,
+				fmt.Sprintf("cookie=%s, priority=11, table=0, in_port=%s, %s dl_dst=ff:ff:ff:ff:ff:ff, arp, "+
+					"actions=%sNORMAL",
+					nodetypes.DefaultOpenFlowCookie, ofPortPhys, matchVLAN, allPatchActions))
+		}
+		if config.IPv6Mode {
+			// dl_dst=33:33:00:00:00:01 is the Ethernet multicast MAC for IPv6
+			// all-nodes multicast (ff02::1). IPv6 multicast MACs are formed as
+			// 33:33 + last 4 bytes of the IPv6 multicast address.
+			// This restricts to unsolicited NAs (IPv6 GARP equivalent) only;
+			// unicast solicited NAs are handled by the priority-10 fan-out.
+			flows = append(flows,
+				fmt.Sprintf("cookie=%s, priority=11, table=0, in_port=%s, %s dl_dst=33:33:00:00:00:01, icmp6, icmpv6_type=%d, "+
+					"actions=%sNORMAL",
+					nodetypes.DefaultOpenFlowCookie, ofPortPhys, matchVLAN, types.NeighborAdvertisementICMPType, allPatchActions))
+		}
+	}
+
+	return flows
+}
+
+// patchOutputActions returns the "output:<port>," action string for patched
+// network ports. If cudnOnly is true, the default network patch port is
+// excluded (only CUDN ports). Must be called with bridge.mutex held.
+func (b *BridgeConfiguration) patchOutputActions(cudnOnly bool) string {
+	defaultNetConfig := b.netConfig[types.DefaultNetworkName]
+	var actions string
+	for _, netConfig := range b.patchedNetConfigs() {
+		if cudnOnly && defaultNetConfig != nil && netConfig.OfPortPatch == defaultNetConfig.OfPortPatch {
+			continue
+		}
+		actions += "output:" + netConfig.OfPortPatch + ","
+	}
+	return actions
+}
+
+// hasCUDNPatchPorts returns true if any non-default network has its patch port set.
+// Must be called with bridge.mutex held.
+func (b *BridgeConfiguration) hasCUDNPatchPorts() bool {
+	return b.patchOutputActions(true) != ""
 }
 
 func getIPv(ipnet *net.IPNet) string {

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
@@ -260,6 +260,81 @@ func TestLocalNoOverlayServiceHairpinUsesUDNGatewayMasqueradeIP(t *testing.T) {
 	expectFlow(t, flows, expectedIPv6Table5)
 }
 
+func TestArpFanoutFilterFlowsIncludeVLAN(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Gateway.Mode = config.GatewayModeShared
+	config.Gateway.VLANID = 100
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+	bridgeMAC := mustParseMAC(t, "62:41:d0:54:3d:64")
+	v4NodeIP := mustParseIPNet(t, "172.18.0.3/24")
+	v6NodeIP := mustParseIPNet(t, "fd00::3/64")
+	v4GatewayMasqIP := mustParseIPNet(t, "169.254.0.11/32")
+	v4ManagementMasqIP := mustParseIPNet(t, "169.254.0.12/32")
+	v6GatewayMasqIP := mustParseIPNet(t, "fd69::11/128")
+	v6ManagementMasqIP := mustParseIPNet(t, "fd69::12/128")
+
+	bridge := &BridgeConfiguration{
+		ofPortPhys: "eth0",
+		ofPortHost: nodetypes.OvsLocalPort,
+		ips:        []*net.IPNet{v4NodeIP, v6NodeIP},
+		macAddress: bridgeMAC,
+		netConfig: map[string]*BridgeUDNConfiguration{
+			types.DefaultNetworkName: {
+				OfPortPatch: "patch-breth0_ov",
+				MasqCTMark:  nodetypes.CtMarkOVN,
+			},
+			"bluenet": {
+				OfPortPatch: "patch-breth0_bluenet",
+				MasqCTMark:  "0x4",
+				V4MasqIPs: &udngenerator.MasqueradeIPs{
+					GatewayRouter:  v4GatewayMasqIP,
+					ManagementPort: v4ManagementMasqIP,
+				},
+				V6MasqIPs: &udngenerator.MasqueradeIPs{
+					GatewayRouter:  v6GatewayMasqIP,
+					ManagementPort: v6ManagementMasqIP,
+				},
+			},
+		},
+	}
+
+	flows, err := bridge.commonFlows(nil)
+	if err != nil {
+		t.Fatalf("failed to render bridge flows: %v", err)
+	}
+
+	expectedIPv4 := fmt.Sprintf("cookie=%s, priority=12, table=0, dl_vlan=100, arp, arp_op=1, arp_tpa=172.18.0.3, "+
+		"actions=output:patch-breth0_ov,NORMAL",
+		nodetypes.DefaultOpenFlowCookie)
+	expectedIPv6 := fmt.Sprintf("cookie=%s, priority=12, table=0, dl_vlan=100, icmp6, icmpv6_type=%d, nd_target=fd00::3, "+
+		"actions=output:patch-breth0_ov,NORMAL",
+		nodetypes.DefaultOpenFlowCookie, types.NeighborSolicitationICMPType)
+
+	expectFlow(t, flows, expectedIPv4)
+	expectFlow(t, flows, expectedIPv6)
+	// Priority-11 flows forward external broadcast ARP/NA to all GR patches.
+	// Action output order is non-deterministic (map iteration), so we use
+	// substring matching instead of exact flow comparison.
+	expectFlowContainingAll(t, flows,
+		fmt.Sprintf("cookie=%s", nodetypes.DefaultOpenFlowCookie),
+		"priority=11", "in_port=eth0", "dl_vlan=100", "dl_dst=ff:ff:ff:ff:ff:ff", "arp",
+		"actions=", "output:patch-breth0_bluenet", "output:patch-breth0_ov", "NORMAL")
+	expectFlowContainingAll(t, flows,
+		fmt.Sprintf("cookie=%s", nodetypes.DefaultOpenFlowCookie),
+		"priority=11", "in_port=eth0", "dl_vlan=100", "dl_dst=33:33:00:00:00:01",
+		fmt.Sprintf("icmpv6_type=%d", types.NeighborAdvertisementICMPType),
+		"actions=", "output:patch-breth0_bluenet", "output:patch-breth0_ov", "NORMAL")
+}
+
 func mustParseMAC(t *testing.T, value string) net.HardwareAddr {
 	t.Helper()
 	mac, err := net.ParseMAC(value)
@@ -287,6 +362,23 @@ func expectFlow(t *testing.T, flows []string, expected string) {
 		}
 	}
 	t.Fatalf("expected flow not found:\n%s\n\nall flows:\n%v", expected, flows)
+}
+
+func expectFlowContainingAll(t *testing.T, flows []string, substrings ...string) {
+	t.Helper()
+	for _, flow := range flows {
+		allFound := true
+		for _, s := range substrings {
+			if !strings.Contains(flow, s) {
+				allFound = false
+				break
+			}
+		}
+		if allFound {
+			return
+		}
+	}
+	t.Fatalf("no flow contains all substrings %v\n\nall flows:\n%v", substrings, flows)
 }
 
 func expectNoFlow(t *testing.T, flows []string, unexpectedSubstring string) {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1145,6 +1145,12 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 --bundle replace-flows breth0 -",
 		})
+		if util.IsNetworkSegmentationSupportEnabled() {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovs-ofctl dump-ports-desc breth0",
+				Output: " 5(patch-breth0_n): addr:00:00:00:00:00:00\n     config:     0\n     state:      LIVE\n",
+			})
+		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-ofctl show breth0",
 			Output: ovsOFOutput,

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"syscall"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -555,6 +556,22 @@ func (udng *UserDefinedNetworkGateway) addNetwork() error {
 		}
 	}
 
+	// Add static kernel neighbor entries for per-CUDN masquerade IPs on
+	// the gateway bridge so that the kernel never sends ARP/NS for these
+	// addresses. Without this, IPv6 NDP resolution for masquerade IPs
+	// fails because NS packets are not forwarded to CUDN patch ports
+	// (blocked by NO_FLOOD).
+	if config.IsModeFull() {
+		bridgeName := udng.openflowManager.getDefaultBridgeName()
+		if uplinkBridge != nil {
+			bridgeName = uplinkBridge.GetGatewayIface()
+		}
+		if err = addUDNMasqIPNeighbors(bridgeName, udng.v4MasqIPs, udng.v6MasqIPs); err != nil {
+			return fmt.Errorf("failed to add masquerade IP neighbor entries on %s for network %s: %w",
+				bridgeName, udng.GetNetworkName(), err)
+		}
+	}
+
 	if config.IsModeDPU() || config.IsModeFull() {
 		var mgmtIPs []*net.IPNet
 		for _, subnet := range nodeSubnets {
@@ -655,6 +672,16 @@ func (udng *UserDefinedNetworkGateway) delNetwork() error {
 			}
 		}
 	}
+	if config.IsModeFull() && udng.openflowManager != nil {
+		bridgeName := udng.openflowManager.getDefaultBridgeName()
+		if udng.Uplink() != "" && udng.gwInterfaceName != "" {
+			bridgeName = udng.gwInterfaceName
+		}
+		if err := delUDNMasqIPNeighbors(bridgeName, udng.v4MasqIPs, udng.v6MasqIPs); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete masquerade IP neighbor entries on %s for network %s: %w",
+				bridgeName, udng.GetNetworkName(), err))
+		}
+	}
 	if udng.openflowManager != nil || config.IsModeDPUHost() {
 		if err := udng.gateway.Reconcile(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile default gateway for network %s, err: %v", udng.GetNetworkName(), err))
@@ -688,6 +715,64 @@ func (udng *UserDefinedNetworkGateway) delNetwork() error {
 	}
 
 	return nil
+}
+
+// addUDNMasqIPNeighbors adds permanent kernel neighbor entries for a
+// user-defined network's gateway router masquerade IPs on the given bridge
+// interface. These IPs are internal to the node and handled entirely by OVS
+// flows, so they will never respond to ARP/NS on the wire. Static entries
+// prevent the kernel from sending ARP/NS requests that would otherwise fail
+// (IPv6 NS is blocked by NO_FLOOD on CUDN patch ports).
+func addUDNMasqIPNeighbors(bridgeName string, v4MasqIPs, v6MasqIPs *udn.MasqueradeIPs) error {
+	link, err := util.LinkSetUp(bridgeName)
+	if err != nil {
+		return fmt.Errorf("unable to get link for %s: %v", bridgeName, err)
+	}
+	for _, ip := range udnMasqGatewayRouterIPs(v4MasqIPs, v6MasqIPs) {
+		mac := util.IPAddrToHWAddr(ip)
+		klog.Infof("Ensuring UDN masquerade IP neighbor entry: %s -> %s on %s", ip, mac, bridgeName)
+		if exists, err := util.LinkNeighExists(link, ip, mac); err == nil && !exists {
+			if err = util.LinkNeighDel(link, ip); err != nil {
+				klog.Warningf("Failed to remove stale neighbor entry for %s on %s: %v",
+					ip, bridgeName, err)
+			}
+			if err = util.LinkNeighSet(link, ip, mac); err != nil {
+				return fmt.Errorf("failed to add neighbor %s -> %s on %s: %v",
+					ip, mac, bridgeName, err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to check neighbor %s on %s: %v", ip, bridgeName, err)
+		}
+	}
+	return nil
+}
+
+// delUDNMasqIPNeighbors removes the kernel neighbor entries previously added
+// by addUDNMasqIPNeighbors.
+func delUDNMasqIPNeighbors(bridgeName string, v4MasqIPs, v6MasqIPs *udn.MasqueradeIPs) error {
+	link, err := util.LinkSetUp(bridgeName)
+	if err != nil {
+		return fmt.Errorf("unable to get link for %s: %v", bridgeName, err)
+	}
+	var errs []error
+	for _, ip := range udnMasqGatewayRouterIPs(v4MasqIPs, v6MasqIPs) {
+		if err := util.LinkNeighDel(link, ip); err != nil && !errors.Is(err, syscall.ENOENT) {
+			errs = append(errs, fmt.Errorf("failed to delete neighbor %s on %s: %v", ip, bridgeName, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// udnMasqGatewayRouterIPs returns the gateway router masquerade IPs for a UDN.
+func udnMasqGatewayRouterIPs(v4MasqIPs, v6MasqIPs *udn.MasqueradeIPs) []net.IP {
+	var ips []net.IP
+	if v4MasqIPs != nil && v4MasqIPs.GatewayRouter != nil {
+		ips = append(ips, v4MasqIPs.GatewayRouter.IP)
+	}
+	if v6MasqIPs != nil && v6MasqIPs.GatewayRouter != nil {
+		ips = append(ips, v6MasqIPs.GatewayRouter.IP)
+	}
+	return ips
 }
 
 // getLocalSubnets returns pod subnets used by the current node.

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -546,13 +546,21 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovs-ofctl -O OpenFlow13 --bundle replace-flows breth0 -",
 	})
+	// SyncNoFlood calls GetNoFloodPorts (dump-ports-desc) during syncFlows.
+	// Before any UDN is added, no ports have NO_FLOOD.
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-ofctl dump-ports-desc breth0",
+		Output: " 5(patch-breth0_w): addr:00:00:00:00:00:00\n     config:     0\n     state:      LIVE\n",
+	})
 }
 
 func setUpUDNOpenflowManagerFakeOVSCommands(fexec *ovntest.FakeExec) {
-	// UDN patch port
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_bluenet_worker1-to-br-int ofport",
 		Output: "15",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-ofctl mod-port breth0 15 no-flood",
 	})
 }
 
@@ -1227,7 +1235,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				&kubeMock, vrf, ipRulesManager, localGw, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			baseFlowCount := 52
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -1243,9 +1252,12 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnFlows).To(Equal(0))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
+			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			Expect(udnGateway.AddNetwork()).To(Succeed())
+
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(70))                                      // 18 UDN Flows are added by default
+			udnDefaultFlows := 22
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount + udnDefaultFlows))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -1263,7 +1275,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			}
 			Expect(udnFlows).To(Equal(16))
 			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_worker1-to-br-int", 5)
-			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
@@ -1283,7 +1294,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -1463,7 +1474,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			udnGateway.mgmtPortController, err = managementport.NewUDNManagementPortController(udnGateway.nodeLister, udnGateway.node.Name, localSubnets, udnGateway.NetInfo)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			baseFlowCount := 52
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -1483,7 +1495,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(err).To(MatchError(ContainSubstring("fake delete metadata error")))
 			By("Ensuring everything else was still cleaned up correctly")
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -1651,7 +1663,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				&kubeMock, vrf, ipRulesManager, localGw, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			baseFlowCount := 52
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
 			for _, flows := range flowMap {
@@ -1666,9 +1679,12 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnFlows).To(Equal(0))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
+			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			Expect(udnGateway.AddNetwork()).To(Succeed())
+
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(70))                                      // 18 UDN Flows are added by default
+			udnDefaultFlows := 22
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount + udnDefaultFlows))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -1686,7 +1702,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			}
 			Expect(udnFlows).To(Equal(16))
 			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_worker1-to-br-int", 5)
-			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
@@ -1706,7 +1721,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -1890,7 +1905,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				&kubeMock, vrf, ipRulesManager, localGw, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			baseFlowCount := 52
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -1906,9 +1922,14 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnFlows).To(Equal(0))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
+			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			Expect(udnGateway.AddNetwork()).To(Succeed())
+
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(78))                                      // 18 UDN Flows, 3 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default (management-port ingress is no longer carved out to LOCAL)
+			udnDefaultFlows := 22
+			advertisedFlows := 3
+			packetMarkFlows := 5
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount + udnDefaultFlows + advertisedFlows + packetMarkFlows))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -1926,7 +1947,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			}
 			Expect(udnFlows).To(Equal(18))
 			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_worker1-to-br-int", 5)
-			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
@@ -1948,7 +1968,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -41,6 +42,7 @@ import (
 	udnfakeclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	factoryMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory/mocks"
+	udn "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	kubemocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
@@ -3435,6 +3437,264 @@ func TestUserDefinedNetworkGateway_updateAdvertisedUDNIsolationRules(t *testing.
 				g.Expect(element.Key[0]).To(BeEquivalentTo(v6Elems[i].Key[0]))
 				g.Expect(element.Comment).To(BeEquivalentTo(v6Elems[i].Comment))
 			}
+		})
+	}
+}
+
+func TestAddUDNMasqIPNeighbors(t *testing.T) {
+	bridgeName := "breth0"
+	linkIndex := 7
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: bridgeName, Index: linkIndex}}
+
+	v4Masq := &udn.MasqueradeIPs{GatewayRouter: ovntest.MustParseIPNet("169.254.0.11/16")}
+	v6Masq := &udn.MasqueradeIPs{GatewayRouter: ovntest.MustParseIPNet("fd69::b/112")}
+	v4IP := net.ParseIP("169.254.0.11")
+	v6IP := net.ParseIP("fd69::b")
+	v4MAC := util.IPAddrToHWAddr(v4IP)
+	v6MAC := util.IPAddrToHWAddr(v6IP)
+
+	tests := []struct {
+		name    string
+		v4      *udn.MasqueradeIPs
+		v6      *udn.MasqueradeIPs
+		setup   func(m *utilmocks.NetLinkOps)
+		wantErr string
+	}{
+		{
+			name: "link lookup fails",
+			v4:   v4Masq, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(nil, fmt.Errorf("no such device"))
+			},
+			wantErr: "unable to get link for breth0",
+		},
+		{
+			name: "dual-stack adds both entries when none exist",
+			v4:   v4Masq, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighList", linkIndex, netlink.FAMILY_V4).Return([]netlink.Neigh{}, nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP)
+				})).Return(nil).Once()
+				m.On("NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP) && n.LinkIndex == linkIndex &&
+						n.HardwareAddr.String() == v4MAC.String() &&
+						n.State == netlink.NUD_PERMANENT
+				})).Return(nil).Once()
+				m.On("NeighList", linkIndex, netlink.FAMILY_V6).Return([]netlink.Neigh{}, nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP)
+				})).Return(nil).Once()
+				m.On("NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP) && n.LinkIndex == linkIndex &&
+						n.HardwareAddr.String() == v6MAC.String() &&
+						n.State == netlink.NUD_PERMANENT
+				})).Return(nil).Once()
+			},
+		},
+		{
+			name: "IPv4-only single-stack adds only v4 entry",
+			v4:   v4Masq, v6: nil,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighList", linkIndex, netlink.FAMILY_V4).Return([]netlink.Neigh{}, nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP)
+				})).Return(nil).Once()
+				m.On("NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP) && n.State == netlink.NUD_PERMANENT
+				})).Return(nil).Once()
+			},
+		},
+		{
+			name: "IPv6-only single-stack adds only v6 entry",
+			v4:   nil, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighList", linkIndex, netlink.FAMILY_V6).Return([]netlink.Neigh{}, nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP)
+				})).Return(nil).Once()
+				m.On("NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP) && n.State == netlink.NUD_PERMANENT
+				})).Return(nil).Once()
+			},
+		},
+		{
+			name: "skips when correct entries already exist",
+			v4:   v4Masq, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				// v4: correct entry exists
+				m.On("NeighList", linkIndex, netlink.FAMILY_V4).Return([]netlink.Neigh{
+					{IP: v4IP, HardwareAddr: v4MAC, State: netlink.NUD_PERMANENT, LinkIndex: linkIndex},
+				}, nil)
+				// v6: correct entry exists
+				m.On("NeighList", linkIndex, netlink.FAMILY_V6).Return([]netlink.Neigh{
+					{IP: v6IP, HardwareAddr: v6MAC, State: netlink.NUD_PERMANENT, LinkIndex: linkIndex},
+				}, nil)
+			},
+		},
+		{
+			name: "replaces stale entry with wrong MAC",
+			v4:   v4Masq, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				staleMAC, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+				// v4: stale entry with wrong MAC
+				m.On("NeighList", linkIndex, netlink.FAMILY_V4).Return([]netlink.Neigh{
+					{IP: v4IP, HardwareAddr: staleMAC, State: netlink.NUD_REACHABLE, LinkIndex: linkIndex},
+				}, nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP)
+				})).Return(nil).Once()
+				m.On("NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP) && n.HardwareAddr.String() == v4MAC.String()
+				})).Return(nil).Once()
+				// v6: no entry
+				m.On("NeighList", linkIndex, netlink.FAMILY_V6).Return([]netlink.Neigh{}, nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP)
+				})).Return(nil).Once()
+				m.On("NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP)
+				})).Return(nil).Once()
+			},
+		},
+		{
+			name: "returns error when NeighSet fails",
+			v4:   v4Masq, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighList", linkIndex, netlink.FAMILY_V4).Return([]netlink.Neigh{}, nil)
+				m.On("NeighDel", mock.Anything).Return(nil)
+				m.On("NeighSet", mock.Anything).Return(fmt.Errorf("permission denied"))
+			},
+			wantErr: "failed to add neighbor",
+		},
+		{
+			name: "returns error when NeighList fails",
+			v4:   v4Masq, v6: v6Masq,
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighList", linkIndex, netlink.FAMILY_V4).Return(nil, fmt.Errorf("netlink error"))
+			},
+			wantErr: "failed to check neighbor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nlMock := new(utilmocks.NetLinkOps)
+			origOps := util.GetNetLinkOps()
+			util.SetNetLinkOpMockInst(nlMock)
+			t.Cleanup(func() { util.SetNetLinkOpMockInst(origOps) })
+
+			tt.setup(nlMock)
+
+			err := addUDNMasqIPNeighbors(bridgeName, tt.v4, tt.v6)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			nlMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDelUDNMasqIPNeighbors(t *testing.T) {
+	bridgeName := "breth0"
+	linkIndex := 7
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: bridgeName, Index: linkIndex}}
+
+	v4Masq := &udn.MasqueradeIPs{GatewayRouter: ovntest.MustParseIPNet("169.254.0.11/16")}
+	v6Masq := &udn.MasqueradeIPs{GatewayRouter: ovntest.MustParseIPNet("fd69::b/112")}
+	v4IP := net.ParseIP("169.254.0.11")
+	v6IP := net.ParseIP("fd69::b")
+
+	tests := []struct {
+		name    string
+		setup   func(m *utilmocks.NetLinkOps)
+		wantErr string
+	}{
+		{
+			name: "deletes both entries",
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP) && n.LinkIndex == linkIndex
+				})).Return(nil).Once()
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP) && n.LinkIndex == linkIndex
+				})).Return(nil).Once()
+			},
+		},
+		{
+			name: "returns error on link lookup failure",
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(nil, fmt.Errorf("no such device"))
+			},
+			wantErr: "unable to get link for breth0",
+		},
+		{
+			name: "ignores ENOENT (already deleted)",
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP)
+				})).Return(fmt.Errorf("failed: %w", syscall.ENOENT)).Once()
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP)
+				})).Return(fmt.Errorf("failed: %w", syscall.ENOENT)).Once()
+			},
+		},
+		{
+			name: "returns error on non-ENOENT NeighDel failure",
+			setup: func(m *utilmocks.NetLinkOps) {
+				m.On("LinkByName", bridgeName).Return(link, nil)
+				m.On("LinkSetUp", link).Return(nil)
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v4IP)
+				})).Return(fmt.Errorf("permission denied")).Once()
+				m.On("NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.IP.Equal(v6IP)
+				})).Return(nil).Once()
+			},
+			wantErr: "failed to delete neighbor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nlMock := new(utilmocks.NetLinkOps)
+			origOps := util.GetNetLinkOps()
+			util.SetNetLinkOpMockInst(nlMock)
+			t.Cleanup(func() { util.SetNetLinkOpMockInst(origOps) })
+
+			tt.setup(nlMock)
+
+			err := delUDNMasqIPNeighbors(bridgeName, v4Masq, v6Masq)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			nlMock.AssertExpectations(t)
 		})
 	}
 }

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -477,6 +477,9 @@ func (b *openflowBridge) syncFlows() error {
 			stderr, len(flows), err)
 	}
 	b.deleteStaleGroups()
+	if err := b.SyncNoFlood(); err != nil {
+		return fmt.Errorf("failed to sync no-flood port config: %w", err)
+	}
 	return nil
 }
 

--- a/go-controller/pkg/node/openflow_manager_test.go
+++ b/go-controller/pkg/node/openflow_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -85,6 +86,9 @@ func TestOpenFlowManagerCleansUnusedUplinkBridgeFlows(t *testing.T) {
 }
 
 func TestOpenFlowManagerSyncsUplinkBridgeFlows(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
 	fexec := ovntest.NewFakeExec()
 	if err := util.SetExec(fexec); err != nil {
 		t.Fatalf("failed to set fake exec: %v", err)

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -488,6 +488,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 			controller.gateway.kubeInterface = &kubeMock
 
 			By("starting UDN controller for user-defined primary network")
+			addOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int", 15)
 			err = controller.Start(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -322,6 +323,62 @@ func runWithEnvVars(cmdPath string, envVars []string, args ...string) (*bytes.Bu
 func RunOVSOfctl(args ...string) (string, string, error) {
 	stdout, stderr, err := run(runner.ofctlPath, args...)
 	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
+}
+
+// SetPortNoFlood sets the OFPPC_NO_FLOOD bit on the given OVS port via
+// "ovs-ofctl mod-port", preventing NORMAL/FLOOD actions from sending
+// packets to that port. The no-flood property is an OpenFlow port
+// config flag and cannot be set through the OVSDB Port table.
+// The caller must resolve the ofport number (e.g. via libovsdb)
+// because ovs-ofctl uses OpenFlow to map names to numbers and OpenFlow
+// limits port names to 15 bytes (see ovs-ofctl(8) --names documentation).
+func SetPortNoFlood(bridgeName, ofport string) error {
+	_, stderr, err := RunOVSOfctl("mod-port", bridgeName, ofport, "no-flood")
+	if err != nil {
+		return fmt.Errorf("failed to set no-flood on ofport %s of bridge %s: stderr: %s, error: %w",
+			ofport, bridgeName, stderr, err)
+	}
+	return nil
+}
+
+// GetNoFloodPorts returns the set of ofport numbers on bridgeName that
+// already have OFPPC_NO_FLOOD set, by parsing "ovs-ofctl dump-ports-desc".
+// The returned map keys are ofport number strings (e.g. "42").
+func GetNoFloodPorts(bridgeName string) (map[string]bool, error) {
+	stdout, stderr, err := RunOVSOfctl("dump-ports-desc", bridgeName)
+	if err != nil {
+		return nil, fmt.Errorf("dump-ports-desc on %s failed: stderr: %s, error: %w",
+			bridgeName, stderr, err)
+	}
+	// Output format (one block per port):
+	//  1(eth0): addr:...
+	//      config:     NO_FLOOD
+	//      state:      LIVE
+	result := make(map[string]bool)
+	var currentOfport string
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Port header, e.g.:
+		//  1(eth0): addr:...
+		if idx := strings.IndexByte(trimmed, '('); idx > 0 {
+			port := strings.TrimSpace(trimmed[:idx])
+			if _, err := strconv.ParseUint(port, 10, 32); err == nil {
+				currentOfport = port
+			}
+			continue
+		}
+		// Port configuration, e.g.:
+		//  config:     NO_FLOOD
+		if currentOfport != "" && strings.HasPrefix(trimmed, "config:") {
+			for _, flag := range strings.Fields(strings.TrimPrefix(trimmed, "config:")) {
+				if flag == "NO_FLOOD" {
+					result[currentOfport] = true
+					break
+				}
+			}
+		}
+	}
+	return result, nil
 }
 
 // RunOVSVsctl runs a command via ovs-vsctl.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - ExternalIPs/LoadBalancerIngress: design/external-ip-and-loadbalancer-ingress.md
     - Internal Subnets: design/ovn-kubernetes-subnets.md
     - External Bridge (breth0) Flows: design/bridge-flows.md
+    - Masquerade IPs: design/masquerade-ips.md
     - Kubevirt VM Live Migration: features/live-migration.md
   - Getting Started:
     - Launching OVN-Kubernetes sandbox env: installation/launching-ovn-kubernetes-on-kind.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Host To NodePort Hairpin: design/host-to-node-port-hairpin-trafficflow.md
     - ExternalIPs/LoadBalancerIngress: design/external-ip-and-loadbalancer-ingress.md
     - Internal Subnets: design/ovn-kubernetes-subnets.md
+    - External Bridge (breth0) Flows: design/bridge-flows.md
     - Kubevirt VM Live Migration: features/live-migration.md
   - Getting Started:
     - Launching OVN-Kubernetes sandbox env: installation/launching-ovn-kubernetes-on-kind.md

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -46,6 +46,7 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
@@ -2486,6 +2487,415 @@ spec:
 				),
 			),
 		)
+	})
+
+	It("should set NO_FLOOD on CUDN patch ports, direct node-IP ARP to default GR (p12 flow), and fan out external GARP to all GRs (p11 flow)", func() {
+		By("getting two nodes: a target node and a sender node")
+		nodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+		framework.ExpectNoError(err)
+		Expect(len(nodes.Items)).To(BeNumerically(">=", 2), "need at least 2 schedulable nodes")
+		targetNode := nodes.Items[0]
+		senderNode := nodes.Items[1]
+
+		targetNodeIPv4, targetNodeIPv6 := getNodeAddresses(&targetNode)
+		senderNodeIPv4, senderNodeIPv6 := getNodeAddresses(&senderNode)
+		hasIPv4 := targetNodeIPv4 != "" && senderNodeIPv4 != ""
+		hasIPv6 := targetNodeIPv6 != "" && senderNodeIPv6 != ""
+		Expect(hasIPv4 || hasIPv6).To(BeTrue(), "nodes must have at least one IP family")
+
+		bridgeName := deploymentconfig.Get().ExternalBridgeName()
+		ovnkNs := deploymentconfig.Get().OVNKubernetesNamespace()
+
+		By("creating a primary Layer3 CUDN")
+		cudnName := randomNetworkMetaName()
+		cudnManifest := generateClusterUserDefinedNetworkManifest(&networkAttachmentConfigParams{
+			name:      cudnName,
+			namespace: f.Namespace.Name,
+			topology:  "layer3",
+			cidr:      primaryLayer3MultiCIDRs(),
+			role:      "primary",
+		}, cs)
+		cleanup, err := createManifest("", cudnManifest)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			cleanup()
+			_, _ = e2ekubectl.RunKubectl("", "delete", "clusteruserdefinednetwork", cudnName, "--wait", fmt.Sprintf("--timeout=%ds", 120))
+		})
+		Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 60*time.Second, time.Second).Should(Succeed())
+
+		if isDynamicUDNEnabled() {
+			// Dynamic UDN allocation only provisions the network on a node
+			// when a pod attached to it is scheduled there. Create a
+			// minimal pod on the target node to trigger patch port creation
+			// on breth0.
+			By("creating a trigger pod on the target node (dynamic UDN mode)")
+			runUDNPod(cs, f.Namespace.Name, podConfiguration{
+				name:         "trigger-pod",
+				namespace:    f.Namespace.Name,
+				containerCmd: []string{"/agnhost", "pause"},
+				nodeSelector: map[string]string{nodeHostnameKey: targetNode.Name},
+			}, nil)
+		}
+
+		By("finding ovnkube-node pods on target and sender nodes")
+		targetOvnkPods, err := cs.CoreV1().Pods(ovnkNs).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: "spec.nodeName=" + targetNode.Name,
+		})
+		framework.ExpectNoError(err)
+		Expect(targetOvnkPods.Items).To(HaveLen(1))
+		ovnkPod := targetOvnkPods.Items[0]
+
+		senderOvnkPods, err := cs.CoreV1().Pods(ovnkNs).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: "spec.nodeName=" + senderNode.Name,
+		})
+		framework.ExpectNoError(err)
+		Expect(senderOvnkPods.Items).To(HaveLen(1))
+		senderOvnkPod := senderOvnkPods.Items[0]
+
+		By("deriving patch port names and resolving ofport numbers")
+		defaultPatchPort := ovnkubeutil.GetPatchPortName(bridgeName, targetNode.Name)
+		scopedNodeName := ovnkubeutil.GetUserDefinedNetworkPrefix(ovntypes.CUDNPrefix+cudnName) + targetNode.Name
+		cudnPatchPort := ovnkubeutil.GetPatchPortName(bridgeName, scopedNodeName)
+		framework.Logf("default patch port: %s, CUDN patch port: %s", defaultPatchPort, cudnPatchPort)
+
+		var defaultOfport, cudnOfport string
+		Eventually(func() error {
+			out, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovs-vsctl get Interface %s ofport", defaultPatchPort),
+				framework.Poll, 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("default patch port %s: %w", defaultPatchPort, err)
+			}
+			defaultOfport = strings.TrimSpace(out)
+			if defaultOfport == "" || defaultOfport == "-1" {
+				return fmt.Errorf("default patch port %s has ofport %s", defaultPatchPort, defaultOfport)
+			}
+			out, err = e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovs-vsctl get Interface %s ofport", cudnPatchPort),
+				framework.Poll, 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("CUDN patch port %s: %w", cudnPatchPort, err)
+			}
+			cudnOfport = strings.TrimSpace(out)
+			if cudnOfport == "" || cudnOfport == "-1" {
+				return fmt.Errorf("CUDN patch port %s has ofport %s", cudnPatchPort, cudnOfport)
+			}
+			return nil
+		}, 120*time.Second, 5*time.Second).Should(Succeed())
+		framework.Logf("default ofport: %s, CUDN ofport: %s", defaultOfport, cudnOfport)
+
+		By("verifying NO_FLOOD is set on the CUDN patch port")
+		Eventually(func() bool {
+			cmd := fmt.Sprintf("ovs-ofctl dump-ports-desc %s %s", bridgeName, cudnOfport)
+			output, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name, cmd, framework.Poll, 30*time.Second)
+			if err != nil {
+				return false
+			}
+			return strings.Contains(output, "NO_FLOOD")
+		}, 120*time.Second, 5*time.Second).Should(BeTrue(),
+			"NO_FLOOD must be set on CUDN patch port %s (ofport %s)", cudnPatchPort, cudnOfport)
+
+		By("resolving the physical (uplink) ofport on the bridge")
+		var physOfport string
+		Eventually(func() error {
+			out, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovs-vsctl br-get-external-id %s bridge-uplink", bridgeName),
+				framework.Poll, 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("bridge-uplink external-id not set on %s: %w", bridgeName, err)
+			}
+			uplinkPort := strings.TrimSpace(out)
+			if uplinkPort == "" {
+				return fmt.Errorf("bridge-uplink external-id is empty on %s", bridgeName)
+			}
+			out, err = e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovs-vsctl get Interface %s ofport", uplinkPort),
+				framework.Poll, 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("getting ofport for %s: %w", uplinkPort, err)
+			}
+			physOfport = strings.TrimSpace(out)
+			if physOfport == "" || physOfport == "-1" {
+				return fmt.Errorf("physical port %s has ofport %s", uplinkPort, physOfport)
+			}
+			framework.Logf("physical (uplink) port: %s, ofport: %s", uplinkPort, physOfport)
+			return nil
+		}, 60*time.Second, 5*time.Second).Should(Succeed())
+
+		if hasIPv4 {
+			By("verifying the priority-12 ARP flow outputs only to the default GR patch port")
+			var arpFlow string
+			Eventually(func() string {
+				out, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovs-ofctl dump-flows %s table=0,arp,arp_tpa=%s", bridgeName, targetNodeIPv4),
+					framework.Poll, 30*time.Second)
+				if err != nil {
+					return ""
+				}
+				arpFlow = out
+				return out
+			}, 60*time.Second, 5*time.Second).Should(
+				And(
+					ContainSubstring(fmt.Sprintf("output:%s", defaultOfport)),
+					Not(ContainSubstring(fmt.Sprintf("output:%s", cudnOfport))),
+				),
+				"priority-12 ARP flow must output to default patch (ofport %s) not CUDN patch (ofport %s):\n%s",
+				defaultOfport, cudnOfport, arpFlow,
+			)
+
+			By("verifying the priority-11 ARP flow forwards external broadcast ARP to all GR patch ports")
+			var fanoutFlow string
+			Eventually(func() string {
+				out, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovs-ofctl dump-flows %s table=0,in_port=%s,dl_dst=ff:ff:ff:ff:ff:ff,arp | grep priority=11", bridgeName, physOfport),
+					framework.Poll, 30*time.Second)
+				if err != nil {
+					return ""
+				}
+				fanoutFlow = out
+				return out
+			}, 60*time.Second, 5*time.Second).Should(
+				And(
+					ContainSubstring(fmt.Sprintf("output:%s", defaultOfport)),
+					ContainSubstring(fmt.Sprintf("output:%s", cudnOfport)),
+					ContainSubstring("NORMAL"),
+				),
+				"priority-11 ARP fanout flow must output to both default (ofport %s) and CUDN (ofport %s) patches:\n%s",
+				defaultOfport, cudnOfport, fanoutFlow,
+			)
+		}
+
+		if hasIPv6 {
+			By("verifying the priority-12 NS flow outputs only to the default GR patch port (IPv6)")
+			var nsFlow string
+			Eventually(func() string {
+				out, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovs-ofctl dump-flows %s table=0,icmp6,icmpv6_type=%d,nd_target=%s",
+						bridgeName, ovntypes.NeighborSolicitationICMPType, targetNodeIPv6),
+					framework.Poll, 30*time.Second)
+				if err != nil {
+					return ""
+				}
+				nsFlow = out
+				return out
+			}, 60*time.Second, 5*time.Second).Should(
+				And(
+					ContainSubstring(fmt.Sprintf("output:%s", defaultOfport)),
+					Not(ContainSubstring(fmt.Sprintf("output:%s", cudnOfport))),
+				),
+				"priority-12 NS flow must output to default patch (ofport %s) not CUDN patch (ofport %s):\n%s",
+				defaultOfport, cudnOfport, nsFlow,
+			)
+
+			By("verifying the priority-11 NA flow forwards external unsolicited NA to all GR patch ports (IPv6)")
+			var naFanoutFlow string
+			Eventually(func() string {
+				out, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovs-ofctl dump-flows %s table=0,in_port=%s,dl_dst=33:33:00:00:00:01,icmp6,icmpv6_type=%d | grep priority=11",
+						bridgeName, physOfport, ovntypes.NeighborAdvertisementICMPType),
+					framework.Poll, 30*time.Second)
+				if err != nil {
+					return ""
+				}
+				naFanoutFlow = out
+				return out
+			}, 60*time.Second, 5*time.Second).Should(
+				And(
+					ContainSubstring(fmt.Sprintf("output:%s", defaultOfport)),
+					ContainSubstring(fmt.Sprintf("output:%s", cudnOfport)),
+					ContainSubstring("NORMAL"),
+				),
+				"priority-11 NA fanout flow must output to both default (ofport %s) and CUDN (ofport %s) patches:\n%s",
+				defaultOfport, cudnOfport, naFanoutFlow,
+			)
+		}
+
+		cudnGR := cudnGatewayRouterName(cudnName, targetNode.Name)
+		defaultGR := ovntypes.GWRouterPrefix + targetNode.Name
+
+		if hasIPv4 {
+			By("logging MAC_Bindings for sender IP before arping")
+			macBindingsBefore, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --columns=logical_port,ip find MAC_Binding ip=%q", senderNodeIPv4),
+				framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err)
+			framework.Logf("MAC_Bindings for sender IP %s BEFORE arping:\n%s", senderNodeIPv4, macBindingsBefore)
+
+			By("clearing MAC_Bindings for sender IP to establish a clean baseline")
+			_, _ = e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=%q | xargs -r -n1 ovn-sbctl destroy MAC_Binding", senderNodeIPv4),
+				framework.Poll, 30*time.Second)
+			Eventually(func() string {
+				out, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=%q", senderNodeIPv4),
+					framework.Poll, 30*time.Second)
+				return strings.TrimSpace(out)
+			}, 10*time.Second, 2*time.Second).Should(BeEmpty(), "MAC_Bindings for %s should be cleared", senderNodeIPv4)
+
+			By("sending ARP for target node IP from sender node")
+			arpCmd := fmt.Sprintf("arping -c 3 -w 5 -I %s %s", bridgeName, targetNodeIPv4)
+			_, err = e2epodoutput.RunHostCmdWithRetries(senderOvnkPod.Namespace, senderOvnkPod.Name, arpCmd, framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err, "arping from sender to %s failed", targetNodeIPv4)
+
+			// With always_learn_from_arp_request=false, OVN northd generates
+			// a priority-110 exemption flow in lr_in_lookup_neighbor that
+			// hardcodes reg9[3]=1 for ARP requests targeting the router's own
+			// IP. This lets put_arp fire immediately, creating a MAC_Binding
+			// for the sender on the first poll.
+			By("verifying MAC_Bindings confirm priority-12 directed ARP to default GR only")
+			Consistently(func(g Gomega) {
+				macBindings, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --columns=logical_port find MAC_Binding ip=%q", senderNodeIPv4),
+					framework.Poll, 30*time.Second)
+				g.Expect(err).NotTo(HaveOccurred(), "ovn-sbctl find MAC_Binding failed")
+				framework.Logf("MAC_Bindings for sender IP %s AFTER arping:\n%s", senderNodeIPv4, macBindings)
+				g.Expect(macBindings).To(ContainSubstring(defaultGR),
+					"ARP must create a MAC_Binding on default GR %s for sender IP %s", defaultGR, senderNodeIPv4)
+				g.Expect(macBindings).NotTo(ContainSubstring(cudnGR),
+					"node-IP ARP must NOT create a MAC_Binding on CUDN GR %s for sender IP %s", cudnGR, senderNodeIPv4)
+			}, 4*time.Second, 1*time.Second).Should(Succeed())
+
+			By("logging MAC_Bindings for sender IP before GARP test")
+			macBindingsBeforeGARP, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --columns=logical_port,ip find MAC_Binding ip=%q", senderNodeIPv4),
+				framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err)
+			framework.Logf("MAC_Bindings for sender IP %s BEFORE GARP:\n%s", senderNodeIPv4, macBindingsBeforeGARP)
+
+			By("clearing MAC_Bindings for sender IP before GARP test")
+			_, _ = e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=%q | xargs -r -n1 ovn-sbctl destroy MAC_Binding", senderNodeIPv4),
+				framework.Poll, 30*time.Second)
+			Eventually(func() string {
+				out, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=%q", senderNodeIPv4),
+					framework.Poll, 30*time.Second)
+				return strings.TrimSpace(out)
+			}, 10*time.Second, 2*time.Second).Should(BeEmpty(), "MAC_Bindings for %s should be cleared", senderNodeIPv4)
+
+			By("sending GARP from sender node to exercise the priority-11 fanout flow")
+			garpCmd := fmt.Sprintf("arping -A -c 3 -w 5 -I %s %s", bridgeName, senderNodeIPv4)
+			_, err = e2epodoutput.RunHostCmdWithRetries(senderOvnkPod.Namespace, senderOvnkPod.Name, garpCmd, framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err, "GARP from sender for %s failed", senderNodeIPv4)
+
+			By("verifying MAC_Bindings confirm priority-11 fanned GARP to both default and CUDN GRs")
+			Consistently(func(g Gomega) {
+				macBindings, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --columns=logical_port find MAC_Binding ip=%q", senderNodeIPv4),
+					framework.Poll, 30*time.Second)
+				g.Expect(err).NotTo(HaveOccurred(), "ovn-sbctl find MAC_Binding failed")
+				framework.Logf("MAC_Bindings for sender IP %s AFTER GARP:\n%s", senderNodeIPv4, macBindings)
+				g.Expect(macBindings).To(ContainSubstring(defaultGR),
+					"GARP must create a MAC_Binding on default GR %s for sender IP %s", defaultGR, senderNodeIPv4)
+				g.Expect(macBindings).To(ContainSubstring(cudnGR),
+					"GARP must create a MAC_Binding on CUDN GR %s for sender IP %s (priority-11 fanout)", cudnGR, senderNodeIPv4)
+			}, 4*time.Second, 1*time.Second).Should(Succeed())
+		}
+
+		if hasIPv6 {
+			By("logging MAC_Bindings for sender IPv6 before NS test")
+			macBindingsV6Before, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --columns=logical_port,ip find MAC_Binding ip=\\\"%s\\\"", senderNodeIPv6),
+				framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err)
+			framework.Logf("MAC_Bindings for sender IPv6 %s BEFORE ndisc6:\n%s", senderNodeIPv6, macBindingsV6Before)
+
+			By("clearing MAC_Bindings for sender IPv6 before NS test")
+			_, _ = e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=\\\"%s\\\" | xargs -r -n1 ovn-sbctl destroy MAC_Binding", senderNodeIPv6),
+				framework.Poll, 30*time.Second)
+			Eventually(func() string {
+				out, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=\\\"%s\\\"", senderNodeIPv6),
+					framework.Poll, 30*time.Second)
+				return strings.TrimSpace(out)
+			}, 10*time.Second, 2*time.Second).Should(BeEmpty(), "MAC_Bindings for %s should be cleared", senderNodeIPv6)
+
+			By("sending NS for target node IPv6 from sender node using ndisc6 with global source")
+			nsCmd := fmt.Sprintf("ndisc6 -1 -r 3 -s %s %s %s", senderNodeIPv6, targetNodeIPv6, bridgeName)
+			nsOut, err := e2epodoutput.RunHostCmdWithRetries(senderOvnkPod.Namespace, senderOvnkPod.Name, nsCmd, framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err, "ndisc6 NS from sender %s to target %s failed", senderNodeIPv6, targetNodeIPv6)
+			framework.Logf("ndisc6 output:\n%s", nsOut)
+
+			// TODO(OVN northd bug, https://redhat.atlassian.net/browse/FDP-4198):
+			// Unlike ARP requests, NS packets targeting the router's own
+			// IPv6 do NOT get a priority-110 exemption flow in
+			// lr_in_lookup_neighbor when always_learn_from_arp_request=false.
+			// The priority-110 flow (which hardcodes reg9[3]=1 to allow
+			// put_arp) is only generated for IPv4 addresses (n_ipv4_addrs
+			// loop in northd commit 61ccc6b). NS hits the generic
+			// priority-100 flow where reg9[3]=lookup_nd_ip()=0 (no
+			// pre-existing binding), causing the priority-100 skip
+			// condition in lr_in_learn_neighbor to fire. The GR responds
+			// with NA but never learns the sender's MAC/IP.
+			// Any MAC_Binding that appears after a longer delay is from
+			// background traffic triggering the GR's own NS resolution
+			// (via arp_request table), not from the test's ndisc6.
+			By("verifying NS does NOT immediately create a MAC_Binding (OVN northd IPv6 learning bug)")
+			Consistently(func() string {
+				macBindings, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --bare --columns=logical_port find MAC_Binding ip=\\\"%s\\\"", senderNodeIPv6),
+					framework.Poll, 30*time.Second)
+				return strings.TrimSpace(macBindings)
+			}, 2*time.Second, 1*time.Second).Should(BeEmpty(),
+				"NS must NOT create a MAC_Binding due to OVN northd bug — always_learn_from_arp_request=false "+
+					"priority-110 exemption is missing for IPv6 NS (only implemented for IPv4 ARP)")
+
+			By("clearing MAC_Bindings for sender IPv6 before unsolicited NA test")
+			_, _ = e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=\\\"%s\\\" | xargs -r -n1 ovn-sbctl destroy MAC_Binding", senderNodeIPv6),
+				framework.Poll, 30*time.Second)
+			Eventually(func() string {
+				out, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --bare --columns=_uuid find MAC_Binding ip=\\\"%s\\\"", senderNodeIPv6),
+					framework.Poll, 30*time.Second)
+				return strings.TrimSpace(out)
+			}, 10*time.Second, 2*time.Second).Should(BeEmpty(), "MAC_Bindings for %s should be cleared", senderNodeIPv6)
+
+			// ndptool sends NAs with a link-local source IP. OVN's
+			// lr_in_lookup_neighbor has a priority-110 flow matching
+			// (nd_na && ip6.src == fe80::/10 && ip6.dst == ff00::/8)
+			// that sets reg9[3]=lookup_nd_ip() instead of reg9[3]=1,
+			// so it only updates existing bindings, never creates new
+			// ones. A proper GARP-equivalent NA (with a global source)
+			// would bypass this flow and hit the priority-100 nd_na
+			// flow where reg9[3]=1, allowing put_nd to fire. This
+			// requires ndsend (not available on Fedora). We verify the
+			// priority-11 fanout via flow counter instead.
+			By("recording priority-11 NA flow counter before ndptool")
+			naFlowBefore, err := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+				fmt.Sprintf("ovs-ofctl dump-flows %s table=0,in_port=%s,dl_dst=33:33:00:00:00:01,icmp6,icmpv6_type=136 | grep priority=11",
+					bridgeName, physOfport),
+				framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err, "failed to dump priority-11 NA flow")
+			framework.Logf("Priority-11 NA flow BEFORE ndptool:\n%s", naFlowBefore)
+
+			By("sending unsolicited NA from sender node using ndptool (link-local source)")
+			ndptoolCmd := fmt.Sprintf("ndptool -t na -U -i %s -T %s send", bridgeName, senderNodeIPv6)
+			_, err = e2epodoutput.RunHostCmdWithRetries(senderOvnkPod.Namespace, senderOvnkPod.Name, ndptoolCmd, framework.Poll, 30*time.Second)
+			framework.ExpectNoError(err, "ndptool unsolicited NA from sender for %s failed", senderNodeIPv6)
+
+			By("verifying priority-11 NA flow counter incremented (proves fanout)")
+			Eventually(func() string {
+				naFlowAfter, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovs-ofctl dump-flows %s table=0,in_port=%s,dl_dst=33:33:00:00:00:01,icmp6,icmpv6_type=136 | grep priority=11",
+						bridgeName, physOfport),
+					framework.Poll, 30*time.Second)
+				return naFlowAfter
+			}, 5*time.Second, 1*time.Second).ShouldNot(Equal(naFlowBefore),
+				"priority-11 NA flow counter must increment after ndptool NA")
+
+			By("verifying ndptool NA with link-local source does not create MAC_Bindings for global sender IPv6")
+			Consistently(func() string {
+				macBindings, _ := e2epodoutput.RunHostCmdWithRetries(ovnkPod.Namespace, ovnkPod.Name,
+					fmt.Sprintf("ovn-sbctl --bare --columns=logical_port find MAC_Binding ip=\\\"%s\\\"", senderNodeIPv6),
+					framework.Poll, 30*time.Second)
+				return strings.TrimSpace(macBindings)
+			}, 2*time.Second, 1*time.Second).Should(BeEmpty(),
+				"ndptool uses link-local source; no MAC_Binding should appear for global %s", senderNodeIPv6)
+		}
 	})
 })
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

The generic priority-10 fan-out rule on breth0 replicates all traffic destined to the bridge MAC to every GR patch port. When multiple CUDN GRs share the same node IP on their external interface, each one generates an ARP reply for that IP. Since all GRs also share the same bridge MAC, these replies are identical — yet they flood the physical network and cause remote nodes to passively learn redundant MAC_Bindings, driving ovs-vswitchd CPU up. In testing, 70 CUDNs drove CPU to ~400% with packet drops.

This patch redesigns the breth0 ARP/NDP handling:

No-flood on CUDN patch ports — Set other_config:no-flood=true (via libovsdb) on all non-default CUDN GR patch ports. This prevents NORMAL/FLOOD from implicitly delivering to CUDNs while still allowing explicit output:<port> actions.

Priority-12: Node-IP ARP/NDP filter — Intercept ARP requests (arp_op=1, arp_tpa=<nodeIP>) and IPv6 NS (nd_target=<nodeIP>) before the fan-out. Send only to the default GR patch + NORMAL. NORMAL performs FDB learning and delivers to LOCAL via static FDB; no-flood excludes CUDNs. Only the default GR replies — no storm.

Priority-11: External broadcast ARP/GARP forwarding — Match broadcast ARP (dl_dst=ff:ff:ff:ff:ff:ff) and unsolicited NA (dl_dst=33:33:00:00:00:01) arriving on the physical port (in_port=<phys>). Explicitly forward to all GR patches + NORMAL, so CUDNs still receive external GARPs for MAC_Binding updates despite no-flood.

Table-1 ICMPv6 FLOOD fix — Existing table-1 flows that FLOOD Router Advertisements (type 134) and Neighbor Advertisements (type 136) are updated to prepend explicit output to CUDN patches before FLOOD, since FLOOD also respects no-flood.

The existing priority-10 shared-MAC fan-out (dl_dst=<nodeMAC>) is unchanged and continues to deliver unicast traffic to all GR patches.

https://cloud-native.slack.com/archives/C08452HR8V6/p1784053926522969

Besides that, also added FDB kernel neighbor entries for masIP for all UDN networks to ensure packets are not leaked to the wire for BGP+LGW nodeport case. See commit 4 for details. 

## Additional Information for reviewers

TBD: For the FDB entries, not the ovs restart w/o ovnkube restart isn't handled yet. Maybe we need masqueradeReconciler to be hooked to udnGateway as well as a FUP? Will see what reviewers say during review

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

Added an E2E test for this.