### PR TITLE
Fix wrong infrastructure-locked role when namespace is missing

### DIFF
--- a/go-controller/pkg/clustermanager/networkconnect/cluster_network_connect.go
+++ b/go-controller/pkg/clustermanager/networkconnect/cluster_network_connect.go
@@ -48,11 +48,12 @@ var (
 func getPrimaryNADForNamespace(networkMgr networkmanager.Interface, namespaceName string) (nadKey string, network util.NetInfo, err error) {
 	namespacePrimaryNetwork, err := networkMgr.GetActiveNetworkForNamespace(namespaceName)
 	if err != nil {
-		if util.IsInvalidPrimaryNetworkError(err) {
-			// We intentionally ignore the invalid primary network error because
+		if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+			// We intentionally ignore transient namespace/network state because
 			// UDN Controller hasn't created the NAD yet, OR NAD doesn't exist in a
 			// namespace that has the required UDN label. It could also be that the
-			// UDN was deleted and the NAD is also gone.
+			// UDN was deleted and the NAD is also gone. Namespace/NAD handlers will
+			// trigger reconciliation when state becomes available.
 			return "", nil, nil
 		}
 		return "", nil, err
@@ -63,7 +64,7 @@ func getPrimaryNADForNamespace(networkMgr networkmanager.Interface, namespaceNam
 	}
 	primaryNADKey, err := networkMgr.GetPrimaryNADForNamespace(namespaceName)
 	if err != nil {
-		if util.IsInvalidPrimaryNetworkError(err) {
+		if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
 			return "", nil, nil
 		}
 		return "", nil, err

--- a/go-controller/pkg/clustermanager/networkconnect/controller.go
+++ b/go-controller/pkg/clustermanager/networkconnect/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) mustProcessCNCForNAD(nad *nadv1.NetworkAttachmentDefinition
 				for _, namespace := range namespaces {
 					nsPrimaryNetwork, err := c.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 					if err != nil {
-						if util.IsInvalidPrimaryNetworkError(err) {
+						if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
 							continue
 						}
 						klog.Errorf("Failed to get active network for namespace %s: %v", namespace.Name, err)

--- a/go-controller/pkg/clustermanager/networkconnect/controller_components_test.go
+++ b/go-controller/pkg/clustermanager/networkconnect/controller_components_test.go
@@ -220,6 +220,8 @@ func TestController_reconcileClusterNetworkConnect(t *testing.T) {
 		expectCacheEntryExists bool
 		// expectCacheEntryDeleted indicates if the cache entry should be deleted (for CNC deletion tests)
 		expectCacheEntryDeleted bool
+		// notFoundNamespaces makes FakeNetworkManager return NotFound for these namespaces.
+		notFoundNamespaces []string
 	}{
 		// Primary CUDN owned NAD selection tests
 		{
@@ -632,6 +634,34 @@ func TestController_reconcileClusterNetworkConnect(t *testing.T) {
 			expectSubnetsAllocated:  false, // no subnets allocated since no networks matched
 			expectCacheEntryExists:  true,
 		},
+		{
+			name: "skips namespace when namespace is absent from informer cache (NotFound) and continues reconciliation",
+			cnc: &testCNC{
+				Name: "test-cnc",
+				NetworkSelectors: []apitypes.NetworkSelector{
+					{
+						NetworkSelectionType: apitypes.PrimaryUserDefinedNetworks,
+						PrimaryUserDefinedNetworkSelector: &apitypes.PrimaryUserDefinedNetworkSelector{
+							NamespaceSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"requires-udn": "true"},
+							},
+						},
+					},
+				},
+			},
+			namespaces: []*testNamespace{
+				{Name: "pending-ns", Labels: map[string]string{"requires-udn": "true"}},
+			},
+			notFoundNamespaces:      []string{"pending-ns"},
+			nads:                    []*testNAD{},
+			reconcile:               "test-cnc",
+			wantErr:                 false,
+			expectSelectedNADs:      []string{},
+			expectSelectedNetworks:  []string{},
+			expectTunnelIDAllocated: true,
+			expectSubnetsAllocated:  false,
+			expectCacheEntryExists:  true,
+		},
 		// Error condition tests
 		{
 			name: "errors when more than 1 primary NAD is found for namespace",
@@ -793,6 +823,9 @@ func TestController_reconcileClusterNetworkConnect(t *testing.T) {
 					}
 					fakeNM.UDNNamespaces.Insert(ns.Name)
 				}
+			}
+			if len(tt.notFoundNamespaces) > 0 {
+				fakeNM.NotFoundNamespaces = sets.New(tt.notFoundNamespaces...)
 			}
 
 			tunnelKeysAllocator := id.NewTunnelKeyAllocator("TunnelKeys")
@@ -1273,6 +1306,8 @@ func TestMustProcessCNCForNAD(t *testing.T) {
 		cncCacheState *clusterNetworkConnectState
 		// mustProcessCNC is the expected result of mustProcessCNCForNAD
 		mustProcessCNC bool
+		// notFoundNamespaces makes FakeNetworkManager return NotFound for these namespaces.
+		notFoundNamespaces []string
 	}{
 		{
 			name: "Primary CUDN owned NAD starts matching but CNC cache doesn't exist (CNC not created yet) - should NOT process CNC",
@@ -1577,6 +1612,39 @@ func TestMustProcessCNCForNAD(t *testing.T) {
 			},
 			mustProcessCNC: false,
 		},
+		{
+			name: "Primary UDN NAD cannot match when namespace active network lookup returns NotFound",
+			cnc: &testCNC{
+				Name: "cnc1",
+				NetworkSelectors: []apitypes.NetworkSelector{
+					{
+						NetworkSelectionType: apitypes.PrimaryUserDefinedNetworks,
+						PrimaryUserDefinedNetworkSelector: &apitypes.PrimaryUserDefinedNetworkSelector{
+							NamespaceSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"selected": "true"},
+							},
+						},
+					},
+				},
+			},
+			nad: &testNAD{
+				Name:      "udn-test",
+				Namespace: "test",
+				Network:   util.GenerateUDNNetworkName("test", "udn-test"),
+				IsUDN:     true,
+				IsPrimary: true,
+			},
+			namespaces: []testNamespace{
+				{Name: "test", Labels: map[string]string{"selected": "true"}},
+			},
+			cncCacheState: &clusterNetworkConnectState{
+				name:             "cnc1",
+				selectedNADs:     sets.New[string](),
+				selectedNetworks: sets.New[string](),
+			},
+			notFoundNamespaces: []string{"test"},
+			mustProcessCNC:     false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1633,6 +1701,9 @@ func TestMustProcessCNCForNAD(t *testing.T) {
 				netInfo, err := util.ParseNADInfo(nadObj)
 				g.Expect(err).ToNot(gomega.HaveOccurred(), "ParseNADInfo for %s failed", nadKey)
 				fakeNM.NADNetworks[nadKey] = netInfo
+			}
+			if len(tt.notFoundNamespaces) > 0 {
+				fakeNM.NotFoundNamespaces = sets.New(tt.notFoundNamespaces...)
 			}
 
 			tunnelKeysAllocator := id.NewTunnelKeyAllocator("TunnelKeys")

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -60,8 +60,10 @@ type watchFactory interface {
 type Interface interface {
 	// GetActiveNetworkForNamespace returns a copy of the primary network for
 	// the namespace if any or the default network otherwise.
-	// If the network is non-existent for a legitimate reason (namespace gone or
-	// filtered by Dynamic UDN) it returns nil NetInfo and no error.
+	// If the network is non-existent for a legitimate reason (filtered by
+	// Dynamic UDN) it returns nil NetInfo and no error.
+	// Returns a NotFound error if the namespace is absent from the informer
+	// cache (not necessarily definitively deleted).
 	// If the network is non-existent, but should exist, return InvalidPrimaryNetworkError.
 	// If unsure, use this one and not GetActiveNetworkForNamespaceFast.
 	// Note this function is filtered by Dynamic UDN, so if your caller wants NAD/Network

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -79,6 +79,8 @@ type Interface interface {
 	// GetPrimaryNADForNamespace returns the full namespaced key of the
 	// primary NAD for the given namespace, if one exists.
 	// Returns default network if namespace has no primary UDN.
+	// Returns a NotFound error if the namespace is absent from the informer
+	// cache (not necessarily definitively deleted).
 	// This function is not filtered based on Dynamic UDN.
 	GetPrimaryNADForNamespace(namespace string) (string, error)
 

--- a/go-controller/pkg/networkmanager/fake.go
+++ b/go-controller/pkg/networkmanager/fake.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
@@ -68,6 +70,8 @@ type FakeNetworkManager struct {
 	nextNetworkRefID      uint64
 	// UDNNamespaces are a list of namespaces that require UDN for primary network
 	UDNNamespaces sets.Set[string]
+	// NotFoundNamespaces are namespaces absent from the informer cache for GetActiveNetworkForNamespace.
+	NotFoundNamespaces sets.Set[string]
 	// ActiveNodes tracks node activity per network for Dynamic UDN tests.
 	ActiveNodes map[string]map[string]bool
 }
@@ -131,6 +135,13 @@ func (fnm *FakeNetworkManager) Start() error { return nil }
 func (fnm *FakeNetworkManager) Stop() {}
 
 func (fnm *FakeNetworkManager) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
+	fnm.Lock()
+	if fnm.NotFoundNamespaces != nil && fnm.NotFoundNamespaces.Has(namespace) {
+		fnm.Unlock()
+		return nil, fmt.Errorf("failed to fetch namespace %q: %w", namespace,
+			apierrors.NewNotFound(corev1.Resource("namespaces"), namespace))
+	}
+	fnm.Unlock()
 	network := fnm.GetActiveNetworkForNamespaceFast(namespace)
 	if network == nil {
 		return nil, util.NewInvalidPrimaryNetworkError(namespace)
@@ -141,6 +152,10 @@ func (fnm *FakeNetworkManager) GetActiveNetworkForNamespace(namespace string) (u
 func (fnm *FakeNetworkManager) GetPrimaryNADForNamespace(namespace string) (string, error) {
 	fnm.Lock()
 	defer fnm.Unlock()
+	if fnm.NotFoundNamespaces != nil && fnm.NotFoundNamespaces.Has(namespace) {
+		return "", fmt.Errorf("failed to fetch namespace %q: %w", namespace,
+			apierrors.NewNotFound(corev1.Resource("namespaces"), namespace))
+	}
 	if primaryNetwork, ok := fnm.PrimaryNetworks[namespace]; ok {
 		if primaryNetwork == nil {
 			return "", util.NewInvalidPrimaryNetworkError(namespace)

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -1398,10 +1398,6 @@ func (c *nadController) GetPrimaryNADForNamespace(namespace string) (string, err
 	// Double-check if the namespace *requires* a primary UDN.
 	ns, err := c.namespaceLister.Get(namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Namespace is gone — no primary NAD by definition.
-			return "", nil
-		}
 		return "", fmt.Errorf("failed to fetch namespace %q: %w", namespace, err)
 	}
 	if _, exists := ns.Labels[types.RequiredUDNNamespaceLabel]; exists {

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -1383,7 +1383,9 @@ func (c *nadController) GetActiveNetworkForNamespaceFast(namespace string) util.
 
 // GetPrimaryNADForNamespace returns the full namespaced key of the
 // primary NAD for the given namespace, if one exists.
-// Returns default network if namespace has no primary UDN or Network Segmentation is disabled
+// Returns default network if namespace has no primary UDN or Network Segmentation is disabled.
+// Returns a NotFound error if the namespace is absent from the informer
+// cache (not necessarily definitively deleted).
 func (c *nadController) GetPrimaryNADForNamespace(namespace string) (string, error) {
 	if !util.IsNetworkSegmentationSupportEnabled() {
 		return types.DefaultNetworkName, nil

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -1334,6 +1334,8 @@ func (c *nadController) nadNeedsUpdate(oldNAD, newNAD *nettypes.NetworkAttachmen
 // Returns DefaultNetwork if Network Segmentation disabled or namespace does not require primary UDN.
 // Returns nil if there is no active network.
 // Returns InvalidPrimaryNetworkError if a network should be present but is not.
+// Returns a NotFound error if the namespace is absent from the informer
+// cache (not necessarily definitively deleted).
 func (c *nadController) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
 	if !util.IsNetworkSegmentationSupportEnabled() {
 		return &util.DefaultNetInfo{}, nil
@@ -1342,10 +1344,6 @@ func (c *nadController) GetActiveNetworkForNamespace(namespace string) (util.Net
 	// check if required UDN label is on namespace
 	ns, err := c.namespaceLister.Get(namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// namespace is gone, no active network for it
-			return nil, nil
-		}
 		return nil, fmt.Errorf("failed to get namespace %q: %w", namespace, err)
 	}
 	if _, exists := ns.Labels[types.RequiredUDNNamespaceLabel]; !exists {

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -3328,3 +3328,40 @@ func TestOnNetworkRefChangeNotifiesConnectedRemoteNetworkControllers(t *testing.
 		})
 	}
 }
+
+type notFoundNamespaceLister struct {
+	notFound sets.Set[string]
+}
+
+func (l *notFoundNamespaceLister) List(labels.Selector) ([]*corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (l *notFoundNamespaceLister) Get(name string) (*corev1.Namespace, error) {
+	if l.notFound != nil && l.notFound.Has(name) {
+		return nil, apierrors.NewNotFound(corev1.Resource("namespaces"), name)
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{types.RequiredUDNNamespaceLabel: ""},
+		},
+	}, nil
+}
+
+func TestGetActiveNetworkForNamespace_ReturnsNotFoundWhenNamespaceAbsent(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	c := &nadController{
+		namespaceLister: &notFoundNamespaceLister{
+			notFound: sets.New("missing-ns"),
+		},
+	}
+
+	_, err := c.GetActiveNetworkForNamespace("missing-ns")
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1253,7 +1253,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 			// During startup sync, avoid failing the entire processExisting loop for namespaces that
 			// require a UDN but have no primary NAD yet (or it has been deleted). Those services will
 			// be reconciled later via regular add/update events once the NAD exists.
-			if util.IsInvalidPrimaryNetworkError(err) {
+			if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
 				continue
 			}
 			errors = append(errors, err)
@@ -1446,8 +1446,9 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 		// and allows graceful handling of deletion race conditions.
 		netInfo, err := npw.networkManager.GetActiveNetworkForNamespace(namespacedName.Namespace)
 		if err != nil {
-			// If the UDN was deleted or not processed yet, skip adding new service rules
-			if util.IsInvalidPrimaryNetworkError(err) {
+			// If the UDN was deleted, not processed yet, or namespace is absent from the informer cache,
+			// skip adding new service rules.
+			if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
 				klog.V(5).Infof("Skipping addServiceRules for %s/%s during endpoint slice delete: primary network unavailable: %v",
 					namespacedName.Namespace, namespacedName.Name, err)
 				return utilerrors.Join(errors...)
@@ -1671,7 +1672,7 @@ func (npwnft *nodePortWatcherNFTables) SyncServices(services []interface{}) erro
 			// During startup sync, avoid failing the entire processExisting loop for namespaces that
 			// require a UDN but have no primary NAD yet (or it has been deleted). Those services will
 			// be reconciled later via regular add/update events once the NAD exists.
-			if util.IsInvalidPrimaryNetworkError(err) {
+			if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
 				continue
 			}
 			errors = append(errors, err)

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -110,8 +110,8 @@ func (m *mockNetworkManagerWithNamespaceNotFoundError) GetPrimaryNADForNamespace
 }
 
 func (m *mockNetworkManagerWithNamespaceNotFoundError) GetActiveNetworkForNamespace(_ string) (util.NetInfo, error) {
-	// Namespace is gone; new GetActiveNetworkForNamespace semantics return nil, nil.
-	return nil, nil
+	return nil, fmt.Errorf("failed to get namespace %q: %w", "test-ns",
+		apierrors.NewNotFound(corev1.Resource("namespaces"), "test-ns"))
 }
 
 // mockNetworkManagerWithInvalidPrimaryNetworkError simulates UDN deletion scenario
@@ -479,6 +479,28 @@ var _ = Describe("SyncServices", func() {
 
 			verifyNFTablesRule(nft, "10.96.0.20", 80, 30091, false,
 				"nftables rule should not be created when primary network is invalid")
+		})
+	})
+
+	Context("when namespace is absent from informer cache", func() {
+		It("should skip service sync without failing startup", func() {
+			service := newService(testService, testNamespace, "10.96.0.21",
+				[]corev1.ServicePort{{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   30094,
+				}},
+				corev1.ServiceTypeNodePort, nil, corev1.ServiceStatus{}, false, false)
+
+			npw.networkManager = &mockNetworkManagerWithNamespaceNotFoundError{}
+
+			err := npw.SyncServices([]interface{}{service})
+			Expect(err).NotTo(HaveOccurred())
+
+			verifyNFTablesRule(nft, "10.96.0.21", 80, 30094, false,
+				"nftables rule should not be created when namespace lookup returns NotFound")
 		})
 	})
 

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -18,6 +18,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -102,9 +103,10 @@ type mockNetworkManagerWithNamespaceNotFoundError struct {
 	networkmanager.Interface
 }
 
-func (m *mockNetworkManagerWithNamespaceNotFoundError) GetPrimaryNADForNamespace(_ string) (string, error) {
-	// Simulate namespace deletion: no primary NAD by definition.
-	return "", nil
+func (m *mockNetworkManagerWithNamespaceNotFoundError) GetPrimaryNADForNamespace(namespace string) (string, error) {
+	// Namespace absent from the informer cache (not proof of deletion).
+	return "", fmt.Errorf("failed to fetch namespace %q: %w", namespace,
+		apierrors.NewNotFound(corev1.Resource("namespaces"), namespace))
 }
 
 func (m *mockNetworkManagerWithNamespaceNotFoundError) GetActiveNetworkForNamespace(_ string) (util.NetInfo, error) {

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -346,6 +347,9 @@ func (bnc *BaseNetworkController) shouldFilterNamespace(namespace string) bool {
 
 	nadKey, err := bnc.networkManager.GetPrimaryNADForNamespace(namespace)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false
+		}
 		return util.IsInvalidPrimaryNetworkError(err)
 	}
 	if nadKey == types.DefaultNetworkName {

--- a/go-controller/pkg/ovn/base_network_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace_test.go
@@ -4,17 +4,41 @@
 package ovn
 
 import (
+	"fmt"
 	"testing"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+// primaryNADNetworkManager is a minimal mock for shouldFilterNamespace tests.
+type primaryNADNetworkManager struct {
+	networkmanager.Interface
+	nadKey       string
+	err          error
+	nadToNetwork map[string]string
+}
+
+func (m *primaryNADNetworkManager) GetPrimaryNADForNamespace(string) (string, error) {
+	return m.nadKey, m.err
+}
+
+func (m *primaryNADNetworkManager) GetNetworkNameForNADKey(nadKey string) string {
+	if m.nadToNetwork == nil {
+		return ""
+	}
+	return m.nadToNetwork[nadKey]
+}
 
 func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 	tests := []struct {
@@ -83,6 +107,129 @@ func TestBaseNetworkController_shouldWatchNamespaces(t *testing.T) {
 				t.Fail()
 			}
 			assert.Equal(t, tt.expectedReturn, bnc.shouldWatchNamespaces())
+		})
+	}
+}
+
+func TestBaseNetworkController_shouldFilterNamespace(t *testing.T) {
+	const (
+		nsName    = "test-ns"
+		udnName   = "udn1"
+		udnNADKey = "test-ns/primary-nad"
+		otherUDN  = "other-udn"
+		otherNAD  = "test-ns/other-nad"
+	)
+
+	mustNetInfo := func(t *testing.T, name, role string) util.NetInfo {
+		t.Helper()
+		ni, err := util.NewNetInfo(&ovncnitypes.NetConf{
+			NetConf:  cnitypes.NetConf{Name: name},
+			Topology: types.Layer3Topology,
+			Role:     role,
+		})
+		require.NoError(t, err)
+		return ni
+	}
+
+	tests := []struct {
+		name           string
+		netInfo        func(t *testing.T) util.NetInfo
+		networkManager networkmanager.Interface
+		wantFilter     bool
+	}{
+		{
+			name: "secondary network never filters",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, "secondary", types.NetworkRoleSecondary)
+			},
+			networkManager: &primaryNADNetworkManager{err: apierrors.NewNotFound(corev1.Resource("namespaces"), nsName)},
+			wantFilter:     false,
+		},
+		{
+			name: "does not filter when namespace is NotFound in informer cache",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, udnName, types.NetworkRolePrimary)
+			},
+			networkManager: &primaryNADNetworkManager{
+				err: apierrors.NewNotFound(corev1.Resource("namespaces"), nsName),
+			},
+			wantFilter: false,
+		},
+		{
+			name: "filters on InvalidPrimaryNetworkError",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, udnName, types.NetworkRolePrimary)
+			},
+			networkManager: &primaryNADNetworkManager{
+				err: util.NewInvalidPrimaryNetworkError(nsName),
+			},
+			wantFilter: true,
+		},
+		{
+			name: "does not filter on unexpected lookup errors",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, udnName, types.NetworkRolePrimary)
+			},
+			networkManager: &primaryNADNetworkManager{
+				err: fmt.Errorf("unexpected failure"),
+			},
+			wantFilter: false,
+		},
+		{
+			name: "filters default-network namespaces for primary UDN controller",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, udnName, types.NetworkRolePrimary)
+			},
+			networkManager: &primaryNADNetworkManager{
+				nadKey: types.DefaultNetworkName,
+			},
+			wantFilter: true,
+		},
+		{
+			name: "does not filter when namespace primary NAD matches controller",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, udnName, types.NetworkRolePrimary)
+			},
+			networkManager: &primaryNADNetworkManager{
+				nadKey:       udnNADKey,
+				nadToNetwork: map[string]string{udnNADKey: udnName},
+			},
+			wantFilter: false,
+		},
+		{
+			name: "filters when namespace primary NAD belongs to another network",
+			netInfo: func(t *testing.T) util.NetInfo {
+				t.Helper()
+				return mustNetInfo(t, udnName, types.NetworkRolePrimary)
+			},
+			networkManager: &primaryNADNetworkManager{
+				nadKey:       otherNAD,
+				nadToNetwork: map[string]string{otherNAD: otherUDN},
+			},
+			wantFilter: true,
+		},
+	}
+
+	t.Cleanup(func() {
+		require.NoError(t, config.PrepareTestConfig())
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			util.PrepareTestConfig()
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+			bnc := &BaseNetworkController{
+				ReconcilableNetInfo: util.NewReconcilableNetInfo(tt.netInfo(t)),
+				networkManager:      tt.networkManager,
+			}
+			assert.Equal(t, tt.wantFilter, bnc.shouldFilterNamespace(nsName))
 		})
 	}
 }

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -15,6 +15,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/utils/net"
@@ -23,6 +24,7 @@ import (
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -504,6 +506,144 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 		retry.CheckRetryObjectEventually(key, true, bnc.retryPods)
 	})
 
+	Context("when shouldFilterNamespace does not filter a pod because the namespace is missing from the informer", func() {
+		const (
+			missingNamespace = "greenamespace"
+			podName          = "dummy"
+			localNode        = "worker1"
+		)
+
+		var (
+			bnc     *BaseUserDefinedNetworkController
+			fakeOVN *FakeOVN
+			pod     *corev1.Pod
+		)
+
+		BeforeEach(func() {
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.IPv4Mode = true
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "dummy-pod-uid",
+					Namespace: missingNamespace,
+					Name:      podName,
+				},
+				Spec: corev1.PodSpec{
+					NodeName: localNode,
+				},
+			}
+			fakeOVN = NewFakeOVN(false, localNode)
+			fakeOVN.start(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: localNode,
+						Annotations: map[string]string{
+							"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+							util.OvnNodeChassisID:     chassisIDForNode(localNode),
+						},
+					},
+				},
+				pod,
+			)
+			DeferCleanup(fakeOVN.shutdown)
+			Expect(fakeOVN.NewUserDefinedNetworkController(nad)).To(Succeed())
+			controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
+			Expect(ok).To(BeTrue())
+			bnc = controller.bnc
+			Expect(bnc.shouldFilterNamespace(missingNamespace)).To(BeFalse())
+		})
+
+		It("ensurePod with addPort=true returns an error until the namespace is in the informer", func() {
+			err := bnc.ensurePodForUserDefinedNetwork(pod, true)
+			Expect(err).To(MatchError(ContainSubstring("failed to get primary network namespace NAD")))
+			Expect(err).To(MatchError(apierrors.IsNotFound, "IsNotFound"))
+
+			_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Namespaces().Create(
+				context.Background(),
+				newUDNNamespace(missingNamespace),
+				metav1.CreateOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			nadToCreate := nad.DeepCopy()
+			ovntest.AnnotateNADWithNetworkID("3", nadToCreate)
+			_, err = fakeOVN.fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nadToCreate.Namespace).Create(
+				context.Background(), nadToCreate, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			nadKey := util.GetNADName(nad.Namespace, nad.Name)
+			nodeSubnet := ovntest.MustParseIPNet("100.128.0.0/24")
+			switchName := bnc.GetNetworkScopedSwitchName(localNode)
+			Expect(bnc.lsManager.AddOrUpdateSwitch(switchName, []*net.IPNet{nodeSubnet}, nil)).To(Succeed())
+			Expect(libovsdbops.CreateOrUpdateLogicalSwitch(fakeOVN.nbClient, &nbdb.LogicalSwitch{Name: switchName})).To(Succeed())
+
+			Eventually(func() error {
+				return bnc.ensurePodForUserDefinedNetwork(pod, true)
+			}).Should(Succeed())
+
+			updatedPod, err := fakeOVN.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Get(
+				context.Background(), pod.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			podAnnotation, err := util.UnmarshalPodAnnotation(updatedPod.Annotations, nadKey)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podAnnotation.IPs).To(HaveLen(1))
+			Expect(nodeSubnet.Contains(podAnnotation.IPs[0].IP)).To(BeTrue())
+			Expect(podAnnotation.MAC).NotTo(BeEmpty())
+			Expect(podAnnotation.Role).To(Equal(types.NetworkRolePrimary))
+
+			lspName := util.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadKey)
+			lsps, err := libovsdbops.FindLogicalSwitchPortWithPredicate(fakeOVN.nbClient, func(p *nbdb.LogicalSwitchPort) bool {
+				return p.Name == lspName
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lsps).To(HaveLen(1))
+			Expect(lsps[0].Addresses).To(ConsistOf(fmt.Sprintf("%s %s", podAnnotation.MAC, podAnnotation.IPs[0].IP)))
+		})
+
+		It("removePod deletes this network's logical port while the namespace is missing", func() {
+			nadKey := util.GetNADName(nad.Namespace, nad.Name)
+			bnc.networkManager = &nadKeyNameOverlay{
+				Interface:    bnc.networkManager,
+				nadToNetwork: map[string]string{nadKey: bnc.GetNetworkName()},
+			}
+
+			annotations, err := util.MarshalPodAnnotation(nil, &util.PodAnnotation{
+				MAC:  net.HardwareAddr{0x0a, 0x58, 0x0a, 0x80, 0x00, 0x05},
+				IPs:  ovntest.MustParseIPNets("100.128.0.5/24"),
+				Role: types.NetworkRolePrimary,
+			}, nadKey)
+			Expect(err).NotTo(HaveOccurred())
+			pod.Annotations = annotations
+
+			switchName := bnc.GetNetworkScopedSwitchName(localNode)
+			lspName := util.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadKey)
+			ls := &nbdb.LogicalSwitch{Name: switchName}
+			lsp := &nbdb.LogicalSwitchPort{Name: lspName}
+			Expect(libovsdbops.CreateOrUpdateLogicalSwitch(fakeOVN.nbClient, ls)).To(Succeed())
+			Expect(libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(fakeOVN.nbClient, ls, lsp)).To(Succeed())
+
+			lsps, err := libovsdbops.FindLogicalSwitchPortWithPredicate(fakeOVN.nbClient, func(p *nbdb.LogicalSwitchPort) bool {
+				return p.Name == lspName
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lsps).To(HaveLen(1))
+			Expect(lsps[0]).To(Equal(lsp))
+
+			Expect(bnc.removePodForUserDefinedNetwork(pod, map[string]*lpInfo{
+				nadKey: {
+					name:          lspName,
+					uuid:          lsp.UUID,
+					logicalSwitch: switchName,
+				},
+			})).To(Succeed())
+			lsps, err = libovsdbops.FindLogicalSwitchPortWithPredicate(fakeOVN.nbClient, func(p *nbdb.LogicalSwitchPort) bool {
+				return p.Name == lspName
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lsps).To(BeEmpty())
+		})
+	})
+
 })
 
 func TestAdvertisedSharedGatewaySNATUsesLiveAllowedExtIPSets(t *gotesting.T) {
@@ -966,3 +1106,17 @@ var _ = Describe("localnet DHCP IPAM pod lifecycle", func() {
 		Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedSwitch, newExpectedLSP(podMAC+" "+podIP)))
 	})
 })
+
+// nadKeyNameOverlay keeps GetPrimaryNADForNamespace (and thus namespace-informer
+// NotFound) on the wrapped manager, while allowing tests to claim a NAD key.
+type nadKeyNameOverlay struct {
+	networkmanager.Interface
+	nadToNetwork map[string]string
+}
+
+func (m *nadKeyNameOverlay) GetNetworkNameForNADKey(nadKey string) string {
+	if name, ok := m.nadToNetwork[nadKey]; ok {
+		return name
+	}
+	return m.Interface.GetNetworkNameForNADKey(nadKey)
+}

--- a/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
+++ b/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
@@ -6,7 +6,6 @@ package egressfirewall
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -246,8 +245,7 @@ func (oc *EFController) syncNAD(key string) error {
 	return nil
 }
 
-// initialSync deletes stale db entries for previous versions of Egress Firewall implementation and removes
-// stale db entries for Egress Firewalls that don't exist anymore.
+// initialSync deletes stale db entries for Egress Firewalls that don't exist anymore.
 // Egress firewall implementation had many versions, the latest one makes no difference for gateway modes, and creates
 // ACLs on namespaced port groups.
 func (oc *EFController) initialSync() error {
@@ -267,12 +265,6 @@ func (oc *EFController) initialSync() error {
 	efACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, aclP)
 	if err != nil {
 		return fmt.Errorf("cannot find Egress Firewall ACLs: %v", err)
-	}
-
-	// another sync to move ACLs to the right port group
-	err = oc.moveACLsToNamespacedPortGroups(existingEFNamespaces, efACLs)
-	if err != nil {
-		return err
 	}
 
 	getPGPredicate := func(acl *nbdb.ACL) func(item *nbdb.PortGroup) bool {
@@ -341,9 +333,7 @@ func (oc *EFController) initialSync() error {
 						name, strings.Join(pgNames, ","))
 				}
 				for _, pg := range foundPGs {
-					// delete stale ACLs from namespaced port group
-					// both port group and acls may not exist after moveACLsToNamespacedPortGroups,
-					// but DeleteACLsFromPortGroupOps doesn't return error in these cases
+					// DeleteACLsFromPortGroupOps does not error if the port group or ACLs are already gone.
 					ops, err = libovsdbops.DeleteACLsFromPortGroupOps(oc.nbClient, ops, pg.Name, acls...)
 					if err != nil {
 						return fmt.Errorf("failed to build cleanup ops: %w", err)
@@ -852,72 +842,6 @@ func (oc *EFController) addEgressFirewallRules(ef *egressFirewall, pgName string
 	return nil
 }
 
-// moveACLsToNamespacedPortGroups syncs db from the previous version where all ACLs were attached to the ClusterPortGroup
-// to the new version where ACLs are attached to the namespace port groups.
-func (oc *EFController) moveACLsToNamespacedPortGroups(existingEFNamespaces map[string]bool, efACLs []*nbdb.ACL) error {
-	// find stale ACLs attached to a cluster port group, and move them to namespaced port groups
-	clusterPG, err := libovsdbops.GetPortGroup(oc.nbClient, &nbdb.PortGroup{
-		Name: libovsdbutil.GetPortGroupName(libovsdbops.NewDbObjectIDs(libovsdbops.PortGroupCluster, types.DefaultNetworkControllerName,
-			map[libovsdbops.ExternalIDKey]string{
-				libovsdbops.ObjectNameKey: types.ClusterPortGroupNameBase,
-			})),
-	})
-	if err != nil {
-		if errors.Is(err, libovsdbclient.ErrNotFound) {
-			return nil
-		}
-		return fmt.Errorf("failed to get cluster port group: %w", err)
-	}
-	staleUUIDs := sets.NewString(clusterPG.ACLs...)
-
-	// move ACLs from cluster port group to per-namespace port group
-	// old acl matches on the address set, which is still valid. match change from address set to port group will be
-	// performed by the egress firewall handler.
-	staleNamespaces := map[string][]*nbdb.ACL{}
-	for _, acl := range efACLs {
-		namespace := acl.ExternalIDs[libovsdbops.ObjectNameKey.String()]
-		// no key will be treated as an empty namespace and ACLs will just be deleted
-		if staleUUIDs.Has(acl.UUID) {
-			staleNamespaces[namespace] = append(staleNamespaces[namespace], acl)
-		}
-	}
-	if len(staleNamespaces) == 0 {
-		return nil
-	}
-
-	err = batching.BatchMap[*nbdb.ACL](aclChangePGBatchSize, staleNamespaces, func(batchNsACLs map[string][]*nbdb.ACL) error {
-		var ops []ovsdb.Operation
-		var err error
-		for namespace, acls := range batchNsACLs {
-			if namespace != "" && existingEFNamespaces[namespace] {
-				pgName, err := oc.getNamespacePortGroupName(namespace)
-				if err != nil {
-					klog.Warningf("Skipping egress firewall ACL move for namespace %s: %v", namespace, err)
-					continue
-				}
-				// re-attach from ClusterPortGroupNameBase to namespaced port group.
-				// port group should exist, because namespace handler will create it.
-				ops, err = libovsdbops.AddACLsToPortGroupOps(oc.nbClient, ops, pgName, acls...)
-				if err != nil {
-					return fmt.Errorf("failed to build cleanup ops: %w", err)
-				}
-			}
-			// delete all EF ACLs from ClusterPortGroupNameBase
-			ops, err = libovsdbops.DeleteACLsFromPortGroupOps(oc.nbClient, ops,
-				clusterPG.Name, acls...)
-			if err != nil {
-				return fmt.Errorf("failed to build cleanup from ClusterPortGroup ops: %w", err)
-			}
-		}
-		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-		if err != nil {
-			return fmt.Errorf("failed to clean up egress firewall ACLs: %w", err)
-		}
-		return nil
-	})
-	return err
-}
-
 // createEgressFirewallACLOps uses the previously generated elements and creates the
 // acls for all node switches
 func (oc *EFController) createEgressFirewallACLOps(ops []ovsdb.Operation, egressFirewallACL *nbdb.ACL, pgName string) ([]ovsdb.Operation, error) {
@@ -1029,22 +953,6 @@ func getNamespacePortGroupDbIDs(ns string, controller string) *libovsdbops.DbObj
 		map[libovsdbops.ExternalIDKey]string{
 			libovsdbops.ObjectNameKey: ns,
 		})
-}
-
-func (oc *EFController) getNamespacePortGroupName(namespace string) (string, error) {
-	nadKey, err := oc.networkManager.GetPrimaryNADForNamespace(namespace)
-	if err != nil {
-		return "", fmt.Errorf("failed to get primary NAD for namespace %s: %w", namespace, err)
-	}
-	networkName := types.DefaultNetworkName
-	if nadKey != types.DefaultNetworkName && nadKey != "" {
-		networkName = oc.networkManager.GetNetworkNameForNADKey(nadKey)
-		if networkName == "" {
-			return "", fmt.Errorf("failed to resolve network name for NAD %s in namespace %s", nadKey, namespace)
-		}
-	}
-	ownerController := networkName + "-network-controller"
-	return libovsdbutil.GetPortGroupName(getNamespacePortGroupDbIDs(namespace, ownerController)), nil
 }
 
 func (oc *EFController) GetSamplingConfig() *libovsdbops.SamplingConfig {

--- a/go-controller/pkg/ovn/controller/networkconnect/controller.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller.go
@@ -603,9 +603,7 @@ func (c *Controller) reconcileService(key string) error {
 	// This determines which network the service belongs to.
 	networkOwnerKey, err := c.getNetworkOwnerKeyForNamespace(namespace)
 	if err != nil {
-		// Log and skip - namespace might not have a primary UDN
-		klog.V(5).Infof("Could not get network owner key for namespace %s: %v", namespace, err)
-		return nil
+		return fmt.Errorf("could not get network owner key for namespace %s: %w", namespace, err)
 	}
 	if networkOwnerKey == "" {
 		// Namespace uses default network, which we don't handle for network-connect

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_components_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_components_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -1087,4 +1088,45 @@ func TestController_reconcileService(t *testing.T) {
 		defer reconciledMutex.Unlock()
 		return reconciledCNCs.UnsortedList()
 	}).Should(gomega.ConsistOf("cnc1"))
+}
+
+func TestController_reconcileService_ReturnsErrorOnNamespaceNotFound(t *testing.T) {
+	g := gomega.NewWithT(t)
+	setupTestConfig(true, true)
+
+	fakeClientset := util.GetOVNClientset().GetOVNKubeControllerClientset()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"},
+	}
+	_, err := fakeClientset.KubeClient.CoreV1().Services("ns1").Create(
+		context.Background(), svc, metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClientset, "test-node")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = wf.Start()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer wf.Shutdown()
+
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer syncCancel()
+	g.Expect(cache.WaitForCacheSync(
+		syncCtx.Done(),
+		wf.ServiceCoreInformer().Informer().HasSynced,
+	)).To(gomega.BeTrue())
+
+	fakeNetworkManager := &networkmanager.FakeNetworkManager{
+		NotFoundNamespaces: sets.New[string]("ns1"),
+	}
+
+	c := &Controller{
+		cncLister:      wf.ClusterNetworkConnectInformer().Lister(),
+		serviceLister:  wf.ServiceCoreInformer().Lister(),
+		networkManager: fakeNetworkManager,
+		cncCache:       map[string]*networkConnectState{},
+	}
+
+	err = c.reconcileService("ns1/svc1")
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -1071,6 +1071,12 @@ func (c *Controller) skipServiceForNetwork(state *networkState, name, namespace 
 	if util.IsNetworkSegmentationSupportEnabled() {
 		serviceNAD, err := c.networkManager.GetPrimaryNADForNamespace(namespace)
 		if err != nil {
+			// If the corresponding namespace is not found in the informer cache, then we should
+			// not skip the service. The correct controller will process the service once the
+			// namespace is in the informer cache.
+			if apierrors.IsNotFound(err) {
+				return false
+			}
 			// If the namespace's primary NAD state is unknown (e.g., NAD deleted during
 			// network recreation), all controllers must skip. The correct controller
 			// will process the service once the NAD is re-established and triggers a re-sync.

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
@@ -1786,6 +1787,31 @@ func TestReconcileNetworkSkipsUnregisteredNetwork(t *testing.T) {
 
 	_, ok := controller.networkStates.Load(udn.GetNetworkName())
 	g.Expect(ok).To(gomega.BeFalse())
+}
+
+// notFoundPrimaryNADNetworkManager returns a wrapped namespace NotFound from GetPrimaryNADForNamespace.
+type notFoundPrimaryNADNetworkManager struct {
+	networkmanager.Interface
+}
+
+func (m *notFoundPrimaryNADNetworkManager) GetPrimaryNADForNamespace(namespace string) (string, error) {
+	return "", fmt.Errorf("failed to fetch namespace %q: %w", namespace,
+		apierrors.NewNotFound(corev1.Resource("namespaces"), namespace))
+}
+
+func TestSkipServiceForNetwork_NotFoundDoNotSkip(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+	c := &Controller{
+		networkManager: &notFoundPrimaryNADNetworkManager{},
+	}
+	state := &networkState{netInfo: &util.DefaultNetInfo{}}
+
+	g.Expect(c.skipServiceForNetwork(state, "svc1", "namespace1")).To(gomega.BeFalse())
 }
 
 func nodeLogicalSwitch(nodeName string, lbGroups []string, namespacedServiceNames ...string) *nbdb.LogicalSwitch {

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -352,7 +352,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						t.PrimaryACLTier,
 					)
 					purgeACL.UUID = "purgeACL-UUID"
-					// no externalIDs present => dbIDs can't be built
+
+					// Leftover ACLs on the cluster port group are not migrated and stay put.
 					purgeACL2 := libovsdbops.BuildACL(
 						"purgeACL2",
 						nbdb.ACLDirectionFromLport,
@@ -362,10 +363,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						t.OvnACLLoggingMeter,
 						"",
 						false,
+						purgeIDs.GetExternalIDs(),
 						nil,
-						nil,
-						// we should not be in a situation where we have ACLs without externalIDs
-						// but if we do have such lame ACLs then they will interfere with AdminNetPol logic
 						t.PrimaryACLTier,
 					)
 					purgeACL2.UUID = "purgeACL2-UUID"
@@ -395,31 +394,12 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					)
 					updateACL.UUID = "updateACL-UUID"
 
-					// this ACL is not in the egress firewall priority range and should be untouched
-					ignoreACL := libovsdbops.BuildACL(
-						"ignoreACL",
-						nbdb.ACLDirectionFromLport,
-						t.MinimumReservedEgressFirewallPriority-1,
-						"",
-						nbdb.ACLActionDrop,
-						t.OvnACLLoggingMeter,
-						"",
-						false,
-						nil,
-						nil,
-						// we should not be in a situation where we have unknown ACL that doesn't belong to any feature
-						// but if we do have such lame ACLs then they will interfere with AdminNetPol logic
-						t.PrimaryACLTier,
-					)
-					ignoreACL.UUID = "ignoreACL-UUID"
-
-					clusterPortGroup.ACLs = []string{purgeACL.UUID, purgeACL2.UUID, updateACL.UUID, ignoreACL.UUID}
+					clusterPortGroup.ACLs = []string{purgeACL2.UUID}
 
 					dbSetup := libovsdb.TestSetup{
 						NBData: []libovsdb.TestData{
 							purgeACL,
 							purgeACL2,
-							ignoreACL,
 							updateACL,
 							nodeSwitch,
 							joinSwitch,
@@ -429,8 +409,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					}
 
 					startOvn(dbSetup, []corev1.Namespace{namespace1}, []egressfirewallapi.EgressFirewall{*egressFirewall}, true)
-					// purgeACL will be deleted as its namespace doesn't exist
-					clusterPortGroup.ACLs = []string{ignoreACL.UUID, purgeACL2.UUID}
 
 					// updateACL will be updated
 					// Direction of both ACLs will be converted to
@@ -448,7 +426,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					expectedDatabaseState := []libovsdb.TestData{
 						purgeACL2,
-						ignoreACL,
 						updateACL,
 						nodeSwitch,
 						joinSwitch,

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -426,8 +426,9 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 				if !newNamespaceSelector.Matches(namespaceLabels) && oldNamespaceSelector.Matches(namespaceLabels) {
 					ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 					if err != nil {
-						if util.IsInvalidPrimaryNetworkError(err) {
-							// NAD reconciler will notify us later
+						if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+							// InvalidPrimaryNetworkError: NAD reconciler will replay.
+							// NotFound: listed namespace concurrently removed, namespace/pod handlers will catch up.
 							continue
 						}
 						return fmt.Errorf("failed to get active network for namespace %s: %w", namespace.Name, err)
@@ -443,8 +444,9 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 				if newNamespaceSelector.Matches(namespaceLabels) && !oldNamespaceSelector.Matches(namespaceLabels) {
 					ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 					if err != nil {
-						if util.IsInvalidPrimaryNetworkError(err) {
-							// NAD reconciler will notify us later
+						if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+							// InvalidPrimaryNetworkError: NAD reconciler will replay.
+							// NotFound: listed namespace concurrently removed, namespace/pod handlers will catch up.
 							continue
 						}
 						return fmt.Errorf("failed to get active network for namespace %s: %w", namespace.Name, err)
@@ -477,8 +479,9 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 					if !newPodSelector.Matches(podLabels) && oldPodSelector.Matches(podLabels) {
 						ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 						if err != nil {
-							if util.IsInvalidPrimaryNetworkError(err) {
-								// NAD reconciler will notify us later
+							if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+								// InvalidPrimaryNetworkError: NAD reconciler will replay.
+								// NotFound: listed namespace concurrently removed, namespace/pod handlers will catch up.
 								continue
 							}
 							return fmt.Errorf("failed to get active network for namespace %s: %w", namespace.Name, err)
@@ -494,8 +497,9 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 					if newPodSelector.Matches(podLabels) && !oldPodSelector.Matches(podLabels) {
 						ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 						if err != nil {
-							if util.IsInvalidPrimaryNetworkError(err) {
-								// NAD reconciler will notify us later
+							if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+								// InvalidPrimaryNetworkError: NAD reconciler will replay.
+								// NotFound: listed namespace concurrently removed, namespace/pod handlers will catch up.
 								continue
 							}
 							return fmt.Errorf("failed to get active network for namespace %s: %w", namespace.Name, err)
@@ -525,8 +529,9 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 				// reason to look at the pod selector.
 				ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 				if err != nil {
-					if util.IsInvalidPrimaryNetworkError(err) {
-						// NAD reconciler will notify us later
+					if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+						// InvalidPrimaryNetworkError: NAD reconciler will replay.
+						// NotFound: listed namespace concurrently removed, namespace/pod handlers will catch up.
 						continue
 					}
 					return fmt.Errorf("failed to get active network for namespace %s: %w", namespace.Name, err)
@@ -643,8 +648,19 @@ func (e *EgressIPController) reconcileEgressIPNamespace(old, new *corev1.Namespa
 					if util.IsInvalidPrimaryNetworkError(err) {
 						// NAD reconciler will notify us later
 						return nil
+					} else if apierrors.IsNotFound(err) {
+						prefix := namespaceName + "/"
+						for _, podKey := range e.podAssignment.GetKeys() {
+							if !strings.HasPrefix(podKey, prefix) {
+								continue
+							}
+							if ni = e.getNetworkFromPodAssignment(podKey); ni != nil {
+								break
+							}
+						}
+					} else {
+						return fmt.Errorf("failed to get active network for namespace %s: %w", namespaceName, err)
 					}
-					return fmt.Errorf("failed to get active network for namespace %s: %w", namespaceName, err)
 				}
 				if ni == nil {
 					// our node does not have this network
@@ -659,8 +675,9 @@ func (e *EgressIPController) reconcileEgressIPNamespace(old, new *corev1.Namespa
 				mark := getEgressIPPktMark(eIP.Name, eIP.Annotations)
 				ni, err := e.networkManager.GetActiveNetworkForNamespace(namespaceName)
 				if err != nil {
-					if util.IsInvalidPrimaryNetworkError(err) {
-						// NAD reconciler will notify us later
+					if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
+						// InvalidPrimaryNetworkError: NAD reconciler will replay.
+						// NotFound: listed namespace concurrently removed, namespace/pod handlers will catch up.
 						return nil
 					}
 					return fmt.Errorf("failed to get active network for namespace %s: %w", namespaceName, err)
@@ -794,7 +811,8 @@ func (e *EgressIPController) reconcileEgressIPPod(old, new *corev1.Pod) (err err
 				}
 
 				ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
-				if err != nil && !util.IsInvalidPrimaryNetworkError(err) {
+				if err != nil && !util.IsInvalidPrimaryNetworkError(err) &&
+					(!apierrors.IsNotFound(err) || (apierrors.IsNotFound(err) && !deletePath)) {
 					return fmt.Errorf("failed to get active network for namespace %s: %w", namespace.Name, err)
 				}
 				haveNetwork := ni != nil
@@ -868,7 +886,7 @@ func (e *EgressIPController) addEgressIPAssignments(name string, statusAssignmen
 	for _, namespace := range namespaces {
 		ni, err := e.networkManager.GetActiveNetworkForNamespace(namespace.Name)
 		if err != nil {
-			if util.IsInvalidPrimaryNetworkError(err) {
+			if util.IsInvalidPrimaryNetworkError(err) || apierrors.IsNotFound(err) {
 				continue
 			}
 			return fmt.Errorf("failed to get active network for namespace %s: %v", namespace.Name, err)

--- a/go-controller/pkg/ovn/network_segmentation_test.go
+++ b/go-controller/pkg/ovn/network_segmentation_test.go
@@ -4,17 +4,21 @@
 package ovn
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -144,6 +148,106 @@ var _ = ginkgo.Describe("OVN Pod Operations with network segmentation", func() {
 
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("on pod add", func() {
+		ginkgo.It("does not annotate a pod until its namespace appears in the namespace informer", func() {
+			app.Action = func(*cli.Context) error {
+				namespaceT := *testing.NewNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				pod := testing.NewPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				key, err := retry.GetResourceKey(pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Pod informer will see the pod, but the namespace informer will
+				// not have the namespace yet. GetPrimaryNADForNamespace returns
+				// an error, and GetNetworkRole will fail and pod annotation will
+				// not be written.
+				fakeOvn.startWithDBSetup(initialDB,
+					&corev1.NamespaceList{
+						Items: []corev1.Namespace{},
+					},
+					&corev1.NodeList{
+						Items: []corev1.Node{
+							*newNode(node1Name, "192.168.126.202/24"),
+						},
+					},
+					&corev1.PodList{
+						Items: []corev1.Pod{
+							*pod,
+						},
+					},
+				)
+				t.populateLogicalSwitchCache(fakeOvn)
+
+				err = fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Pod add fails and is queued for retry while namespace is missing.
+				retry.CheckRetryObjectEventually(key, true, fakeOvn.controller.retryPods)
+
+				// Pod annotation must not be written before namespace is in the informer.
+				gomega.Consistently(func() bool {
+					p, getErr := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(
+						context.TODO(), t.podName, metav1.GetOptions{})
+					gomega.Expect(getErr).NotTo(gomega.HaveOccurred())
+					_, ok := p.Annotations[ovntypes.OvnPodAnnotationName]
+					return ok
+				}, time.Second, 100*time.Millisecond).Should(gomega.BeFalse(),
+					"pod annotation must not be written before namespace is in the informer")
+
+				// Create namespace so that it is added to the namespace informer.
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Create(
+					context.TODO(), &namespaceT, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Wait until the namespace informer has the object, then retry.
+				gomega.Eventually(func() error {
+					_, getErr := fakeOvn.watcher.GetNamespace(namespaceT.Name)
+					return getErr
+				}).Should(gomega.Succeed(), "namespace informer should have the namespace")
+
+				// Set retry object with no backoff to immediately retry the pod.
+				retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryPods)
+				fakeOvn.controller.retryPods.RequestRetryObjs()
+
+				// Pod annotation should be written and should have role=primary.
+				var podAnnotation *util.PodAnnotation
+				gomega.Eventually(func() bool {
+					annotations := getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
+					if len(annotations) == 0 {
+						return false
+					}
+					podAnnotation, err = util.UnmarshalPodAnnotation(
+						map[string]string{ovntypes.OvnPodAnnotationName: annotations},
+						ovntypes.DefaultNetworkName,
+					)
+					if err != nil {
+						return false
+					}
+					return podAnnotation.Role == ovntypes.NetworkRolePrimary
+				}).Should(gomega.BeTrue(), fmt.Sprintf("pod annotation should be written and should have role=primary: %v", podAnnotation))
+
+				// Pod should not be queued for retry.
+				retry.CheckRetryObjectEventually(key, false, fakeOvn.controller.retryPods)
+
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

GetPrimaryNADForNamespace returns an empty string when the namespace is not yet in the informer cache. GetNetworkRole treated any non-default value as infrastructure-locked, so default-network pods could be annotated incorrectly during that race. Return an error instead  from GetPrimaryNADForNamespace so allocation retries until the namespace is known. Add unit tests to verify the role resolution and annotation path.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
