### PR TITLE
Fix lint to run when Makefile is invoked from another directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,11 +63,12 @@ jobs:
       id: go
 
     - name: Verify
-      uses: golangci/golangci-lint-action@v8.0.0
-      with:
-        version: v2.12.2
-        working-directory: go-controller
-        args: --modules-download-mode=vendor --timeout=15m0s --verbose
+      run: |
+        set -x
+        # Run natively so golangci-lint uses the Go toolchain from setup-go
+        # (go-version-file: go-controller/go.mod), not the version baked into
+        # the golangci-lint container image.
+        make -C go-controller/ lint CONTAINER_RUNTIME=run-natively
 
   build-base:
     name: Build-base

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -92,21 +92,26 @@ clean:
 
 .PHONY: lint gofmt verify-go-mod-vendor third-party-licenses verify-third-party-licenses
 
+# Absolute path to this Makefile's directory (go-controller/), so lint works when invoked
+# via `make -f <path-to-go-controller-dir>/Makefile lint` from another directory.
+GO_CONTROLLER_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+LINT_SH := $(GO_CONTROLLER_ROOT)hack/lint.sh
+
 lint:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	@GOPATH=${GOPATH} ./hack/lint.sh $(CONTAINER_RUNTIME) || { echo "lint failed! Try running 'make lint-fix'"; exit 1; }
+	@GOPATH=${GOPATH} $(LINT_SH) $(CONTAINER_RUNTIME) || { echo "lint failed! Try running 'make lint-fix'"; exit 1; }
 else
 	echo "no container runtime. attempting to run natively";
-	@GOPATH=${GOPATH} ./hack/lint.sh run-natively || { echo "running lint locally failed!"; exit 1; }
+	@GOPATH=${GOPATH} $(LINT_SH) run-natively || { echo "running lint locally failed!"; exit 1; }
 endif
 
 lint-fix:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	@GOPATH=${GOPATH} ./hack/lint.sh $(CONTAINER_RUNTIME) fix || { echo "ERROR: lint fix failed! There is a bug that changes file ownership to root \
+	@GOPATH=${GOPATH} $(LINT_SH) $(CONTAINER_RUNTIME) fix || { echo "ERROR: lint fix failed! There is a bug that changes file ownership to root \
 	when this happens. To fix it, simply run 'chown -R <user>:<group> *' from the repo root."; exit 1; }
 else
 	echo "no container runtime. attempting to run natively w/ -fix flag";
-	@GOPATH=${GOPATH} ./hack/lint.sh run-natively fix || { echo "running lint fix locally failed! There is a bug that changes file ownership to root \
+	@GOPATH=${GOPATH} $(LINT_SH) run-natively fix || { echo "running lint fix locally failed! There is a bug that changes file ownership to root \
 	when this happens. To fix it, simply run 'chown -R <user>:<group> *' from the repo root."; exit 1; }
 endif
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Resolve hack/lint.sh via the Makefile's absolute directory so `make -f go-controller/Makefile lint` succeeds outside go-controller/.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
