### PR TITLE
e2e: fix egress IP traffic-monitor pod startup race

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -3149,17 +3149,33 @@ spec:
 				gomega.Expect(podCIDR).NotTo(gomega.BeEmpty(), "pod CIDR must not be empty for node %s", pod1Node.name)
 				monitorFilter := fmt.Sprintf("src net %s and dst host %s", podCIDR, targetIP)
 
+				// Create the monitor pod and wait (up to retryTimeout) until it is Running
+				// (capturing) before generating any traffic, so the capture cannot miss the
+				// EgressIP transition and stopping the capture in Step 8 cannot race the pod
+				// startup. A failure or timeout to start aborts the spec here, on the main
+				// goroutine.
 				ctx, ctxCancel := context.WithCancel(context.Background())
-				monitorOutput := ""
-				finishedMonitor := make(chan struct{})
-				go func() {
-					defer close(finishedMonitor)
-					var monitorErr error
-					monitorOutput, monitorErr = monitorTcpdumpOnNode(ctx, f, monitorPodName, egress1Node.name, secondaryIface.InfName,
-						"-n -vv -l", monitorFilter)
-					framework.ExpectNoError(monitorErr, "Failed to read monitor pod logs")
-				}()
+				// Guarantee the capture is stopped and the goroutine below is unblocked on every
+				// exit path, including an early failure before Step 8.
+				defer ctxCancel()
+				startTcpdumpMonitorPodOnNode(ctx, f, retryTimeout, monitorPodName, egress1Node.name, secondaryIface.InfName,
+					"-n -vv -l", monitorFilter)
 				framework.Logf("Traffic monitor pod started on node %s", egress1Node.name)
+
+				// Collect the captured output in the background until the capture context is
+				// cancelled in Step 8. The goroutine only reads logs (bounded by retryTimeout);
+				// its error is checked on the main goroutine after monitorWg.Wait().
+				monitorOutput := ""
+				var monitorErr error
+				var monitorWg sync.WaitGroup
+				monitorWg.Add(1)
+				go func() {
+					defer ginkgo.GinkgoRecover()
+					defer monitorWg.Done()
+					<-ctx.Done()
+					monitorOutput, monitorErr = e2ekubectl.NewKubectlCommand(f.Namespace.Name, "logs", monitorPodName).
+						WithTimeout(time.After(retryTimeout)).Exec()
+				}()
 
 				ginkgo.By(fmt.Sprintf("Step 4: Create %d pods FIRST (before EgressIP exists)", numTestPods))
 				// Pods are created before EgressIP, they will initially use normal routing (their pod IPs as source)
@@ -3324,7 +3340,8 @@ spec:
 				ginkgo.By("Step 8: Analyze traffic capture for pod IP leaks during EgressIP application")
 				// This is the critical check: did any traffic leak with pod IPs during the transition?
 				ctxCancel()
-				<-finishedMonitor
+				monitorWg.Wait()
+				framework.ExpectNoError(monitorErr, "Failed to read monitor pod logs")
 				if strings.Contains(monitorOutput, targetIP) {
 					framework.Failf("TRAFFIC LEAK DETECTED! Pod IPs were seen in traffic to %s"+
 						"This indicates traffic leaked with pod source IPs instead of egress IP %s during EgressIP application to existing pods.\ntcpdump output:\n%s",

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -3149,16 +3149,12 @@ spec:
 				gomega.Expect(podCIDR).NotTo(gomega.BeEmpty(), "pod CIDR must not be empty for node %s", pod1Node.name)
 				monitorFilter := fmt.Sprintf("src net %s and dst host %s", podCIDR, targetIP)
 
-				ctx, ctxCancel := context.WithCancel(context.Background())
-				monitorOutput := ""
-				finishedMonitor := make(chan struct{})
-				go func() {
-					defer close(finishedMonitor)
-					var monitorErr error
-					monitorOutput, monitorErr = monitorTcpdumpOnNode(ctx, f, monitorPodName, egress1Node.name, secondaryIface.InfName,
-						"-n -vv -l", monitorFilter)
-					framework.ExpectNoError(monitorErr, "Failed to read monitor pod logs")
-				}()
+				// Create the monitor pod and wait (up to retryTimeout) until it is Running
+				// (capturing) before generating any traffic, so the capture cannot miss the
+				// EgressIP transition and reading the capture in Step 8 cannot race the pod
+				// startup. A failure or timeout to start aborts the spec here.
+				startTcpdumpMonitorPodOnNode(f, retryTimeout, monitorPodName, egress1Node.name, secondaryIface.InfName,
+					"-n -vv -l", monitorFilter)
 				framework.Logf("Traffic monitor pod started on node %s", egress1Node.name)
 
 				ginkgo.By(fmt.Sprintf("Step 4: Create %d pods FIRST (before EgressIP exists)", numTestPods))
@@ -3323,8 +3319,10 @@ spec:
 
 				ginkgo.By("Step 8: Analyze traffic capture for pod IP leaks during EgressIP application")
 				// This is the critical check: did any traffic leak with pod IPs during the transition?
-				ctxCancel()
-				<-finishedMonitor
+				// tcpdump keeps running; kubectl logs reads the capture so far (line-buffered via -l).
+				monitorOutput, monitorErr := e2ekubectl.NewKubectlCommand(f.Namespace.Name, "logs", monitorPodName).
+					WithTimeout(time.After(retryTimeout)).Exec()
+				framework.ExpectNoError(monitorErr, "Failed to read monitor pod logs")
 				if strings.Contains(monitorOutput, targetIP) {
 					framework.Failf("TRAFFIC LEAK DETECTED! Pod IPs were seen in traffic to %s"+
 						"This indicates traffic leaked with pod source IPs instead of egress IP %s during EgressIP application to existing pods.\ntcpdump output:\n%s",

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1861,12 +1861,13 @@ func firstSubnetOf(subnet string, subnetSize int) string {
 	return fmt.Sprintf("%s/%d", ipNet.IP, subnetSize)
 }
 
-// monitorTcpdumpOnNode creates a privileged host-network pod on the given node that runs
-// tcpdump on the specified interface with the provided filter. It blocks until ctx is
-// cancelled, then fetches the pod logs and deletes the monitor pod. Returns all captured
-// tcpdump output.
-func monitorTcpdumpOnNode(ctx context.Context, f *framework.Framework,
-	name, nodeName, nodeIface, options, filter string) (string, error) {
+// startTcpdumpMonitorPodOnNode creates a privileged host-network pod on the given node that
+// runs tcpdump on the specified interface with the provided filter, and waits up to
+// startupTimeout for the pod to be Running. Returning means the capture is active, so callers
+// can start generating traffic. It fails the spec if the pod cannot be created or does not
+// become Running within startupTimeout.
+func startTcpdumpMonitorPodOnNode(ctx context.Context, f *framework.Framework, startupTimeout time.Duration,
+	name, nodeName, nodeIface, options, filter string) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1895,15 +1896,8 @@ func monitorTcpdumpOnNode(ctx context.Context, f *framework.Framework,
 		},
 	}
 
-	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Failed to create traffic monitor pod")
-	err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, createdPod)
-	framework.ExpectNoError(err, "Monitor pod failed to start")
-
-	<-ctx.Done()
-	logs, err := e2ekubectl.RunKubectl(f.Namespace.Name, "logs", name)
-	if err != nil {
-		return "", err
-	}
-	return logs, nil
+	err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, name, f.Namespace.Name, startupTimeout)
+	framework.ExpectNoError(err, fmt.Sprintf("traffic monitor pod %s did not become Running within %v", name, startupTimeout))
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1861,12 +1861,13 @@ func firstSubnetOf(subnet string, subnetSize int) string {
 	return fmt.Sprintf("%s/%d", ipNet.IP, subnetSize)
 }
 
-// monitorTcpdumpOnNode creates a privileged host-network pod on the given node that runs
-// tcpdump on the specified interface with the provided filter. It blocks until ctx is
-// cancelled, then fetches the pod logs and deletes the monitor pod. Returns all captured
-// tcpdump output.
-func monitorTcpdumpOnNode(ctx context.Context, f *framework.Framework,
-	name, nodeName, nodeIface, options, filter string) (string, error) {
+// startTcpdumpMonitorPodOnNode creates a privileged host-network pod on the given node that
+// runs tcpdump on the specified interface with the provided filter, and waits up to
+// startupTimeout for the pod to be Running. Returning means the capture is active, so callers
+// can start generating traffic. It fails the spec if the pod cannot be created or does not
+// become Running within startupTimeout.
+func startTcpdumpMonitorPodOnNode(f *framework.Framework, startupTimeout time.Duration,
+	name, nodeName, nodeIface, options, filter string) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1895,15 +1896,12 @@ func monitorTcpdumpOnNode(ctx context.Context, f *framework.Framework,
 		},
 	}
 
-	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-	framework.ExpectNoError(err, "Failed to create traffic monitor pod")
-	err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, createdPod)
-	framework.ExpectNoError(err, "Monitor pod failed to start")
+	// Bound pod creation and the readiness wait by a single startupTimeout budget.
+	startupCtx, cancel := context.WithTimeout(context.Background(), startupTimeout)
+	defer cancel()
 
-	<-ctx.Done()
-	logs, err := e2ekubectl.RunKubectl(f.Namespace.Name, "logs", name)
-	if err != nil {
-		return "", err
-	}
-	return logs, nil
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(startupCtx, pod, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "Failed to create traffic monitor pod")
+	err = e2epod.WaitTimeoutForPodRunningInNamespace(startupCtx, f.ClientSet, name, f.Namespace.Name, startupTimeout)
+	framework.ExpectNoError(err, fmt.Sprintf("traffic monitor pod %s did not become Running within %v", name, startupTimeout))
 }


### PR DESCRIPTION
The [secondary-host-eip] leak test created the tcpdump monitor pod inside a goroutine and reused the capture context for the pod-start wait, without ever waiting for the pod to be Running. When the leak check cancelled that context to stop the capture, it could instead abort a pod-start wait that was still in progress (e.g. the pod was still pulling its image), failing with "Monitor pod failed to start". With no GinkgoRecover in that goroutine, the resulting panic crashed the whole suite instead of failing the spec.

Create the monitor pod and wait for Running synchronously before generating traffic; the goroutine now only collects the captured logs. Stopping the capture can no longer race pod startup, and failures surface on the main goroutine.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
