### PR TITLE
Fix false positives in own-update detection via managed fields

### DIFF
--- a/go-controller/pkg/clustermanager/managedbgp/controller.go
+++ b/go-controller/pkg/clustermanager/managedbgp/controller.go
@@ -217,8 +217,8 @@ func (c *Controller) onFRRUpdate(oldObj, newObj interface{}) {
 // isOwnUpdate checks if an object was last updated by this controller,
 // as indicated by its managed fields. Used to avoid reconciling events
 // that result from our own writes.
-func isOwnUpdate(managedFields []metav1.ManagedFieldsEntry) bool {
-	return util.IsLastUpdatedByManager(fieldManager, managedFields)
+func isOwnUpdate(oldManagedFields, newManagedFields []metav1.ManagedFieldsEntry) bool {
+	return util.IsLastUpdatedByManager(fieldManager, oldManagedFields, newManagedFields)
 }
 
 // isManagedRA returns true if RA name has ovnk-managed-bgp prefix
@@ -295,7 +295,7 @@ func (c *Controller) cudnNeedsUpdate(oldCUDN, newCUDN *userdefinednetworkv1.Clus
 		return false
 	}
 	// Ignore events from our own writes (e.g. ensureManagedNetworkLabel)
-	if isOwnUpdate(newCUDN.ManagedFields) {
+	if isOwnUpdate(oldCUDN.ManagedFields, newCUDN.ManagedFields) {
 		return false
 	}
 
@@ -321,9 +321,15 @@ func (c *Controller) raNeedsUpdate(oldRA, newRA *ratypes.RouteAdvertisements) bo
 	if newRA == nil {
 		return true
 	}
+	var oldManagedFields []metav1.ManagedFieldsEntry
+	if oldRA != nil {
+		oldManagedFields = oldRA.ManagedFields
+	}
+	if isOwnUpdate(oldManagedFields, newRA.ManagedFields) {
+		return false
+	}
 	if oldRA == nil {
-		// Ignore events from our own creations
-		return !isOwnUpdate(newRA.ManagedFields)
+		return true
 	}
 	return !reflect.DeepEqual(oldRA.Spec, newRA.Spec)
 }
@@ -335,9 +341,15 @@ func (c *Controller) frrNeedsUpdate(oldFRR, newFRR *frrtypes.FRRConfiguration) b
 	if newFRR == nil {
 		return true
 	}
+	var oldManagedFields []metav1.ManagedFieldsEntry
+	if oldFRR != nil {
+		oldManagedFields = oldFRR.ManagedFields
+	}
+	if isOwnUpdate(oldManagedFields, newFRR.ManagedFields) {
+		return false
+	}
 	if oldFRR == nil {
-		// Ignore events from our own creations
-		return !isOwnUpdate(newFRR.ManagedFields)
+		return true
 	}
 	oldValue, oldHasLabel := oldFRR.Labels[managedNetworkLabel]
 	newValue, newHasLabel := newFRR.Labels[managedNetworkLabel]

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -1654,8 +1654,8 @@ func (c *Controller) getEgressIPsByNodesByNetworks(networks sets.Set[string]) (m
 
 // isOwnUpdate checks if an object was updated by us last, as indicated by its
 // managed fields. Used to avoid reconciling an update that we made ourselves.
-func isOwnUpdate(managedFields []metav1.ManagedFieldsEntry) bool {
-	return util.IsLastUpdatedByManager(fieldManager, managedFields)
+func isOwnUpdate(oldManagedFields, newManagedFields []metav1.ManagedFieldsEntry) bool {
+	return util.IsLastUpdatedByManager(fieldManager, oldManagedFields, newManagedFields)
 }
 
 func raNeedsUpdate(oldObj, newObj *ratypes.RouteAdvertisements) bool {
@@ -1664,7 +1664,11 @@ func raNeedsUpdate(oldObj, newObj *ratypes.RouteAdvertisements) bool {
 
 func frrConfigurationNeedsUpdate(oldObj, newObj *frrtypes.FRRConfiguration) bool {
 	// ignore if it was created or updated by ourselves
-	if newObj != nil && isOwnUpdate(newObj.ManagedFields) {
+	var oldManagedFields []metav1.ManagedFieldsEntry
+	if oldObj != nil {
+		oldManagedFields = oldObj.ManagedFields
+	}
+	if newObj != nil && isOwnUpdate(oldManagedFields, newObj.ManagedFields) {
 		return false
 	}
 	return oldObj == nil || newObj == nil || oldObj.Generation != newObj.Generation ||
@@ -1674,7 +1678,11 @@ func frrConfigurationNeedsUpdate(oldObj, newObj *frrtypes.FRRConfiguration) bool
 
 func nadNeedsUpdate(oldObj, newObj *nadtypes.NetworkAttachmentDefinition) bool {
 	// ignore if it updated by ourselves
-	if newObj != nil && isOwnUpdate(newObj.ManagedFields) {
+	var oldManagedFields []metav1.ManagedFieldsEntry
+	if oldObj != nil {
+		oldManagedFields = oldObj.ManagedFields
+	}
+	if newObj != nil && isOwnUpdate(oldManagedFields, newObj.ManagedFields) {
 		return false
 	}
 	nadSupported := func(nad *nadtypes.NetworkAttachmentDefinition) bool {

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -1284,8 +1284,8 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 
 // isOwnUpdate checks if an object was updated by us last, as indicated by its
 // managed fields. Used to avoid reconciling an update that we made ourselves.
-func isOwnUpdate(manager string, managedFields []metav1.ManagedFieldsEntry) bool {
-	return util.IsLastUpdatedByManager(manager, managedFields)
+func isOwnUpdate(manager string, oldManagedFields, newManagedFields []metav1.ManagedFieldsEntry) bool {
+	return util.IsLastUpdatedByManager(manager, oldManagedFields, newManagedFields)
 }
 
 func (c *nadController) nadNeedsUpdate(oldNAD, newNAD *nettypes.NetworkAttachmentDefinition) (needsUpdate bool) {
@@ -1299,7 +1299,7 @@ func (c *nadController) nadNeedsUpdate(oldNAD, newNAD *nettypes.NetworkAttachmen
 		return false
 	}
 
-	if isOwnUpdate(c.name, newNAD.ManagedFields) {
+	if isOwnUpdate(c.name, oldNAD.ManagedFields, newNAD.ManagedFields) {
 		return false
 	}
 

--- a/go-controller/pkg/node/controllers/evpn/evpn_node_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_node_controller.go
@@ -277,7 +277,7 @@ func (c *Controller) onNodeUpdate(oldObj, newObj interface{}) {
 		return
 	}
 	// don't reconcile on our own updates
-	if util.IsLastUpdatedByManager(vtepAnnotationFieldManager, newNode.ManagedFields) {
+	if util.IsLastUpdatedByManager(vtepAnnotationFieldManager, oldNode.ManagedFields, newNode.ManagedFields) {
 		return
 	}
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -883,11 +883,18 @@ func GetConntrackZone() int {
 	return config.Default.ConntrackZone
 }
 
-// IsLastUpdatedByManager checks if an object was updated by the manager last,
-// as indicated by a set of managed fields.
-func IsLastUpdatedByManager(manager string, managedFields []metav1.ManagedFieldsEntry) bool {
+// IsLastUpdatedByManager reports whether the named manager made the most recent
+// update to an object by comparing the managed fields timestamps before and
+// after the update. It returns true only when the manager holds the latest
+// timestamp among all managers AND that timestamp advanced from old to new.
+// This avoids false positives when other managers are just resetting fields,
+// which doesn't update any timestamp. False negatives are possible when the
+// manager itself resets fields without updating or claiming new ones, as its
+// timestamp won't advance; callers should consider this so that these false
+// negatives ideally lead to no-op reconciliations.
+func IsLastUpdatedByManager(manager string, oldManagedFields, newManagedFields []metav1.ManagedFieldsEntry) bool {
 	var lastUpdateTheirs, lastUpdateOurs time.Time
-	for _, managedFieldEntry := range managedFields {
+	for _, managedFieldEntry := range newManagedFields {
 		switch managedFieldEntry.Manager {
 		case manager:
 			if managedFieldEntry.Time.Time.After(lastUpdateOurs) {
@@ -899,5 +906,14 @@ func IsLastUpdatedByManager(manager string, managedFields []metav1.ManagedFields
 			}
 		}
 	}
-	return lastUpdateOurs.After(lastUpdateTheirs)
+	if !lastUpdateOurs.After(lastUpdateTheirs) {
+		return false
+	}
+	var oldLastUpdateOurs time.Time
+	for _, managedFieldEntry := range oldManagedFields {
+		if managedFieldEntry.Manager == manager && managedFieldEntry.Time.Time.After(oldLastUpdateOurs) {
+			oldLastUpdateOurs = managedFieldEntry.Time.Time
+		}
+	}
+	return lastUpdateOurs.After(oldLastUpdateOurs)
 }

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -855,6 +856,91 @@ func TestDoesEndpointSliceContainEligibleEndpoint(t *testing.T) {
 			if !reflect.DeepEqual(answer, tt.want) {
 				t.Errorf("got %v, want %v", answer, tt.want)
 			}
+		})
+	}
+}
+
+func TestLikelyLastUpdatedByManager(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Second)
+	t3 := t2.Add(time.Second)
+
+	mf := func(manager string, t time.Time) metav1.ManagedFieldsEntry {
+		return metav1.ManagedFieldsEntry{
+			Manager: manager,
+			Time:    &metav1.Time{Time: t},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		manager          string
+		oldManagedFields []metav1.ManagedFieldsEntry
+		newManagedFields []metav1.ManagedFieldsEntry
+		want             bool
+	}{
+		{
+			name:             "manager made the latest update",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("us", t1), mf("them", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t2), mf("them", t1)},
+			want:             true,
+		},
+		{
+			name:             "another manager made the latest update",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("us", t1), mf("them", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t1), mf("them", t2)},
+			want:             false,
+		},
+		{
+			name:             "another manager reset fields: our timestamp is latest but unchanged",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("us", t2), mf("them", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t2), mf("them", t1)},
+			want:             false,
+		},
+		{
+			name:             "no old managed fields (object creation)",
+			manager:          "us",
+			oldManagedFields: nil,
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t2), mf("them", t1)},
+			want:             true,
+		},
+		{
+			name:             "manager not present in new managed fields",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("them", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("them", t2)},
+			want:             false,
+		},
+		{
+			name:             "only our manager present",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("us", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t2)},
+			want:             true,
+		},
+		{
+			name:             "multiple other managers, ours is latest and advanced",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("us", t1), mf("a", t1), mf("b", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t3), mf("a", t1), mf("b", t2)},
+			want:             true,
+		},
+		{
+			name:             "multiple other managers, ours is not latest",
+			manager:          "us",
+			oldManagedFields: []metav1.ManagedFieldsEntry{mf("us", t1), mf("a", t1), mf("b", t1)},
+			newManagedFields: []metav1.ManagedFieldsEntry{mf("us", t2), mf("a", t1), mf("b", t3)},
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsLastUpdatedByManager(tt.manager, tt.oldManagedFields, tt.newManagedFields)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Compare old and new managed fields to detect own updates instead of only looking at the new object. When another manager resets fields, no manager's entry is updated, so the previous approach could incorrectly identify the update as our own if we held the latest timestamp. Now we additionally verify that our timestamp actually advanced.

Rename IsLastUpdatedByManager to LikelyLastUpdatedByManager to reflect that false negatives are possible when the manager itself resets fields.


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
