### PR TITLE
Trim node object fields to reduce memory footprint

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -1069,7 +1069,7 @@ func (ncc *networkClusterController) clearInitialNodeNetworkUnavailableCondition
 					condition.Reason = "RouteCreated"
 					condition.Message = "ovn-kube cleared kubelet-set NoRouteCreated"
 					condition.LastTransitionTime = metav1.Now()
-					if err = ncc.kube.UpdateNodeStatus(node); err == nil {
+					if err = ncc.kube.PatchNodeStatus(oldNode, node); err == nil {
 						cleared = true
 					}
 				}

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -538,7 +538,7 @@ func (na *NodeAllocator) updateNodeNetworkAnnotationsWithRetry(nodeName string, 
 	// Retry if it fails because of potential conflict which is transient. Return error in the
 	// case of other errors (say temporary API server down), and it will be taken care of by the
 	// retry mechanism.
-	resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	resultErr := retry.OnError(retry.DefaultBackoff, util.IsNodeAnnotationPatchRetryable, func() error {
 		// Informer cache should not be mutated, so get a copy of the object
 		node, err := na.nodeLister.Get(nodeName)
 		if err != nil {
@@ -570,9 +570,10 @@ func (na *NodeAllocator) updateNodeNetworkAnnotationsWithRetry(nodeName string, 
 					node.Name, tunnelID, networkName, err)
 			}
 		}
-		// It is possible to update the node annotations using status subresource
-		// because changes to metadata via status subresource are not restricted for nodes.
-		return na.kube.UpdateNodeStatus(cnode)
+		// Patch only the changed annotations via the status subresource instead
+		// of a full status update, which would overwrite fields trimmed by the
+		// informer transform (e.g. Images, VolumesAttached).
+		return na.kube.PatchNodeStatusAnnotations(node, cnode)
 	})
 	if resultErr != nil {
 		return fmt.Errorf("failed to update node %s annotation: %w", nodeName, resultErr)

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -318,6 +318,22 @@ func informerObjectTrim(obj interface{}) (interface{}, error) {
 			pod.Status.Conditions[i].ObservedGeneration = 0
 		}
 	}
+	if node, ok := obj.(*corev1.Node); ok {
+		// OVN-K does not consume these node fields from informer cache.
+		node.Status.Images = nil
+		node.Status.VolumesAttached = nil
+		node.Status.VolumesInUse = nil
+		node.Status.DaemonEndpoints = corev1.NodeDaemonEndpoints{}
+		node.Status.Capacity = nil
+		node.Status.Allocatable = nil
+		node.Status.Config = nil
+		node.Status.RuntimeHandlers = nil
+		node.Status.Features = nil
+		node.Spec.Taints = nil
+		node.Spec.PodCIDRs = nil
+		node.OwnerReferences = nil
+		node.Finalizers = nil
+	}
 	return obj, nil
 }
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	knet "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -2253,5 +2254,112 @@ var _ = Describe("Watch Factory Operations", func() {
 		Consistently(c.getUpdated, 2).Should(Equal(0))
 
 		wf.RemovePodHandler(h)
+	})
+})
+
+var _ = Describe("informerObjectTrim", func() {
+	It("strips unnecessary node fields", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+				Labels: map[string]string{
+					"kubernetes.io/hostname": "test-node",
+				},
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": `{"default":"10.128.0.0/23"}`,
+				},
+				ManagedFields: []metav1.ManagedFieldsEntry{
+					{Manager: "kubelet"},
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: "owner"},
+				},
+				Finalizers: []string{"ovn-kubernetes.io/node-cleanup"},
+			},
+			Status: corev1.NodeStatus{
+				Images: []corev1.ContainerImage{
+					{Names: []string{"registry.io/image:latest"}, SizeBytes: 100000},
+				},
+				VolumesAttached: []corev1.AttachedVolume{
+					{Name: "vol1", DevicePath: "/dev/sda"},
+				},
+				VolumesInUse: []corev1.UniqueVolumeName{"vol1"},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:    corev1.NodeReady,
+						Status:  corev1.ConditionTrue,
+						Reason:  "KubeletReady",
+						Message: "kubelet is posting ready status",
+					},
+				},
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("3"),
+				},
+				DaemonEndpoints: corev1.NodeDaemonEndpoints{
+					KubeletEndpoint: corev1.DaemonEndpoint{Port: 10250},
+				},
+				NodeInfo: corev1.NodeSystemInfo{
+					KernelVersion: "5.14.0",
+				},
+				Config: &corev1.NodeConfigStatus{
+					Active: &corev1.NodeConfigSource{
+						ConfigMap: &corev1.ConfigMapNodeConfigSource{
+							Name:      "kubelet-config",
+							Namespace: "kube-system",
+						},
+					},
+				},
+				RuntimeHandlers: []corev1.NodeRuntimeHandler{
+					{Name: "runc", Features: &corev1.NodeRuntimeHandlerFeatures{}},
+				},
+				Features: &corev1.NodeFeatures{},
+			},
+			Spec: corev1.NodeSpec{
+				PodCIDR:  "10.128.0.0/23",
+				PodCIDRs: []string{"10.128.0.0/23"},
+				Taints: []corev1.Taint{
+					{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+				},
+			},
+		}
+
+		trimmed, err := informerObjectTrim(node)
+		Expect(err).NotTo(HaveOccurred())
+		n := trimmed.(*corev1.Node)
+
+		// Verify fields that SHOULD be cleared
+		Expect(n.Status.Images).To(BeNil(), "Status.Images should be cleared")
+		Expect(n.Status.VolumesAttached).To(BeNil(), "Status.VolumesAttached should be cleared")
+		Expect(n.Status.VolumesInUse).To(BeNil(), "Status.VolumesInUse should be cleared")
+		Expect(n.OwnerReferences).To(BeNil(), "OwnerReferences should be cleared")
+		Expect(n.ManagedFields).To(BeNil(), "ManagedFields should be cleared")
+		Expect(n.Finalizers).To(BeNil(), "Finalizers should be cleared")
+		Expect(n.Status.DaemonEndpoints).To(Equal(corev1.NodeDaemonEndpoints{}), "Status.DaemonEndpoints should be cleared")
+		Expect(n.Status.NodeInfo).To(Equal(corev1.NodeSystemInfo{KernelVersion: "5.14.0"}), "Status.NodeInfo must be preserved")
+		Expect(n.Status.Capacity).To(BeNil(), "Status.Capacity should be cleared")
+		Expect(n.Status.Allocatable).To(BeNil(), "Status.Allocatable should be cleared")
+		Expect(n.Status.Config).To(BeNil(), "Status.Config should be cleared")
+		Expect(n.Status.RuntimeHandlers).To(BeNil(), "Status.RuntimeHandlers should be cleared")
+		Expect(n.Status.Features).To(BeNil(), "Status.Features should be cleared")
+		Expect(n.Spec.Taints).To(BeNil(), "Spec.Taints should be cleared")
+		Expect(n.Spec.PodCIDRs).To(BeNil(), "Spec.PodCIDRs should be cleared")
+
+		// Verify condition subfields: Type/Status/Reason/Message preserved
+		Expect(n.Status.Conditions).To(HaveLen(1))
+		Expect(n.Status.Conditions[0].Reason).To(Equal("KubeletReady"), "Condition.Reason must be preserved")
+		Expect(n.Status.Conditions[0].Message).To(Equal("kubelet is posting ready status"), "Condition.Message must be preserved")
+
+		// Verify fields that MUST be preserved
+		Expect(n.Name).To(Equal("test-node"))
+		Expect(n.Labels).To(HaveKey("kubernetes.io/hostname"))
+		Expect(n.Annotations).To(HaveKey("k8s.ovn.org/node-subnets"))
+		Expect(n.Status.Addresses).To(HaveLen(1))
+		Expect(n.Spec.PodCIDR).To(Equal("10.128.0.0/23"))
 	})
 })

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -63,7 +63,8 @@ type Interface interface {
 	SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error
 	SetLabelsOnNode(nodeName string, labels map[string]interface{}) error
 	PatchNode(old, new *corev1.Node) error
-	UpdateNodeStatus(node *corev1.Node) error
+	PatchNodeStatus(old, new *corev1.Node) error
+	PatchNodeStatusAnnotations(oldNode, newNode *corev1.Node) error
 	PatchPodStatusAnnotations(oldPod, newPod *corev1.Pod) error
 	// GetNodeForWindows should only be used for windows hybrid overlay binary and never in linux code
 	GetNodeForWindows(name string) (*corev1.Node, error)
@@ -176,7 +177,7 @@ func (k *Kube) PatchPodStatusAnnotations(oldPod, newPod *corev1.Pod) error {
 
 	ops := []jsonPatchOp{}
 	requiresResourceVersionGuard := false
-	if oldPod.Annotations == nil {
+	if len(oldPod.Annotations) == 0 {
 		ops = append(ops, jsonPatchOp{
 			Op:    "add",
 			Path:  "/metadata/annotations",
@@ -384,10 +385,161 @@ func (k *Kube) PatchNode(old, new *corev1.Node) error {
 	return nil
 }
 
-// UpdateNodeStatus takes the node object and sets the provided update status
-func (k *Kube) UpdateNodeStatus(node *corev1.Node) error {
-	klog.Infof("Updating status on node %s", node.Name)
-	_, err := k.KClient.CoreV1().Nodes().UpdateStatus(context.TODO(), node, metav1.UpdateOptions{})
+// PatchNodeStatus patches the node status subresource using a strategic merge
+// patch computed from the old and new node objects. Only the fields that differ
+// between old and new are sent to the API server, so informer-trimmed fields
+// that are identical in both objects do not overwrite the server state.
+//
+// ResourceVersion from the new object is included in the patch to enable
+// optimistic conflict detection: the API server rejects the patch with 409
+// if the server's current resourceVersion differs, preventing silent
+// overwrites from stale data.
+func (k *Kube) PatchNodeStatus(old, new *corev1.Node) error {
+	// Clear ResourceVersion from old so it appears in the computed diff.
+	// This makes the patch carry new's resourceVersion, enabling the API
+	// server to reject stale updates with 409 Conflict.
+	oldForPatch := old.DeepCopy()
+	oldForPatch.ResourceVersion = ""
+
+	oldNodeObjectJson, err := json.Marshal(oldForPatch)
+	if err != nil {
+		klog.Errorf("Unable to marshal node %s: %v", old.Name, err)
+		return err
+	}
+
+	newNodeObjectJson, err := json.Marshal(new)
+	if err != nil {
+		klog.Errorf("Unable to marshal node %s: %v", new.Name, err)
+		return err
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldNodeObjectJson, newNodeObjectJson, corev1.Node{})
+	if err != nil {
+		klog.Errorf("Unable to create patch for node %s: %v", old.Name, err)
+		return err
+	}
+
+	if _, err = k.KClient.CoreV1().Nodes().Patch(context.TODO(), old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status"); err != nil {
+		klog.Errorf("Unable to patch node status %s: %v", old.Name, err)
+		return err
+	}
+
+	return nil
+}
+
+// PatchNodeStatusAnnotations patches only node annotations through the status
+// subresource using compare-and-retry semantics on the old node state. This
+// avoids sending the full node status (which may have fields trimmed by the
+// informer transform) back to the API server.
+//
+// There are two concurrency cases to handle:
+//  1. The annotation key already exists on the old node. In that case we can use a
+//     narrow JSON patch "test" on that specific key so we only retry if another
+//     writer changed the same annotation.
+//  2. The annotation key does not exist on the old node. In that case a per-key
+//     "test" cannot protect us because two stale writers could both issue an
+//     unconditional "add" and the last one would win. For that create case we add
+//     a resourceVersion guard so only one writer based on that node snapshot can
+//     create the missing key; losers will retry from the latest node state and
+//     recompute a merged annotation value.
+//
+// Real informer/API nodes always have a resourceVersion. If a synthetic caller
+// passes an object without one, we skip that extra guard and fall back to the
+// narrower per-key tests that are available.
+func (k *Kube) PatchNodeStatusAnnotations(oldNode, newNode *corev1.Node) error {
+	if oldNode.Name != newNode.Name {
+		return fmt.Errorf("cannot patch annotations for different nodes %s and %s",
+			oldNode.Name, newNode.Name)
+	}
+
+	changedKeys := make(map[string]struct{})
+	for key, oldValue := range oldNode.Annotations {
+		if newValue, ok := newNode.Annotations[key]; !ok || oldValue != newValue {
+			changedKeys[key] = struct{}{}
+		}
+	}
+	for key, newValue := range newNode.Annotations {
+		if oldValue, ok := oldNode.Annotations[key]; !ok || oldValue != newValue {
+			changedKeys[key] = struct{}{}
+		}
+	}
+	if len(changedKeys) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(changedKeys))
+	for key := range changedKeys {
+		keys = append(keys, key)
+	}
+
+	ops := []jsonPatchOp{}
+	requiresResourceVersionGuard := false
+	if len(oldNode.Annotations) == 0 {
+		ops = append(ops, jsonPatchOp{
+			Op:    "add",
+			Path:  "/metadata/annotations",
+			Value: map[string]string{},
+		})
+		requiresResourceVersionGuard = true
+	}
+	for _, key := range keys {
+		path := "/metadata/annotations/" + escapeJSONPatchPathKey(key)
+		oldValue, oldOK := oldNode.Annotations[key]
+		newValue, newOK := newNode.Annotations[key]
+		if oldOK {
+			ops = append(ops, jsonPatchOp{
+				Op:    "test",
+				Path:  path,
+				Value: oldValue,
+			})
+		} else if newOK {
+			requiresResourceVersionGuard = true
+		}
+		switch {
+		case newOK && oldOK:
+			ops = append(ops, jsonPatchOp{
+				Op:    "replace",
+				Path:  path,
+				Value: newValue,
+			})
+		case newOK:
+			ops = append(ops, jsonPatchOp{
+				Op:    "add",
+				Path:  path,
+				Value: newValue,
+			})
+		default:
+			ops = append(ops, jsonPatchOp{
+				Op:   "remove",
+				Path: path,
+			})
+		}
+	}
+	if requiresResourceVersionGuard && oldNode.ResourceVersion != "" {
+		ops = append([]jsonPatchOp{{
+			Op:    "test",
+			Path:  "/metadata/resourceVersion",
+			Value: oldNode.ResourceVersion,
+		}}, ops...)
+	}
+
+	patchData, err := json.Marshal(ops)
+	if err != nil {
+		return fmt.Errorf("failed to marshal annotation patch for node %s: %w", oldNode.Name, err)
+	}
+
+	klog.Infof("Patching annotations on node %s", oldNode.Name)
+	_, err = k.KClient.CoreV1().Nodes().Patch(
+		context.TODO(),
+		oldNode.Name,
+		types.JSONPatchType,
+		patchData,
+		metav1.PatchOptions{},
+		"status",
+	)
+	if err != nil {
+		klog.Errorf("Error in patching annotations on node %s: %v", oldNode.Name, err)
+	}
 	return err
 }
 

--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -246,6 +247,338 @@ var _ = Describe("Kube", func() {
 			Expect(patchOps[1].Op).To(Equal("replace"))
 			Expect(patchOps[1].Path).To(Equal("/metadata/annotations/ovn"))
 			Expect(patchOps[1].Value).To(Equal("new"))
+		})
+	})
+
+	Describe("PatchNodeStatusAnnotations", func() {
+		var kube Kube
+
+		BeforeEach(func() {
+			kube = Kube{
+				KClient: fake.NewSimpleClientset(),
+			}
+		})
+
+		It("adds annotations without dropping existing ones", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-node",
+					Annotations: map[string]string{"existing": "value"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := node.DeepCopy()
+			newNode := node.DeepCopy()
+			newNode.Annotations["added"] = "new-value"
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("existing", "value"))
+			Expect(node.Annotations).To(HaveKeyWithValue("added", "new-value"))
+		})
+
+		It("can create and remove annotations", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-node",
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := node.DeepCopy()
+			newNode := node.DeepCopy()
+			newNode.Annotations = map[string]string{"ovn": "value"}
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("ovn", "value"))
+
+			oldNode = node.DeepCopy()
+			newNode = node.DeepCopy()
+			delete(newNode.Annotations, "ovn")
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).ToNot(HaveKey("ovn"))
+		})
+
+		It("adds a resourceVersion guard when creating a missing annotation key", func() {
+			var patchOps []jsonPatchOp
+			kube.KClient.(*fake.Clientset).Fake.PrependReactor("patch", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
+				patchAction := action.(ktesting.PatchAction)
+				Expect(patchAction.GetSubresource()).To(Equal("status"))
+				Expect(json.Unmarshal(patchAction.GetPatch(), &patchOps)).To(Succeed())
+				return true, &corev1.Node{}, nil
+			})
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "my-node",
+					ResourceVersion: "7",
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations = map[string]string{"ovn": "value"}
+
+			err := kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(patchOps).To(HaveLen(3))
+			Expect(patchOps[0].Op).To(Equal("test"))
+			Expect(patchOps[0].Path).To(Equal("/metadata/resourceVersion"))
+			Expect(patchOps[0].Value).To(Equal("7"))
+			Expect(patchOps[1].Op).To(Equal("add"))
+			Expect(patchOps[1].Path).To(Equal("/metadata/annotations"))
+			Expect(patchOps[2].Op).To(Equal("add"))
+			Expect(patchOps[2].Path).To(Equal("/metadata/annotations/ovn"))
+		})
+
+		It("uses a per-key guard when updating an existing annotation key", func() {
+			var patchOps []jsonPatchOp
+			kube.KClient.(*fake.Clientset).Fake.PrependReactor("patch", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
+				patchAction := action.(ktesting.PatchAction)
+				Expect(patchAction.GetSubresource()).To(Equal("status"))
+				Expect(json.Unmarshal(patchAction.GetPatch(), &patchOps)).To(Succeed())
+				return true, &corev1.Node{}, nil
+			})
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "my-node",
+					ResourceVersion: "9",
+					Annotations:     map[string]string{"ovn": "old"},
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations["ovn"] = "new"
+
+			err := kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(patchOps).To(HaveLen(2))
+			Expect(patchOps[0].Op).To(Equal("test"))
+			Expect(patchOps[0].Path).To(Equal("/metadata/annotations/ovn"))
+			Expect(patchOps[0].Value).To(Equal("old"))
+			Expect(patchOps[1].Op).To(Equal("replace"))
+			Expect(patchOps[1].Path).To(Equal("/metadata/annotations/ovn"))
+			Expect(patchOps[1].Value).To(Equal("new"))
+		})
+
+		It("adds annotations when oldNode has empty non-nil annotation map", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-node",
+					Annotations: map[string]string{},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := node.DeepCopy()
+			if oldNode.Annotations == nil {
+				oldNode.Annotations = map[string]string{}
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations["k8s.ovn.org/node-subnets"] = `{"default":"10.128.0.0/23"}`
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err = kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("k8s.ovn.org/node-subnets", `{"default":"10.128.0.0/23"}`))
+		})
+
+		It("returns an error when old and new node names differ", func() {
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node-a",
+					Annotations: map[string]string{"ovn": "value"},
+				},
+			}
+			newNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node-b",
+					Annotations: map[string]string{"ovn": "updated"},
+				},
+			}
+
+			err := kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("different nodes"))
+			Expect(err.Error()).To(ContainSubstring("node-a"))
+			Expect(err.Error()).To(ContainSubstring("node-b"))
+
+			actions := kube.KClient.(*fake.Clientset).Actions()
+			for _, a := range actions {
+				Expect(a.GetVerb()).ToNot(Equal("patch"), "no patch should be sent for mismatched node names")
+			}
+		})
+
+		It("does not send trimmed node status fields via annotations patch", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-node",
+					Annotations: map[string]string{"existing": "value"},
+				},
+				Status: corev1.NodeStatus{
+					Images:          []corev1.ContainerImage{{Names: []string{"img:latest"}, SizeBytes: 100}},
+					VolumesAttached: []corev1.AttachedVolume{{Name: "vol1", DevicePath: "/dev/sda"}},
+					VolumesInUse:    []corev1.UniqueVolumeName{"vol1"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			serverNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := serverNode.DeepCopy()
+			oldNode.Status.Images = nil
+			oldNode.Status.VolumesAttached = nil
+			oldNode.Status.VolumesInUse = nil
+			newNode := oldNode.DeepCopy()
+			newNode.Annotations["ovn"] = "subnet-data"
+
+			err = kube.PatchNodeStatusAnnotations(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Annotations).To(HaveKeyWithValue("ovn", "subnet-data"))
+			Expect(node.Status.Images).To(HaveLen(1))
+			Expect(node.Status.VolumesAttached).To(HaveLen(1))
+			Expect(node.Status.VolumesInUse).To(HaveLen(1))
+		})
+	})
+
+	Describe("PatchNodeStatus", func() {
+		var kube Kube
+
+		BeforeEach(func() {
+			kube.KClient = fake.NewSimpleClientset()
+		})
+
+		It("updates a node condition without clobbering other status fields", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Status: corev1.NodeStatus{
+					Images:          []corev1.ContainerImage{{Names: []string{"img:latest"}, SizeBytes: 100}},
+					VolumesAttached: []corev1.AttachedVolume{{Name: "vol1", DevicePath: "/dev/sda"}},
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeNetworkUnavailable, Status: corev1.ConditionTrue, Reason: "NoRouteCreated"},
+					},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Status: corev1.NodeStatus{
+					Images:          nil,
+					VolumesAttached: nil,
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeNetworkUnavailable, Status: corev1.ConditionTrue, Reason: "NoRouteCreated"},
+					},
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Status.Conditions[0].Status = corev1.ConditionFalse
+			newNode.Status.Conditions[0].Reason = "RouteCreated"
+
+			err = kube.PatchNodeStatus(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Status.Conditions).To(HaveLen(1))
+			Expect(node.Status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
+			Expect(node.Status.Conditions[0].Reason).To(Equal("RouteCreated"))
+			Expect(node.Status.Images).To(HaveLen(1), "trimmed field should not be overwritten on server")
+			Expect(node.Status.VolumesAttached).To(HaveLen(1), "trimmed field should not be overwritten on server")
+		})
+
+		It("does not overwrite additionally trimmed status fields", func() {
+			_, err := kube.KClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Spec: corev1.NodeSpec{
+					Taints:   []corev1.Taint{{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule}},
+					PodCIDRs: []string{"10.128.0.0/23"},
+				},
+				Status: corev1.NodeStatus{
+					Capacity:    corev1.ResourceList{corev1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI)},
+					Allocatable: corev1.ResourceList{corev1.ResourceCPU: *resource.NewQuantity(3, resource.DecimalSI)},
+					DaemonEndpoints: corev1.NodeDaemonEndpoints{
+						KubeletEndpoint: corev1.DaemonEndpoint{Port: 10250},
+					},
+					NodeInfo: corev1.NodeSystemInfo{KernelVersion: "5.14.0"},
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "KubeletReady"},
+					},
+					Config: &corev1.NodeConfigStatus{
+						Active: &corev1.NodeConfigSource{
+							ConfigMap: &corev1.ConfigMapNodeConfigSource{
+								Name:      "kubelet-config",
+								Namespace: "kube-system",
+							},
+						},
+					},
+					RuntimeHandlers: []corev1.NodeRuntimeHandler{
+						{Name: "runc"},
+					},
+					Features: &corev1.NodeFeatures{},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-node"},
+				Spec:       corev1.NodeSpec{Taints: nil, PodCIDRs: nil},
+				Status: corev1.NodeStatus{
+					Capacity:        nil,
+					Allocatable:     nil,
+					DaemonEndpoints: corev1.NodeDaemonEndpoints{},
+					NodeInfo:        corev1.NodeSystemInfo{KernelVersion: "5.14.0"},
+					Config:          nil,
+					RuntimeHandlers: nil,
+					Features:        nil,
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "KubeletReady"},
+					},
+				},
+			}
+			newNode := oldNode.DeepCopy()
+			newNode.Status.Conditions[0].Reason = "KubeletReady-Updated"
+
+			err = kube.PatchNodeStatus(oldNode, newNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			node, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), "my-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node.Status.Conditions[0].Reason).To(Equal("KubeletReady-Updated"))
+			Expect(node.Status.Capacity).NotTo(BeNil(), "Capacity must not be overwritten by trimmed patch")
+			Expect(node.Status.Allocatable).NotTo(BeNil(), "Allocatable must not be overwritten by trimmed patch")
+			Expect(node.Status.DaemonEndpoints.KubeletEndpoint.Port).To(Equal(int32(10250)), "DaemonEndpoints must not be overwritten")
+			Expect(node.Status.NodeInfo.KernelVersion).To(Equal("5.14.0"), "NodeInfo must not be overwritten")
+			Expect(node.Spec.Taints).To(HaveLen(1), "Taints must not be overwritten by trimmed patch")
+			Expect(node.Spec.PodCIDRs).To(HaveLen(1), "PodCIDRs must not be overwritten by trimmed patch")
+			Expect(node.Status.Config).NotTo(BeNil(), "Status.Config must not be overwritten by trimmed patch")
+			Expect(node.Status.RuntimeHandlers).To(HaveLen(1), "RuntimeHandlers must not be overwritten by trimmed patch")
+			Expect(node.Status.Features).NotTo(BeNil(), "Features must not be overwritten by trimmed patch")
 		})
 	})
 })

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -116,6 +116,42 @@ func (_m *Interface) PatchNode(old *corev1.Node, new *corev1.Node) error {
 	return r0
 }
 
+// PatchNodeStatus provides a mock function with given fields: old, new
+func (_m *Interface) PatchNodeStatus(old *corev1.Node, new *corev1.Node) error {
+	ret := _m.Called(old, new)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatus")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*corev1.Node, *corev1.Node) error); ok {
+		r0 = rf(old, new)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// PatchNodeStatusAnnotations provides a mock function with given fields: oldNode, newNode
+func (_m *Interface) PatchNodeStatusAnnotations(oldNode *corev1.Node, newNode *corev1.Node) error {
+	ret := _m.Called(oldNode, newNode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatusAnnotations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*corev1.Node, *corev1.Node) error); ok {
+		r0 = rf(oldNode, newNode)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PatchPodStatusAnnotations provides a mock function with given fields: oldPod, newPod
 func (_m *Interface) PatchPodStatusAnnotations(oldPod *corev1.Pod, newPod *corev1.Pod) error {
 	ret := _m.Called(oldPod, newPod)
@@ -235,24 +271,6 @@ func (_m *Interface) SetLabelsOnNode(nodeName string, labels map[string]interfac
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
 		r0 = rf(nodeName, labels)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateNodeStatus provides a mock function with given fields: node
-func (_m *Interface) UpdateNodeStatus(node *corev1.Node) error {
-	ret := _m.Called(node)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateNodeStatus")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*corev1.Node) error); ok {
-		r0 = rf(node)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/kube/mocks/InterfaceOVN.go
+++ b/go-controller/pkg/kube/mocks/InterfaceOVN.go
@@ -278,6 +278,42 @@ func (_m *InterfaceOVN) PatchNode(old *apicorev1.Node, new *apicorev1.Node) erro
 	return r0
 }
 
+// PatchNodeStatus provides a mock function with given fields: old, new
+func (_m *InterfaceOVN) PatchNodeStatus(old *apicorev1.Node, new *apicorev1.Node) error {
+	ret := _m.Called(old, new)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatus")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*apicorev1.Node, *apicorev1.Node) error); ok {
+		r0 = rf(old, new)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// PatchNodeStatusAnnotations provides a mock function with given fields: oldNode, newNode
+func (_m *InterfaceOVN) PatchNodeStatusAnnotations(oldNode *apicorev1.Node, newNode *apicorev1.Node) error {
+	ret := _m.Called(oldNode, newNode)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchNodeStatusAnnotations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*apicorev1.Node, *apicorev1.Node) error); ok {
+		r0 = rf(oldNode, newNode)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PatchPodStatusAnnotations provides a mock function with given fields: oldPod, newPod
 func (_m *InterfaceOVN) PatchPodStatusAnnotations(oldPod *apicorev1.Pod, newPod *apicorev1.Pod) error {
 	ret := _m.Called(oldPod, newPod)
@@ -499,24 +535,6 @@ func (_m *InterfaceOVN) UpdateIPAMClaimIPs(updatedIPAMClaim *v1alpha1.IPAMClaim)
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*v1alpha1.IPAMClaim) error); ok {
 		r0 = rf(updatedIPAMClaim)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateNodeStatus provides a mock function with given fields: node
-func (_m *InterfaceOVN) UpdateNodeStatus(node *apicorev1.Node) error {
-	ret := _m.Called(node)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateNodeStatus")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*apicorev1.Node) error); ok {
-		r0 = rf(node)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -1112,7 +1112,7 @@ func (c *Controller) migrateFromAddrLabelToAnnotation() error {
 	if len(assignedAddresses) == 0 {
 		return nil
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err = c.nodeLister.Get(c.nodeName)
 		if err != nil {
 			return err
@@ -1126,7 +1126,7 @@ func (c *Controller) migrateFromAddrLabelToAnnotation() error {
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(nodeToUpdate)
+		return c.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 
@@ -1136,7 +1136,7 @@ func (c *Controller) addIPToAnnotation(ip string) error {
 	if !isValidIP(ip) {
 		return fmt.Errorf("invalid IP %q", ip)
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err := c.nodeLister.Get(c.nodeName)
 		if err != nil {
 			return err
@@ -1162,7 +1162,7 @@ func (c *Controller) addIPToAnnotation(ip string) error {
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(nodeToUpdate)
+		return c.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 
@@ -1172,7 +1172,7 @@ func (c *Controller) deleteIPFromAnnotation(ip string) error {
 	if !isValidIP(ip) {
 		return fmt.Errorf("invalid IP %q", ip)
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err := c.nodeLister.Get(c.nodeName)
 		if err != nil {
 			return err
@@ -1198,7 +1198,7 @@ func (c *Controller) deleteIPFromAnnotation(ip string) error {
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(patch)
-		return c.kube.UpdateNodeStatus(nodeToUpdate)
+		return c.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 

--- a/go-controller/pkg/node/egressip/gateway_egressip.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip.go
@@ -257,25 +257,35 @@ func (g *BridgeEIPAddrManager) UpdateEgressIP(oldEIP, newEIP *egressipv1.EgressI
 
 	var isUpdated bool
 
-	// Delete old if it exists and is different from new
+	// Delete old from bridge and cache if it exists
 	if !oldSkip {
 		if err = g.deleteIPBridge(oldIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because failed to delete address from link: %v", err)
 		}
 		g.cache.deleteMarkIP(oldMark, oldIP)
-		if err = g.deleteIPsFromAnnotation(oldIP); err != nil {
-			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to delete EgressIP IP from Node annotation: %v", err)
-		}
 		isUpdated = true
 	}
 
-	// Add new if it exists
+	// Add new to cache before annotation update
 	if !newSkip {
-		// must always add to cache before adding IP because we want to inform node ip handler that this is not a valid node IP
 		g.cache.insertMarkIP(newMark, newIP)
-		if err = g.addIPToAnnotation(newIP); err != nil {
-			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
-		}
+	}
+
+	// Combined annotation update: delete old and add new in a single patch
+	// to avoid stale-lister races between consecutive patches.
+	var addIPs, delIPs []net.IP
+	if !oldSkip {
+		delIPs = []net.IP{oldIP}
+	}
+	if !newSkip {
+		addIPs = []net.IP{newIP}
+	}
+	if err = g.updateAnnotationIPs(addIPs, delIPs); err != nil {
+		return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because unable to update Node annotation: %v", err)
+	}
+
+	// Add new to bridge if it exists
+	if !newSkip {
 		if err = g.addIPBridge(newIP); err != nil {
 			return isUpdated, fmt.Errorf("failed to update EgressIP gateway config because failed to add address to link: %v", err)
 		}
@@ -314,6 +324,7 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 	g.annotationIPs = sets.New[string](getIPsStr(annotIPs...)...)
 	g.nodeAnnotationMu.Unlock()
 	configs := markIPs{v4: map[int]string{}, v6: map[int]string{}}
+	ipsToAdd := make([]net.IP, 0)
 	for _, obj := range objs {
 		eip, ok := obj.(*egressipv1.EgressIP)
 		if !ok {
@@ -329,12 +340,10 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 			continue
 		}
 		configs.insert(pktMark, ip)
-		if err = g.addIPToAnnotation(ip); err != nil {
-			return fmt.Errorf("failed to sync EgressIP gateway config because unable to add EgressIP IP to Node annotation: %v", err)
-		}
 		if err = g.addIPBridge(ip); err != nil {
 			return fmt.Errorf("failed to sync EgressIP gateway config because failed to add address to link: %v", err)
 		}
+		ipsToAdd = append(ipsToAdd, ip)
 	}
 	ipsToDel := make([]net.IP, 0)
 	for _, annotIP := range annotIPs {
@@ -346,10 +355,9 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 		}
 		ipsToDel = append(ipsToDel, annotIP)
 	}
-	if len(ipsToDel) > 0 {
-		klog.V(5).Infof("Deleting stale EgressIP IPs from Node annotation: %v", getIPsStr(ipsToDel...))
-		if err = g.deleteIPsFromAnnotation(ipsToDel...); err != nil {
-			return fmt.Errorf("failed to delete EgressIP IPs from Node annotation: %v", err)
+	if len(ipsToAdd) > 0 || len(ipsToDel) > 0 {
+		if err = g.updateAnnotationIPs(ipsToAdd, ipsToDel); err != nil {
+			return fmt.Errorf("failed to update EgressIP IPs in Node annotation: %v", err)
 		}
 	}
 	g.cache.replaceAll(configs)
@@ -360,7 +368,7 @@ func (g *BridgeEIPAddrManager) SyncEgressIP(objs []interface{}) error {
 // updateAnnotationLocked updates the node's egress IPs
 // Must be called with nodeAnnotationMu locked
 func (g *BridgeEIPAddrManager) updateAnnotationLocked(updatedIPs sets.Set[string]) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.OnError(retry.DefaultRetry, util.IsNodeAnnotationPatchRetryable, func() error {
 		node, err := g.nodeLister.Get(g.nodeName)
 		if err != nil {
 			return err
@@ -374,17 +382,18 @@ func (g *BridgeEIPAddrManager) updateAnnotationLocked(updatedIPs sets.Set[string
 			nodeToUpdate.Annotations = map[string]string{}
 		}
 		nodeToUpdate.Annotations[util.OVNNodeBridgeEgressIPs] = string(patch)
-		return g.kube.UpdateNodeStatus(nodeToUpdate)
+		return g.kube.PatchNodeStatusAnnotations(node, nodeToUpdate)
 	})
 }
 
-// addIPToAnnotation adds an address to the collection of existing addresses stored in the nodes annotation. Caller
-// may repeat addition of addresses without care for duplicate addresses being added.
-func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
+// updateAnnotationIPs atomically adds and deletes IPs from the node annotation
+// in a single patch. Either addIPs or delIPs may be nil.
+func (g *BridgeEIPAddrManager) updateAnnotationIPs(addIPs, delIPs []net.IP) error {
 	g.nodeAnnotationMu.Lock()
 	defer g.nodeAnnotationMu.Unlock()
 	updatedIPs := sets.New[string](g.annotationIPs.UnsortedList()...)
-	updatedIPs.Insert(candidateIP.String())
+	updatedIPs.Delete(getIPsStr(delIPs...)...)
+	updatedIPs.Insert(getIPsStr(addIPs...)...)
 	if updatedIPs.Equal(g.annotationIPs) {
 		return nil
 	}
@@ -395,22 +404,12 @@ func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
 	return nil
 }
 
-// deleteIPsFromAnnotation deletes address from annotation. If multiple users, callers must synchronise.
-// deletion of address that doesn't exist will not cause an error.
+func (g *BridgeEIPAddrManager) addIPToAnnotation(candidateIP net.IP) error {
+	return g.updateAnnotationIPs([]net.IP{candidateIP}, nil)
+}
+
 func (g *BridgeEIPAddrManager) deleteIPsFromAnnotation(candidateIPs ...net.IP) error {
-	g.nodeAnnotationMu.Lock()
-	defer g.nodeAnnotationMu.Unlock()
-	candidateIPsStr := getIPsStr(candidateIPs...)
-	updatedIPs := sets.New[string](g.annotationIPs.UnsortedList()...)
-	updatedIPs.Delete(candidateIPsStr...)
-	if updatedIPs.Equal(g.annotationIPs) {
-		return nil
-	}
-	if err := g.updateAnnotationLocked(updatedIPs); err != nil {
-		return err
-	}
-	g.annotationIPs = updatedIPs
-	return nil
+	return g.updateAnnotationIPs(nil, candidateIPs)
 }
 
 func (g *BridgeEIPAddrManager) addIPBridge(ip net.IP) error {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -974,8 +974,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		factoryMock.On("GetNodeForWindows", "worker1").Return(node, nil)
-		cnode := node.DeepCopy()
-		kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			ofm := getDummyOpenflowManager()
@@ -1065,8 +1063,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		factoryMock.On("GetNodeForWindows", "worker1").Return(node, nil)
-		cnode := node.DeepCopy()
-		kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			ofm := getDummyOpenflowManager()
@@ -1292,8 +1288,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			removeOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int")
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
@@ -1719,8 +1713,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			removeOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int")
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))
@@ -1966,8 +1958,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			removeOVSPatchPortInterface(ovsClient, "breth0", "patch-breth0_bluenet_worker1-to-br-int")
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.defaultBridge.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(baseFlowCount))

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -541,8 +541,6 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 			Expect(v6MasqIPRule).To(BeTrue())
 
 			By("delete the network and ensure its associated VRF device is also deleted")
-			cnode := node.DeepCopy()
-			kubeMock.On("UpdateNodeStatus", cnode).Return(nil)
 			err = controller.Cleanup()
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() error {

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gaissmai/cidrtree"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 
@@ -21,6 +22,15 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
+
+// IsNodeAnnotationPatchRetryable returns true for errors that should trigger a
+// relist-and-retry when patching node annotations via JSON Patch.
+//
+// JSON Patch "test" failures from the apiserver are surfaced as Invalid rather
+// than Conflict, so this retry path needs to handle both.
+func IsNodeAnnotationPatchRetryable(err error) bool {
+	return apierrors.IsConflict(err) || apierrors.IsInvalid(err)
+}
 
 // This handles the annotations used by the node to pass information about its local
 // network configuration to the ovnkube controller:

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
@@ -971,6 +974,36 @@ func TestParseNodeManagementPortAnnotation(t *testing.T) {
 				require.NoError(t, err)
 				assert.True(t, reflect.DeepEqual(mpDetails, tc.expectedOutput))
 			}
+		})
+	}
+}
+
+func TestIsNodeAnnotationPatchRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "conflict error is retryable",
+			err:      apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node1", fmt.Errorf("conflict")),
+			expected: true,
+		},
+		{
+			name:     "invalid error is retryable (JSON Patch test failure)",
+			err:      apierrors.NewInvalid(schema.GroupKind{Group: "", Kind: "Node"}, "node1", field.ErrorList{field.Invalid(field.NewPath("metadata"), nil, "test failed")}),
+			expected: true,
+		},
+		{
+			name:     "plain error is not retryable",
+			err:      fmt.Errorf("plain error"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsNodeAnnotationPatchRetryable(tc.err))
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR reduces the memory footprint of the ovn-kubernetes controller by trimming unused fields from Node objects in the shared informer cache, and replaces the full-object `UpdateNodeStatus` with targeted patch methods that are safe to use with trimmed objects.

OVN-K does not consume storage-related fields from the Node informer cache. Fields like `Status.Images`, `VolumesAttached`, and `VolumesInUse` can grow significantly large, unnecessarily increasing the controller's heap usage. This change clears these specific fields during `informerObjectTrim`.

Additionally, refactor `UpdateEgressIP` to combine add/delete annotation IP calls into a single `updateAnnotationIPs` patch. This prevents a stale-lister race between consecutive annotation updates.

### Changes

1. **Trim Node fields in `informerObjectTrim`:**
   - Status: `Images`, `VolumesAttached`, `VolumesInUse`, `DaemonEndpoints`,
     `Capacity`, `Allocatable`, `Config`, `RuntimeHandlers`, `Features`
   - Spec: `Taints`, `PodCIDRs`
   - ObjectMeta: `OwnerReferences`, `Finalizers`
   - Preserved: `Status.Addresses`, `Status.Conditions`, `Status.NodeInfo`,
     `Spec.PodCIDR`, labels, annotations

2. **Replace `UpdateNodeStatus` with targeted patch methods:**
   - `PatchNodeStatus(old, new)` — Strategic Merge Patch; sends only changed
     fields. Includes ResourceVersion for optimistic conflict detection.
   - `PatchNodeStatusAnnotations(oldNode, newNode)` — JSON Patch (RFC 6902);
     patches only changed annotations via status subresource with
     compare-and-retry semantics.

3. **Batch EgressIP annotation updates:**
   - `UpdateEgressIP` and `SyncEgressIP` combined separate add/delete annotation
     patches into a single `updateAnnotationIPs` call to avoid stale-lister races.

4. **Add `IsNodeAnnotationPatchRetryable` retry predicate:**
   - Handles both `Conflict` (409) and `Invalid` (422, from JSON Patch "test"
     failures). All node annotation patch sites migrated from
     `retry.RetryOnConflict` to `retry.OnError`.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
