### PR TITLE
Support IPv6 static IP allocation beyond bitmap cap (offsets > 65535)

### DIFF
--- a/go-controller/pkg/allocator/ip/allocator.go
+++ b/go-controller/pkg/allocator/ip/allocator.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"sync"
 
 	utilnet "k8s.io/utils/net"
 
@@ -95,6 +96,11 @@ type Range struct {
 	max int
 
 	alloc allocator.Interface
+
+	// staticIPsOutOfRange tracks static IPv6 allocations whose offset from the
+	// subnet base exceeds the bitmap cap (65535). Keyed by the canonical IP string.
+	staticIPsOutOfRange map[string]bool
+	mu                  sync.RWMutex
 }
 
 // NewAllocatorCIDRRange creates a Range over a net.IPNet, calling allocatorFactory to construct the backing store.
@@ -133,9 +139,10 @@ func NewAllocatorFullCIDRRange(cidr *net.IPNet, allocatorFactory allocator.Alloc
 		}
 	}
 	r := Range{
-		net:  cidr,
-		base: base,
-		max:  int(max),
+		net:                 cidr,
+		base:                base,
+		max:                 int(max),
+		staticIPsOutOfRange: make(map[string]bool),
 	}
 	var err error
 	r.alloc, err = allocatorFactory(r.max, rangeSpec)
@@ -176,19 +183,40 @@ func (r *Range) CIDR() net.IPNet {
 // or has already been reserved.  ErrFull will be returned if there
 // are no addresses left.
 func (r *Range) Allocate(ip net.IP) error {
-	ok, offset := r.contains(ip)
-	if !ok {
+	if !r.net.Contains(ip) {
 		return &ErrNotInRange{r.net.String()}
 	}
 
-	allocated, err := r.alloc.Allocate(offset)
-	if err != nil {
-		return err
+	bigOffset := calculateIPOffsetBig(r.base, ip)
+	if bigOffset.Sign() < 0 {
+		return &ErrNotInRange{r.net.String()}
 	}
-	if !allocated {
-		return ErrAllocated
+
+	if bigOffset.IsInt64() && int(bigOffset.Int64()) < r.max {
+		allocated, err := r.alloc.Allocate(int(bigOffset.Int64()))
+		if err != nil {
+			return err
+		}
+		if !allocated {
+			return ErrAllocated
+		}
+		return nil
 	}
-	return nil
+
+	// For IPv6 subnets where the bitmap was capped, allow static allocation
+	// of IPs beyond the bitmap range using the overflow map.
+	if utilnet.IsIPv6CIDR(r.net) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		ipStr := ip.String()
+		if r.staticIPsOutOfRange[ipStr] {
+			return ErrAllocated
+		}
+		r.staticIPsOutOfRange[ipStr] = true
+		return nil
+	}
+
+	return &ErrNotInRange{r.net.String()}
 }
 
 // AllocateNext reserves one of the IPs from the pool. ErrFull may
@@ -208,12 +236,25 @@ func (r *Range) AllocateNext() (net.IP, error) {
 // unallocated IP or an IP out of the range is a no-op and
 // returns no error.
 func (r *Range) Release(ip net.IP) {
-	ok, offset := r.contains(ip)
-	if !ok {
+	if !r.net.Contains(ip) {
 		return
 	}
 
-	r.alloc.Release(offset)
+	bigOffset := calculateIPOffsetBig(r.base, ip)
+	if bigOffset.Sign() < 0 {
+		return
+	}
+
+	if bigOffset.IsInt64() && int(bigOffset.Int64()) < r.max {
+		r.alloc.Release(int(bigOffset.Int64()))
+		return
+	}
+
+	if utilnet.IsIPv6CIDR(r.net) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		delete(r.staticIPsOutOfRange, ip.String())
+	}
 }
 
 // ForEach calls the provided function for each allocated IP.
@@ -222,17 +263,40 @@ func (r *Range) ForEach(fn func(net.IP)) {
 		ip, _ := utilnet.GetIndexedIP(r.net, offset+1) // +1 because Range doesn't store IP 0
 		fn(ip)
 	})
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for ipStr := range r.staticIPsOutOfRange {
+		ip := net.ParseIP(ipStr)
+		if ip != nil {
+			fn(ip)
+		}
+	}
 }
 
 // Has returns true if the provided IP is already allocated and a call
 // to Allocate(ip) would fail with ErrAllocated.
 func (r *Range) Has(ip net.IP) bool {
-	ok, offset := r.contains(ip)
-	if !ok {
+	if !r.net.Contains(ip) {
 		return false
 	}
 
-	return r.alloc.Has(offset)
+	bigOffset := calculateIPOffsetBig(r.base, ip)
+	if bigOffset.Sign() < 0 {
+		return false
+	}
+
+	if bigOffset.IsInt64() && int(bigOffset.Int64()) < r.max {
+		return r.alloc.Has(int(bigOffset.Int64()))
+	}
+
+	if utilnet.IsIPv6CIDR(r.net) {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.staticIPsOutOfRange[ip.String()]
+	}
+
+	return false
 }
 
 // Reserved returns true if the provided IP can't be allocated. This is *only*
@@ -269,22 +333,8 @@ func (r *Range) Reserved(ip net.IP) bool {
 	return false
 }
 
-// contains returns true and the offset if the ip is in the range, and false
-// and nil otherwise. The first and last addresses of the CIDR are omitted.
-func (r *Range) contains(ip net.IP) (bool, int) {
-	if !r.net.Contains(ip) {
-		return false, 0
-	}
-
-	offset := calculateIPOffset(r.base, ip)
-	if offset < 0 || offset >= r.max {
-		return false, 0
-	}
-	return true, offset
-}
-
-// calculateIPOffset calculates the integer offset of ip from base such that
-// base + offset = ip. It requires ip >= base.
-func calculateIPOffset(base *big.Int, ip net.IP) int {
-	return int(big.NewInt(0).Sub(utilnet.BigForIP(ip), base).Int64())
+// calculateIPOffsetBig calculates the offset of ip from base as a *big.Int,
+// safe for arbitrarily large IPv6 offsets that would overflow int/int64.
+func calculateIPOffsetBig(base *big.Int, ip net.IP) *big.Int {
+	return new(big.Int).Sub(utilnet.BigForIP(ip), base)
 }

--- a/go-controller/pkg/allocator/ip/allocator_test.go
+++ b/go-controller/pkg/allocator/ip/allocator_test.go
@@ -20,7 +20,9 @@ limitations under the License.
 package ip
 
 import (
+	"fmt"
 	"net"
+	"sync"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -54,10 +56,9 @@ func TestAllocate(t *testing.T) {
 			free:     65535,
 			released: "2001:db8:1::5",
 			outOfRange: []string{
-				"2001:db8::1",     // not in 2001:db8:1::/48
-				"2001:db8:1::",    // reserved (base address)
-				"2001:db8:1::1:0", // not in the low 16 bits of 2001:db8:1::/48
-				"2001:db8:2::2",   // not in 2001:db8:1::/48
+				"2001:db8::1",   // not in 2001:db8:1::/48
+				"2001:db8:1::",  // reserved (base address)
+				"2001:db8:2::2", // not in 2001:db8:1::/48
 			},
 			alreadyAllocated: "2001:db8:1::1",
 		},
@@ -67,10 +68,9 @@ func TestAllocate(t *testing.T) {
 			free:     65535,
 			released: "2605:b100:283:1::e",
 			outOfRange: []string{
-				"2605:b100:283:0::1",   // not in 2605:b100:283:1::/64
-				"2605:b100:283:1::",    // reserved (base address)
-				"2605:b100:283:1::1:0", // not in the low 16 bits of 2605:b100:283:1::/64
-				"2605:b100:284:2::2",   // not in 2605:b100:283:1::/64
+				"2605:b100:283:0::1", // not in 2605:b100:283:1::/64
+				"2605:b100:283:1::",  // reserved (base address)
+				"2605:b100:284:2::2", // not in 2605:b100:283:1::/64
 			},
 			alreadyAllocated: "2605:b100:283:1::1",
 		},
@@ -286,5 +286,210 @@ func TestReserved(t *testing.T) {
 
 	if r.Reserved(net.ParseIP("192.168.1.254")) {
 		t.Errorf("should not be a reserved address: %s", "192.168.1.254")
+	}
+}
+
+func TestIPv6StaticAllocationBeyondBitmapCap(t *testing.T) {
+	testCases := []struct {
+		name  string
+		cidr  string
+		ips   []string
+		notIn []string // IPs truly outside the CIDR
+	}{
+		{
+			name: "/64 subnet",
+			cidr: "2001:db8:1::/64",
+			ips: []string{
+				"2001:db8:1::1:0",       // offset 65536
+				"2001:db8:1::2:0",       // offset 131072
+				"2001:db8:1::ffff:ffff", // large offset
+			},
+			notIn: []string{
+				"2001:db8:2::1", // different subnet
+			},
+		},
+		{
+			name: "/48 subnet",
+			cidr: "2001:db8:1::/48",
+			ips: []string{
+				"2001:db8:1::1:0",     // offset 65536
+				"2001:db8:1:1::1",     // offset in different /64 block
+				"2001:db8:1:ffff::99", // far into the /48
+			},
+			notIn: []string{
+				"2001:db8:2::1", // different /48
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cidr, err := net.ParseCIDR(tc.cidr)
+			if err != nil {
+				t.Fatalf("failed to parse CIDR %q: %v", tc.cidr, err)
+			}
+			r, err := NewCIDRRange(cidr)
+			if err != nil {
+				t.Fatalf("failed to create Range for CIDR %q: %v", tc.cidr, err)
+			}
+
+			// Allocate IPs beyond bitmap cap
+			for _, ipStr := range tc.ips {
+				ip := net.ParseIP(ipStr)
+				if err := r.Allocate(ip); err != nil {
+					t.Errorf("Allocate(%s) should succeed, got: %v", ipStr, err)
+				}
+				if !r.Has(ip) {
+					t.Errorf("Has(%s) should return true after allocation", ipStr)
+				}
+			}
+
+			// Double allocation must fail with ErrAllocated
+			for _, ipStr := range tc.ips {
+				ip := net.ParseIP(ipStr)
+				if err := r.Allocate(ip); err != ErrAllocated {
+					t.Errorf("Allocate(%s) twice should return ErrAllocated, got: %v", ipStr, err)
+				}
+			}
+
+			// IPs outside the CIDR must still be rejected
+			for _, ipStr := range tc.notIn {
+				ip := net.ParseIP(ipStr)
+				err := r.Allocate(ip)
+				if _, ok := err.(*ErrNotInRange); !ok {
+					t.Errorf("Allocate(%s) should return ErrNotInRange, got: %v", ipStr, err)
+				}
+			}
+
+			// Release and re-allocate
+			for _, ipStr := range tc.ips {
+				ip := net.ParseIP(ipStr)
+				r.Release(ip)
+				if r.Has(ip) {
+					t.Errorf("Has(%s) should return false after release", ipStr)
+				}
+				if err := r.Allocate(ip); err != nil {
+					t.Errorf("re-Allocate(%s) after release should succeed, got: %v", ipStr, err)
+				}
+			}
+
+			// ForEach must include out-of-range static IPs
+			found := sets.New[string]()
+			r.ForEach(func(ip net.IP) {
+				found.Insert(ip.String())
+			})
+			for _, ipStr := range tc.ips {
+				canonical := net.ParseIP(ipStr).String()
+				if !found.Has(canonical) {
+					t.Errorf("ForEach should include %s", ipStr)
+				}
+			}
+		})
+	}
+}
+
+func TestIPv6StaticAndDynamicCoexistence(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("2001:db8:1::/64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewCIDRRange(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Static allocation within bitmap range
+	inRange := net.ParseIP("2001:db8:1::100")
+	if err := r.Allocate(inRange); err != nil {
+		t.Fatalf("static Allocate within bitmap should succeed: %v", err)
+	}
+
+	// Static allocation beyond bitmap range
+	outRange := net.ParseIP("2001:db8:1::1:0")
+	if err := r.Allocate(outRange); err != nil {
+		t.Fatalf("static Allocate beyond bitmap should succeed: %v", err)
+	}
+
+	// Dynamic allocation should skip the in-range static IP
+	for i := 0; i < 200; i++ {
+		ip, err := r.AllocateNext()
+		if err != nil {
+			t.Fatalf("AllocateNext error at %d: %v", i, err)
+		}
+		if ip.Equal(inRange) {
+			t.Fatalf("AllocateNext returned statically allocated IP %s", inRange)
+		}
+	}
+
+	// Both IPs should report as allocated
+	if !r.Has(inRange) {
+		t.Error("Has should be true for in-range static IP")
+	}
+	if !r.Has(outRange) {
+		t.Error("Has should be true for out-of-range static IP")
+	}
+}
+
+func TestIPv6SmallSubnetUnaffected(t *testing.T) {
+	// /112 has exactly 65536 addresses, should work unchanged
+	_, cidr, err := net.ParseCIDR("2001:db8:1::/112")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewCIDRRange(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Last IP in /112 range should be allocatable
+	ip := net.ParseIP("2001:db8:1::fffe")
+	if err := r.Allocate(ip); err != nil {
+		t.Errorf("Allocate last-but-one IP in /112 should succeed: %v", err)
+	}
+
+	// IP outside /112 must be rejected
+	ipOutside := net.ParseIP("2001:db8:1::1:0")
+	err = r.Allocate(ipOutside)
+	if _, ok := err.(*ErrNotInRange); !ok {
+		t.Errorf("Allocate outside /112 should return ErrNotInRange, got: %v", err)
+	}
+}
+
+func TestIPv6StaticAllocationConcurrency(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("2001:db8:cafe::/64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewCIDRRange(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const count = 100
+	var wg sync.WaitGroup
+	errs := make(chan error, count)
+
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ip := net.ParseIP(fmt.Sprintf("2001:db8:cafe::%x:0", idx+1))
+			if err := r.Allocate(ip); err != nil {
+				errs <- fmt.Errorf("Allocate(%s): %w", ip, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+
+	for i := 0; i < count; i++ {
+		ip := net.ParseIP(fmt.Sprintf("2001:db8:cafe::%x:0", i+1))
+		if !r.Has(ip) {
+			t.Errorf("Has(%s) should be true after concurrent allocation", ip)
+		}
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This PR fixes a bug where the OVN-Kubernetes IPAM allocator incorrectly rejects valid IPv6 static IP addresses if their host-part offset from the subnet base exceeds 65,535. 

Currently, the IPv6 allocator caps the bitmap size at 65,536 entries for memory efficiency. However, the contains() validation strictly rejects any IP with an offset >= 65536, even if it is perfectly valid within a larger subnet CIDR (e.g., a /64). This breaks critical use cases, such as KubeVirt VirtualMachine static IP assignment on User-Defined Networks (UDNs), when users request IPs beyond the first 65,536 addresses.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
