### PR TITLE
ovn: remove deprecated gateway router join address fallback

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -128,15 +128,9 @@ func (oc *DefaultNetworkController) nodeGatewayConfig(node *corev1.Node) (*Gatew
 
 	gwLRPIPs, err := udn.GetGWRouterIPs(node, oc.GetNetInfo())
 	if err != nil {
-		if util.IsAnnotationNotSetError(err) {
-			// FIXME(tssurya): This is present for backwards compatibility
-			// Remove me a few months from now
-			var err1 error
-			gwLRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-			if err1 != nil {
-				return nil, fmt.Errorf("failed to get join switch port IP address for node %s: %v/%v", node.Name, err, err1)
-			}
-		}
+		// The join address has to be derived from the node id alone so that
+		// the local and the remote view of it agree.
+		return nil, fmt.Errorf("failed to get join switch port IP address for node %s: %w", node.Name, err)
 	}
 
 	return &GatewayConfig{

--- a/go-controller/pkg/ovn/master_gateway_config_test.go
+++ b/go-controller/pkg/ovn/master_gateway_config_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ovn
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = ginkgo.Describe("nodeGatewayConfig join address contract", func() {
+	const (
+		clusterCIDR = "10.1.0.0/16"
+	)
+
+	var app *cli.App
+
+	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	ginkgo.It("derives join addresses from node-id", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
+						"k8s.ovn.org/node-chassis-id":   "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec",
+						"k8s.ovn.org/node-subnets":      `{"default":["10.244.1.0/24"]}`,
+						util.OvnNodeID:                  "2",
+					},
+				},
+			}
+
+			oc := getFakeController("default-network-controller")
+			gwConfig, err := oc.nodeGatewayConfig(node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(gwConfig.gwRouterJoinCIDRs).To(gomega.HaveLen(1))
+			gomega.Expect(gwConfig.gwRouterJoinCIDRs[0].IP.String()).To(gomega.Equal("100.64.0.2"))
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("fails when node-id is missing", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.255.33.2/24", "next-hop":"169.255.33.1"}}`,
+						"k8s.ovn.org/node-chassis-id":   "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec",
+						"k8s.ovn.org/node-subnets":      `{"default":["10.244.1.0/24"]}`,
+						// Retired annotation with a valid value: if the deprecated
+						// node-id fallback is ever restored, this test would stop
+						// failing and thus catch the regression.
+						"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.99/16"}`,
+					},
+				},
+			}
+
+			oc := getFakeController("default-network-controller")
+			_, err = oc.nodeGatewayConfig(node)
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+				fmt.Sprintf("failed to get join switch port IP address for node %s", node.Name))))
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+				fmt.Sprintf("%s annotation not found", util.OvnNodeID))))
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -257,19 +257,7 @@ func (zic *ZoneInterconnectHandler) AddRemoteZoneNode(node *corev1.Node) error {
 	if !zic.IsUserDefinedNetwork() || (util.IsNetworkSegmentationSupportEnabled() && zic.IsPrimaryNetwork()) {
 		nodeGRPIPs, err = udn.GetGWRouterIPs(node, zic.GetNetInfo())
 		if err != nil {
-			if util.IsAnnotationNotSetError(err) {
-				// FIXME(tssurya): This is present for backwards compatibility
-				// Remove me a few months from now
-				var err1 error
-				nodeGRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-				if err1 != nil {
-					err1 = fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
-					if util.IsAnnotationNotSetError(err1) {
-						return types.NewSuppressedError(err1)
-					}
-					return err1
-				}
-			}
+			return fmt.Errorf("failed to get the gateway router port IP addresses for node %s: %w", node.Name, err)
 		}
 	}
 
@@ -733,15 +721,14 @@ func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(node *corev1.Nod
 	// Clear the routes connecting to the GW Router for the default network
 	nodeGRPIPs, err := udn.GetGWRouterIPs(node, zic.GetNetInfo())
 	if err != nil {
-		if util.IsAnnotationNotSetError(err) {
-			// FIXME(tssurya): This is present for backwards compatibility
-			// Remove me a few months from now
-			var err1 error
-			nodeGRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-			if err1 != nil {
-				return fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
-			}
+		// Without node-id we can't reconstruct the GR join IPs; delete by owner.
+		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+			return lrsr.ExternalIDs["ic-node"] == node.Name
 		}
+		if opserr := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(zic.nbClient, zic.networkClusterRouterName, p); opserr != nil {
+			return fmt.Errorf("failed to delete gateway router static routes for node %s: %w", node.Name, opserr)
+		}
+		return fmt.Errorf("failed to get the gateway router port IP addresses for node %s: %w", node.Name, err)
 	}
 
 	nodenodeGRPIPStaticRoutes := zic.getStaticRoutes(nodeGRPIPs, nodeTransitSwitchPortIPs, true)

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -903,6 +903,129 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("AddRemoteZoneNode rejects missing node-id even when the legacy join annotation is present", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				routesBefore := len(clusterRouter.StaticRoutes)
+
+				remoteNodeWithoutNodeID := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "remote-without-node-id",
+						Annotations: map[string]string{
+							ovnNodeChassisIDAnnotation:         "cb9ec8fa-b409-4ef3-9f42-d9283c47aac9",
+							ovnNodeZoneNameAnnotation:          "foo",
+							ovnNodeSubnetsAnnotation:           "{\"default\":[\"10.244.5.0/24\"]}",
+							ovnTransitSwitchPortAddrAnnotation: "{\"ipv4\":\"100.88.0.5/16\"}",
+							// Retired annotation with a valid value: if the deprecated
+							// node-id fallback is ever restored, this add would stop
+							// failing and thus catch the regression.
+							"k8s.ovn.org/node-gateway-router-lrp-ifaddr": "{\"ipv4\":\"100.64.0.5/16\"}",
+						},
+					},
+				}
+
+				err = zoneICHandler.AddRemoteZoneNode(&remoteNodeWithoutNodeID)
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("failed to get node id for node - remote-without-node-id")))
+
+				clusterRouter, err = libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(clusterRouter.StaticRoutes).To(gomega.HaveLen(routesBefore))
+
+				remotePortName := getNetworkScopedName(types.DefaultNetworkName, types.TransitSwitchToRouterPrefix+remoteNodeWithoutNodeID.Name)
+				_, err = libovsdbops.GetLogicalSwitchPort(libovsdbOvnNBClient, &nbdb.LogicalSwitchPort{Name: remotePortName})
+				gomega.Expect(err).To(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("deleteLocalNodeStaticRoutes cleans up gateway-router routes when node-id lookup fails", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				nodeWithoutNodeID := testNode3.DeepCopy()
+				delete(nodeWithoutNodeID.Annotations, ovnNodeIDAnnotaton)
+				// Retired annotation with a valid value: if the deprecated node-id
+				// fallback is ever restored, this delete would stop failing and thus
+				// catch the regression.
+				nodeWithoutNodeID.Annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.4/16\"}"
+
+				nodeTransitSwitchPortIPs, err := util.ParseNodeTransitSwitchPortAddrs(nodeWithoutNodeID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = zoneICHandler.deleteLocalNodeStaticRoutes(nodeWithoutNodeID, nodeTransitSwitchPortIPs)
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("failed to get the gateway router port IP addresses for node node3")))
+
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nodeRoutesPredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.ExternalIDs != nil && route.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				nodeRoutes, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, nodeRoutesPredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(nodeRoutes).To(gomega.BeEmpty())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Secondary networks", func() {

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -76,12 +76,6 @@ const (
 	// OvnNodeIfAddr is the CIDR form representation of primary network interface's attached IP address (i.e: 192.168.126.31/24 or 0:0:0:0:0:feff:c0a8:8e0c/64)
 	OvnNodeIfAddr = "k8s.ovn.org/node-primary-ifaddr"
 
-	// ovnNodeGRLRPAddr is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.5/24)
-	// DEPRECATED; use ovnNodeGRLRPAddrs moving forward
-	// FIXME(tssurya): Remove this a few months from now; needed for backwards
-	// compatbility during upgrades while updating to use the new annotation "ovnNodeGRLRPAddrs"
-	ovnNodeGRLRPAddr = "k8s.ovn.org/node-gateway-router-lrp-ifaddr"
-
 	// ovnNodeGRLRPAddrs is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.4/16)
 	// for all the networks keyed by the network-name and ipFamily.
 	// "k8s.ovn.org/node-gateway-router-lrp-ifaddrs": "{
@@ -125,6 +119,9 @@ const (
 	OvnTransitSwitchPortAddr = "k8s.ovn.org/node-transit-switch-port-ifaddr"
 
 	// OvnNodeID is the id (of type integer) of a node. It is set by cluster-manager.
+	// Controllers derive the gateway router join switch port address from this value
+	// so that the local and remote views of the address agree. The deprecated
+	// k8s.ovn.org/node-gateway-router-lrp-ifaddr annotation is not used as a fallback.
 	OvnNodeID = "k8s.ovn.org/node-id"
 
 	// InvalidNodeID indicates an invalid node id
@@ -696,27 +693,6 @@ func ParseNodePrimaryIfAddr(node *corev1.Node) (*ParsedNodeEgressIPConfiguration
 	return parsedEgressIPConfig, nil
 }
 
-// ParseNodeGatewayRouterLRPAddr returns the IPv4 / IPv6 values for the node's gateway router
-// DEPRECATED; kept for backwards compatibility
-func ParseNodeGatewayRouterLRPAddr(node *corev1.Node) (net.IP, error) {
-	nodeIfAddrAnnotation, ok := node.Annotations[ovnNodeGRLRPAddr]
-	if !ok {
-		return nil, newAnnotationNotSetError("%s annotation not found for node %q", ovnNodeGRLRPAddr, node.Name)
-	}
-	nodeIfAddr := PrimaryIfAddrAnnotation{}
-	if err := json.Unmarshal([]byte(nodeIfAddrAnnotation), &nodeIfAddr); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal annotation: %s for node %q, err: %v", ovnNodeGRLRPAddr, node.Name, err)
-	}
-	if nodeIfAddr.IPv4 == "" && nodeIfAddr.IPv6 == "" {
-		return nil, fmt.Errorf("node: %q does not have any IP information set", node.Name)
-	}
-	ip, _, err := net.ParseCIDR(nodeIfAddr.IPv4)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse annotation: %s for node %q, err: %v", ovnNodeGRLRPAddr, node.Name, err)
-	}
-	return ip, nil
-}
-
 // parsePrimaryIfAddrAnnotation unmarshals the IPv4 / IPv6 values in the
 // primaryIfAddrAnnotation format from the nodeAnnotation map with the
 // provided 'annotationName' as key and returns the addresses.
@@ -757,12 +733,6 @@ func convertPrimaryIfAddrAnnotationToIPNet(ifAddr PrimaryIfAddrAnnotation) ([]*n
 		ipAddrs = append(ipAddrs, &net.IPNet{IP: ip, Mask: ipNet.Mask})
 	}
 	return ipAddrs, nil
-}
-
-// ParseNodeGatewayRouterLRPAddrs returns the IPv4 and/or IPv6 addresses for the node's gateway router port
-// stored in the 'ovnNodeGRLRPAddr' annotation
-func ParseNodeGatewayRouterLRPAddrs(node *corev1.Node) ([]*net.IPNet, error) {
-	return parsePrimaryIfAddrAnnotation(node, ovnNodeGRLRPAddr)
 }
 
 // ParseNodeTransitSwitchPortAddrs returns the IPv4 and/or IPv6 addresses for the node's transit switch port

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -488,62 +488,6 @@ func TestParseNodeManagementPortMACAddresses(t *testing.T) {
 	}
 }
 
-func TestParseNodeGatewayRouterLRPAddr(t *testing.T) {
-	tests := []struct {
-		desc        string
-		inpNode     corev1.Node
-		errExpected bool
-		expOutput   bool
-	}{
-		{
-			desc:      "Gateway router LPR IP address annotation not found for node, however, does not return error",
-			inpNode:   corev1.Node{},
-			expOutput: false,
-		},
-		{
-			desc: "success: Gateway router parse LPR IP address",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16"}`},
-				},
-			},
-			expOutput: true,
-		},
-		{
-			desc: "success: Gateway router parse LPR IP address dual stack",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5/16", "ipv6":"fd:98::/64"}`},
-				},
-			},
-			expOutput: true,
-		},
-		{
-			desc: "error: Gateway router parse LPR IP address error",
-			inpNode: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"k8s.ovn.org/node-gateway-router-lrp-ifaddr": `{"ipv4":"100.64.0.5"}`},
-				},
-			},
-			errExpected: true,
-		},
-	}
-
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			cfg, e := ParseNodeGatewayRouterLRPAddr(&tc.inpNode)
-			if tc.errExpected {
-				t.Log(e)
-				require.Error(t, e)
-				assert.Nil(t, cfg)
-			}
-			if tc.expOutput {
-				assert.NotNil(t, cfg)
-			}
-		})
-	}
-}
-
 func TestSetGatewayMTUSupport(t *testing.T) {
 	mockAnnotator := new(annotatorMock.Annotator)
 


### PR DESCRIPTION
The k8s.ovn.org/node-gateway-router-lrp-ifaddr annotation is already stale. The join address must be derived from k8s.ovn.org/node-id alone, so waiting for that annotation is what keeps the local and the remote view of the address consistent.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
