### PR TITLE
udn: allow configuring kubelet service names

### DIFF
--- a/docs/installation/ovn_k8s.conf.5
+++ b/docs/installation/ovn_k8s.conf.5
@@ -19,6 +19,11 @@ MTU value used for the overlay network.
 ConntrackZone affects only the gateway nodes, This value is used to track connections
 that are initiated from the pods so that the reverse connections go back to the pods.
 This represents the conntrack zone used for the conntrack flow rules.
+.TP
+\fBkubelet-service-names\fR=kubelet.service
+Comma-separated systemd service names. Each non-empty entry is an OR candidate:
+the kubelet service matches if any candidate matches. Surrounding whitespace is
+trimmed and empty entries are ignored; configuration fails if none remain.
 .PP
 .SH [Logging]
 .TP

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -115,6 +115,7 @@ var (
 		RawClusterSubnets:            "10.128.0.0/14/23",
 		Zone:                         types.OvnDefaultZone,
 		RawUDNAllowedDefaultServices: "default/kubernetes,kube-system/kube-dns",
+		RawKubeletServiceNames:       "kubelet.service",
 		Transport:                    "",
 	}
 
@@ -369,6 +370,13 @@ type DefaultConfig struct {
 	// UDNAllowedDefaultServices holds a list of namespaced names of
 	// default cluster network services accessible from primary user-defined networks
 	UDNAllowedDefaultServices []string
+
+	// RawKubeletServiceNames holds the unparsed kubelet systemd service names.
+	// It should only be used inside the config module.
+	RawKubeletServiceNames string `gcfg:"kubelet-service-names"`
+
+	// KubeletServiceNames holds the systemd service names that may run kubelet.
+	KubeletServiceNames []string
 
 	// Transport specifies the transport technology used for the default network.
 	// Accepts: "" (empty, uses OVN default overlay) or "no-overlay".
@@ -808,6 +816,7 @@ func init() {
 	savedOvsPaths = OvsPaths
 	savedNoOverlay = NoOverlay
 	savedManagedBGP = ManagedBGP
+	cliConfig.Default.RawKubeletServiceNames = savedDefault.RawKubeletServiceNames
 	cli.VersionPrinter = func(_ *cli.Context) {
 		fmt.Printf("Version: %s\n", Version)
 		fmt.Printf("Git commit: %s\n", Commit)
@@ -2619,6 +2628,11 @@ func completeDefaultConfig(allSubnets *ConfigSubnets) error {
 		return fmt.Errorf("UDN allowed services field is invalid: %v", err)
 	}
 
+	Default.KubeletServiceNames, err = parseKubeletServiceNames(Default.RawKubeletServiceNames)
+	if err != nil {
+		return fmt.Errorf("kubelet service names field is invalid: %v", err)
+	}
+
 	Default.HostMasqConntrackZone = Default.ConntrackZone + 1
 	Default.OVNMasqConntrackZone = Default.ConntrackZone + 2
 	Default.HostNodePortConntrackZone = Default.ConntrackZone + 3
@@ -2645,6 +2659,19 @@ func parseServicesNamespacedNames(servicesRaw string) ([]string, error) {
 		services = append(services, svcKey)
 	}
 	return services, nil
+}
+
+func parseKubeletServiceNames(rawServiceNames string) ([]string, error) {
+	var serviceNames []string
+	for _, rawServiceName := range strings.Split(rawServiceNames, ",") {
+		if serviceName := strings.TrimSpace(rawServiceName); serviceName != "" {
+			serviceNames = append(serviceNames, serviceName)
+		}
+	}
+	if len(serviceNames) == 0 {
+		return nil, fmt.Errorf("kubelet service names must contain at least one name")
+	}
+	return serviceNames, nil
 }
 
 // getConfigFilePath returns config file path and 'true' if the config file is

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -339,6 +339,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.128.0.0/14"), 23},
 			}))
+			gomega.Expect(Default.KubeletServiceNames).To(gomega.Equal([]string{"kubelet.service"}))
 			gomega.Expect(Default.Zone).To(gomega.Equal("global"))
 			gomega.Expect(IPv4Mode).To(gomega.BeTrue())
 			gomega.Expect(IPv6Mode).To(gomega.BeFalse())
@@ -1480,6 +1481,57 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 			"-config-file=" + cfgFile.Name(),
 		}
 		err = app.Run(cliArgs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	DescribeTable("parses kubelet service names",
+		func(raw string, expected []string) {
+			serviceNames, err := parseKubeletServiceNames(raw)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(serviceNames).To(gomega.Equal(expected))
+		},
+		Entry("one name", "kubelet.service", []string{"kubelet.service"}),
+		Entry("multiple names with whitespace and empty entries",
+			" kubelet.service, , custom-kubelet.service,",
+			[]string{"kubelet.service", "custom-kubelet.service"}),
+	)
+
+	It("rejects empty kubelet service names", func() {
+		serviceNames, err := parseKubeletServiceNames(" , , ")
+		gomega.Expect(err).To(gomega.MatchError("kubelet service names must contain at least one name"))
+		gomega.Expect(serviceNames).To(gomega.BeNil())
+	})
+
+	It("accepts configured kubelet service names", func() {
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
+kubelet-service-names= kubelet.service, , custom-kubelet.service,
+`), 0o644)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		app.Action = func(ctx *cli.Context) error {
+			_, err = InitConfig(ctx, kexec.New(), nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(Default.KubeletServiceNames).To(gomega.Equal(
+				[]string{"kubelet.service", "custom-kubelet.service"}))
+			return nil
+		}
+		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	It("rejects configured empty kubelet service names", func() {
+		err := os.WriteFile(cfgFile.Name(), []byte(`[default]
+kubelet-service-names= , ,
+`), 0o644)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		app.Action = func(ctx *cli.Context) error {
+			_, err = InitConfig(ctx, kexec.New(), nil)
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+				"kubelet service names must contain at least one name")))
+			return nil
+		}
+		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 	Describe("OvnDBAuth operations", func() {

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -166,7 +166,7 @@ func newDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, sto
 	}
 	if util.IsNetworkSegmentationSupportEnabled() && (config.IsModeDPUHost() || config.IsModeFull()) {
 		c.udnHostIsolationManager = NewUDNHostIsolationManager(config.IPv4Mode, config.IPv6Mode,
-			cnnci.watchFactory.PodCoreInformer(), cnnci.name, cnnci.recorder)
+			cnnci.watchFactory.PodCoreInformer(), cnnci.name, cnnci.recorder, config.Default.KubeletServiceNames)
 	}
 	c.masqReconciler = &masqueradeReconciler{
 		routeManager: routeManager,

--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -53,13 +53,14 @@ const (
 // It uses nftables chain "udn-isolation" to only allow connection to primary UDN pods from kubelet.
 // It also listens to systemd events to re-apply the rules after kubelet restart as cgroup matching is used.
 type UDNHostIsolationManager struct {
-	nft               knftables.Interface
-	ipv4, ipv6        bool
-	podController     controller.Controller
-	podLister         corelisters.PodLister
-	kubeletCgroupPath string
-	nodeName          string
-	recorder          record.EventRecorder
+	nft                 knftables.Interface
+	ipv4, ipv6          bool
+	podController       controller.Controller
+	podLister           corelisters.PodLister
+	kubeletCgroupPath   string
+	kubeletServiceNames sets.Set[string]
+	nodeName            string
+	recorder            record.EventRecorder
 
 	udnPodIPsv4 *nftPodElementsSet
 	udnPodIPsv6 *nftPodElementsSet
@@ -71,19 +72,20 @@ type UDNHostIsolationManager struct {
 	udnOpenPortsICMPv6 *nftPodElementsSet
 }
 
-func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodInformer, nodeName string, recorder record.EventRecorder) *UDNHostIsolationManager {
+func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodInformer, nodeName string, recorder record.EventRecorder, kubeletServiceNames []string) *UDNHostIsolationManager {
 	m := &UDNHostIsolationManager{
-		podLister:          podInformer.Lister(),
-		ipv4:               ipv4,
-		ipv6:               ipv6,
-		nodeName:           nodeName,
-		recorder:           recorder,
-		udnPodIPsv4:        newNFTPodElementsSet(nftablesUDNPodIPsv4, false),
-		udnPodIPsv6:        newNFTPodElementsSet(nftablesUDNPodIPsv6, false),
-		udnOpenPortsv4:     newNFTPodElementsSet(nftablesUDNOpenPortsv4, true),
-		udnOpenPortsv6:     newNFTPodElementsSet(nftablesUDNOpenPortsv6, true),
-		udnOpenPortsICMPv4: newNFTPodElementsSet(nftablesUDNOpenPortsICMPv4, false),
-		udnOpenPortsICMPv6: newNFTPodElementsSet(nftablesUDNOpenPortsICMPv6, false),
+		podLister:           podInformer.Lister(),
+		ipv4:                ipv4,
+		ipv6:                ipv6,
+		nodeName:            nodeName,
+		recorder:            recorder,
+		kubeletServiceNames: sets.New(kubeletServiceNames...),
+		udnPodIPsv4:         newNFTPodElementsSet(nftablesUDNPodIPsv4, false),
+		udnPodIPsv6:         newNFTPodElementsSet(nftablesUDNPodIPsv6, false),
+		udnOpenPortsv4:      newNFTPodElementsSet(nftablesUDNOpenPortsv4, true),
+		udnOpenPortsv6:      newNFTPodElementsSet(nftablesUDNOpenPortsv6, true),
+		udnOpenPortsICMPv4:  newNFTPodElementsSet(nftablesUDNOpenPortsICMPv4, false),
+		udnOpenPortsICMPv6:  newNFTPodElementsSet(nftablesUDNOpenPortsICMPv6, false),
 	}
 	controllerConfig := &controller.ControllerConfig[corev1.Pod]{
 		Informer:       podInformer.Informer(),
@@ -96,6 +98,58 @@ func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodIn
 	return m
 }
 
+func (m *UDNHostIsolationManager) isKubeletService(serviceName string) bool {
+	return m.kubeletServiceNames.Has(serviceName)
+}
+
+// decodeSystemdUnitName decodes a systemd unit name that has been escaped using
+// systemd's escaping rules (where special characters are replaced by an underscore
+// followed by their two-digit hexadecimal value, e.g., "_2d" or "_2D" for "-").
+// If an escape sequence is malformed, it is preserved in its original form.
+func decodeSystemdUnitName(escapedUnit string) string {
+	var unitName strings.Builder
+	unitName.Grow(len(escapedUnit))
+
+	for i := 0; i < len(escapedUnit); i++ {
+		if escapedUnit[i] == '_' && i+2 < len(escapedUnit) {
+			decodedByte, err := strconv.ParseUint(escapedUnit[i+1:i+3], 16, 8)
+			if err == nil {
+				unitName.WriteByte(byte(decodedByte))
+				i += 2
+				continue
+			}
+		}
+		unitName.WriteByte(escapedUnit[i])
+	}
+
+	return unitName.String()
+}
+
+func (m *UDNHostIsolationManager) findKubeletCgroupPath(cgroupRoot string) error {
+	err := filepath.WalkDir(cgroupRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && m.isKubeletService(d.Name()) {
+			cgroupPath, err := filepath.Rel(cgroupRoot, path)
+			if err != nil {
+				return err
+			}
+			m.kubeletCgroupPath = cgroupPath
+			klog.Infof("Found kubelet cgroup path: %s", m.kubeletCgroupPath)
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find kubelet cgroup path: %w", err)
+	}
+	if m.kubeletCgroupPath == "" {
+		return fmt.Errorf("failed to find kubelet cgroup path")
+	}
+	return nil
+}
+
 // Start must be called on node setup.
 func (m *UDNHostIsolationManager) Start(ctx context.Context) error {
 	klog.Infof("Starting UDN host isolation manager")
@@ -103,19 +157,8 @@ func (m *UDNHostIsolationManager) Start(ctx context.Context) error {
 		// find kubelet cgroup path.
 		// kind cluster uses "kubelet.slice/kubelet.service", while OCP cluster uses "system.slice/kubelet.service".
 		// as long as ovn-k node is running as a privileged container, we can access the host cgroup directory.
-		err := filepath.WalkDir("/sys/fs/cgroup", func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return nil
-			}
-			if d.Name() == "kubelet.service" {
-				m.kubeletCgroupPath = strings.TrimPrefix(path, "/sys/fs/cgroup/")
-				klog.Infof("Found kubelet cgroup path: %s", m.kubeletCgroupPath)
-				return filepath.SkipAll
-			}
-			return nil
-		})
-		if err != nil || m.kubeletCgroupPath == "" {
-			return fmt.Errorf("failed to find kubelet cgroup path: %w", err)
+		if err := m.findKubeletCgroupPath("/sys/fs/cgroup"); err != nil {
+			return err
 		}
 	} else {
 		// We can't use cgroup v2 match, so m.kubeletCgroupPath will be empty.
@@ -312,6 +355,32 @@ func (m *UDNHostIsolationManager) updateKubeletCgroup() error {
 	return nil
 }
 
+func (m *UDNHostIsolationManager) handleKubeletRestartSignal(signal *dbus.Signal) error {
+	parts := strings.Split(string(signal.Path), "/")
+	if len(parts) < 6 || parts[4] != "unit" {
+		return nil
+	}
+	unitName := decodeSystemdUnitName(parts[5])
+	if !m.isKubeletService(unitName) || len(signal.Body) < 2 {
+		return nil
+	}
+	changes, ok := signal.Body[1].(map[string]dbus.Variant)
+	if !ok {
+		return nil
+	}
+	state, exists := changes["ActiveState"]
+	if !exists {
+		return nil
+	}
+	newState, ok := state.Value().(string)
+	if !ok || newState != "active" {
+		return nil
+	}
+
+	klog.Info("Kubelet restarted, re-applying isolation")
+	return m.updateKubeletCgroup()
+}
+
 // runKubeletRestartTracker listens to systemd events to re-apply the UDN host isolation rules after kubelet restart.
 // cgroupv2 match doesn't actually match cgroup paths, but rather resolves them to numeric cgroup IDs when such
 // rules are loaded into kernel, and does not automatically update them in any way afterwards.
@@ -363,26 +432,8 @@ func (m *UDNHostIsolationManager) runKubeletRestartTracker(ctx context.Context) 
 					return
 				}
 				klog.V(5).Infof("D-Bus event received: %#v", signal)
-				// Extract unit name from path
-				unitPath := signal.Path
-				parts := strings.Split(string(unitPath), "/")
-				if len(parts) < 6 || parts[4] != "unit" {
-					continue
-				}
-				escapedUnit := parts[5]
-				unitName := strings.ReplaceAll(escapedUnit, "_2e", ".")
-
-				if unitName == "kubelet.service" {
-					changes := signal.Body[1].(map[string]dbus.Variant)
-					if state, exists := changes["ActiveState"]; exists {
-						newState := state.Value().(string)
-						if newState == "active" {
-							klog.Info("Kubelet restarted, re-applying isolation")
-							if err := m.updateKubeletCgroup(); err != nil {
-								klog.Errorf("Failed to re-apply isolation: %v", err)
-							}
-						}
-					}
+				if err := m.handleKubeletRestartSignal(signal); err != nil {
+					klog.Errorf("Failed to re-apply isolation: %v", err)
 				}
 			}
 		}

--- a/go-controller/pkg/node/udn_isolation_test.go
+++ b/go-controller/pkg/node/udn_isolation_test.go
@@ -7,7 +7,11 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/godbus/dbus/v5"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,7 +287,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		wf, err = factory.NewNodeWatchFactory(fakeClient, "node1")
 		Expect(err).NotTo(HaveOccurred())
 
-		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil)
+		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil, config.Default.KubeletServiceNames)
 
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -318,6 +322,97 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		}
 	})
 
+	Context("kubelet service discovery", func() {
+		It("matches any configured kubelet service", func() {
+			manager := &UDNHostIsolationManager{
+				kubeletServiceNames: sets.New("kubelet.service", "custom-kubelet.service"),
+			}
+
+			Expect(manager.isKubeletService("kubelet.service")).To(BeTrue())
+			Expect(manager.isKubeletService("custom-kubelet.service")).To(BeTrue())
+			Expect(manager.isKubeletService("unrelated.service")).To(BeFalse())
+		})
+
+		DescribeTable("decodes systemd unit names",
+			func(escapedUnit, expectedUnit string) {
+				Expect(decodeSystemdUnitName(escapedUnit)).To(Equal(expectedUnit))
+			},
+			Entry("hyphen and dot", "custom_2dkubelet_2eservice", "custom-kubelet.service"),
+			Entry("escaped underscore", "custom_5fkubelet.service", "custom_kubelet.service"),
+			Entry("at sign", "kubelet_40node.service", "kubelet@node.service"),
+			Entry("uppercase hex digits", "custom_2Dkubelet_2Eservice", "custom-kubelet.service"),
+			Entry("multibyte UTF-8", "kubelet_2d_e6_9c_8d_e5_8a_a1_2eservice", "kubelet-服务.service"),
+		)
+
+		It("preserves malformed systemd escape sequences", func() {
+			Expect(decodeSystemdUnitName("custom_zz_+a_2_service_")).To(Equal("custom_zz_+a_2_service_"))
+		})
+
+		It("finds a cgroup for a non-default configured service", func() {
+			cgroupRoot := GinkgoT().TempDir()
+			expectedPath := filepath.Join("system.slice", "custom-kubelet.service")
+			Expect(os.MkdirAll(filepath.Join(cgroupRoot, expectedPath), 0o755)).To(Succeed())
+			manager := &UDNHostIsolationManager{
+				kubeletServiceNames: sets.New("kubelet.service", "custom-kubelet.service"),
+			}
+
+			Expect(manager.findKubeletCgroupPath(cgroupRoot)).To(Succeed())
+			Expect(manager.kubeletCgroupPath).To(Equal(expectedPath))
+		})
+
+		It("ignores regular files named for configured services", func() {
+			cgroupRoot := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(cgroupRoot, "custom-kubelet.service"), nil, 0o644)).To(Succeed())
+			expectedPath := filepath.Join("system.slice", "kubelet.service")
+			Expect(os.MkdirAll(filepath.Join(cgroupRoot, expectedPath), 0o755)).To(Succeed())
+			manager := &UDNHostIsolationManager{
+				kubeletServiceNames: sets.New("kubelet.service", "custom-kubelet.service"),
+			}
+
+			Expect(manager.findKubeletCgroupPath(cgroupRoot)).To(Succeed())
+			Expect(manager.kubeletCgroupPath).To(Equal(expectedPath))
+		})
+
+		It("fails when no configured service has a cgroup", func() {
+			manager := &UDNHostIsolationManager{
+				kubeletServiceNames: sets.New("kubelet.service", "custom-kubelet.service"),
+			}
+
+			Expect(manager.findKubeletCgroupPath(GinkgoT().TempDir())).To(
+				MatchError("failed to find kubelet cgroup path"))
+		})
+
+		It("reapplies isolation for an active configured service signal", func() {
+			nft := nodenft.SetFakeNFTablesHelper()
+			manager := &UDNHostIsolationManager{
+				nft:                 nft,
+				ipv4:                true,
+				ipv6:                true,
+				kubeletCgroupPath:   "kubelet.slice/kubelet.service",
+				kubeletServiceNames: sets.New("custom-kubelet.service"),
+			}
+			Expect(manager.setupUDNIsolationFromHost()).To(Succeed())
+			tx := nft.NewTransaction()
+			tx.Add(&knftables.Rule{Chain: UDNIsolationChain, Rule: "counter"})
+			Expect(nft.Run(context.Background(), tx)).To(Succeed())
+			Expect(nft.Dump()).To(ContainSubstring("counter"))
+
+			signal := &dbus.Signal{
+				Path: dbus.ObjectPath("/org/freedesktop/systemd1/unit/custom_2dkubelet_2eservice"),
+				Body: []interface{}{
+					"org.freedesktop.systemd1.Unit",
+					map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("inactive")},
+				},
+			}
+
+			Expect(manager.handleKubeletRestartSignal(signal)).To(Succeed())
+			Expect(nft.Dump()).To(ContainSubstring("counter"))
+			signal.Body[1] = map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}
+			Expect(manager.handleKubeletRestartSignal(signal)).To(Succeed())
+			Expect(nft.Dump()).To(Equal(getExpectedDump(nil, nil)))
+		})
+	})
+
 	It("correctly handles host-network and not ready pods on initial sync", func() {
 		hostNetPod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -339,7 +434,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		var err error
 		wf, err = factory.NewNodeWatchFactory(fakeClient, "node1")
 		Expect(err).NotTo(HaveOccurred())
-		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil)
+		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil, config.Default.KubeletServiceNames)
 		nft = nodenft.SetFakeNFTablesHelper()
 		manager.nft = nft
 
@@ -365,7 +460,7 @@ add rule inet ovn-kubernetes udn-isolation ip6 daddr @udn-pod-default-ips-v6 dro
 		var err error
 		wf, err = factory.NewNodeWatchFactory(fakeClient, "node1")
 		Expect(err).NotTo(HaveOccurred())
-		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil)
+		manager = NewUDNHostIsolationManager(true, true, wf.PodCoreInformer(), "node1", nil, config.Default.KubeletServiceNames)
 		Expect(wf.Start()).To(Succeed())
 		Expect(manager.reconcilePod(notReadyPod.Namespace + "/" + notReadyPod.Name)).To(Succeed())
 	})

--- a/helm/ovn-kubernetes/templates/ovn-setup.yaml
+++ b/helm/ovn-kubernetes/templates/ovn-setup.yaml
@@ -61,8 +61,11 @@ metadata:
   namespace: ovn-kubernetes
 data:
   ovnkube.conf: |
-{{- if .Values.global.enableNoOverlay }}
     [default]
+{{- if .Values.global.kubeletServiceNames }}
+    kubelet-service-names = {{ .Values.global.kubeletServiceNames }}
+{{- end }}
+{{- if .Values.global.enableNoOverlay }}
     transport = no-overlay
 
     [no-overlay]

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -65,6 +65,8 @@ global:
   enableMultiNetwork: false
   # -- Configure to use user defined networks (UDN) feature with ovn-kubernetes
   enableNetworkSegmentation: false
+  # -- Comma-separated systemd service names that may run kubelet
+  kubeletServiceNames: "kubelet.service"
   # -- Configure to use route advertisements feature with ovn-kubernetes
   enableRouteAdvertisements: false
   # -- Optional Linux routing table ID start used by ovnkube-node for generated VRF/route tables.

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -71,6 +71,8 @@ global:
   enableMultiNetwork: false
   # -- Configure to use user defined networks (UDN) feature with ovn-kubernetes
   enableNetworkSegmentation: false
+  # -- Comma-separated systemd service names that may run kubelet
+  kubeletServiceNames: "kubelet.service"
   # -- Configure to enable cluster network connect feature with ovn-kubernetes
   enableNetworkConnect: false
   # -- Configure to use route advertisements feature with ovn-kubernetes


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Kubelet may run under a non-default systemd unit name(such as in RKE2), preventing UDN host isolation from finding its cgroup and refreshing nftables rules after a restart.

Add a comma-separated kubelet-service-names setting and use the configured names for cgroup discovery and systemd restart events. Expose the setting through config. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
E2E tests use Kinds cluster, which still uses the kubelet  systemd unit name. It  has verified in a RKE2 cluster.  