### PR TITLE
ci: run DPU Offload tests through dpu-simulator's CI scripts

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -21,250 +21,31 @@ concurrency:
   group: kind-dpu-offload-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
-env:
-  DPU_SIM_REF: main
-  OVN_KUBERNETES_PATH: ${{ github.workspace }}/ovn-kubernetes
-  KIND_EXPERIMENTAL_PROVIDER: docker
-
 jobs:
   kind-dpu-offload:
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-      - name: Checkout OVN-Kubernetes (PR/push)
-        uses: actions/checkout@v4
-        with:
-          path: ovn-kubernetes
-          persist-credentials: false
-
-      - name: Checkout dpu-simulator
-        uses: actions/checkout@v4
-        with:
-          repository: ovn-kubernetes/dpu-simulator
-          ref: ${{ env.DPU_SIM_REF }}
-          path: dpu-simulator
-          persist-credentials: false
-
-      - name: Set up Go from dpu-simulator
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: dpu-simulator/go.mod
-          cache: true
-
-      - name: Install libvirt development headers
-        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-
-      - name: Set up Python for traffic flow tests
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install kind
-        run: |
-          KIND_VERSION=v0.31.0
-          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
-          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
-          chmod +x /tmp/kind-linux-amd64
-          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
-
-      - name: Build dpu-simulator
-        working-directory: dpu-simulator
-        run: make build
-
-      - name: Disable containerd image store
-        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
-        run: |
-          sudo mkdir -p /etc/docker
-          [ -s "/etc/docker/daemon.json" ] && {
-            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          } || {
-            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          }
-          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Deploy Kind clusters (OVN-Kubernetes from PR source)
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH"
-
-      - name: Verify clusters are ready
-        working-directory: dpu-simulator
-        run: |
-          kubectl wait --for=condition=Ready nodes --all \
-            --kubeconfig kubeconfig/dpu-sim-host.kubeconfig --timeout=25m
-          kubectl wait --for=condition=Ready nodes --all \
-            --kubeconfig kubeconfig/dpu-sim-dpu.kubeconfig --timeout=25m
-
-      - name: TFT Python venv
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft venv --config config-kind-ovnk-offload.yaml
-
-      - name: Run traffic flow tests
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft run --check --config config-kind-ovnk-offload.yaml
-
-      - name: Export kind logs on failure
-        if: failure()
-        run: |
-          kind export logs /tmp/kind-offload-logs --name dpu-sim-host-kind 2>/dev/null || true
-          kind export logs /tmp/kind-offload-logs --name dpu-sim-dpu-kind 2>/dev/null || true
-
-      - name: Upload kind logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-dpu-offload-logs
-          path: /tmp/kind-offload-logs
-          if-no-files-found: ignore
-
-      - name: Upload TFT results on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tft-results
-          path: dpu-simulator/kubernetes-traffic-flow-tests/ft-logs
-          if-no-files-found: ignore
-
-      - name: Cleanup
-        if: always()
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true
-
-  kind-dpu-no-overlay:
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    env:
-      DPU_SIM_PATH: ${{ github.workspace }}/dpu-simulator
-      DPU_SIM_CONFIG: config-kind-ovnk-offload.yaml
-      KIND_EXPERIMENTAL_PROVIDER: docker
-    steps:
-      - name: Checkout OVN-Kubernetes (PR/push)
-        uses: actions/checkout@v4
-        with:
-          path: ovn-kubernetes
-          persist-credentials: false
-
-      - name: Checkout dpu-simulator
-        uses: actions/checkout@v4
-        with:
-          repository: ovn-kubernetes/dpu-simulator
-          ref: ${{ env.DPU_SIM_REF }}
-          path: dpu-simulator
-          persist-credentials: false
-
-      - name: Set up Go from dpu-simulator
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: dpu-simulator/go.mod
-          cache: true
-
-      - name: Install libvirt development headers
-        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
-
-      - name: Install VRF kernel module
-        run: |
-          set -x
-          sudo apt update
-          sudo apt-get install linux-modules-extra-$(uname -r) -y
-          sudo modprobe vrf
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-
-      - name: Set up Python for traffic flow tests
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install kind
-        run: |
-          KIND_VERSION=v0.31.0
-          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
-          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
-          chmod +x /tmp/kind-linux-amd64
-          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
-
-      - name: Build dpu-simulator
-        working-directory: dpu-simulator
-        run: make build
-
-      - name: Disable containerd image store
-        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
-        run: |
-          sudo mkdir -p /etc/docker
-          [ -s "/etc/docker/daemon.json" ] && {
-            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          } || {
-            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          }
-          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Deploy no-overlay DPU simulator with Helm
-        working-directory: ovn-kubernetes
-        run: ./contrib/kind-dpu-sim-no-overlay.sh
-
-      - name: TFT Python venv
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft venv --config "${DPU_SIM_CONFIG}"
-
-      - name: Run traffic flow tests
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft run --check --config "${DPU_SIM_CONFIG}"
-
-      - name: Run Uplink DPU e2e tests
-        working-directory: ovn-kubernetes
-        run: |
-          set -euo pipefail
-          source "${DPU_SIM_PATH}/kubeconfig/helm-values/dpu-sim-dpu-frr-k8s.env"
-          export KUBECONFIG="${DPU_SIM_PATH}/kubeconfig/dpu-sim-host.kubeconfig"
-          export OVN_TEST_DPU_UPLINK_NETWORK="dpu-sim-uplink"
-          export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="eth0-16"
-          export OVN_TEST_DPU_UPLINK_EXPECTED_BRIDGE="breth-uplink"
-          export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV4="172.27.0.0/16"
-          export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV6="fc00:f853:ccd:e797::/64"
-          export ENABLE_MULTI_NET=true
-          export ENABLE_NETWORK_SEGMENTATION=true
-          export ENABLE_ROUTE_ADVERTISEMENTS=true
-          export ENABLE_NO_OVERLAY=true
-          export DYNAMIC_UDN_ALLOCATION=true
-          make -C test control-plane WHAT="Network Segmentation Uplink route advertisements uses the Uplink interface as the targetVRF auto BGP peering path"
-          make -C test control-plane WHAT="Uplink route advertisements with Dynamic UDN allocation allows node-disjoint Dynamic CUDNs to share a targetVRF auto Uplink and rejects overlap"
-
-      - name: Export kind logs on failure
-        if: failure()
-        run: |
-          mkdir -p /tmp/kind-dpu-no-overlay-logs
-          for cluster in dpu-sim-host dpu-sim-host-kind dpu-sim-dpu dpu-sim-dpu-kind; do
-            kind export logs /tmp/kind-dpu-no-overlay-logs --name "${cluster}" 2>/dev/null || true
-          done
-          kubectl --kubeconfig dpu-simulator/kubeconfig/dpu-sim-host.kubeconfig get pods -A -o wide \
-            > /tmp/kind-dpu-no-overlay-logs/dpu-sim-host-pods.txt 2>&1 || true
-          kubectl --kubeconfig dpu-simulator/kubeconfig/dpu-sim-dpu.kubeconfig get pods -A -o wide \
-            > /tmp/kind-dpu-no-overlay-logs/dpu-sim-dpu-pods.txt 2>&1 || true
-
-      - name: Upload kind logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-dpu-no-overlay-logs
-          path: /tmp/kind-dpu-no-overlay-logs
-          if-no-files-found: ignore
-
-      - name: Upload TFT results on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dpu-no-overlay-tft-results
-          path: dpu-simulator/kubernetes-traffic-flow-tests/ft-logs
-          if-no-files-found: ignore
-
-      - name: Cleanup
-        if: always()
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim --config "${DPU_SIM_CONFIG}" --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true
+    name: Kind DPU ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: overlay
+            deploy-mode: overlay
+            run-kube-burner: true
+            run-tft: true
+            artifact-prefix: kind-dpu-offload
+          - name: no-overlay
+            deploy-mode: no-overlay
+            run-kube-burner: false
+            run-tft: true
+            artifact-prefix: kind-dpu-no-overlay
+    uses: ovn-kubernetes/dpu-simulator/.github/workflows/kind-tft.yml@main
+    with:
+      deploy-mode: ${{ matrix.deploy-mode }}
+      run-kube-burner: ${{ matrix.run-kube-burner }}
+      run-tft: ${{ matrix.run-tft }}
+      artifact-prefix: ${{ matrix.artifact-prefix }}
+      # Test the PR merge commit (PR + current base) or the push/dispatch SHA,
+      # instead of dpu-sim's default (master tip). Use the base repo so the
+      # pull_request merge commit is fetchable for fork PRs.
+      ovn-kubernetes-repo-url: ${{ github.server_url }}/${{ github.repository }}
+      ovn-kubernetes-ref: ${{ github.sha }}

--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -21,253 +21,31 @@ concurrency:
   group: kind-dpu-offload-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
-env:
-  DPU_SIM_REF: main
-  OVN_KUBERNETES_PATH: ${{ github.workspace }}/ovn-kubernetes
-  KIND_EXPERIMENTAL_PROVIDER: docker
-
 jobs:
   kind-dpu-offload:
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-      - name: Checkout OVN-Kubernetes (PR/push)
-        uses: actions/checkout@v4
-        with:
-          path: ovn-kubernetes
-          persist-credentials: false
-
-      - name: Checkout dpu-simulator
-        uses: actions/checkout@v4
-        with:
-          repository: ovn-kubernetes/dpu-simulator
-          ref: ${{ env.DPU_SIM_REF }}
-          path: dpu-simulator
-          persist-credentials: false
-
-      - name: Set up Go from dpu-simulator
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: dpu-simulator/go.mod
-          cache: true
-
-      - name: Install libvirt development headers
-        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-
-      - name: Set up Python for traffic flow tests
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install kind
-        run: |
-          KIND_VERSION=v0.31.0
-          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
-          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
-          chmod +x /tmp/kind-linux-amd64
-          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
-
-      - name: Build dpu-simulator
-        working-directory: dpu-simulator
-        run: make build
-
-      - name: Disable containerd image store
-        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
-        run: |
-          sudo mkdir -p /etc/docker
-          [ -s "/etc/docker/daemon.json" ] && {
-            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          } || {
-            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          }
-          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Deploy Kind clusters (OVN-Kubernetes from PR source)
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH"
-
-      - name: Verify clusters are ready
-        working-directory: dpu-simulator
-        run: |
-          kubectl wait --for=condition=Ready nodes --all \
-            --kubeconfig kubeconfig/dpu-sim-host.kubeconfig --timeout=25m
-          kubectl wait --for=condition=Ready nodes --all \
-            --kubeconfig kubeconfig/dpu-sim-dpu.kubeconfig --timeout=25m
-
-      - name: TFT Python venv
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft venv --config config-kind-ovnk-offload.yaml
-
-      - name: Run traffic flow tests
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft run --check --config config-kind-ovnk-offload.yaml
-
-      - name: Export kind logs on failure
-        if: failure()
-        run: |
-          kind export logs /tmp/kind-offload-logs --name dpu-sim-host-kind 2>/dev/null || true
-          kind export logs /tmp/kind-offload-logs --name dpu-sim-dpu-kind 2>/dev/null || true
-
-      - name: Upload kind logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-dpu-offload-logs
-          path: /tmp/kind-offload-logs
-          if-no-files-found: ignore
-
-      - name: Upload TFT results on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tft-results
-          path: dpu-simulator/kubernetes-traffic-flow-tests/ft-logs
-          if-no-files-found: ignore
-
-      - name: Cleanup
-        if: always()
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true
-
-  kind-dpu-no-overlay:
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    env:
-      DPU_SIM_PATH: ${{ github.workspace }}/dpu-simulator
-      DPU_SIM_CONFIG: config-kind-ovnk-offload.yaml
-      KIND_EXPERIMENTAL_PROVIDER: docker
-    steps:
-      - name: Checkout OVN-Kubernetes (PR/push)
-        uses: actions/checkout@v4
-        with:
-          path: ovn-kubernetes
-          persist-credentials: false
-
-      - name: Checkout dpu-simulator
-        uses: actions/checkout@v4
-        with:
-          repository: ovn-kubernetes/dpu-simulator
-          ref: ${{ env.DPU_SIM_REF }}
-          path: dpu-simulator
-          persist-credentials: false
-
-      - name: Set up Go from dpu-simulator
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: dpu-simulator/go.mod
-          cache: true
-
-      - name: Install libvirt development headers
-        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
-
-      - name: Install VRF kernel module
-        run: |
-          set -x
-          sudo apt update
-          sudo apt-get install linux-modules-extra-$(uname -r) -y
-          sudo modprobe vrf
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-
-      - name: Set up Python for traffic flow tests
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install kind
-        run: |
-          KIND_VERSION=v0.31.0
-          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
-          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
-          chmod +x /tmp/kind-linux-amd64
-          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
-
-      - name: Build dpu-simulator
-        working-directory: dpu-simulator
-        run: make build
-
-      - name: Disable containerd image store
-        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
-        run: |
-          sudo mkdir -p /etc/docker
-          [ -s "/etc/docker/daemon.json" ] && {
-            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          } || {
-            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
-          }
-          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Deploy no-overlay DPU simulator with Helm
-        working-directory: ovn-kubernetes
-        run: ./contrib/kind-dpu-sim-no-overlay.sh
-
-      - name: TFT Python venv
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft venv --config "${DPU_SIM_CONFIG}"
-
-      - name: Run traffic flow tests
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft run --check --config "${DPU_SIM_CONFIG}"
-
-      - name: Run Uplink DPU e2e tests
-        working-directory: ovn-kubernetes
-        run: |
-          set -euo pipefail
-          source "${DPU_SIM_PATH}/kubeconfig/helm-values/dpu-sim-dpu-frr-k8s.env"
-          export KUBECONFIG="${DPU_SIM_PATH}/kubeconfig/dpu-sim-host.kubeconfig"
-          export OVN_TEST_DPU_UPLINK_NETWORK="dpu-sim-uplink"
-          export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="eth0-16"
-          export OVN_TEST_DPU_UPLINK_EXPECTED_BRIDGE="breth-uplink"
-          export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV4="172.27.0.0/16"
-          export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV6="fc00:f853:ccd:e797::/64"
-          export ENABLE_MULTI_NET=true
-          export ENABLE_NETWORK_SEGMENTATION=true
-          export ENABLE_ROUTE_ADVERTISEMENTS=true
-          export ENABLE_NO_OVERLAY=true
-          export DYNAMIC_UDN_ALLOCATION=true
-          make -C test control-plane WHAT="Network Segmentation Uplink route advertisements uses the Uplink interface as the targetVRF auto BGP peering path"
-          make -C test control-plane WHAT="Uplink route advertisements with Dynamic UDN allocation allows node-disjoint Dynamic CUDNs to share a targetVRF auto Uplink and rejects overlap"
-          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions keeps one writer per condition and recovers a missing host interface"
-          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions recreates an UplinkState deleted out of band"
-          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions resolves the bridge by host function and falls back to host MAC"
-
-      - name: Export kind logs on failure
-        if: failure()
-        run: |
-          mkdir -p /tmp/kind-dpu-no-overlay-logs
-          for cluster in dpu-sim-host dpu-sim-host-kind dpu-sim-dpu dpu-sim-dpu-kind; do
-            kind export logs /tmp/kind-dpu-no-overlay-logs --name "${cluster}" 2>/dev/null || true
-          done
-          kubectl --kubeconfig dpu-simulator/kubeconfig/dpu-sim-host.kubeconfig get pods -A -o wide \
-            > /tmp/kind-dpu-no-overlay-logs/dpu-sim-host-pods.txt 2>&1 || true
-          kubectl --kubeconfig dpu-simulator/kubeconfig/dpu-sim-dpu.kubeconfig get pods -A -o wide \
-            > /tmp/kind-dpu-no-overlay-logs/dpu-sim-dpu-pods.txt 2>&1 || true
-
-      - name: Upload kind logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-dpu-no-overlay-logs
-          path: /tmp/kind-dpu-no-overlay-logs
-          if-no-files-found: ignore
-
-      - name: Upload TFT results on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dpu-no-overlay-tft-results
-          path: dpu-simulator/kubernetes-traffic-flow-tests/ft-logs
-          if-no-files-found: ignore
-
-      - name: Cleanup
-        if: always()
-        working-directory: dpu-simulator
-        run: ./bin/dpu-sim --config "${DPU_SIM_CONFIG}" --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true
+    name: Kind DPU ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: overlay
+            deploy-mode: overlay
+            run-kube-burner: true
+            run-tft: true
+            artifact-prefix: kind-dpu-offload
+          - name: no-overlay
+            deploy-mode: no-overlay
+            run-kube-burner: false
+            run-tft: true
+            artifact-prefix: kind-dpu-no-overlay
+    uses: ovn-kubernetes/dpu-simulator/.github/workflows/kind-tft.yml@main
+    with:
+      deploy-mode: ${{ matrix.deploy-mode }}
+      run-kube-burner: ${{ matrix.run-kube-burner }}
+      run-tft: ${{ matrix.run-tft }}
+      artifact-prefix: ${{ matrix.artifact-prefix }}
+      # Test the PR merge commit (PR + current base) or the push/dispatch SHA,
+      # instead of dpu-sim's default (master tip). Use the base repo so the
+      # pull_request merge commit is fetchable for fork PRs.
+      ovn-kubernetes-repo-url: ${{ github.server_url }}/${{ github.repository }}
+      ovn-kubernetes-ref: ${{ github.sha }}


### PR DESCRIPTION
## 📑 Description

To ensure consistency and re-usability, we should use the dpu-simulator's CI workflow for TFT and deployment. This will allow the OVN-Kubernetes workflow to select the relevant tests while dpu-simulator will continue to own the work flow for cluster setup, testing (TFT or others), export & artifact collection.

This PR urgently fixes current DPU Offload CI issues where artifacts are not properly created upon failure, which prevents debugging of issues.