### PR TITLE
Uplink: fix Resolved condition arbitration between DPU and DPU-host

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -235,6 +235,7 @@ jobs:
           export DYNAMIC_UDN_ALLOCATION=true
           make -C test control-plane WHAT="Network Segmentation Uplink route advertisements uses the Uplink interface as the targetVRF auto BGP peering path"
           make -C test control-plane WHAT="Uplink route advertisements with Dynamic UDN allocation allows node-disjoint Dynamic CUDNs to share a targetVRF auto Uplink and rejects overlap"
+          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions keeps one writer per condition and recovers a missing host interface"
 
       - name: Export kind logs on failure
         if: failure()

--- a/docs/features/user-defined-networks/uplinks.md
+++ b/docs/features/user-defined-networks/uplinks.md
@@ -395,6 +395,15 @@ Common problems:
   `DefaultGatewayBridgeUnsupported`: the selected bridge is the cluster
   default shared gateway bridge, which cannot currently be reused as an
   Uplink.
+* `UplinkState` with `Resolved` condition status `False` and reason
+  `WaitingForDPUHost` (split DPU mode only): the DPU side is waiting for the
+  DPU-Host to publish complete host interface data. Check the `HostDataReady`
+  condition on the same `UplinkState` for the DPU-Host-side cause.
+* `UplinkState` with `HostDataReady` condition status `False` (split DPU mode
+  only): host interface data discovery failed on the DPU-Host; the reason
+  carries the cause, for example `HostInterfaceNotFound` when the selected
+  `hostInterfaceName` does not exist on the DPU-Host, or
+  `GatewayInfoUnavailable` when the interface has no IP addresses yet.
 * `UplinkState` with `GatewayReady` condition status `False` and reason
   `GatewayConfigurationPending`: the active CUDN set changed and complete
   gateway programming has not converged yet.
@@ -428,6 +437,12 @@ Common problems:
 * CUDN with `UplinksReady` condition status `False` and reason
   `UplinkUnsupportedTransport`: the CUDN uses EVPN transport, which is not
   supported with Uplinks.
+
+In split DPU mode each `UplinkState` condition has a single writer: the
+DPU-Host publishes the host interface data and the `HostDataReady` condition,
+while ovnkube-node on the DPU publishes `Resolved` and `GatewayReady`. Bridge
+reasons (`BridgeNotFound`, `BridgeUplinkNotFound`) therefore always describe
+OVS on the DPU, and `HostDataReady` reasons always describe the DPU-Host.
 
 ## References
 

--- a/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
+++ b/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
@@ -991,11 +991,14 @@ path.
 ### Uplink
 
 * If the selected host interface is missing, or the resolved OVS bridge is missing or malformed on a node, the matching
-  `UplinkState` reports `Resolved=False`. Retries continue, and local netlink/OVS change notifications or periodic resync
-  requeue the Uplink when admin-owned host or OVS state changes.
+  `UplinkState` reports `Resolved=False`. Retries continue while unresolved: discovery reports the failure in the
+  `UplinkState` and returns an error, and its controller retries with rate-limited backoff and unbounded attempts,
+  re-polling admin-owned host and OVS state, which generates no Kubernetes watch events. Once a side reports success,
+  its published data is refreshed on the next Kubernetes-triggered reconcile.
 * Per-node failures are reported on the matching `UplinkState`; `Uplink.status.conditions` reports aggregate health only.
-* If an admin deletes or changes the OVS bridge, OVN-Kubernetes does not recreate or repair the bridge. It updates status
-  and retries validation.
+* If an admin deletes or changes the OVS bridge, OVN-Kubernetes does not recreate or repair the bridge. While discovery
+  is unresolved, it updates status and retries validation. A converged `Resolved=True` status is not re-validated until
+  the next Kubernetes event or ovnkube-node restart triggers a reconcile.
 * If an admin requests deletion of a `Uplink` while one or more CUDNs reference it, OVN-Kubernetes keeps the `Uplink`
   finalizer and deletion remains pending. This prevents accidental disruption of active CUDNs. Since `spec.uplinks` is
   immutable in this OKEP, clearing the reference requires deleting or recreating the CUDN without that `Uplink`. Once no

--- a/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
+++ b/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
@@ -414,7 +414,8 @@ discovery state:
 * `DefaultGatewayBridgeUnsupported`: the resolved bridge is the node's default shared gateway bridge, which cannot be
   selected as an `Uplink` in this OKEP.
 * `InvalidHostInterface`: the selected host interface resolves to an unsupported bridge role, such as the bridge's
-  physical uplink port instead of its host gateway interface.
+  physical uplink port instead of its host gateway interface, or the interface has no usable MAC address (missing,
+  all-zero or multicast) on the node or DPU-Host.
 * `GatewayInfoUnavailable`: OVN-Kubernetes cannot discover the gateway MAC/IP data needed for OVN configuration.
 * `WaitingForDPUHost`: DPU-side reconciliation is waiting for the DPU-Host to publish complete host-side L3 data. The
   DPU-Host-side cause is reported on the `HostDataReady` condition.
@@ -426,7 +427,7 @@ If the `Uplink` no longer selects the node, the Uplink discovery reconciler dele
 instead of retaining stale state with `Resolved=False`.
 
 In split DPU mode the `HostDataReady` condition reports host interface data discovery on the DPU-Host:
-`HostDataReady=True` with reason `HostDataDiscovered` once discovery succeeds (which guarantees a MAC and an
+`HostDataReady=True` with reason `HostDataDiscovered` once discovery succeeds (which guarantees a usable MAC and an
 address for each enabled IP family, so the DPU side can consume the data), and `HostDataReady=False` with a host-side
 discovery reason (`HostInterfaceNotFound`, `InvalidHostInterface`, `GatewayInfoUnavailable`, `NodeSelectorOverlap`)
 otherwise. Full mode does not publish this condition.

--- a/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
+++ b/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
@@ -397,9 +397,11 @@ stored per `UplinkState`. `UplinkState` stores only reusable per-node host gatew
 
 #### UplinkState conditions
 
-`UplinkState.status.conditions` reports two independent node-local conditions. The Uplink discovery reconciler owns
-`Resolved`, while a node-level Uplink gateway coordinator owns `GatewayReady`; a gateway programming failure does not
-overwrite successful Uplink resolution. Individual CUDN gateway reconcilers do not write `GatewayReady` directly.
+`UplinkState.status.conditions` reports independent node-local conditions, and each condition has a single writer.
+The Uplink discovery reconciler owns `Resolved` (published by the DPU side in split DPU mode), the DPU-Host discovery
+reconciler owns `HostDataReady` (split DPU mode only), and a node-level Uplink gateway coordinator owns `GatewayReady`;
+a gateway programming failure does not overwrite successful Uplink resolution. Individual CUDN gateway reconcilers do
+not write `GatewayReady` directly.
 
 The `Resolved` condition reports host interface, gateway data, and OVS bridge discovery. Reasons describe the current
 discovery state:
@@ -414,14 +416,20 @@ discovery state:
 * `InvalidHostInterface`: the selected host interface resolves to an unsupported bridge role, such as the bridge's
   physical uplink port instead of its host gateway interface.
 * `GatewayInfoUnavailable`: OVN-Kubernetes cannot discover the gateway MAC/IP data needed for OVN configuration.
-* `WaitingForDPU`: DPU-Host has published host-side data but is waiting for DPU-side bridge validation.
-* `WaitingForDPUHost`: DPU-side reconciliation is waiting for the DPU-Host to publish host-side L3 data.
+* `WaitingForDPUHost`: DPU-side reconciliation is waiting for the DPU-Host to publish complete host-side L3 data. The
+  DPU-Host-side cause is reported on the `HostDataReady` condition.
 * `NodeSelectorOverlap`: more than one `Uplink.spec.nodeConfigs` entry applies to this node, so OVN-Kubernetes cannot
   select a single node config for this `Uplink`/node pair.
 
 When discovery is complete, `Resolved=True` with reason `Resolved`. For the other reasons above, `Resolved=False`.
 If the `Uplink` no longer selects the node, the Uplink discovery reconciler deletes the corresponding `UplinkState`
 instead of retaining stale state with `Resolved=False`.
+
+In split DPU mode the `HostDataReady` condition reports host interface data discovery on the DPU-Host:
+`HostDataReady=True` with reason `HostDataDiscovered` once discovery succeeds (which guarantees a MAC and an
+address for each enabled IP family, so the DPU side can consume the data), and `HostDataReady=False` with a host-side
+discovery reason (`HostInterfaceNotFound`, `InvalidHostInterface`, `GatewayInfoUnavailable`, `NodeSelectorOverlap`)
+otherwise. Full mode does not publish this condition.
 
 The `GatewayReady` condition reports aggregate gateway programming for the complete set of CUDNs active on the resolved
 Uplink path on this node. The node-level coordinator is the sole writer of this condition and serializes reconciliation
@@ -697,8 +705,8 @@ treats the route set as pending for that network rather than importing routes fr
 * Aggregates `UplinkState.status.conditions[Resolved]` into `Uplink.status.conditions[Ready]`. For node-scoped failures,
   the condition message includes a bounded count and sample of affected nodes and underlying reasons such as
   `HostInterfaceNotFound`, `BridgeNotFound`, `BridgeUplinkNotFound`, `BridgeInvalid`,
-  `DefaultGatewayBridgeUnsupported`, `InvalidHostInterface`, `GatewayInfoUnavailable`, `WaitingForDPU`,
-  `WaitingForDPUHost`, and `NodeSelectorOverlap`.
+  `DefaultGatewayBridgeUnsupported`, `InvalidHostInterface`, `GatewayInfoUnavailable`, `WaitingForDPUHost`, and
+  `NodeSelectorOverlap`.
 * Derives CUDN reason `UplinkOverlapOnNode` from affected `UplinkState` objects with reason `NodeSelectorOverlap`.
 * Resolves nodes selected by a referencing active CUDN but not selected by any `Uplink.spec.nodeConfigs` entry into CUDN
   reason `UplinkNotFoundForNode`.
@@ -778,7 +786,7 @@ DPU-Host reconciler:
 4. Determine the CUDN's effective routing domain from matching `RouteAdvertisements`. Attach the selected host interface
    to the host-side CUDN VRF only for per-CUDN VRF-Lite isolation; otherwise leave it in the default VRF.
 5. Update this node's `UplinkState.status` with `hostInterfaceName`, `macAddress`, `ipAddresses`, `defaultGateways`, and
-   host-side discovery conditions.
+   the `HostDataReady` condition. The DPU-Host does not write the `Resolved` condition; the DPU side owns it.
 
 DPU-side reconciler:
 
@@ -787,7 +795,8 @@ DPU-side reconciler:
 3. Detect the DPU-side host gateway/PF representor by matching the host interface MAC to the existing representor peer
    relationship. The bridge is pre-provisioned, so the representor must already be attached to an OVS bridge on the DPU.
 4. Resolve the OVS bridge that contains the representor, validate the bridge layout, and publish `status.ovsBridge.name`
-   plus DPU-side bridge validation conditions in `UplinkState`.
+   plus the `Resolved` condition in `UplinkState`. While host data is missing or incomplete, publish `Resolved=False`
+   with reason `WaitingForDPUHost`.
 5. Create or reconcile the DPU-local route-import VRF for the CUDN only when the CUDN resolves to per-CUDN VRF-Lite
    isolation. This VRF uses the same name that `RouteAdvertisements targetVRF: auto` resolves to for the CUDN.
 6. For per-CUDN VRF-Lite isolation, use the resolved bridge's `LOCAL` interface as the DPU-local FRR peering interface
@@ -802,8 +811,9 @@ DPU-side reconciler:
 Although both DPU-Host and DPU-side reconcilers update the same `UplinkState`, updates are dependency ordered and low
 frequency. The DPU side waits for the DPU-Host to publish host-side gateway data, especially `status.macAddress`, before
 resolving and publishing DPU-local bridge data such as `status.ovsBridge.name`. Implementations should use status patches
-or server-side apply field ownership for the fields each side owns, so normal retry-on-conflict handling is sufficient
-and the object should not become a hot write target.
+or server-side apply field ownership for the fields each side owns, and each status condition has a single writer
+(`HostDataReady` on the DPU-Host, `Resolved` and `GatewayReady` on the DPU), so normal retry-on-conflict handling is
+sufficient and the object cannot become a hot write target.
 
 This avoids publishing PF IDs, host PCI addresses, or DPU-local bridge names in the `Uplink` spec. The DPU-Host publishes
 the host interface MAC as the handoff point, and the DPU side uses the existing representor peer relationship to discover

--- a/go-controller/pkg/clustermanager/uplink/controller.go
+++ b/go-controller/pkg/clustermanager/uplink/controller.go
@@ -752,9 +752,12 @@ func uplinkStateNotResolvedReason(
 		uplinkv1alpha1.UplinkStateConditionResolved,
 	)
 	if cond == nil {
-		return "ResolvedConditionMissing"
+		return hostDataFailureReason(state, "ResolvedConditionMissing")
 	}
 	if cond.Status != metav1.ConditionTrue {
+		if cond.Reason == uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost {
+			return hostDataFailureReason(state, cond.Reason)
+		}
 		if cond.Reason != "" {
 			return cond.Reason
 		}
@@ -764,6 +767,20 @@ func uplinkStateNotResolvedReason(
 		return "NodeConfigMismatch"
 	}
 	return ""
+}
+
+// hostDataFailureReason surfaces the DPU-host-side root cause when the DPU
+// side is blocked on host data: the aggregate message samples only reasons,
+// and WaitingForDPUHost alone would hide why the host has not published.
+func hostDataFailureReason(state *uplinkv1alpha1.UplinkState, fallback string) string {
+	cond := meta.FindStatusCondition(
+		state.Status.Conditions,
+		uplinkv1alpha1.UplinkStateConditionHostDataReady,
+	)
+	if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason != "" {
+		return cond.Reason
+	}
+	return fallback
 }
 
 func uplinkStateResolved(state *uplinkv1alpha1.UplinkState, nodeConfig uplinkv1alpha1.UplinkNodeConfig) bool {

--- a/go-controller/pkg/clustermanager/uplink/controller.go
+++ b/go-controller/pkg/clustermanager/uplink/controller.go
@@ -134,6 +134,7 @@ func NewController(
 
 	uplinkCfg := &controllerutil.ControllerConfig[uplinkv1alpha1.Uplink]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.UplinkInformer().Informer(),
 		Lister:         c.uplinkLister.List,
 		Reconcile:      c.reconcileUplink,
@@ -147,6 +148,7 @@ func NewController(
 
 	uplinkStateCfg := &controllerutil.ControllerConfig[uplinkv1alpha1.UplinkState]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.UplinkStateInformer().Informer(),
 		Lister:         c.uplinkStateLister.List,
 		Reconcile:      c.reconcileUplinkState,
@@ -160,6 +162,7 @@ func NewController(
 
 	cudnCfg := &controllerutil.ControllerConfig[udnv1.ClusterUserDefinedNetwork]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.ClusterUserDefinedNetworkInformer().Informer(),
 		Lister:         c.cudnLister.List,
 		Reconcile:      c.reconcileCUDN,
@@ -173,6 +176,7 @@ func NewController(
 
 	nodeCfg := &controllerutil.ControllerConfig[corev1.Node]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.NodeCoreInformer().Informer(),
 		Lister:         c.nodeLister.List,
 		Reconcile:      c.reconcileNode,
@@ -186,6 +190,7 @@ func NewController(
 
 	networkRefCfg := &controllerutil.ReconcilerConfig{
 		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+		MaxAttempts: controllerutil.InfiniteAttempts,
 		Reconcile:   c.reconcileNetworkRef,
 		Threadiness: 1,
 	}
@@ -301,12 +306,15 @@ func (c *Controller) reconcileUplink(key string) error {
 
 	selected, conflicts, validationErr := c.resolveSelectedNodeConfigs(uplink)
 	if validationErr != nil {
-		if err := c.updateStatus(uplink,
+		err := c.updateStatus(uplink,
 			metav1.ConditionFalse, reasonInvalidSpec,
-			"Uplink is not ready because its spec is not accepted"); err != nil {
-			return err
-		}
+			"Uplink is not ready because its spec is not accepted")
 		c.reconcileCUDNNames(referencingCUDNs)
+		if err != nil {
+			return errors.Join(validationErr, err)
+		}
+		// A rejected spec is not retryable: the cluster admin must fix the
+		// Uplink CR, and that update triggers a new reconcile.
 		return nil
 	}
 
@@ -320,6 +328,8 @@ func (c *Controller) reconcileUplink(key string) error {
 		return err
 	}
 	c.reconcileCUDNNames(referencingCUDNs)
+	// A not-ready Uplink needs no retry: readiness is recomputed whenever
+	// an UplinkState, node or CUDN changes.
 	return nil
 }
 

--- a/go-controller/pkg/clustermanager/uplink/controller_test.go
+++ b/go-controller/pkg/clustermanager/uplink/controller_test.go
@@ -118,8 +118,8 @@ func TestUplinkControllerReportsBoundedPartialFailureSummary(t *testing.T) {
 			uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound),
 		newUnresolvedUplinkState("br-blue", "node-b", "br-blue",
 			uplinkv1alpha1.UplinkStateReasonBridgeNotFound),
-		newUnresolvedUplinkState("br-blue", "node-c", "br-blue",
-			uplinkv1alpha1.UplinkStateReasonWaitingForDPU),
+		newDPUHostBlockedUplinkState("br-blue", "node-c", "br-blue",
+			uplinkv1alpha1.UplinkStateReasonInvalidHostInterface),
 		newUnresolvedUplinkState("br-blue", "node-d", "br-blue",
 			uplinkv1alpha1.UplinkStateReasonGatewayInfoUnavailable),
 		newResolvedUplinkState("br-blue", "node-e", "br-blue"),
@@ -134,7 +134,7 @@ func TestUplinkControllerReportsBoundedPartialFailureSummary(t *testing.T) {
 		gomega.HaveField("Message", gomega.ContainSubstring("4 of 5 selected node(s)")),
 		gomega.HaveField("Message", gomega.ContainSubstring("node-a=HostInterfaceNotFound")),
 		gomega.HaveField("Message", gomega.ContainSubstring("node-b=BridgeNotFound")),
-		gomega.HaveField("Message", gomega.ContainSubstring("node-c=WaitingForDPU")),
+		gomega.HaveField("Message", gomega.ContainSubstring("node-c=InvalidHostInterface")),
 		gomega.HaveField("Message", gomega.Not(gomega.ContainSubstring("node-d="))),
 	))
 }
@@ -1084,6 +1084,48 @@ func newUnresolvedUplinkState(
 	state := newResolvedUplinkState(uplinkName, nodeName, hostInterfaceName)
 	state.Status.Conditions[0].Status = metav1.ConditionFalse
 	state.Status.Conditions[0].Reason = reason
+	return state
+}
+
+func TestUplinkStateNotResolvedReasonSurfacesHostCause(t *testing.T) {
+	g := gomega.NewWithT(t)
+	nodeConfig := uplinkv1alpha1.UplinkNodeConfig{
+		Type:              uplinkv1alpha1.UplinkTypeOVSBridge,
+		HostInterfaceName: "br-blue",
+	}
+
+	// The DPU is blocked on host data: the host-side cause is surfaced.
+	state := newDPUHostBlockedUplinkState("br-blue", "node-a", "br-blue",
+		uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound)
+	g.Expect(uplinkStateNotResolvedReason(state, nodeConfig)).
+		To(gomega.Equal(uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound))
+
+	// Same when the DPU has not written a Resolved condition at all.
+	meta.RemoveStatusCondition(&state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionResolved)
+	g.Expect(uplinkStateNotResolvedReason(state, nodeConfig)).
+		To(gomega.Equal(uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound))
+
+	// Without a host-side failure either, fall back to the generic reason.
+	meta.RemoveStatusCondition(&state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionHostDataReady)
+	g.Expect(uplinkStateNotResolvedReason(state, nodeConfig)).
+		To(gomega.Equal("ResolvedConditionMissing"))
+}
+
+// newDPUHostBlockedUplinkState models a split DPU state where the DPU waits
+// on host data and the DPU-host reports the root cause on HostDataReady.
+func newDPUHostBlockedUplinkState(
+	uplinkName string,
+	nodeName string,
+	hostInterfaceName string,
+	hostDataReason string,
+) *uplinkv1alpha1.UplinkState {
+	state := newUnresolvedUplinkState(uplinkName, nodeName, hostInterfaceName,
+		uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost)
+	state.Status.Conditions = append(state.Status.Conditions, metav1.Condition{
+		Type:   uplinkv1alpha1.UplinkStateConditionHostDataReady,
+		Status: metav1.ConditionFalse,
+		Reason: hostDataReason,
+	})
 	return state
 }
 

--- a/go-controller/pkg/clustermanager/uplink/controller_test.go
+++ b/go-controller/pkg/clustermanager/uplink/controller_test.go
@@ -261,6 +261,35 @@ func TestUplinkControllerReportsOverlappingSelectors(t *testing.T) {
 	g.Expect(states.Items).To(gomega.BeEmpty())
 }
 
+func TestUplinkControllerReportsInvalidSpec(t *testing.T) {
+	g := gomega.NewWithT(t)
+	uplink := newUplink("br-blue", "role", "blue", "br-blue")
+	// A LabelSelector can pass CRD schema validation yet fail to parse:
+	// Exists takes no values (LabelSelectorOpIn would be the right operator
+	// for matching against values).
+	uplink.Spec.NodeConfigs[0].NodeSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "role",
+			Operator: metav1.LabelSelectorOpExists,
+			Values:   []string{"blue"},
+		}},
+	}
+	controller, client := newTestController(t,
+		newNode("node-a", map[string]string{"role": "blue"}),
+		uplink,
+	)
+
+	// A rejected spec is reported but not retried: the cluster admin must
+	// fix the Uplink CR, and that update triggers a new reconcile.
+	g.Expect(controller.reconcileUplink("br-blue")).To(gomega.Succeed())
+
+	cond := getUplinkCondition(g, client, "br-blue", uplinkv1alpha1.UplinkConditionReady)
+	g.Expect(cond).To(gomega.And(
+		gomega.HaveField("Status", metav1.ConditionFalse),
+		gomega.HaveField("Reason", reasonInvalidSpec),
+	))
+}
+
 func TestUplinkControllerEnsuresFinalizerFromCUDNReference(t *testing.T) {
 	g := gomega.NewWithT(t)
 	setSharedGatewayMode(t)

--- a/go-controller/pkg/crd/uplink/v1alpha1/types.go
+++ b/go-controller/pkg/crd/uplink/v1alpha1/types.go
@@ -15,14 +15,20 @@ const (
 	UplinkConditionReady = "Ready"
 )
 
+// Each UplinkState condition has a single writer per node: in split DPU mode
+// the DPU-host owns HostDataReady, the DPU owns Resolved, and the DPU-side
+// gateway coordinator owns GatewayReady. In full mode the discovery
+// reconciler owns Resolved and HostDataReady is not published.
 const (
-	UplinkStateConditionResolved     = "Resolved"
-	UplinkStateConditionGatewayReady = "GatewayReady"
+	UplinkStateConditionResolved      = "Resolved"
+	UplinkStateConditionGatewayReady  = "GatewayReady"
+	UplinkStateConditionHostDataReady = "HostDataReady"
 )
 
 const (
 	UplinkStateReasonResolved                        = "Resolved"
 	UplinkStateReasonGatewayConfigured               = "GatewayConfigured"
+	UplinkStateReasonHostDataDiscovered              = "HostDataDiscovered"
 	UplinkStateReasonHostInterfaceNotFound           = "HostInterfaceNotFound"
 	UplinkStateReasonBridgeNotFound                  = "BridgeNotFound"
 	UplinkStateReasonBridgeUplinkNotFound            = "BridgeUplinkNotFound"
@@ -30,7 +36,6 @@ const (
 	UplinkStateReasonDefaultGatewayBridgeUnsupported = "DefaultGatewayBridgeUnsupported"
 	UplinkStateReasonInvalidHostInterface            = "InvalidHostInterface"
 	UplinkStateReasonGatewayInfoUnavailable          = "GatewayInfoUnavailable"
-	UplinkStateReasonWaitingForDPU                   = "WaitingForDPU"
 	UplinkStateReasonWaitingForDPUHost               = "WaitingForDPUHost"
 	UplinkStateReasonNodeSelectorOverlap             = "NodeSelectorOverlap"
 	UplinkStateReasonGatewayConfigurationPending     = "GatewayConfigurationPending"
@@ -152,6 +157,7 @@ type UplinkList struct {
 // +kubebuilder:printcolumn:name="Uplink",type=string,JSONPath=".spec.uplinkName"
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=".spec.nodeName"
 // +kubebuilder:printcolumn:name="Resolved",type=string,JSONPath=`.status.conditions[?(@.type=="Resolved")].status`
+// +kubebuilder:printcolumn:name="HostDataReady",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="HostDataReady")].status`
 type UplinkState struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -294,6 +294,21 @@ func (c *Controller) reconcileUplinkState(key string) error {
 		}
 	}
 
+	if config.OvnKubeNode.Mode == ovntypes.NodeModeDPUHost {
+		// Host interface discovery succeeded, which is everything the
+		// DPU-host reports: publish HostDataReady=True. Bridge resolution,
+		// validation and the Resolved condition belong to the DPU side.
+		return c.updateUplinkStateStatus(
+			state,
+			hostInterfaceName,
+			hostState,
+			"",
+			metav1.ConditionTrue,
+			uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			"Uplink host interface data discovered",
+		)
+	}
+
 	defaultBridgeName, err := defaultGatewayBridgeName(node)
 	if err != nil {
 		return c.updateUplinkStateStatus(
@@ -337,44 +352,6 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			hostState,
 			bridgeName,
 			"Uplink DPU bridge discovery succeeded",
-		)
-	}
-
-	if config.OvnKubeNode.Mode == ovntypes.NodeModeDPUHost {
-		bridgeName := ""
-		if string(state.Status.HostInterfaceName) == hostInterfaceName && state.Status.OVSBridge != nil {
-			bridgeName = state.Status.OVSBridge.Name
-		}
-		if err := validateDefaultGatewayBridge(bridgeName, defaultBridgeName); err != nil {
-			return c.updateUplinkStateStatus(
-				state,
-				hostInterfaceName,
-				hostState,
-				"",
-				metav1.ConditionFalse,
-				discoveryReason(err),
-				err.Error(),
-			)
-		}
-		if dpuSideBridgeResolvedForHostInterface(state, hostInterfaceName) {
-			// The DPU side has resolved the OVS bridge. The DPU-host side
-			// now publishes host interface details under its field manager.
-			return c.updateResolvedUplinkStateStatus(
-				state,
-				hostInterfaceName,
-				hostState,
-				"",
-				"Uplink DPU bridge discovery succeeded",
-			)
-		}
-		return c.updateUplinkStateStatus(
-			state,
-			hostInterfaceName,
-			hostState,
-			"",
-			metav1.ConditionFalse,
-			uplinkv1alpha1.UplinkStateReasonWaitingForDPU,
-			"waiting for DPU-side bridge discovery",
 		)
 	}
 
@@ -504,6 +481,12 @@ func (c *Controller) updateResolvedUplinkStateStatus(
 	)
 }
 
+// updateUplinkStateStatus applies the status fields this reconciler writes
+// together with the condition it owns: the DPU-host reports HostDataReady,
+// while the DPU and full mode report Resolved (see statusConditionType).
+// Full mode writes every status field; the split DPU modes each write their
+// own subset and cannot write the peer's condition. Callers pass the
+// condition status, reason and message.
 func (c *Controller) updateUplinkStateStatus(
 	state *uplinkv1alpha1.UplinkState,
 	hostInterfaceName string,
@@ -513,7 +496,7 @@ func (c *Controller) updateUplinkStateStatus(
 	reason string,
 	message string,
 ) error {
-	condition := resolvedCondition(state, hostInterfaceName, status, reason, message)
+	condition := statusCondition(state, status, reason, message)
 	desiredStatus := desiredUplinkStateStatus(state, hostInterfaceName, hostState, bridgeName, condition)
 	if reflect.DeepEqual(state.Status, desiredStatus) {
 		return nil
@@ -523,7 +506,10 @@ func (c *Controller) updateUplinkStateStatus(
 		WithType(uplinkv1alpha1.UplinkTypeOVSBridge).
 		WithConditions(util.ConditionToApply(condition))
 
-	if hostInterfaceName != "" {
+	// Only the DPU-host applies hostInterfaceName: it confirms which
+	// interface the host-owned MAC/IP data belongs to, so the DPU must not
+	// bump it ahead of fresh host data on a spec change.
+	if config.OvnKubeNode.Mode != ovntypes.NodeModeDPU && hostInterfaceName != "" {
 		statusApply = statusApply.WithHostInterfaceName(
 			uplinkv1alpha1.InterfaceName(hostInterfaceName),
 		)
@@ -575,7 +561,11 @@ func desiredUplinkStateStatus(
 	}
 
 	desired.Type = uplinkv1alpha1.UplinkTypeOVSBridge
-	desired.HostInterfaceName = uplinkv1alpha1.InterfaceName(hostInterfaceName)
+	// The DPU side does not apply hostInterfaceName, so its desired status
+	// keeps whatever the DPU-host side published.
+	if config.OvnKubeNode.Mode != ovntypes.NodeModeDPU {
+		desired.HostInterfaceName = uplinkv1alpha1.InterfaceName(hostInterfaceName)
+	}
 	desired.Conditions = append([]metav1.Condition(nil), state.Status.Conditions...)
 	meta.SetStatusCondition(&desired.Conditions, condition)
 
@@ -616,16 +606,6 @@ func setUplinkStateBridgeStatus(status *uplinkv1alpha1.UplinkStateStatus, bridge
 	}
 }
 
-func dpuSideBridgeResolvedForHostInterface(state *uplinkv1alpha1.UplinkState, hostInterfaceName string) bool {
-	if state.Status.OVSBridge == nil || state.Status.OVSBridge.Name == "" {
-		return false
-	}
-	resolvedCondition := resolvedConditionForHostInterface(state, hostInterfaceName)
-	return resolvedCondition != nil &&
-		resolvedCondition.Status == metav1.ConditionTrue &&
-		resolvedCondition.Reason == uplinkv1alpha1.UplinkStateReasonResolved
-}
-
 // StatusFieldManager returns the field manager used by ovnkube-node when it
 // applies UplinkState status.
 func StatusFieldManager() string {
@@ -639,34 +619,33 @@ func StatusFieldManager() string {
 	}
 }
 
-func resolvedCondition(
+// statusConditionType returns the condition this side of the discovery
+// reconcile owns: each UplinkState condition has a single writer, so the
+// DPU-host reports on HostDataReady while the DPU (and full mode) reports on
+// Resolved.
+func statusConditionType() string {
+	if config.OvnKubeNode.Mode == ovntypes.NodeModeDPUHost {
+		return uplinkv1alpha1.UplinkStateConditionHostDataReady
+	}
+	return uplinkv1alpha1.UplinkStateConditionResolved
+}
+
+func statusCondition(
 	state *uplinkv1alpha1.UplinkState,
-	hostInterfaceName string,
 	status metav1.ConditionStatus,
 	reason string,
 	message string,
 ) metav1.Condition {
-	var existing []metav1.Condition
-	if current := resolvedConditionForHostInterface(state, hostInterfaceName); current != nil {
-		existing = []metav1.Condition{*current}
-	}
-	condition, _ := util.MergeStatusCondition(existing, metav1.Condition{
-		Type:    uplinkv1alpha1.UplinkStateConditionResolved,
+	// The stored condition of this type, which may predate a
+	// hostInterfaceName change, is read only to carry its LastTransitionTime
+	// over into the new condition; its reason and message are not reused.
+	condition, _ := util.MergeStatusCondition(state.Status.Conditions, metav1.Condition{
+		Type:    statusConditionType(),
 		Status:  status,
 		Reason:  reason,
 		Message: message,
 	})
 	return condition
-}
-
-func resolvedConditionForHostInterface(state *uplinkv1alpha1.UplinkState, hostInterfaceName string) *metav1.Condition {
-	if string(state.Status.HostInterfaceName) != hostInterfaceName {
-		return nil
-	}
-	return meta.FindStatusCondition(
-		state.Status.Conditions,
-		uplinkv1alpha1.UplinkStateConditionResolved,
-	)
 }
 
 func (c *Controller) ensureUplinkState(
@@ -751,12 +730,17 @@ func desiredUplinkState(
 	}
 	if nodeConfig != nil {
 		state.Status.Type = nodeConfig.Type
-		state.Status.HostInterfaceName = nodeConfig.HostInterfaceName
+		// The DPU side does not seed hostInterfaceName on creation either:
+		// only the DPU-host publishes it, as confirmation of which interface
+		// the host-owned MAC/IP data belongs to.
+		if config.OvnKubeNode.Mode != ovntypes.NodeModeDPU {
+			state.Status.HostInterfaceName = nodeConfig.HostInterfaceName
+		}
 	}
 	if nodeConfigErr != nil {
 		state.Status.Conditions = []metav1.Condition{
 			{
-				Type:               uplinkv1alpha1.UplinkStateConditionResolved,
+				Type:               statusConditionType(),
 				Status:             metav1.ConditionFalse,
 				Reason:             discoveryReason(nodeConfigErr),
 				Message:            nodeConfigErr.Error(),

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -899,6 +899,15 @@ func (d netlinkHostInterfaceDiscoverer) Discover(hostInterfaceName string) (*hos
 			fmt.Errorf("host interface %s was not found: %w", hostInterfaceName, err),
 		)
 	}
+	// The MAC becomes the OVN gateway interface MAC: reject unusable ones
+	// here rather than far away in gateway programming.
+	macAddress := link.Attrs().HardwareAddr
+	if !util.IsUsableEthernetMAC(macAddress) {
+		return nil, newDiscoveryError(
+			uplinkv1alpha1.UplinkStateReasonInvalidHostInterface,
+			fmt.Errorf("host interface %s has no usable MAC address", hostInterfaceName),
+		)
+	}
 	addrs, err := nodeutil.GetNetworkInterfaceIPAddresses(hostInterfaceName)
 	if err != nil {
 		return nil, newDiscoveryError(
@@ -923,7 +932,7 @@ func (d netlinkHostInterfaceDiscoverer) Discover(hostInterfaceName string) (*hos
 		defaultGateways = append(defaultGateways, route.Gw)
 	}
 	return &hostInterfaceState{
-		macAddress:      link.Attrs().HardwareAddr,
+		macAddress:      macAddress,
 		ipAddresses:     addrs,
 		defaultGateways: defaultGateways,
 	}, nil

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -11,8 +11,10 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/time/rate"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -97,6 +99,17 @@ type Controller struct {
 	nodeController        controllerutil.Controller
 }
 
+// discoveryRateLimiter is the default controller rate limiter with its
+// exponential backoff capped at 30s instead of 1000s: retries re-poll
+// admin-owned host and OVS state, so the cap bounds how long discovery
+// takes to notice an admin fix.
+func discoveryRateLimiter() workqueue.TypedRateLimiter[string] {
+	return workqueue.NewTypedMaxOfRateLimiter(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[string](5*time.Millisecond, 30*time.Second),
+		&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+}
+
 // NewController creates an ovnkube-node Uplink controller.
 func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util.OVNNodeClientset, ovsClient libovsdbclient.Client,
 ) *Controller {
@@ -111,7 +124,8 @@ func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util
 	}
 
 	uplinkCfg := &controllerutil.ControllerConfig[uplinkv1alpha1.Uplink]{
-		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		RateLimiter:    discoveryRateLimiter(),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.UplinkInformer().Informer(),
 		Lister:         c.uplinkLister.List,
 		Reconcile:      c.reconcileUplink,
@@ -124,7 +138,8 @@ func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util
 	)
 
 	uplinkStateCfg := &controllerutil.ControllerConfig[uplinkv1alpha1.UplinkState]{
-		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		RateLimiter:    discoveryRateLimiter(),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.UplinkStateInformer().Informer(),
 		Lister:         c.uplinkStateLister.List,
 		Reconcile:      c.reconcileUplinkState,
@@ -137,7 +152,8 @@ func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util
 	)
 
 	nodeCfg := &controllerutil.ControllerConfig[corev1.Node]{
-		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		RateLimiter:    discoveryRateLimiter(),
+		MaxAttempts:    controllerutil.InfiniteAttempts,
 		Informer:       wf.NodeCoreInformer().Informer(),
 		Lister:         c.nodeLister.List,
 		Reconcile:      c.reconcileNode,
@@ -200,7 +216,7 @@ func (c *Controller) reconcileUplink(key string) error {
 		return nil
 	}
 	if nodeConfigErr != nil {
-		return c.updateUplinkStateStatus(
+		return errors.Join(nodeConfigErr, c.updateUplinkStateStatus(
 			state,
 			string(state.Status.HostInterfaceName),
 			nil,
@@ -208,7 +224,7 @@ func (c *Controller) reconcileUplink(key string) error {
 			metav1.ConditionFalse,
 			discoveryReason(nodeConfigErr),
 			nodeConfigErr.Error(),
-		)
+		))
 	}
 	// Creation also produces an UplinkState watch event, but existing states
 	// need explicit rediscovery when the selected Uplink config changes.
@@ -250,7 +266,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 
 	nodeConfig, err := selectedNodeConfigForNode(uplink, node)
 	if err != nil {
-		return c.updateUplinkStateStatus(
+		return errors.Join(err, c.updateUplinkStateStatus(
 			state,
 			string(state.Status.HostInterfaceName),
 			nil,
@@ -258,7 +274,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			metav1.ConditionFalse,
 			discoveryReason(err),
 			err.Error(),
-		)
+		))
 	}
 	if nodeConfig == nil {
 		return c.deleteUplinkState(state.Name)
@@ -269,7 +285,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 	if config.OvnKubeNode.Mode == ovntypes.NodeModeDPU {
 		hostState, err = hostInterfaceStateFromStatus(state, hostInterfaceName)
 		if err != nil {
-			return c.updateUplinkStateStatus(
+			return errors.Join(err, c.updateUplinkStateStatus(
 				state,
 				hostInterfaceName,
 				nil,
@@ -277,12 +293,12 @@ func (c *Controller) reconcileUplinkState(key string) error {
 				metav1.ConditionFalse,
 				uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost,
 				err.Error(),
-			)
+			))
 		}
 	} else {
 		hostState, err = c.hostDiscoverer.Discover(hostInterfaceName)
 		if err != nil {
-			return c.updateUplinkStateStatus(
+			return errors.Join(err, c.updateUplinkStateStatus(
 				state,
 				hostInterfaceName,
 				nil,
@@ -290,7 +306,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 				metav1.ConditionFalse,
 				discoveryReason(err),
 				err.Error(),
-			)
+			))
 		}
 	}
 
@@ -311,7 +327,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 
 	defaultBridgeName, err := defaultGatewayBridgeName(node)
 	if err != nil {
-		return c.updateUplinkStateStatus(
+		return errors.Join(err, c.updateUplinkStateStatus(
 			state,
 			hostInterfaceName,
 			hostState,
@@ -319,13 +335,13 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			metav1.ConditionFalse,
 			discoveryReason(err),
 			err.Error(),
-		)
+		))
 	}
 
 	if config.OvnKubeNode.Mode == ovntypes.NodeModeDPU {
 		bridgeName, err := c.bridgeResolver.ResolveByHostMAC(hostState.macAddress, c.nodeName)
 		if err != nil {
-			return c.updateUplinkStateStatus(
+			return errors.Join(err, c.updateUplinkStateStatus(
 				state,
 				hostInterfaceName,
 				hostState,
@@ -333,10 +349,10 @@ func (c *Controller) reconcileUplinkState(key string) error {
 				metav1.ConditionFalse,
 				discoveryReason(err),
 				err.Error(),
-			)
+			))
 		}
 		if err := c.validateBridgeUplink(bridgeName, hostInterfaceName, defaultBridgeName, false); err != nil {
-			return c.updateUplinkStateStatus(
+			return errors.Join(err, c.updateUplinkStateStatus(
 				state,
 				hostInterfaceName,
 				hostState,
@@ -344,7 +360,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 				metav1.ConditionFalse,
 				discoveryReason(err),
 				err.Error(),
-			)
+			))
 		}
 		return c.updateResolvedUplinkStateStatus(
 			state,
@@ -357,7 +373,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 
 	bridgeName, err := c.bridgeResolver.Resolve(hostInterfaceName)
 	if err != nil {
-		return c.updateUplinkStateStatus(
+		return errors.Join(err, c.updateUplinkStateStatus(
 			state,
 			hostInterfaceName,
 			hostState,
@@ -365,10 +381,10 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			metav1.ConditionFalse,
 			discoveryReason(err),
 			err.Error(),
-		)
+		))
 	}
 	if err := c.validateBridgeUplink(bridgeName, hostInterfaceName, defaultBridgeName, true); err != nil {
-		return c.updateUplinkStateStatus(
+		return errors.Join(err, c.updateUplinkStateStatus(
 			state,
 			hostInterfaceName,
 			hostState,
@@ -376,7 +392,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			metav1.ConditionFalse,
 			discoveryReason(err),
 			err.Error(),
-		)
+		))
 	}
 
 	return c.updateResolvedUplinkStateStatus(
@@ -486,7 +502,13 @@ func (c *Controller) updateResolvedUplinkStateStatus(
 // while the DPU and full mode report Resolved (see statusConditionType).
 // Full mode writes every status field; the split DPU modes each write their
 // own subset and cannot write the peer's condition. Callers pass the
-// condition status, reason and message.
+// condition status, reason and message, and on failure return their
+// underlying error joined with any write error: discovery inputs live in
+// netlink and OVSDB, which generate no Kubernetes events, so the
+// controller's rate-limited retries are what re-polls them.
+//
+// TODO: subscribe to netlink and OVSDB events and reconcile on relevant
+// changes instead of polling through retries.
 func (c *Controller) updateUplinkStateStatus(
 	state *uplinkv1alpha1.UplinkState,
 	hostInterfaceName string,

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -16,6 +16,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -496,12 +497,10 @@ func TestNodeUplinkControllerRejectsDefaultGatewayBridge(t *testing.T) {
 			mode: ovntypes.NodeModeFull,
 		},
 		{
+			// The DPU-host does not validate the bridge: the DPU side owns
+			// bridge validation and the Resolved condition.
 			name: "DPU",
 			mode: ovntypes.NodeModeDPU,
-		},
-		{
-			name: "DPU host",
-			mode: ovntypes.NodeModeDPUHost,
 		},
 	}
 
@@ -512,11 +511,8 @@ func TestNodeUplinkControllerRejectsDefaultGatewayBridge(t *testing.T) {
 			config.OvnKubeNode.Mode = test.mode
 
 			state := newUplinkState("br-blue.node-a", "br-blue", "node-a")
-			if test.mode == ovntypes.NodeModeDPU || test.mode == ovntypes.NodeModeDPUHost {
+			if test.mode == ovntypes.NodeModeDPU {
 				state = newHostResolvedUplinkState("br-blue.node-a", "br-blue", "node-a", "uplink0")
-			}
-			if test.mode == ovntypes.NodeModeDPUHost {
-				state.Status.OVSBridge = &uplinkv1alpha1.OVSBridgeStatus{Name: "br-default"}
 			}
 
 			controller, client := newTestController(t,
@@ -544,27 +540,35 @@ func TestNodeUplinkControllerRejectsDefaultGatewayBridge(t *testing.T) {
 
 func TestNodeUplinkControllerSkipsUnchangedStatus(t *testing.T) {
 	tests := []struct {
-		name       string
-		mode       string
-		bridgeName string
-		message    string
+		name          string
+		mode          string
+		bridgeName    string
+		conditionType string
+		reason        string
+		message       string
 	}{
 		{
-			name:       "Full",
-			mode:       ovntypes.NodeModeFull,
-			bridgeName: "br-blue",
-			message:    "Uplink discovery succeeded",
+			name:          "Full",
+			mode:          ovntypes.NodeModeFull,
+			bridgeName:    "br-blue",
+			conditionType: uplinkv1alpha1.UplinkStateConditionResolved,
+			reason:        uplinkv1alpha1.UplinkStateReasonResolved,
+			message:       "Uplink discovery succeeded",
 		},
 		{
-			name:    "DPU host preserves DPU bridge",
-			mode:    ovntypes.NodeModeDPUHost,
-			message: "Uplink DPU bridge discovery succeeded",
+			name:          "DPU host preserves DPU bridge",
+			mode:          ovntypes.NodeModeDPUHost,
+			conditionType: uplinkv1alpha1.UplinkStateConditionHostDataReady,
+			reason:        uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			message:       "Uplink host interface data discovered",
 		},
 		{
-			name:       "DPU preserves host gateway data",
-			mode:       ovntypes.NodeModeDPU,
-			bridgeName: "br-blue",
-			message:    "Uplink DPU bridge discovery succeeded",
+			name:          "DPU preserves host gateway data",
+			mode:          ovntypes.NodeModeDPU,
+			bridgeName:    "br-blue",
+			conditionType: uplinkv1alpha1.UplinkStateConditionResolved,
+			reason:        uplinkv1alpha1.UplinkStateReasonResolved,
+			message:       "Uplink DPU bridge discovery succeeded",
 		},
 	}
 
@@ -573,7 +577,7 @@ func TestNodeUplinkControllerSkipsUnchangedStatus(t *testing.T) {
 			g := gomega.NewWithT(t)
 			g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 			config.OvnKubeNode.Mode = test.mode
-			state := newResolvedStatusTestUplinkState(test.message)
+			state := newResolvedStatusTestUplinkState(test.conditionType, test.reason, test.message)
 			controller, client := newTestController(t, fakeHostDiscoverer{}, fakeBridgeResolver{}, state)
 
 			g.Expect(controller.updateUplinkStateStatus(
@@ -582,7 +586,7 @@ func TestNodeUplinkControllerSkipsUnchangedStatus(t *testing.T) {
 				newStatusTestHostState(),
 				test.bridgeName,
 				metav1.ConditionTrue,
-				uplinkv1alpha1.UplinkStateReasonResolved,
+				test.reason,
 				test.message,
 			)).To(gomega.Succeed())
 			g.Expect(client.UplinkClient.(*uplinkfake.Clientset).Actions()).To(gomega.BeEmpty())
@@ -592,27 +596,35 @@ func TestNodeUplinkControllerSkipsUnchangedStatus(t *testing.T) {
 
 func TestNodeUplinkControllerAppliesOwnedStatusClears(t *testing.T) {
 	tests := []struct {
-		name       string
-		mode       string
-		hostState  *hostInterfaceState
-		bridgeName string
-		message    string
+		name          string
+		mode          string
+		hostState     *hostInterfaceState
+		bridgeName    string
+		conditionType string
+		reason        string
+		message       string
 	}{
 		{
-			name:    "Full",
-			mode:    ovntypes.NodeModeFull,
-			message: "Uplink discovery succeeded",
+			name:          "Full",
+			mode:          ovntypes.NodeModeFull,
+			conditionType: uplinkv1alpha1.UplinkStateConditionResolved,
+			reason:        uplinkv1alpha1.UplinkStateReasonResolved,
+			message:       "Uplink discovery succeeded",
 		},
 		{
-			name:    "DPU host clears host gateway data",
-			mode:    ovntypes.NodeModeDPUHost,
-			message: "Uplink DPU bridge discovery succeeded",
+			name:          "DPU host clears host gateway data",
+			mode:          ovntypes.NodeModeDPUHost,
+			conditionType: uplinkv1alpha1.UplinkStateConditionHostDataReady,
+			reason:        uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			message:       "Uplink host interface data discovered",
 		},
 		{
-			name:      "DPU clears bridge data",
-			mode:      ovntypes.NodeModeDPU,
-			hostState: newStatusTestHostState(),
-			message:   "Uplink DPU bridge discovery succeeded",
+			name:          "DPU clears bridge data",
+			mode:          ovntypes.NodeModeDPU,
+			hostState:     newStatusTestHostState(),
+			conditionType: uplinkv1alpha1.UplinkStateConditionResolved,
+			reason:        uplinkv1alpha1.UplinkStateReasonResolved,
+			message:       "Uplink DPU bridge discovery succeeded",
 		},
 	}
 
@@ -621,7 +633,7 @@ func TestNodeUplinkControllerAppliesOwnedStatusClears(t *testing.T) {
 			g := gomega.NewWithT(t)
 			g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 			config.OvnKubeNode.Mode = test.mode
-			state := newResolvedStatusTestUplinkState(test.message)
+			state := newResolvedStatusTestUplinkState(test.conditionType, test.reason, test.message)
 			controller, client := newTestController(t, fakeHostDiscoverer{}, fakeBridgeResolver{}, state)
 
 			g.Expect(controller.updateUplinkStateStatus(
@@ -630,7 +642,7 @@ func TestNodeUplinkControllerAppliesOwnedStatusClears(t *testing.T) {
 				test.hostState,
 				test.bridgeName,
 				metav1.ConditionTrue,
-				uplinkv1alpha1.UplinkStateReasonResolved,
+				test.reason,
 				test.message,
 			)).To(gomega.Succeed())
 			actions := client.UplinkClient.(*uplinkfake.Clientset).Actions()
@@ -886,30 +898,112 @@ func TestNodeUplinkControllerIgnoresMismatchedStateIdentity(t *testing.T) {
 	g.Expect(controller.uplinkStateController.(*controllerutil.FakeController).Reconciles).To(gomega.BeEmpty())
 }
 
-func TestNodeUplinkControllerDPUHostWaitsForDPU(t *testing.T) {
+func TestNodeUplinkControllerDPUHostPublishesHostData(t *testing.T) {
+	tests := []struct {
+		name                string
+		ipAddresses         []*net.IPNet
+		expectedIPAddresses []uplinkv1alpha1.IPAddressCIDR
+	}{
+		{
+			name:                "single stack",
+			ipAddresses:         []*net.IPNet{ovntest.MustParseIPNet("192.0.2.11/24")},
+			expectedIPAddresses: []uplinkv1alpha1.IPAddressCIDR{"192.0.2.11/24"},
+		},
+		{
+			name: "dual stack",
+			ipAddresses: []*net.IPNet{
+				ovntest.MustParseIPNet("192.0.2.11/24"),
+				ovntest.MustParseIPNet("2001:db8::11/64"),
+			},
+			expectedIPAddresses: []uplinkv1alpha1.IPAddressCIDR{"192.0.2.11/24", "2001:db8::11/64"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+			config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
+
+			controller, client := newTestController(t,
+				fakeHostDiscoverer{state: &hostInterfaceState{
+					macAddress:  net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x03},
+					ipAddresses: test.ipAddresses,
+				}},
+				failingBridgeResolver{t: t},
+				newNode("node-a", map[string]string{"role": "blue"}),
+				newUplink("br-blue", "role", "blue", "breth0"),
+				newUplinkState("br-blue.node-a", "br-blue", "node-a"),
+			)
+
+			g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+
+			state := getUplinkState(g, client, "br-blue.node-a")
+			g.Expect(state.Status.OVSBridge).To(gomega.BeNil())
+			g.Expect(state.Status.MACAddress).To(gomega.Equal(uplinkv1alpha1.MACAddress("02:42:ac:12:00:03")))
+			g.Expect(state.Status.IPAddresses).To(gomega.Equal(test.expectedIPAddresses))
+			g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+				gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionHostDataReady),
+				gomega.HaveField("Status", metav1.ConditionTrue),
+				gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonHostDataDiscovered),
+			)))
+			// The DPU side is the only writer of the Resolved condition.
+			g.Expect(meta.FindStatusCondition(
+				state.Status.Conditions,
+				uplinkv1alpha1.UplinkStateConditionResolved,
+			)).To(gomega.BeNil())
+		})
+	}
+}
+
+func TestNodeUplinkControllerDPUHostLeavesResolvedToDPU(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 	config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
 
-	controller, client := newTestController(t,
-		fakeHostDiscoverer{state: &hostInterfaceState{
-			macAddress:  net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x03},
-			ipAddresses: []*net.IPNet{ovntest.MustParseIPNet("192.0.2.11/24")},
-		}},
-		fakeBridgeResolver{bridgeName: "br-blue"},
-		newNode("node-a", map[string]string{"role": "blue"}),
-		newUplink("br-blue", "role", "blue", "breth0"),
-		newUplinkState("br-blue.node-a", "br-blue", "node-a"),
-	)
+	// A DPU-authored bridge discovery failure is already recorded: the
+	// DPU-host publishes its data and HostDataReady without touching it.
+	state := newUplinkState("br-blue.node-a", "br-blue", "node-a")
+	state.Status.Type = uplinkv1alpha1.UplinkTypeOVSBridge
+	state.Status.HostInterfaceName = "breth0"
+	state.Status.OVSBridge = &uplinkv1alpha1.OVSBridgeStatus{Name: "br-blue"}
+	state.Status.Conditions = []metav1.Condition{
+		{
+			Type:               uplinkv1alpha1.UplinkStateConditionResolved,
+			Status:             metav1.ConditionFalse,
+			Reason:             uplinkv1alpha1.UplinkStateReasonBridgeUplinkNotFound,
+			Message:            "failed to resolve physical uplink for OVS bridge br-blue",
+			LastTransitionTime: metav1.NewTime(time.Unix(1, 0)),
+		},
+	}
+
+	hostDiscoverer := fakeHostDiscoverer{state: &hostInterfaceState{
+		macAddress:  net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x03},
+		ipAddresses: []*net.IPNet{ovntest.MustParseIPNet("192.0.2.11/24")},
+	}}
+	node := newNode("node-a", map[string]string{"role": "blue"})
+	uplink := newUplink("br-blue", "role", "blue", "breth0")
+	controller, client := newTestController(t, hostDiscoverer, failingBridgeResolver{t: t}, node, uplink, state)
 
 	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
 
-	state := getUplinkState(g, client, "br-blue.node-a")
-	g.Expect(state.Status.OVSBridge).To(gomega.BeNil())
+	state = getUplinkState(g, client, "br-blue.node-a")
+	g.Expect(state.Status.MACAddress).To(gomega.Equal(uplinkv1alpha1.MACAddress("02:42:ac:12:00:03")))
 	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+		gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionResolved),
 		gomega.HaveField("Status", metav1.ConditionFalse),
-		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonWaitingForDPU),
+		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonBridgeUplinkNotFound),
+		gomega.HaveField("Message", "failed to resolve physical uplink for OVS bridge br-blue"),
 	)))
+	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+		gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionHostDataReady),
+		gomega.HaveField("Status", metav1.ConditionTrue),
+	)))
+
+	// A reconcile of the published status must not write again.
+	controller, client = newTestController(t, hostDiscoverer, failingBridgeResolver{t: t}, node, uplink, state)
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(client.UplinkClient.(*uplinkfake.Clientset).Actions()).To(gomega.BeEmpty())
 }
 
 func TestNodeUplinkControllerDPUHostIgnoresStaleDPUBridge(t *testing.T) {
@@ -925,7 +1019,7 @@ func TestNodeUplinkControllerDPUHostIgnoresStaleDPUBridge(t *testing.T) {
 			macAddress:  net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x05},
 			ipAddresses: []*net.IPNet{ovntest.MustParseIPNet("192.0.2.13/24")},
 		}},
-		fakeBridgeResolver{},
+		failingBridgeResolver{t: t},
 		newNode("node-a", map[string]string{"role": "blue"}),
 		newUplink("br-blue", "role", "blue", "breth1"),
 		state,
@@ -935,10 +1029,94 @@ func TestNodeUplinkControllerDPUHostIgnoresStaleDPUBridge(t *testing.T) {
 
 	state = getUplinkState(g, client, "br-blue.node-a")
 	g.Expect(state.Status.HostInterfaceName).To(gomega.Equal(uplinkv1alpha1.InterfaceName("breth1")))
+	// The stale DPU-owned bridge is left for the DPU side to refresh.
+	g.Expect(state.Status.OVSBridge).NotTo(gomega.BeNil())
 	g.Expect(state.Status.OVSBridge.Name).To(gomega.Equal("br-old"))
 	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+		gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionHostDataReady),
+		gomega.HaveField("Status", metav1.ConditionTrue),
+		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonHostDataDiscovered),
+	)))
+}
+
+func TestNodeUplinkControllerDPUDoesNotAdoptStaleHostState(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	// The Uplink spec changed breth0->breth1 but the DPU-host has not
+	// republished yet: status still carries breth0 and its MAC. The DPU must
+	// not bump status.hostInterfaceName itself, or the next reconcile would
+	// validate the stale MAC as belonging to breth1 and resolve the old
+	// bridge.
+	node := newNode("node-a", map[string]string{"role": "blue"})
+	uplink := newUplink("br-blue", "role", "blue", "breth1")
+	state := newHostResolvedUplinkState("br-blue.node-a", "br-blue", "node-a", "breth0")
+	hostDiscoverer := fakeHostDiscoverer{err: fmt.Errorf("must not inspect host interface")}
+	bridgeResolver := fakeBridgeResolver{bridgeName: "br-old", bridgeUplink: "p0"}
+
+	controller, client := newTestController(t, hostDiscoverer, bridgeResolver, node, uplink, state)
+
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+
+	state = getUplinkState(g, client, "br-blue.node-a")
+	g.Expect(state.Status.HostInterfaceName).To(gomega.Equal(uplinkv1alpha1.InterfaceName("breth0")))
+	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+		gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionResolved),
 		gomega.HaveField("Status", metav1.ConditionFalse),
-		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonWaitingForDPU),
+		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost),
+		gomega.HaveField("Message", gomega.ContainSubstring("waiting for DPU-host state for interface breth1")),
+	)))
+
+	// A second reconcile on the published state must be a no-op, not a
+	// resolve of br-old against the stale breth0 MAC.
+	controller, client = newTestController(t, hostDiscoverer, bridgeResolver, node, uplink, state)
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(client.UplinkClient.(*uplinkfake.Clientset).Actions()).To(gomega.BeEmpty())
+}
+
+func TestNodeUplinkControllerDPULeavesHostDataReadyToDPUHost(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	// Host discovery failed on the DPU-host: the root cause lives in the
+	// host-owned HostDataReady condition, and the blocked DPU reports its
+	// own state on Resolved without touching it.
+	state := newUplinkState("br-blue.node-a", "br-blue", "node-a")
+	state.Status.Type = uplinkv1alpha1.UplinkTypeOVSBridge
+	state.Status.HostInterfaceName = "breth0"
+	state.Status.Conditions = []metav1.Condition{
+		{
+			Type:               uplinkv1alpha1.UplinkStateConditionHostDataReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound,
+			Message:            "host interface breth0 was not found: link not found",
+			LastTransitionTime: metav1.NewTime(time.Unix(1, 0)),
+		},
+	}
+
+	controller, client := newTestController(t,
+		fakeHostDiscoverer{err: fmt.Errorf("must not inspect host interface")},
+		fakeBridgeResolver{bridgeName: "br-blue", bridgeUplink: "p0"},
+		newNode("node-a", map[string]string{"role": "blue"}),
+		newUplink("br-blue", "role", "blue", "breth0"),
+		state,
+	)
+
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+
+	state = getUplinkState(g, client, "br-blue.node-a")
+	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+		gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionHostDataReady),
+		gomega.HaveField("Status", metav1.ConditionFalse),
+		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound),
+		gomega.HaveField("Message", "host interface breth0 was not found: link not found"),
+	)))
+	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
+		gomega.HaveField("Type", uplinkv1alpha1.UplinkStateConditionResolved),
+		gomega.HaveField("Status", metav1.ConditionFalse),
+		gomega.HaveField("Reason", uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost),
 	)))
 }
 
@@ -1070,22 +1248,24 @@ func newHostResolvedUplinkState(name, uplinkName, nodeName, hostInterfaceName st
 	state.Status.DefaultGateways = []uplinkv1alpha1.IPAddress{"192.0.2.1"}
 	state.Status.Conditions = []metav1.Condition{
 		{
-			Type:   uplinkv1alpha1.UplinkStateConditionResolved,
-			Status: metav1.ConditionFalse,
-			Reason: uplinkv1alpha1.UplinkStateReasonWaitingForDPU,
+			Type:               uplinkv1alpha1.UplinkStateConditionHostDataReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			Message:            "Uplink host interface data discovered",
+			LastTransitionTime: metav1.NewTime(time.Unix(1, 0)),
 		},
 	}
 	return state
 }
 
-func newResolvedStatusTestUplinkState(message string) *uplinkv1alpha1.UplinkState {
+func newResolvedStatusTestUplinkState(conditionType, reason, message string) *uplinkv1alpha1.UplinkState {
 	state := newHostResolvedUplinkState("br-blue.node-a", "br-blue", "node-a", "breth0")
 	state.Status.OVSBridge = &uplinkv1alpha1.OVSBridgeStatus{Name: "br-blue"}
 	state.Status.Conditions = []metav1.Condition{
 		{
-			Type:               uplinkv1alpha1.UplinkStateConditionResolved,
+			Type:               conditionType,
 			Status:             metav1.ConditionTrue,
-			Reason:             uplinkv1alpha1.UplinkStateReasonResolved,
+			Reason:             reason,
 			Message:            message,
 			LastTransitionTime: metav1.NewTime(time.Unix(1, 0)),
 		},
@@ -1118,6 +1298,31 @@ type fakeHostDiscoverer struct {
 
 func (d fakeHostDiscoverer) Discover(_ string) (*hostInterfaceState, error) {
 	return d.state, d.err
+}
+
+// failingBridgeResolver pins the invariant that the DPU-host side never
+// queries local OVS: it runs no OVS, the bridge is resolved on the DPU.
+type failingBridgeResolver struct {
+	t *testing.T
+}
+
+func (r failingBridgeResolver) fail() error {
+	r.t.Helper()
+	err := fmt.Errorf("DPU-host must not query local OVS")
+	r.t.Error(err)
+	return err
+}
+
+func (r failingBridgeResolver) Resolve(string) (string, error) {
+	return "", r.fail()
+}
+
+func (r failingBridgeResolver) ResolveByHostMAC(net.HardwareAddr, string) (string, error) {
+	return "", r.fail()
+}
+
+func (r failingBridgeResolver) BridgeUplink(string) (string, error) {
+	return "", r.fail()
 }
 
 type fakeBridgeResolver struct {

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -107,6 +107,51 @@ func TestNodeNeedsUpdate(t *testing.T) {
 	g.Expect(controller.nodeNeedsUpdate(remoteNode, updatedRemoteNode)).To(gomega.BeFalse())
 }
 
+func TestNetlinkHostInterfaceDiscovererRejectsUnusableMAC(t *testing.T) {
+	tests := []struct {
+		name   string
+		hwAddr net.HardwareAddr
+	}{
+		{
+			name: "no MAC",
+		},
+		{
+			name:   "all-zero MAC",
+			hwAddr: net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:   "multicast MAC",
+			hwAddr: net.HardwareAddr{0x01, 0x00, 0x5e, 0x00, 0x00, 0x01},
+		},
+		{
+			name: "non-Ethernet hardware address",
+			hwAddr: net.HardwareAddr{
+				0x80, 0x00, 0x02, 0x08, 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x02, 0xc9, 0x03, 0x00, 0x0a, 0x5f, 0x21,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			netlinkOps := utilmocks.NewNetLinkOps(t)
+			util.SetNetLinkOpMockInst(netlinkOps)
+			t.Cleanup(util.ResetNetLinkOpMockInst)
+			netlinkOps.On("LinkByName", "breth0").
+				Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{
+					Name:         "breth0",
+					HardwareAddr: test.hwAddr,
+				}}, nil)
+
+			_, err := netlinkHostInterfaceDiscoverer{}.Discover("breth0")
+			g.Expect(err).To(gomega.MatchError(
+				gomega.ContainSubstring("host interface breth0 has no usable MAC address")))
+			g.Expect(discoveryReason(err)).To(gomega.Equal(uplinkv1alpha1.UplinkStateReasonInvalidHostInterface))
+		})
+	}
+}
+
 func TestDefaultOVSBridgeResolverUsesOVSDB(t *testing.T) {
 	g := gomega.NewWithT(t)
 	const (

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -523,7 +523,8 @@ func TestNodeUplinkControllerRejectsDefaultGatewayBridge(t *testing.T) {
 				state,
 			)
 
-			g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+			g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+				gomega.MatchError(gomega.ContainSubstring("default shared gateway bridge br-default")))
 
 			state = getUplinkState(g, client, "br-blue.node-a")
 			g.Expect(state.Status.OVSBridge).NotTo(gomega.BeNil())
@@ -708,20 +709,21 @@ func TestNodeUplinkControllerPreservesGatewayReadyCondition(t *testing.T) {
 func TestNodeUplinkControllerReportsHostInterfaceFailure(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+
+	discoveryErr := newDiscoveryError(
+		uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound,
+		fmt.Errorf("host interface missing"),
+	)
 	controller, client := newTestController(t,
-		fakeHostDiscoverer{
-			err: newDiscoveryError(
-				uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound,
-				fmt.Errorf("host interface missing"),
-			),
-		},
+		fakeHostDiscoverer{err: discoveryErr},
 		fakeBridgeResolver{},
 		newNode("node-a", map[string]string{"role": "blue"}),
 		newUplink("br-blue", "role", "blue", "breth0"),
 		newUplinkState("br-blue.node-a", "br-blue", "node-a"),
 	)
 
-	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+		gomega.MatchError(discoveryErr))
 
 	state := getUplinkState(g, client, "br-blue.node-a")
 	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(
@@ -733,24 +735,27 @@ func TestNodeUplinkControllerReportsHostInterfaceFailure(t *testing.T) {
 func TestNodeUplinkControllerReportsBridgeUplinkFailure(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+
+	bridgeUplinkErr := newDiscoveryError(
+		uplinkv1alpha1.UplinkStateReasonBridgeUplinkNotFound,
+		fmt.Errorf("missing bridge uplink"),
+	)
 	controller, client := newTestController(t,
 		fakeHostDiscoverer{state: &hostInterfaceState{
 			macAddress:  net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x02},
 			ipAddresses: []*net.IPNet{ovntest.MustParseIPNet("192.0.2.10/24")},
 		}},
 		fakeBridgeResolver{
-			bridgeName: "br-blue",
-			bridgeUplinkErr: newDiscoveryError(
-				uplinkv1alpha1.UplinkStateReasonBridgeUplinkNotFound,
-				fmt.Errorf("missing bridge uplink"),
-			),
+			bridgeName:      "br-blue",
+			bridgeUplinkErr: bridgeUplinkErr,
 		},
 		newNode("node-a", map[string]string{"role": "blue"}),
 		newUplink("br-blue", "role", "blue", "breth0"),
 		newUplinkState("br-blue.node-a", "br-blue", "node-a"),
 	)
 
-	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+		gomega.MatchError(bridgeUplinkErr))
 
 	state := getUplinkState(g, client, "br-blue.node-a")
 	g.Expect(state.Status.OVSBridge.Name).To(gomega.Equal("br-blue"))
@@ -774,7 +779,8 @@ func TestNodeUplinkControllerRejectsBridgeUplinkAsHostInterface(t *testing.T) {
 		newUplinkState("br-blue.node-a", "br-blue", "node-a"),
 	)
 
-	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+		gomega.MatchError(gomega.ContainSubstring("physical uplink port for OVS bridge br-blue")))
 
 	state := getUplinkState(g, client, "br-blue.node-a")
 	g.Expect(state.Status.HostInterfaceName).To(gomega.Equal(uplinkv1alpha1.InterfaceName("eth1")))
@@ -785,6 +791,45 @@ func TestNodeUplinkControllerRejectsBridgeUplinkAsHostInterface(t *testing.T) {
 	)))
 }
 
+func TestNodeUplinkControllerRetriesWhileUnresolved(t *testing.T) {
+	// Unresolved discovery returns an error so the controller keeps
+	// retrying with backoff: netlink and OVS changes generate no watch
+	// events, so the retries are what re-poll them.
+	t.Run("unresolved returns an error", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		config.OvnKubeNode.Mode = ovntypes.NodeModeFull
+
+		discoveryErr := newDiscoveryError(
+			uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound,
+			fmt.Errorf("host interface missing"),
+		)
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{err: discoveryErr},
+			fakeBridgeResolver{},
+			newNode("node-a", map[string]string{"role": "blue"}),
+			newUplink("br-blue", "role", "blue", "breth0"),
+			newUplinkState("br-blue.node-a", "br-blue", "node-a"),
+		)
+		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+			gomega.MatchError(discoveryErr))
+	})
+
+	t.Run("resolved returns nil", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		config.OvnKubeNode.Mode = ovntypes.NodeModeFull
+
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{state: newStatusTestHostState()},
+			fakeBridgeResolver{bridgeName: "br-blue", bridgeUplink: "eth0"},
+			newNode("node-a", map[string]string{"role": "blue"}),
+			newUplink("br-blue", "role", "blue", "breth0"),
+			newUplinkState("br-blue.node-a", "br-blue", "node-a"),
+		)
+		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	})
+}
 func TestNodeUplinkControllerCreatesSelectedNodeState(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
@@ -819,7 +864,8 @@ func TestNodeUplinkControllerCreatesOverlappingNodeStateWithInitialStatus(t *tes
 		uplink,
 	)
 
-	g.Expect(controller.reconcileUplink("br-blue")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplink("br-blue")).To(
+		gomega.MatchError(gomega.ContainSubstring("multiple Uplink \"br-blue\" nodeConfigs select node \"node-a\"")))
 
 	state := getUplinkState(g, client, uplinkutil.StateName("br-blue", "node-a"))
 	g.Expect(state.Spec.UplinkName).To(gomega.Equal("br-blue"))
@@ -1057,7 +1103,8 @@ func TestNodeUplinkControllerDPUDoesNotAdoptStaleHostState(t *testing.T) {
 
 	controller, client := newTestController(t, hostDiscoverer, bridgeResolver, node, uplink, state)
 
-	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+		gomega.MatchError(gomega.ContainSubstring("waiting for DPU-host state for interface breth1")))
 
 	state = getUplinkState(g, client, "br-blue.node-a")
 	g.Expect(state.Status.HostInterfaceName).To(gomega.Equal(uplinkv1alpha1.InterfaceName("breth0")))
@@ -1071,7 +1118,8 @@ func TestNodeUplinkControllerDPUDoesNotAdoptStaleHostState(t *testing.T) {
 	// A second reconcile on the published state must be a no-op, not a
 	// resolve of br-old against the stale breth0 MAC.
 	controller, client = newTestController(t, hostDiscoverer, bridgeResolver, node, uplink, state)
-	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+		gomega.MatchError(gomega.ContainSubstring("waiting for DPU-host state for interface breth1")))
 	g.Expect(client.UplinkClient.(*uplinkfake.Clientset).Actions()).To(gomega.BeEmpty())
 }
 
@@ -1104,7 +1152,8 @@ func TestNodeUplinkControllerDPULeavesHostDataReadyToDPUHost(t *testing.T) {
 		state,
 	)
 
-	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+	g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(
+		gomega.MatchError(gomega.ContainSubstring("waiting for DPU-host MAC address for interface breth0")))
 
 	state = getUplinkState(g, client, "br-blue.node-a")
 	g.Expect(state.Status.Conditions).To(gomega.ContainElement(gomega.And(

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -236,8 +236,8 @@ func hostPeerMACAddress(rep string, flavour sriovnet.PortFlavour) (net.HardwareA
 	}
 	// GetRepresentorPeerMacAddress can succeed with an empty or all-zero MAC
 	// when the peer function MAC is unset; treat that as absent too.
-	if len(mac) == 0 || isZeroMAC(mac) {
-		return nil, fmt.Errorf("representor %s peer MAC is unset; devlink lookup also failed: %v", rep, devlinkErr)
+	if !IsUsableEthernetMAC(mac) {
+		return nil, fmt.Errorf("representor %s peer MAC is unusable; devlink lookup also failed: %v", rep, devlinkErr)
 	}
 	return mac, nil
 }

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
@@ -370,6 +371,13 @@ func ParseIPNets[T ~string](strs []T) ([]*net.IPNet, error) {
 		ipnets[i] = ipnet
 	}
 	return ipnets, nil
+}
+
+// IsUsableEthernetMAC reports whether mac can serve as a unicast interface
+// MAC, mirroring the kernel's is_valid_ether_addr: a 6-byte Ethernet address
+// that is neither all-zero nor multicast.
+func IsUsableEthernetMAC(mac net.HardwareAddr) bool {
+	return len(mac) == 6 && mac[0]&1 == 0 && !bytes.Equal(mac, make(net.HardwareAddr, 6))
 }
 
 // GenerateRandMAC generates a random unicast and locally administered MAC address.

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -486,3 +486,25 @@ func TestContainsCIDR(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUsableEthernetMAC(t *testing.T) {
+	tests := []struct {
+		name     string
+		mac      net.HardwareAddr
+		expected bool
+	}{
+		{name: "unicast Ethernet", mac: net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x03}, expected: true},
+		{name: "nil", mac: nil, expected: false},
+		{name: "all-zero", mac: net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, expected: false},
+		{name: "multicast", mac: net.HardwareAddr{0x01, 0x00, 0x5e, 0x00, 0x00, 0x01}, expected: false},
+		{name: "broadcast", mac: net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, expected: false},
+		{name: "EUI-64 length", mac: net.HardwareAddr{0x02, 0x42, 0xac, 0x12, 0x00, 0x03, 0x00, 0x01}, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUsableEthernetMAC(tt.mac); got != tt.expected {
+				t.Errorf("IsUsableEthernetMAC(%v) = %v, expected %v", tt.mac, got, tt.expected)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -135,19 +135,10 @@ func (defaultSriovnetOps) GetDevlinkPortFunctionMacAddress(netdev string) (net.H
 		return nil, fmt.Errorf("devlink port for netdev %s does not report function attributes", netdev)
 	}
 	// Drivers may report an unset function MAC as 00:00:00:00:00:00.
-	if len(port.Fn.HwAddr) == 0 || isZeroMAC(port.Fn.HwAddr) {
-		return nil, fmt.Errorf("devlink port function for netdev %s does not report a hardware address", netdev)
+	if !IsUsableEthernetMAC(port.Fn.HwAddr) {
+		return nil, fmt.Errorf("devlink port function for netdev %s does not report a usable hardware address", netdev)
 	}
 	return port.Fn.HwAddr, nil
-}
-
-func isZeroMAC(mac net.HardwareAddr) bool {
-	for _, b := range mac {
-		if b != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 func (defaultSriovnetOps) GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error) {

--- a/go-controller/pkg/util/sriovnet_linux_test.go
+++ b/go-controller/pkg/util/sriovnet_linux_test.go
@@ -269,13 +269,13 @@ func TestGetDevlinkPortFunctionMacAddress(t *testing.T) {
 		{
 			desc:   "fails when the hardware address is absent",
 			port:   &netlink.DevlinkPort{Fn: &netlink.DevlinkPortFn{}},
-			expErr: "does not report a hardware address",
+			expErr: "does not report a usable hardware address",
 		},
 		{
 			desc: "fails when the hardware address is all zeros",
 			// Drivers may report an unset function MAC as 00:00:00:00:00:00.
 			port:   &netlink.DevlinkPort{Fn: &netlink.DevlinkPortFn{HwAddr: ovntest.MustParseMAC("00:00:00:00:00:00")}},
-			expErr: "does not report a hardware address",
+			expErr: "does not report a usable hardware address",
 		},
 	}
 	for i, tc := range tests {

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_uplinkstates.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_uplinkstates.yaml
@@ -24,6 +24,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Resolved")].status
       name: Resolved
       type: string
+    - jsonPath: .status.conditions[?(@.type=="HostDataReady")].status
+      name: HostDataReady
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -25,6 +25,7 @@ import (
 	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -46,6 +47,7 @@ import (
 const (
 	uplinkPoll                      = time.Second
 	uplinkShortTimeout              = 60 * time.Second
+	uplinkConditionStableWindow     = 15 * time.Second
 	uplinkTimeout                   = 240 * time.Second
 	uplinkCurlMaxTime               = 1
 	uplinkDPUGatewayNetworkEnv      = "OVN_TEST_DPU_UPLINK_NETWORK"
@@ -750,6 +752,218 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 		}
 	})
 })
+
+var _ = ginkgo.Describe("Network Segmentation Uplink split DPU status conditions", feature.NetworkSegmentation, func() {
+	f := wrappedTestFramework("uplink-conditions")
+	f.SkipNamespaceCreation = true
+
+	var ictx infraapi.Context
+	var ipFamilySet sets.Set[utilnet.IPFamily]
+	var testSuffix string
+
+	ginkgo.BeforeEach(func() {
+		if IsGatewayModeLocal(f.ClientSet) {
+			e2eskipper.Skipf("Uplink CUDN gateway plumbing is only supported in shared gateway mode")
+		}
+		if !isDPUUplinkE2E() {
+			e2eskipper.Skipf("split DPU status condition e2e requires the DPU simulator environment")
+		}
+		ipFamilySet = sets.New(getSupportedIPFamiliesSlice(f.ClientSet)...)
+		ictx = infraprovider.Get().NewTestContext()
+		testSuffix = framework.RandomSuffix()
+	})
+
+	ginkgo.It("keeps one writer per condition and recovers a missing host interface", func() {
+		schedulableNodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		dpuHostNodes := filterNodesByLabel(schedulableNodes.Items, uplinkDPUHostNodeLabel)
+		gomega.Expect(dpuHostNodes).NotTo(gomega.BeEmpty(), "expected at least one ready schedulable DPU host node")
+		nodeIfaces := collectDPUHostUplinkInterfaces(dpuHostNodes)
+
+		ginkgo.By("resolving an Uplink on the provisioned host interface")
+		uplinkName := "upcond" + testSuffix
+		createUplink(f, ictx, uplinkName, dpuHostNodes, nodeIfaces, "")
+		waitForUplinkStatesResolved(f, uplinkName, os.Getenv(uplinkDPUExpectedBridgeEnv), dpuHostNodes)
+
+		ginkgo.By("verifying the DPU-host reported its discovery on HostDataReady")
+		for _, node := range dpuHostNodes {
+			state, err := getUplinkState(f, uplinkName, node.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				metav1.ConditionTrue,
+				uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			)).To(gomega.Succeed())
+		}
+
+		ginkgo.By("pointing an Uplink at a host interface that does not exist")
+		node := dpuHostNodes[0]
+		missingIface := "upe" + testSuffix
+		missingUplink := "upmiss" + testSuffix
+		createUplink(f, ictx, missingUplink, []corev1.Node{node}, nodeIfaces, missingIface)
+
+		gomega.Eventually(func() error {
+			state, err := getUplinkState(f, missingUplink, node.Name)
+			if err != nil {
+				return err
+			}
+			if err := checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				metav1.ConditionFalse,
+				uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound,
+			); err != nil {
+				return err
+			}
+			return checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionResolved,
+				metav1.ConditionFalse,
+				uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost,
+			)
+		}).WithTimeout(uplinkShortTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the DPU-host to report the missing interface on HostDataReady and the DPU to wait on Resolved",
+		)
+		// Each condition must keep a single writer in the failure window
+		// too: assert both conditions stay stable, including the transition
+		// timestamps, which a competing writer would churn.
+		snapshotConditions := func() (map[string]metav1.Condition, error) {
+			state, err := getUplinkState(f, missingUplink, node.Name)
+			if err != nil {
+				return nil, err
+			}
+			conditions := map[string]metav1.Condition{}
+			for _, conditionType := range []string{
+				uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				uplinkv1alpha1.UplinkStateConditionResolved,
+			} {
+				condition, err := uplinkStateCondition(state, conditionType)
+				if err != nil {
+					return nil, err
+				}
+				conditions[conditionType] = *condition
+			}
+			return conditions, nil
+		}
+		conditions, err := snapshotConditions()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Consistently(snapshotConditions).WithTimeout(uplinkConditionStableWindow).WithPolling(uplinkPoll).Should(
+			gomega.Equal(conditions),
+			"expected stable conditions while unresolved: reason, message and lastTransitionTime unchanged",
+		)
+
+		ginkgo.By("creating the host interface and waiting for host discovery to recover")
+		ictx.AddCleanUpFn(func() error {
+			return runNodeCommand(node.Name, "ip link del %s || true", missingIface)
+		})
+		createIface := fmt.Sprintf(
+			"ip link add %[1]s type dummy && ip addr add 192.0.2.1/24 dev %[1]s", missingIface)
+		if ipFamilySet.Has(utilnet.IPv6) {
+			createIface += fmt.Sprintf(" && ip addr add 2001:db8:e2e::1/64 dev %s", missingIface)
+		}
+		createIface += fmt.Sprintf(" && ip link set %s up", missingIface)
+		gomega.Expect(runNodeCommand(node.Name, "%s", createIface)).To(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			state, err := getUplinkState(f, missingUplink, node.Name)
+			if err != nil {
+				return err
+			}
+			if err := checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				metav1.ConditionTrue,
+				uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			); err != nil {
+				return err
+			}
+			// The DPU consumed the recovered host data: it moved past
+			// WaitingForDPUHost to a bridge discovery verdict of its own.
+			// Which verdict depends on the DPU-side environment (a dummy
+			// interface MAC matches no DPU bridge), so only the transition
+			// is asserted.
+			resolved, err := uplinkStateCondition(state, uplinkv1alpha1.UplinkStateConditionResolved)
+			if err != nil {
+				return err
+			}
+			if resolved.Status != metav1.ConditionFalse ||
+				resolved.Reason == uplinkv1alpha1.UplinkStateReasonWaitingForDPUHost {
+				return fmt.Errorf("UplinkState %s Resolved is %s/%s, expected a DPU-side discovery verdict",
+					state.GetName(), resolved.Status, resolved.Reason)
+			}
+			return nil
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected host discovery to recover without a restart and the DPU to consume the new data",
+		)
+
+		ginkgo.By("removing the host interface and waiting for the published host data to be pruned")
+		// Unlike the missing-interface phase above, host data has been
+		// published by now and must be withdrawn, not just flagged: a stale
+		// macAddress would keep feeding the DPU's bridge matching. Link
+		// deletion generates no Kubernetes events and a successful side does
+		// not retry, so force a reconcile with a node label change.
+		gomega.Expect(runNodeCommand(node.Name, "ip link del %s", missingIface)).To(gomega.Succeed())
+		pokeLabel := "e2e.k8s.ovn.org/uplink-poke"
+		e2enode.AddOrUpdateLabelOnNode(f.ClientSet, node.Name, pokeLabel, testSuffix)
+		ginkgo.DeferCleanup(e2enode.RemoveLabelOffNode, f.ClientSet, node.Name, pokeLabel)
+		gomega.Eventually(func() error {
+			state, err := getUplinkState(f, missingUplink, node.Name)
+			if err != nil {
+				return err
+			}
+			if err := checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				metav1.ConditionFalse,
+				uplinkv1alpha1.UplinkStateReasonHostInterfaceNotFound,
+			); err != nil {
+				return err
+			}
+			// Server-side apply removes the host-owned data fields once the
+			// DPU-host stops asserting them.
+			macAddress, _, err := unstructured.NestedString(state.Object, "status", "macAddress")
+			if err != nil {
+				return err
+			}
+			if macAddress != "" {
+				return fmt.Errorf("UplinkState %s still reports macAddress %q for the removed interface",
+					state.GetName(), macAddress)
+			}
+			return nil
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the host-owned data fields to be pruned once discovery fails",
+		)
+	})
+})
+
+func uplinkStateCondition(state *unstructured.Unstructured, conditionType string) (*metav1.Condition, error) {
+	conditions, err := getConditions(state)
+	if err != nil {
+		return nil, err
+	}
+	condition := meta.FindStatusCondition(conditions, conditionType)
+	if condition == nil {
+		return nil, fmt.Errorf("UplinkState %s has no %s condition", state.GetName(), conditionType)
+	}
+	return condition, nil
+}
+
+func checkUplinkStateCondition(
+	state *unstructured.Unstructured,
+	conditionType string,
+	status metav1.ConditionStatus,
+	reason string,
+) error {
+	condition, err := uplinkStateCondition(state, conditionType)
+	if err != nil {
+		return err
+	}
+	if condition.Status != status || condition.Reason != reason {
+		return fmt.Errorf("UplinkState %s condition %s is %s/%s, expected %s/%s",
+			state.GetName(), conditionType,
+			condition.Status, condition.Reason, status, reason)
+	}
+	return nil
+}
 
 func runDPUUplinkVRFLiteRouteAdvertisements(
 	f *framework.Framework,

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -297,6 +297,7 @@ if [ "$ENABLE_EVPN" = true ] && [[ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}"* ]]
         -procs=3 \
         -v \
         --focus="${FOCUS:-.}" \
+        --fail-on-empty \
         --timeout="${TEST_TIMEOUT}m" \
         --flake-attempts="${FLAKE_ATTEMPTS:-2}" \
         --skip="${SKIPPED_TESTS}" \
@@ -312,6 +313,7 @@ else
   go test -test.timeout ${GO_TEST_TIMEOUT}m -v . \
           -ginkgo.v \
           -ginkgo.focus ${FOCUS:-.} \
+          -ginkgo.fail-on-empty \
           -ginkgo.timeout ${TEST_TIMEOUT}m \
           -ginkgo.flake-attempts ${FLAKE_ATTEMPTS:-2} \
           -ginkgo.skip="${SKIPPED_TESTS}" \


### PR DESCRIPTION
## 📑 Description
On DPU-enabled nodes both ovnkube-node (DPU-host) and ovnkube-node-dpu (DPU) applied the same UplinkState `Resolved` condition, each overwriting the other side's failure reasons with its generic `WaitingForDPU`/`WaitingForDPUHost`. This hid the real diagnostic and livelocked both sides rewriting each other's status.

Following the review discussion, give each condition a single writer instead: the DPU owns `Resolved`, and the DPU-host reports host interface discovery on a new `HostDataReady` condition. `WaitingForDPU` is removed, having no writer left. The livelock becomes impossible by construction, and each side's root cause stays visible in the `UplinkState` status (with a new printcolumn) and in the aggregate `Uplink` `Ready` message. The DPU also no longer applies `status.hostInterfaceName` (DPU-host-owned): on a spec change it could transiently resolve the old bridge against a stale MAC.

Also fixed along the way:
- an unresolved status is no longer terminal: discovery reports it and returns the underlying error, retried with exponential backoff (capped at 30s, infinite attempts), since netlink/OVSDB changes generate no watch events. The clustermanager aggregation stays watch-driven and returns nil when not ready, but no longer hides a spec validation error behind a status write failure. Re-validating a converged successful status is tracked separately in #6784;
- host interfaces without a usable MAC (missing, all-zero, multicast, non-Ethernet) fail discovery instead of breaking much later in gateway programming, via a new `util.IsUsableEthernetMAC` helper mirroring the kernel's `is_valid_ether_addr`, which the existing devlink/representor MAC checks now also use.

An e2e in the DPU simulator lane now covers the split conditions end to end: per-condition field ownership via `managedFields`, failure reporting, recovery through the discovery retries, and server-side apply pruning of withdrawn host data. The control-plane e2e harness also fails runs whose focus selects zero specs, so a renamed spec cannot silently turn a lane green.

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

