### PR TITLE
RA controller: refresh status when failure reason or message changes

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	metaapply "k8s.io/client-go/applyconfigurations/meta/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -1618,26 +1617,6 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 		cstatus = metav1.ConditionFalse
 	}
 
-	var updateStatus bool
-	condition := meta.FindStatusCondition(ra.Status.Conditions, conditionTypeAccepted)
-	switch {
-	case condition == nil:
-		fallthrough
-	case condition.ObservedGeneration != ra.Generation:
-		fallthrough
-	case (err == nil) != (condition.Status == metav1.ConditionTrue):
-		fallthrough
-	case hadUpdates:
-		updateStatus = true
-	}
-	if !updateStatus {
-		// Record the metric from the existing API-confirmed condition so it is
-		// populated after controller restarts, where the informer fires synthetic
-		// creates for all RAs but the condition hasn't changed.
-		metrics.RecordRouteAdvertisementCondition(ra.Name, conditionTypeAccepted, cstatus)
-		return nil
-	}
-
 	status := "Accepted"
 	reason := "Accepted"
 	msg := "ovn-kubernetes cluster-manager validated the resource and requested the necessary configuration changes"
@@ -1654,17 +1633,41 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 		}
 	}
 
+	// MergeStatusCondition reports whether the condition differs from the
+	// existing one (in status, reason, message or observed generation),
+	// preserves the last transition time when the condition status is
+	// unchanged and trims the message to the maximum length allowed for
+	// conditions
+	condition, changed := util.MergeStatusCondition(ra.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeAccepted,
+		Status:             cstatus,
+		Reason:             reason,
+		Message:            msg,
+		ObservedGeneration: ra.Generation,
+	})
+	updateStatus := changed || hadUpdates
+	if !updateStatus {
+		// Record the metric from the existing API-confirmed condition so it is
+		// populated after controller restarts, where the informer fires synthetic
+		// creates for all RAs but the condition hasn't changed.
+		metrics.RecordRouteAdvertisementCondition(ra.Name, conditionTypeAccepted, cstatus)
+		return nil
+	}
+
+	if changed && err != nil {
+		// errConfig/errPending are not retried, so make them visible in the
+		// logs and not just in the status; log only when the condition changes
+		// to avoid repeating the same warning on every reconcile of a steady
+		// error state, which can otherwise still update the status through
+		// hadUpdates
+		klog.Warningf("Reconciling RouteAdvertisements %q failed: %v", ra.Name, err)
+	}
+
 	_, err = c.raClient.K8sV1().RouteAdvertisements().ApplyStatus(
 		context.Background(),
 		raapply.RouteAdvertisements(ra.Name).WithStatus(
 			raapply.RouteAdvertisementsStatus().WithStatus(status).WithConditions(
-				metaapply.Condition().
-					WithType(conditionTypeAccepted).
-					WithStatus(cstatus).
-					WithLastTransitionTime(metav1.NewTime(time.Now())).
-					WithReason(reason).
-					WithMessage(msg).
-					WithObservedGeneration(ra.Generation),
+				util.ConditionToApply(condition),
 			),
 		),
 		metav1.ApplyOptions{

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -460,6 +460,11 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 	if len(nads) == 0 {
 		return nil, nil, fmt.Errorf("%w: no networks selected", errPending)
 	}
+	// ordered, so that processing and error messages are deterministic across
+	// reconciles regardless of lister iteration order
+	slices.SortFunc(nads, func(a, b *nadtypes.NetworkAttachmentDefinition) int {
+		return strings.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
+	})
 
 	// validate and gather information about the networks
 	networkSet := sets.New[string]()
@@ -576,6 +581,9 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 	if len(nodes) == 0 {
 		return nil, nil, fmt.Errorf("%w: no nodes selected", errPending)
 	}
+	// ordered, so that processing and error messages are deterministic across
+	// reconciles regardless of lister iteration order
+	slices.SortFunc(nodes, func(a, b *corev1.Node) int { return strings.Compare(a.Name, b.Name) })
 	// prepare a map of selected nodes to the FRRConfigurations that apply to
 	// them
 	nodeToFRRConfig := map[string][]*frrtypes.FRRConfiguration{}
@@ -595,6 +603,11 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 	if len(frrConfigs) == 0 {
 		return nil, nil, fmt.Errorf("%w: no FRRConfigurations selected", errPending)
 	}
+	// ordered, so that processing and error messages are deterministic across
+	// reconciles regardless of lister iteration order
+	slices.SortFunc(frrConfigs, func(a, b *frrtypes.FRRConfiguration) int {
+		return strings.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
+	})
 
 	frrRouterVRFs := sets.New[string]()
 	for _, frrConfig := range frrConfigs {
@@ -769,7 +782,11 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 	}
 
 	generated := []*frrtypes.FRRConfiguration{}
-	for nodeName, frrConfigs := range nodeToFRRConfig {
+	// iterate nodes in their sorted order rather than ranging over the map, so
+	// that processing and error messages are deterministic across reconciles
+	for _, node := range nodes {
+		nodeName := node.Name
+		frrConfigs := nodeToFRRConfig[nodeName]
 		// reset node specific information
 		selectedNetworks.hostNetworkSubnets = map[string][]string{}
 		selectedNetworks.hostSubnets = []string{}

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -38,6 +38,7 @@ import (
 	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	eiptypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	rafake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
@@ -3539,4 +3540,101 @@ func TestUpdates(t *testing.T) {
 func getRAConditionMetricValue(nameLabel, conditionLabel, statusLabel string) (float64, bool) {
 	metricName := prometheus.BuildFQName(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemClusterManager, "route_advertisement_condition")
 	return ovntest.GetConditionMetricValue(metricName, nameLabel, conditionLabel, statusLabel)
+}
+
+// TestController_updateRAStatus verifies that the 'Accepted' condition is
+// refreshed when consecutive reconciles fail for different reasons, so that
+// the status message never gets stale.
+func TestController_updateRAStatus(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	fakeClientset := util.GetOVNClientset().GetClusterManagerClientset()
+	c := &Controller{raClient: fakeClientset.RouteAdvertisementsClient}
+
+	raName := "ra"
+	tra := &testRA{Name: raName}
+	_, err := fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), tra.RouteAdvertisements(), metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	t.Cleanup(func() { metrics.DeleteRouteAdvertisementCondition(raName) })
+
+	getRA := func() *ratypes.RouteAdvertisements {
+		ra, err := fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Get(context.Background(), raName, metav1.GetOptions{})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		return ra
+	}
+
+	// first reconcile fails with error A
+	err = c.updateRAStatus(getRA(), false, fmt.Errorf("%w: error A", errConfig))
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "first reconcile with error A should update the status")
+	accepted := meta.FindStatusCondition(getRA().Status.Conditions, "Accepted")
+	g.Expect(accepted).NotTo(gomega.BeNil(), "the Accepted condition should be set after the first reconcile")
+	g.Expect(accepted.Status).To(gomega.Equal(metav1.ConditionFalse), "the Accepted condition should be false after error A")
+	g.Expect(accepted.Reason).To(gomega.Equal("ConfigurationError"), "errConfig should be reported as ConfigurationError")
+	g.Expect(accepted.Message).To(gomega.ContainSubstring("error A"), "the message should report error A")
+
+	// rewind the condition transition time one hour into the past, so we can
+	// tell whether subsequent refreshes preserve or bump it: condition
+	// timestamps have one-second resolution and the whole test runs within a
+	// single second, so against a "now" timestamp an unchanged and a wrongly
+	// re-stamped transition time would look identical
+	rewound := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+	ra := getRA()
+	meta.FindStatusCondition(ra.Status.Conditions, "Accepted").LastTransitionTime = rewound
+	_, err = fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().UpdateStatus(context.Background(), ra, metav1.UpdateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "rewinding the condition transition time should succeed")
+
+	// second reconcile fails with error B for the same reason: the message
+	// must be refreshed
+	err = c.updateRAStatus(getRA(), false, fmt.Errorf("%w: error B", errConfig))
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "second reconcile with error B should update the status")
+	accepted = meta.FindStatusCondition(getRA().Status.Conditions, "Accepted")
+	g.Expect(accepted).NotTo(gomega.BeNil(), "the Accepted condition should still be set after error B")
+	g.Expect(accepted.Status).To(gomega.Equal(metav1.ConditionFalse), "the Accepted condition should stay false after error B")
+	g.Expect(accepted.Reason).To(gomega.Equal("ConfigurationError"), "errConfig should still be reported as ConfigurationError")
+	g.Expect(accepted.Message).To(gomega.ContainSubstring("error B"), "the message should be refreshed to error B")
+	g.Expect(accepted.LastTransitionTime.Time).To(gomega.BeTemporally("==", rewound.Time), "a message-only refresh should preserve the transition time")
+
+	// third reconcile fails with a different reason: reason and message must
+	// be refreshed
+	err = c.updateRAStatus(getRA(), false, fmt.Errorf("%w: error C", errPending))
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "third reconcile with error C should update the status")
+	accepted = meta.FindStatusCondition(getRA().Status.Conditions, "Accepted")
+	g.Expect(accepted).NotTo(gomega.BeNil(), "the Accepted condition should still be set after error C")
+	g.Expect(accepted.Status).To(gomega.Equal(metav1.ConditionFalse), "the Accepted condition should stay false after error C")
+	g.Expect(accepted.Reason).To(gomega.Equal("ConfigurationPending"), "errPending should be reported as ConfigurationPending")
+	g.Expect(accepted.Message).To(gomega.ContainSubstring("error C"), "the message should be refreshed to error C")
+	g.Expect(accepted.LastTransitionTime.Time).To(gomega.BeTemporally("==", rewound.Time), "a reason/message refresh should preserve the transition time")
+
+	// fourth reconcile fails with the same error: the status must not be
+	// applied again
+	countStatusPatches := func() int {
+		patches := 0
+		for _, action := range fakeClientset.RouteAdvertisementsClient.(*rafake.Clientset).Actions() {
+			if action.GetVerb() == "patch" {
+				patches++
+			}
+		}
+		return patches
+	}
+	patches := countStatusPatches()
+	err = c.updateRAStatus(getRA(), false, fmt.Errorf("%w: error C", errPending))
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "a reconcile with an unchanged error should succeed")
+	g.Expect(countStatusPatches()).To(gomega.Equal(patches), "an unchanged status must not be re-applied")
+
+	// fifth reconcile fails with the same error but had FRRConfig/NAD updates:
+	// the status must be applied even though the condition is unchanged
+	err = c.updateRAStatus(getRA(), true, fmt.Errorf("%w: error C", errPending))
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "a reconcile with updates should update the status")
+	g.Expect(countStatusPatches()).To(gomega.Equal(patches+1), "hadUpdates should apply the status even when the condition is unchanged")
+	accepted = meta.FindStatusCondition(getRA().Status.Conditions, "Accepted")
+	g.Expect(accepted.LastTransitionTime.Time).To(gomega.BeTemporally("==", rewound.Time), "a hadUpdates apply should preserve the transition time of an unchanged condition")
+
+	// sixth reconcile succeeds: the condition status flips and the transition
+	// time must be bumped
+	err = c.updateRAStatus(getRA(), false, nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "a successful reconcile should update the status")
+	accepted = meta.FindStatusCondition(getRA().Status.Conditions, "Accepted")
+	g.Expect(accepted).NotTo(gomega.BeNil(), "the Accepted condition should still be set after a successful reconcile")
+	g.Expect(accepted.Status).To(gomega.Equal(metav1.ConditionTrue), "the Accepted condition should be true after a successful reconcile")
+	g.Expect(accepted.LastTransitionTime.Time).To(gomega.BeTemporally(">", rewound.Time), "a status flip should bump the transition time")
 }


### PR DESCRIPTION
When consecutive reconciles of a RouteAdvertisements failed for different reasons, the first failure message stayed frozen in the Accepted condition, hiding the real blocker: `updateRAStatus` only rewrote the condition when its boolean flipped or the generation changed, not when reason or message did.

- Compare the computed condition with `util.MergeStatusCondition`, coherent with what the uplink controllers already do: it compares status, reason, message and observed generation, preserves `lastTransitionTime` when the condition status is unchanged, and trims the message to the CRD limit.
- Log configuration/pending errors, which were previously visible only in the status. The warning is emitted only when the status changes, so an RA sitting in a steady error state doesn't repeat it on every reconcile.
- Sort selected NADs, nodes and FRRConfigurations before iterating, so that the same error state always produces the same message; otherwise, with more than one offending item, every reconcile could name a different offender and churn status updates indefinitely.