### PR TITLE
endpointslicemirror: keep VM endpoints eligible during live migration

### DIFF
--- a/docs/features/user-defined-networks/user-defined-networks.md
+++ b/docs/features/user-defined-networks/user-defined-networks.md
@@ -621,6 +621,15 @@ For host-networked pods, the controller retains the same IP addresses as the
 default controller. Custom EndpointSlices not created by the default controller
 are not processed.
 
+The mirror controller makes one exception for KubeVirt live migration. During
+a non-failed migration, the source and target `virt-launcher` pods can both be
+reported as not ready even though the virtual machine remains available on its
+persistent IP address. The controller keeps these VM-owned endpoints ready and
+serving, and reports them as not terminating, so the service load balancer does
+not remove the VM backend during the handoff. This override does not apply after
+a failed migration or to pods that are not owned by a virtual machine; those
+endpoints retain the conditions reported by the default EndpointSlice.
+
 The default EndpointSlices controller creates objects that contain the following labels:
 
 - `endpointslice.kubernetes.io/managed-by:endpointslice-controller.k8s.io` - Indicates

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
@@ -23,9 +24,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -368,16 +371,11 @@ func isManagedByDefault(endpointSlice *v1.EndpointSlice) bool {
 	return types.EndpointSliceDefaultControllerName == endpointSlice.Labels[v1.LabelManagedBy]
 }
 
-// getPodIP retrieves the IP address of a specified Pod within a given namespace and network.
+// getPodIP retrieves the IP address of the given Pod on the given network.
 // If the pod is host networked it returns default pod IP from the status ignoring the network.
 // Otherwise, it unmarshals the Pod's network annotation, and matches the IP from the provided network.
-func (c *Controller) getPodIP(name, namespace, nadKey string, isIPv6 bool) (string, error) {
+func getPodIP(pod *corev1.Pod, nadKey string, isIPv6 bool) (string, error) {
 	var podIP string
-	pod, err := c.podLister.Pods(namespace).Get(name)
-	if err != nil {
-		return "", err
-	}
-
 	if pod.Spec.HostNetwork {
 		podIPs, err := util.DefaultNetworkPodIPs(pod)
 		if err != nil {
@@ -406,6 +404,36 @@ func (c *Controller) getPodIP(name, namespace, nadKey string, isIPv6 bool) (stri
 	}
 
 	return podIP, nil
+}
+
+// keepEndpointEligibleDuringLiveMigration keeps a mirrored endpoint eligible
+// while the KubeVirt virtual machine backing it is being live migrated.
+// During the handoff between the source and the target virt-launcher pods
+// both of their endpoints are briefly reported as not ready; mirroring that
+// would leave the service load balancers with no backends, and since the
+// load balancers are configured with reject=true, OVN would answer the
+// in-flight packets of established connections with TCP RST, permanently
+// breaking connections that the migration is supposed to preserve. The VM
+// keeps serving on its (persistent) network IP throughout a non-failed live
+// migration, so its endpoint is kept ready for the duration.
+func (c *Controller) keepEndpointEligibleDuringLiveMigration(pod *corev1.Pod, endpoint *v1.Endpoint) {
+	if util.IsEndpointReady(*endpoint) || !kubevirt.IsPodOwnedByVirtualMachine(pod) {
+		return
+	}
+	migrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(c.podLister, pod)
+	if err != nil {
+		klog.Warningf("Failed to discover live migration status of pod %s/%s while mirroring EndpointSlices: %v",
+			pod.Namespace, pod.Name, err)
+		return
+	}
+	if migrationStatus == nil || migrationStatus.State == kubevirt.LiveMigrationFailed {
+		return
+	}
+	// The conditions describe the VM, which is serving and not going away
+	// even when the virt-launcher pod holding this endpoint is terminating.
+	endpoint.Conditions.Ready = ptr.To(true)
+	endpoint.Conditions.Serving = ptr.To(true)
+	endpoint.Conditions.Terminating = ptr.To(false)
 }
 
 // mirrorEndpointSlice creates or updates a mirrored EndpointSlice based on the provided defaultEndpointSlice.
@@ -452,12 +480,17 @@ func (c *Controller) mirrorEndpointSlice(mirroredEndpointSlice, defaultEndpointS
 	isIPv6 := defaultEndpointSlice.AddressType == v1.AddressTypeIPv6
 	for i, endpoint := range defaultEndpointSlice.Endpoints {
 		if endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod" {
-			podIP, err := c.getPodIP(endpoint.TargetRef.Name, endpoint.TargetRef.Namespace, nadKey, isIPv6)
+			pod, err := c.podLister.Pods(endpoint.TargetRef.Namespace).Get(endpoint.TargetRef.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Pod %s/%s: %w", endpoint.TargetRef.Namespace, endpoint.TargetRef.Name, err)
+			}
+			podIP, err := getPodIP(pod, nadKey, isIPv6)
 			if err != nil {
 				return nil, fmt.Errorf("failed to determine the Pod IP of: %s/%s: %v", endpoint.TargetRef.Namespace, endpoint.TargetRef.Name, err)
 			}
 			newEp := endpoint.DeepCopy()
 			newEp.Addresses = []string{podIP}
+			c.keepEndpointEligibleDuringLiveMigration(pod, newEp)
 			currentMirror.Endpoints[i] = *newEp
 		}
 	}

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/id"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -515,6 +517,210 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("on KubeVirt live migration", func() {
+		const (
+			vmName = "test-vm"
+
+			subnetsIPv4 = "10.132.2.0/24"
+			subnetsIPv6 = "fd10:0:2::/64"
+
+			podIPv4 = "10.244.2.3"
+			podIPv6 = "fd00:10:244::3"
+			vmIPv4  = "10.132.2.4"
+			vmIPv6  = "fd10:0:2::4"
+		)
+
+		newVirtLauncherPod := func(namespace, name string, creationTime time.Time, podIP, vmIP string) *corev1.Pod {
+			pod := testing.NewPodWithPrimaryNADIP(namespace, name, "", podIP, "l2-network", vmIP)
+			pod.CreationTimestamp = metav1.NewTime(creationTime)
+			pod.Labels = map[string]string{
+				kubevirtv1.AppLabel:                "virt-launcher",
+				kubevirtv1.VirtualMachineNameLabel: vmName,
+			}
+			// Note no AllowPodBridgeNetworkLiveMigrationAnnotation: VMs on a
+			// primary user defined network do not carry it.
+			pod.Annotations[kubevirtv1.DomainAnnotation] = vmName
+			return pod
+		}
+
+		notReadyEndpoint := func(namespace, podName, podIP string) discovery.Endpoint {
+			return discovery.Endpoint{
+				Addresses:  []string{podIP},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(false), Serving: ptr.To(false)},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: namespace,
+					Name:      podName,
+				},
+			}
+		}
+
+		terminatingEndpoint := func(namespace, podName, podIP string) discovery.Endpoint {
+			endpoint := notReadyEndpoint(namespace, podName, podIP)
+			endpoint.Conditions.Serving = ptr.To(true)
+			endpoint.Conditions.Terminating = ptr.To(true)
+			return endpoint
+		}
+
+		type endpointConditions struct {
+			ready   bool
+			serving bool
+		}
+
+		eligible := endpointConditions{ready: true, serving: true}
+		ineligible := endpointConditions{ready: false, serving: false}
+
+		expectMirroredEndpoints := func(namespace, defaultEndpointSliceName, vmIP string, expected []endpointConditions) {
+			ginkgo.GinkgoHelper()
+			gomega.Eventually(func(g gomega.Gomega) {
+				mirroredEndpointSlices, err := util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSliceName, namespace, controller.endpointSliceLister)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(mirroredEndpointSlices).To(gomega.HaveLen(1), "should have one mirrored EndpointSlice")
+				endpoints := mirroredEndpointSlices[0].Endpoints
+				g.Expect(endpoints).To(gomega.HaveLen(len(expected)), "should have the expected len")
+				for i, expectedConditions := range expected {
+					endpoint := endpoints[i]
+					g.Expect(endpoint.Addresses).To(gomega.Equal([]string{vmIP}), "should have VM ip")
+					g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointReady, gomega.Equal(expectedConditions.ready)), "should match expected ready condition state")
+
+					g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointServing, gomega.Equal(expectedConditions.serving)), "should match expected serving condition state")
+
+					if expectedConditions.ready {
+						g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointTerminating, gomega.BeFalse()), "should not be reported as terminating if the endpoint is ready")
+					}
+				}
+			}).WithTimeout(5 * time.Second).Should(gomega.Succeed())
+		}
+
+		newDefaultEndpointSlice := func(namespace string, addressType discovery.AddressType, endpoints ...discovery.Endpoint) discovery.EndpointSlice {
+			return discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-endpointslice",
+					Namespace: namespace,
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc",
+						discovery.LabelManagedBy:   types.EndpointSliceDefaultControllerName,
+					},
+				},
+				AddressType: addressType,
+				Endpoints:   endpoints,
+			}
+		}
+
+		startWithNAD := func(subnets string, objs ...runtime.Object) {
+			start(objs...)
+			nad := testing.GenerateNAD("l2-network", "l2-network", "testns", types.Layer2Topology, subnets, types.NetworkRolePrimary)
+			_, err := fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions("testns").Create(
+				context.TODO(), nad, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		}
+
+		ginkgo.DescribeTable("should preserve the endpoints of the migrating VM to prevent the reset of established connections",
+			func(addressType discovery.AddressType, subnets, podIP, vmIP string) {
+				app.Action = func(*cli.Context) error {
+					namespaceT := *util.NewNamespace("testns")
+					namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
+					// During the handoff both virt-launcher pods are briefly
+					// not ready while the VM keeps serving on its IP.
+					sourcePod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-source", time.Now().Add(-time.Minute), podIP, vmIP)
+					targetPod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-target", time.Now(), podIP, vmIP)
+					defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, addressType,
+						notReadyEndpoint(namespaceT.Name, sourcePod.Name, podIP),
+						notReadyEndpoint(namespaceT.Name, targetPod.Name, podIP))
+
+					// Activate dual stack cluster so we can use test all the
+					// ip families configurations
+					config.IPv4Mode = true
+					config.IPv6Mode = true
+
+					startWithNAD(subnets,
+						&corev1.PodList{Items: []corev1.Pod{*sourcePod, *targetPod}},
+						&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
+						&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+					)
+
+					expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIP, []endpointConditions{eligible, eligible})
+					return nil
+				}
+
+				gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+			},
+			ginkgo.Entry("IPv4", discovery.AddressTypeIPv4, subnetsIPv4, podIPv4, vmIPv4),
+			ginkgo.Entry("IPv6", discovery.AddressTypeIPv6, subnetsIPv6, podIPv6, vmIPv6),
+		)
+
+		ginkgo.It("should not report a terminating source virt-launcher endpoint as terminating while its VM is migrating", func() {
+			app.Action = func(*cli.Context) error {
+				namespaceT := *util.NewNamespace("testns")
+				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
+				// The source pod is terminating once the target domain took
+				// over, but the VM keeps serving on its IP.
+				now := time.Now()
+				sourcePod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-source", now.Add(-time.Minute), podIPv4, vmIPv4)
+				targetPod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-target", now, podIPv4, vmIPv4)
+				defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
+					terminatingEndpoint(namespaceT.Name, sourcePod.Name, podIPv4),
+					notReadyEndpoint(namespaceT.Name, targetPod.Name, podIPv4))
+
+				startWithNAD(subnetsIPv4,
+					&corev1.PodList{Items: []corev1.Pod{*sourcePod, *targetPod}},
+					&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
+					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+				)
+
+				expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIPv4, []endpointConditions{eligible, eligible})
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("should not preserve endpoint availability when the VM live migration failed", func() {
+			app.Action = func(*cli.Context) error {
+				namespaceT := *util.NewNamespace("testns")
+				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
+				sourcePod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-source", time.Now().Add(-time.Minute), podIPv4, vmIPv4)
+				targetPod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-target", time.Now(), podIPv4, vmIPv4)
+				targetPod.Status.Phase = corev1.PodFailed
+				defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
+					notReadyEndpoint(namespaceT.Name, sourcePod.Name, podIPv4),
+					notReadyEndpoint(namespaceT.Name, targetPod.Name, podIPv4))
+
+				startWithNAD(subnetsIPv4,
+					&corev1.PodList{Items: []corev1.Pod{*sourcePod, *targetPod}},
+					&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
+					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+				)
+
+				expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIPv4, []endpointConditions{ineligible, ineligible})
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("should not preserve endpoint availability of non-kubevirt VM pods", func() {
+			app.Action = func(*cli.Context) error {
+				namespaceT := *util.NewNamespace("testns")
+				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
+				pod := testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod", "", podIPv4, "l2-network", vmIPv4)
+				defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
+					notReadyEndpoint(namespaceT.Name, pod.Name, podIPv4))
+
+				startWithNAD(subnetsIPv4,
+					&corev1.PodList{Items: []corev1.Pod{*pod}},
+					&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
+					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+				)
+
+				expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIPv4, []endpointConditions{ineligible})
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 		})
 	})
 })

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
@@ -536,10 +536,8 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 		newVirtLauncherPod := func(namespace, name string, creationTime time.Time, podIP, vmIP string) *corev1.Pod {
 			pod := testing.NewPodWithPrimaryNADIP(namespace, name, "", podIP, "l2-network", vmIP)
 			pod.CreationTimestamp = metav1.NewTime(creationTime)
-			pod.Labels = map[string]string{
-				kubevirtv1.AppLabel:                "virt-launcher",
-				kubevirtv1.VirtualMachineNameLabel: vmName,
-			}
+			pod.Labels[kubevirtv1.AppLabel] = "virt-launcher"
+			pod.Labels[kubevirtv1.VirtualMachineNameLabel] = vmName
 			// Note no AllowPodBridgeNetworkLiveMigrationAnnotation: VMs on a
 			// primary user defined network do not carry it.
 			pod.Annotations[kubevirtv1.DomainAnnotation] = vmName
@@ -573,22 +571,22 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 		eligible := endpointConditions{ready: true, serving: true}
 		ineligible := endpointConditions{ready: false, serving: false}
 
-		expectMirroredEndpoints := func(namespace, defaultEndpointSliceName, vmIP string, expected []endpointConditions) {
+		expectMirroredEndpoints := func(namespace, defaultNetworkEndpointSliceName, vmIP string, expected []endpointConditions) {
 			ginkgo.GinkgoHelper()
 			gomega.Eventually(func(g gomega.Gomega) {
-				mirroredEndpointSlices, err := util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultEndpointSliceName, namespace, controller.endpointSliceLister)
+				mirroredEndpointSlices, err := util.GetMirroredEndpointSlices(types.EndpointSliceMirrorControllerName, defaultNetworkEndpointSliceName, namespace, controller.endpointSliceLister)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(mirroredEndpointSlices).To(gomega.HaveLen(1), "should have one mirrored EndpointSlice")
 				endpoints := mirroredEndpointSlices[0].Endpoints
 				g.Expect(endpoints).To(gomega.HaveLen(len(expected)), "should have the expected len")
-				for i, expectedConditions := range expected {
+				for i, expectedCondition := range expected {
 					endpoint := endpoints[i]
 					g.Expect(endpoint.Addresses).To(gomega.Equal([]string{vmIP}), "should have VM ip")
-					g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointReady, gomega.Equal(expectedConditions.ready)), "should match expected ready condition state")
+					g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointReady, gomega.Equal(expectedCondition.ready)), "should match expected ready condition state")
 
-					g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointServing, gomega.Equal(expectedConditions.serving)), "should match expected serving condition state")
+					g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointServing, gomega.Equal(expectedCondition.serving)), "should match expected serving condition state")
 
-					if expectedConditions.ready {
+					if expectedCondition.ready {
 						g.Expect(endpoint).To(gomega.WithTransform(util.IsEndpointTerminating, gomega.BeFalse()), "should not be reported as terminating if the endpoint is ready")
 					}
 				}
@@ -620,6 +618,10 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 		ginkgo.DescribeTable("should preserve the endpoints of the migrating VM to prevent the reset of established connections",
 			func(addressType discovery.AddressType, subnets, podIP, vmIP string) {
+				// Enable dual stack so the table can exercise both IP families.
+				config.IPv4Mode = true
+				config.IPv6Mode = true
+
 				app.Action = func(*cli.Context) error {
 					namespaceT := *util.NewNamespace("testns")
 					namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
@@ -627,22 +629,17 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					// not ready while the VM keeps serving on its IP.
 					sourcePod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-source", time.Now().Add(-time.Minute), podIP, vmIP)
 					targetPod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-target", time.Now(), podIP, vmIP)
-					defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, addressType,
+					defaultNetworkEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, addressType,
 						notReadyEndpoint(namespaceT.Name, sourcePod.Name, podIP),
 						notReadyEndpoint(namespaceT.Name, targetPod.Name, podIP))
-
-					// Activate dual stack cluster so we can use test all the
-					// ip families configurations
-					config.IPv4Mode = true
-					config.IPv6Mode = true
 
 					startWithNAD(subnets,
 						&corev1.PodList{Items: []corev1.Pod{*sourcePod, *targetPod}},
 						&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
-						&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+						&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultNetworkEndpointSlice}},
 					)
 
-					expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIP, []endpointConditions{eligible, eligible})
+					expectMirroredEndpoints(namespaceT.Name, defaultNetworkEndpointSlice.Name, vmIP, []endpointConditions{eligible, eligible})
 					return nil
 				}
 
@@ -661,62 +658,62 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 				now := time.Now()
 				sourcePod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-source", now.Add(-time.Minute), podIPv4, vmIPv4)
 				targetPod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-target", now, podIPv4, vmIPv4)
-				defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
+				defaultNetworkEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
 					terminatingEndpoint(namespaceT.Name, sourcePod.Name, podIPv4),
 					notReadyEndpoint(namespaceT.Name, targetPod.Name, podIPv4))
 
 				startWithNAD(subnetsIPv4,
 					&corev1.PodList{Items: []corev1.Pod{*sourcePod, *targetPod}},
 					&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
-					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultNetworkEndpointSlice}},
 				)
 
-				expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIPv4, []endpointConditions{eligible, eligible})
+				expectMirroredEndpoints(namespaceT.Name, defaultNetworkEndpointSlice.Name, vmIPv4, []endpointConditions{eligible, eligible})
 				return nil
 			}
 
 			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 		})
 
-		ginkgo.It("should not preserve endpoint availability when the VM live migration failed", func() {
+		ginkgo.It("should leave endpoint conditions unchanged when the VM live migration failed", func() {
 			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
 				sourcePod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-source", time.Now().Add(-time.Minute), podIPv4, vmIPv4)
 				targetPod := newVirtLauncherPod(namespaceT.Name, "virt-launcher-target", time.Now(), podIPv4, vmIPv4)
 				targetPod.Status.Phase = corev1.PodFailed
-				defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
+				defaultNetworkEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
 					notReadyEndpoint(namespaceT.Name, sourcePod.Name, podIPv4),
 					notReadyEndpoint(namespaceT.Name, targetPod.Name, podIPv4))
 
 				startWithNAD(subnetsIPv4,
 					&corev1.PodList{Items: []corev1.Pod{*sourcePod, *targetPod}},
 					&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
-					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultNetworkEndpointSlice}},
 				)
 
-				expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIPv4, []endpointConditions{ineligible, ineligible})
+				expectMirroredEndpoints(namespaceT.Name, defaultNetworkEndpointSlice.Name, vmIPv4, []endpointConditions{ineligible, ineligible})
 				return nil
 			}
 
 			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 		})
 
-		ginkgo.It("should not preserve endpoint availability of non-kubevirt VM pods", func() {
+		ginkgo.It("should leave endpoint conditions unchanged for non-KubeVirt pods", func() {
 			app.Action = func(*cli.Context) error {
 				namespaceT := *util.NewNamespace("testns")
 				namespaceT.Labels[types.RequiredUDNNamespaceLabel] = ""
 				pod := testing.NewPodWithPrimaryNADIP(namespaceT.Name, "test-pod", "", podIPv4, "l2-network", vmIPv4)
-				defaultEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
+				defaultNetworkEndpointSlice := newDefaultEndpointSlice(namespaceT.Name, discovery.AddressTypeIPv4,
 					notReadyEndpoint(namespaceT.Name, pod.Name, podIPv4))
 
 				startWithNAD(subnetsIPv4,
 					&corev1.PodList{Items: []corev1.Pod{*pod}},
 					&corev1.NamespaceList{Items: []corev1.Namespace{namespaceT}},
-					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultEndpointSlice}},
+					&discovery.EndpointSliceList{Items: []discovery.EndpointSlice{defaultNetworkEndpointSlice}},
 				)
 
-				expectMirroredEndpoints(namespaceT.Name, defaultEndpointSlice.Name, vmIPv4, []endpointConditions{ineligible})
+				expectMirroredEndpoints(namespaceT.Name, defaultNetworkEndpointSlice.Name, vmIPv4, []endpointConditions{ineligible})
 				return nil
 			}
 


### PR DESCRIPTION
## 📑 Description

Second of the two fixes for the KubeVirt live-migration ingress flake (#6581).

During live migration the source and target virt-launcher endpoints are both briefly reported as not ready. The mirror controller copies that verbatim, so the mirrored EndpointSlice has no eligible endpoints, the service load balancers end up with no backends and, with `reject=true`, OVN answers the in-flight packets of established connections with TCP RST — permanently breaking the NodePort connections the migration is supposed to preserve.

This keeps the mirrored endpoint ready while the VM has a non-failed live migration in flight. Endpoints of failed migrations and of pods not owned by a virtual machine are mirrored unchanged.

Related to #6581. Companion to #6598, which fixes the other mechanism (the CNI DEL conntrack flush when the NodePort entry node is also the migration source). The diagnostics and downtime reporting used to find and validate this are in #6751.

## Additional Information for reviewers
N/S

## ✅ Checks
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests in `go-controller/pkg/clustermanager/endpointslicemirror`.

Validated on a kind cluster matching the CI kv-live-migration lane (shared gw, dualstack, noSnatGW, 3 workers, network-segmentation, ic-single-node-zones), live migrating a VM in a loop while an external client held an established iperf3 connection to the VM through a NodePort service:

| | before | after |
|---|---|---|
| ingress stalls | reproduced repeatedly, permanent | **0 in 55 migrations** |
| TCP RSTs on the NodePort | 341 and 115 in the two captured failures | **0** |
| LB backends during handoff | emptied | never emptied |
| mirrored endpoint kept ready during handoff | n/a | **33 times** (twice per migration) |
