### PR TITLE
Dynamic UDN - networkmanager: track terminating pods until completion

### DIFF
--- a/go-controller/pkg/networkmanager/pod_tracker.go
+++ b/go-controller/pkg/networkmanager/pod_tracker.go
@@ -209,7 +209,7 @@ func (c *PodTrackerController) syncAll() error {
 	}
 
 	for _, pod := range pods {
-		if pod.Spec.NodeName == "" || pod.DeletionTimestamp != nil {
+		if pod.Spec.NodeName == "" || util.PodCompleted(pod) {
 			continue
 		}
 
@@ -297,6 +297,13 @@ func (c *PodTrackerController) needUpdate(old, new *corev1.Pod) bool {
 		return true
 	}
 
+	// Reconcile when all pod containers have stopped so its network references
+	// can be removed. A deletion timestamp alone does not mean the pod has
+	// finished terminating.
+	if util.PodCompleted(old) != util.PodCompleted(new) {
+		return true
+	}
+
 	// If the network attachment annotations changed, reconcile.
 	oldAnno := old.Annotations[nadv1.NetworkAttachmentAnnot]
 	newAnno := new.Annotations[nadv1.NetworkAttachmentAnnot]
@@ -321,8 +328,8 @@ func (c *PodTrackerController) reconcile(key string) error {
 		return fmt.Errorf("failed to get pod %q from cache: %v", key, err)
 	}
 
-	// If pod is terminating → remove from cache
-	if pod.DeletionTimestamp != nil {
+	// Keep terminating pods tracked until all their containers have stopped.
+	if util.PodCompleted(pod) {
 		c.deletePodFromCache(key)
 		return nil
 	}

--- a/go-controller/pkg/networkmanager/pod_tracker_test.go
+++ b/go-controller/pkg/networkmanager/pod_tracker_test.go
@@ -16,6 +16,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -231,6 +233,78 @@ func TestPodTrackerControllerWithInformerAndDelete(t *testing.T) {
 			}, "2s", "50ms").Should(gomega.Succeed())
 		})
 	}
+}
+
+func TestPodTrackerControllerTracksTerminatingPodsUntilCompleted(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	deletionTimestamp := metav1.Now()
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "testns",
+			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: `[{"name":"secondary"}]`,
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "node1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	terminatingPod := runningPod.DeepCopy()
+	terminatingPod.DeletionTimestamp = &deletionTimestamp
+	completedPod := terminatingPod.DeepCopy()
+	completedPod.Status.Phase = corev1.PodSucceeded
+	completedPod.Name = "completed-pod"
+
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	g.Expect(podIndexer.Add(terminatingPod)).To(gomega.Succeed())
+	g.Expect(podIndexer.Add(completedPod)).To(gomega.Succeed())
+
+	namespaceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	g.Expect(namespaceIndexer.Add(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "testns"},
+	})).To(gomega.Succeed())
+
+	var events []refChange
+	ptc := &PodTrackerController{
+		name:               "test-pod-tracker",
+		nodeNADToPodCache:  make(map[string]map[string]map[string]struct{}),
+		podToNodeNAD:       make(map[string]nodeNAD),
+		podLister:          corelisters.NewPodLister(podIndexer),
+		namespaceLister:    corelisters.NewNamespaceLister(namespaceIndexer),
+		onNetworkRefChange: func(node, nad string, active bool) { events = append(events, refChange{node, nad, active}) },
+		primaryNADForNamespace: func(string) (string, error) {
+			return ovntypes.DefaultNetworkName, nil
+		},
+	}
+
+	// A deletion timestamp by itself must neither enqueue cleanup nor prevent
+	// the pod from being restored during initial cache synchronization.
+	g.Expect(ptc.needUpdate(runningPod, terminatingPod)).To(gomega.BeFalse())
+	g.Expect(ptc.syncAll()).To(gomega.Succeed())
+	g.Expect(ptc.podToNodeNAD).To(gomega.HaveKey("testns/pod"))
+	g.Expect(ptc.podToNodeNAD).NotTo(gomega.HaveKey("testns/completed-pod"))
+
+	// Reconciliation caused by an unrelated event must also retain a
+	// terminating pod while its containers are still running.
+	g.Expect(ptc.reconcile("testns/pod")).To(gomega.Succeed())
+	g.Expect(ptc.podToNodeNAD).To(gomega.HaveKey("testns/pod"))
+
+	// Once the pod is terminal, its update is reconciled and the last network
+	// reference is removed.
+	completedTerminatingPod := terminatingPod.DeepCopy()
+	completedTerminatingPod.Status.Phase = corev1.PodSucceeded
+	g.Expect(ptc.needUpdate(terminatingPod, completedTerminatingPod)).To(gomega.BeTrue())
+	g.Expect(podIndexer.Update(completedTerminatingPod)).To(gomega.Succeed())
+	g.Expect(ptc.reconcile("testns/pod")).To(gomega.Succeed())
+	g.Expect(ptc.podToNodeNAD).NotTo(gomega.HaveKey("testns/pod"))
+	g.Expect(ptc.nodeNADToPodCache).NotTo(gomega.HaveKey("node1"))
+	g.Expect(events).To(gomega.Equal([]refChange{
+		{node: "node1", nad: "testns/secondary", active: true},
+		{node: "node1", nad: "testns/secondary", active: false},
+	}))
 }
 
 func TestPodTrackerControllerSyncAll(t *testing.T) {

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -3147,9 +3148,12 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 	})
 
 	Context("Dynamic UDN allocation", func() {
-		const nodeHostnameKey = "kubernetes.io/hostname"
+		const (
+			nodeHostnameKey         = "kubernetes.io/hostname"
+			terminatingPodFinalizer = "k8s.ovn.org/e2e-terminating-pod"
+		)
 
-		It("should connect cross-node L3 and L2 UDN pods through CNC when dynamic UDN allocation is enabled", func() {
+		It("should connect cross-node UDN pods and retain terminating node state", func() {
 			if !isDynamicUDNEnabled() {
 				Skip("test requires DYNAMIC_UDN_ALLOCATION=true")
 			}
@@ -3170,6 +3174,11 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			var l3PodNode1, l3PodNode2, l2Pod *corev1.Pod
 
 			DeferCleanup(func() {
+				if l3PodNode1 != nil {
+					_, _ = cs.CoreV1().Pods(l3PodNode1.Namespace).Patch(
+						context.Background(), l3PodNode1.Name, types.MergePatchType,
+						[]byte(`{"metadata":{"finalizers":[]}}`), metav1.PatchOptions{})
+				}
 				deleteCNC(cncName)
 				if l3PodNode1 != nil {
 					_ = cs.CoreV1().Pods(l3PodNode1.Namespace).Delete(context.Background(), l3PodNode1.Name, metav1.DeleteOptions{})
@@ -3211,7 +3220,16 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			By(fmt.Sprintf("Creating an L3 pod on %s", node1Name))
 			l3PodNode1Config := httpServerPodConfig("blue-pod-node1", l3Namespace)
 			l3PodNode1Config.nodeSelector = map[string]string{nodeHostnameKey: node1Name}
-			l3PodNode1 = runUDNPod(cs, l3Namespace, l3PodNode1Config, nil)
+			l3PodNode1 = runUDNPod(cs, l3Namespace, l3PodNode1Config, func(pod *corev1.Pod) {
+				terminationGracePeriodSeconds := int64(60)
+				pod.Finalizers = append(pod.Finalizers, terminatingPodFinalizer)
+				pod.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
+				pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+					PreStop: &corev1.LifecycleHandler{
+						Exec: &corev1.ExecAction{Command: []string{"/agnhost", "pause"}},
+					},
+				}
+			})
 
 			By(fmt.Sprintf("Creating a second L3 pod on %s", node2Name))
 			l3PodNode2Config := httpServerPodConfig("blue-pod-node2", l3Namespace)
@@ -3245,9 +3263,68 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, true)
 			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
 
-			By(fmt.Sprintf("Deleting the L3 pod on %s to make that node inactive for the L3 UDN", node1Name))
-			Expect(deletePodWithWait(context.Background(), cs, l3PodNode1)).To(Succeed())
-			l3PodNode1 = nil
+			By(fmt.Sprintf("Deleting the final L3 pod on %s", node1Name))
+			Expect(cs.CoreV1().Pods(l3PodNode1.Namespace).Delete(
+				context.Background(), l3PodNode1.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			By("Waiting for the pod to be terminating while its container still runs")
+			Eventually(func(g Gomega) {
+				pod, err := cs.CoreV1().Pods(l3PodNode1.Namespace).Get(
+					context.Background(), l3PodNode1.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.DeletionTimestamp).NotTo(BeNil())
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+				g.Expect(pod.Status.ContainerStatuses).NotTo(BeEmpty())
+				g.Expect(pod.Status.ContainerStatuses[0].State.Running).NotTo(BeNil())
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			// Force a pod tracker reconciliation while the pod is terminating. A
+			// semantically empty network-selection update must not remove the
+			// primary UDN reference while the container is still running.
+			By("Forcing pod tracker reconciliation during termination")
+			networkSelectionPatch := fmt.Sprintf(
+				`{"metadata":{"annotations":{%q:"[]"}}}`, nadapi.NetworkAttachmentAnnot)
+			_, err = cs.CoreV1().Pods(l3PodNode1.Namespace).Patch(
+				context.Background(), l3PodNode1.Name, types.MergePatchType,
+				[]byte(networkSelectionPatch), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying connectivity and node state persist during termination")
+			Consistently(func(g Gomega) {
+				pod, err := cs.CoreV1().Pods(l3PodNode1.Namespace).Get(
+					context.Background(), l3PodNode1.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+				g.Expect(pod.Status.ContainerStatuses).NotTo(BeEmpty())
+				g.Expect(pod.Status.ContainerStatuses[0].State.Running).NotTo(BeNil())
+				for _, l3PodIP := range l3PodNode1IPs {
+					g.Expect(checkConnectivity(
+						l3PodNode2.Namespace, l3PodNode2.Name, l3PodIP, true)).To(BeTrue(),
+						"expected terminating pod IP %s to remain reachable", l3PodIP)
+				}
+				ports, err := findCNCNodeOVNObjects(
+					f, cs, "Logical_Router_Port", "name", cncName, l3NetworkID, node1ID)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ports).NotTo(BeEmpty())
+				routes, err := findCNCNodeOVNObjects(
+					f, cs, "Logical_Router_Static_Route", "ip_prefix,nexthop",
+					cncName, l3NetworkID, node1ID)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routes).NotTo(BeEmpty())
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("Waiting for the terminating pod to reach a terminal phase")
+			Eventually(func(g Gomega) {
+				pod, err := cs.CoreV1().Pods(l3PodNode1.Namespace).Get(
+					context.Background(), l3PodNode1.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.Status.Phase).To(Or(
+					Equal(corev1.PodSucceeded), Equal(corev1.PodFailed)))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("Verifying terminal pod cleanup removes only the inactive node state")
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, false)
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
 
 			By("Verifying the remaining L3 pod is still reachable through the CNC")
 			for _, l3PodIP := range l3PodNode2IPs {
@@ -3257,9 +3334,15 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 					fmt.Sprintf("expected %s/%s to ping remaining L3 pod IP %s", l2Pod.Namespace, l2Pod.Name, l3PodIP))
 			}
 
-			By("Verifying CNC removed L3 node-specific OVN state for the inactive node only")
-			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, false)
-			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
+			By("Removing the test finalizer and waiting for pod deletion")
+			_, err = cs.CoreV1().Pods(l3PodNode1.Namespace).Patch(
+				context.Background(), l3PodNode1.Name, types.MergePatchType,
+				[]byte(`{"metadata":{"finalizers":[]}}`), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForPodNotFoundInNamespace(
+				context.Background(), cs, l3PodNode1.Name, l3PodNode1.Namespace,
+				l3PodNode1.UID, 30*time.Second)).To(Succeed())
+			l3PodNode1 = nil
 		})
 	})
 

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -3147,9 +3148,12 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 	})
 
 	Context("Dynamic UDN allocation", func() {
-		const nodeHostnameKey = "kubernetes.io/hostname"
+		const (
+			nodeHostnameKey         = "kubernetes.io/hostname"
+			terminatingPodFinalizer = "k8s.ovn.org/e2e-terminating-pod"
+		)
 
-		It("should connect cross-node L3 and L2 UDN pods through CNC when dynamic UDN allocation is enabled", func() {
+		It("should connect cross-node UDN pods and retain terminating node state", func() {
 			if !isDynamicUDNEnabled() {
 				Skip("test requires DYNAMIC_UDN_ALLOCATION=true")
 			}
@@ -3170,6 +3174,11 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			var l3PodNode1, l3PodNode2, l2Pod *corev1.Pod
 
 			DeferCleanup(func() {
+				if l3PodNode1 != nil {
+					_, _ = cs.CoreV1().Pods(l3PodNode1.Namespace).Patch(
+						context.Background(), l3PodNode1.Name, types.MergePatchType,
+						[]byte(`{"metadata":{"finalizers":[]}}`), metav1.PatchOptions{})
+				}
 				deleteCNC(cncName)
 				if l3PodNode1 != nil {
 					_ = cs.CoreV1().Pods(l3PodNode1.Namespace).Delete(context.Background(), l3PodNode1.Name, metav1.DeleteOptions{})
@@ -3211,7 +3220,16 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			By(fmt.Sprintf("Creating an L3 pod on %s", node1Name))
 			l3PodNode1Config := httpServerPodConfig("blue-pod-node1", l3Namespace)
 			l3PodNode1Config.nodeSelector = map[string]string{nodeHostnameKey: node1Name}
-			l3PodNode1 = runUDNPod(cs, l3Namespace, l3PodNode1Config, nil)
+			l3PodNode1 = runUDNPod(cs, l3Namespace, l3PodNode1Config, func(pod *corev1.Pod) {
+				terminationGracePeriodSeconds := int64(90)
+				pod.Finalizers = append(pod.Finalizers, terminatingPodFinalizer)
+				pod.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
+				pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+					PreStop: &corev1.LifecycleHandler{
+						Exec: &corev1.ExecAction{Command: []string{"/agnhost", "pause"}},
+					},
+				}
+			})
 
 			By(fmt.Sprintf("Creating a second L3 pod on %s", node2Name))
 			l3PodNode2Config := httpServerPodConfig("blue-pod-node2", l3Namespace)
@@ -3245,9 +3263,74 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, true)
 			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
 
-			By(fmt.Sprintf("Deleting the L3 pod on %s to make that node inactive for the L3 UDN", node1Name))
-			Expect(deletePodWithWait(context.Background(), cs, l3PodNode1)).To(Succeed())
-			l3PodNode1 = nil
+			By(fmt.Sprintf("Deleting the final L3 pod on %s", node1Name))
+			Expect(cs.CoreV1().Pods(l3PodNode1.Namespace).Delete(
+				context.Background(), l3PodNode1.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			By("Waiting for the pod to be terminating while its container still runs")
+			Eventually(func(g Gomega) {
+				pod, err := cs.CoreV1().Pods(l3PodNode1.Namespace).Get(
+					context.Background(), l3PodNode1.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.DeletionTimestamp).NotTo(BeNil())
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+				g.Expect(pod.Status.ContainerStatuses).NotTo(BeEmpty())
+				g.Expect(pod.Status.ContainerStatuses[0].State.Running).NotTo(BeNil())
+			}, 30*time.Second, time.Second).Should(Succeed(), fmt.Sprintf(
+				"expected pod %s/%s to remain running while terminating",
+				l3PodNode1.Namespace, l3PodNode1.Name))
+
+			// Force a pod tracker reconciliation while the pod is terminating. A
+			// semantically empty network-selection update must not remove the
+			// primary UDN reference while the container is still running.
+			By("Forcing pod tracker reconciliation during termination")
+			networkSelectionPatch := fmt.Sprintf(
+				`{"metadata":{"annotations":{%q:"[]"}}}`, nadapi.NetworkAttachmentAnnot)
+			_, err = cs.CoreV1().Pods(l3PodNode1.Namespace).Patch(
+				context.Background(), l3PodNode1.Name, types.MergePatchType,
+				[]byte(networkSelectionPatch), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying connectivity and node state persist during termination")
+			Consistently(func(g Gomega) {
+				pod, err := cs.CoreV1().Pods(l3PodNode1.Namespace).Get(
+					context.Background(), l3PodNode1.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+				g.Expect(pod.Status.ContainerStatuses).NotTo(BeEmpty())
+				g.Expect(pod.Status.ContainerStatuses[0].State.Running).NotTo(BeNil())
+				for _, l3PodIP := range l3PodNode1IPs {
+					g.Expect(checkConnectivity(
+						l3PodNode2.Namespace, l3PodNode2.Name, l3PodIP, true)).To(BeTrue(),
+						"expected terminating pod IP %s to remain reachable", l3PodIP)
+				}
+				ports, err := findCNCNodeOVNObjects(
+					f, cs, "Logical_Router_Port", "name", cncName, l3NetworkID, node1ID)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ports).NotTo(BeEmpty())
+				routes, err := findCNCNodeOVNObjects(
+					f, cs, "Logical_Router_Static_Route", "ip_prefix,nexthop",
+					cncName, l3NetworkID, node1ID)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routes).NotTo(BeEmpty())
+			}, 30*time.Second, 2*time.Second).Should(Succeed(), fmt.Sprintf(
+				"expected connectivity and node-specific OVN state for terminating pod %s/%s to persist",
+				l3PodNode1.Namespace, l3PodNode1.Name))
+
+			By("Waiting for the terminating pod to reach a terminal phase")
+			Eventually(func(g Gomega) {
+				pod, err := cs.CoreV1().Pods(l3PodNode1.Namespace).Get(
+					context.Background(), l3PodNode1.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.Status.Phase).To(Or(
+					Equal(corev1.PodSucceeded), Equal(corev1.PodFailed)))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed(), fmt.Sprintf(
+				"expected terminating pod %s/%s to reach a terminal phase",
+				l3PodNode1.Namespace, l3PodNode1.Name))
+
+			By("Verifying terminal pod cleanup removes only the inactive node state")
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, false)
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
 
 			By("Verifying the remaining L3 pod is still reachable through the CNC")
 			for _, l3PodIP := range l3PodNode2IPs {
@@ -3257,9 +3340,15 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 					fmt.Sprintf("expected %s/%s to ping remaining L3 pod IP %s", l2Pod.Namespace, l2Pod.Name, l3PodIP))
 			}
 
-			By("Verifying CNC removed L3 node-specific OVN state for the inactive node only")
-			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, false)
-			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
+			By("Removing the test finalizer and waiting for pod deletion")
+			_, err = cs.CoreV1().Pods(l3PodNode1.Namespace).Patch(
+				context.Background(), l3PodNode1.Name, types.MergePatchType,
+				[]byte(`{"metadata":{"finalizers":[]}}`), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForPodNotFoundInNamespace(
+				context.Background(), cs, l3PodNode1.Name, l3PodNode1.Namespace,
+				l3PodNode1.UID, 30*time.Second)).To(Succeed())
+			l3PodNode1 = nil
 		})
 	})
 


### PR DESCRIPTION
Keep terminating pods in the network reference cache until all of their containers stop. A deletion timestamp is set before container teardown, so treating it as a cleanup signal can withdraw network-dependent configuration while the pod still needs connectivity.

Use terminal pod phases for both live reconciliation and initial cache synchronization. Reconcile phase transitions so references are removed when pods complete, while retaining deletion as fallback cleanup.

Assisted-by: OpenAI Codex <codex@openai.com>

