### PR TITLE
egressip: skip nodes with unusable host-cidrs annotation

### DIFF
--- a/docs/features/cluster-egress-controls/egress-ip.md
+++ b/docs/features/cluster-egress-controls/egress-ip.md
@@ -13,6 +13,38 @@ For more info, consider looking at the following links:
 
 Always check the dependencies on the [Requirements page](../requirements.md)
 
+## Node Requirements
+
+The `k8s.ovn.org/host-cidrs` annotation is automatically set during node bootstrap and
+contains the node's host network CIDR(s). A node can be missing this annotation if it is
+stuck in `NodeStatusNeverUpdated`, was orphaned by the cluster autoscaler, or was never
+properly bootstrapped.
+
+Such a node is handled in two places:
+
+* **Conflict detection** skips the node. The annotation is the only source of the node's
+  host addresses, so without it there is no data to check the requested egress IP against.
+  Skipping means the check cannot prove the address is free on that node — it does not mean
+  the node has no conflicting address.
+* **Node assignability** excludes the node. A node whose `host-cidrs` annotation is missing,
+  cannot be parsed, or contains no addresses is marked not assignable even when it carries
+  the `k8s.ovn.org/egress-assignable` label, and any EgressIPs already assigned to it are
+  released so they can move to an eligible node.
+
+Together these prevent a single misconfigured or orphaned node from failing EgressIP
+assignment cluster-wide, while keeping it out of the pool of assignment candidates.
+
+**Important:** Conflict protection is not enforced for a node in this state. Restore the
+node's `host-cidrs` annotation, or remove the stale node from the cluster, before relying
+on conflict detection to catch an egress IP that collides with a host address.
+
+**Troubleshooting:** If an EgressIP is not assigned to an expected node, verify the node
+has the `k8s.ovn.org/host-cidrs` annotation set:
+
+```bash
+kubectl get node <node-name> -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/host-cidrs}'
+```
+
 ## Example
 
 An example of EgressIP might look like this:

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1448,7 +1448,14 @@ func (eIPC *egressIPClusterController) isEgressIPAddrConflict(egressIP net.IP) (
 		}
 		nodeHostAddrsSet, err := util.ParseNodeHostCIDRsDropNetMask(node)
 		if err != nil {
-			return false, "", fmt.Errorf("failed to parse node host cidrs for node %s: %v", node.Name, err)
+			// The annotation is the only source of this node's host addresses.
+			// If it is missing or unparseable there is nothing to compare the
+			// egress IP against, so skip the node rather than failing the check
+			// for every node. Such a node is also excluded from assignment, see
+			// the egress node event handler.
+			klog.Warningf("Skipping node %s for EgressIP conflict check, its host addresses are unknown: %v",
+				node.Name, err)
+			continue
 		}
 		if nodeHostAddrsSet.Has(egressIP.String()) {
 			return true, node.Name, nil

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -91,6 +92,11 @@ func (fehc *fakeEgressIPHealthClient) setFakeProbeFailure(probeFailure bool) {
 	fehc.FakeProbeFailure = probeFailure
 }
 
+const (
+	v4NodeSubnet = "10.128.0.0/24"
+	v6NodeSubnet = "ae70::66/64"
+)
+
 type fakeEgressIPHealthClientAllocator struct{}
 
 func (f *fakeEgressIPHealthClientAllocator) allocate(string) healthcheck.EgressIPHealthClient {
@@ -143,6 +149,40 @@ func newCloudPrivateIPConfigMeta(egressIP string) metav1.ObjectMeta {
 	}
 }
 
+func newEgressTestNode(name, ipv4, ipv6, hostCIDRs string, egressLabelled bool) corev1.Node {
+	annotations := map[string]string{}
+	labels := map[string]string{}
+	if ipv4 != "" || ipv6 != "" {
+		annotations["k8s.ovn.org/node-primary-ifaddr"] = fmt.Sprintf(`{"ipv4": "%s", "ipv6": "%s"}`, ipv4, ipv6)
+		if ipv4 != "" {
+			annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf(`{"default":"%s"}`, v4NodeSubnet)
+		} else {
+			annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf(`{"default":"%s"}`, v6NodeSubnet)
+		}
+	}
+	if hostCIDRs != "" {
+		annotations[util.OVNNodeHostCIDRs] = hostCIDRs
+	}
+	if egressLabelled {
+		labels["k8s.ovn.org/egress-assignable"] = ""
+	}
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
 func setupNode(nodeName string, ipNets []string, mockAllocationIPs map[string]string) egressNode {
 	unlimited := util.UnlimitedNodeCapacity
 	var config = &util.ParsedNodeEgressIPConfiguration{Capacity: util.Capacity{
@@ -188,8 +228,6 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 		egressIPName  = "egressip"
 		egressIPName2 = "egressip-2"
 		namespace     = "egressip-namespace"
-		v4NodeSubnet  = "10.128.0.0/24"
-		v6NodeSubnet  = "ae70::66/64"
 	)
 
 	dialer = fakeEgressIPDialer{}
@@ -1388,6 +1426,199 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				return nil
 			}
 
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should assign EgressIP when one node is missing host-cidrs annotation", func() {
+			app.Action = func(*cli.Context) error {
+				config.IPv4Mode = true
+				config.IPv6Mode = true
+
+				egressIPv4 := "192.168.126.101"
+				egressIPv6 := "ae70::100"
+				node1IPv4 := "192.168.126.12/24"
+				node2IPv6 := "ae70::2/64"
+
+				node1 := newEgressTestNode(node1Name, node1IPv4, "", fmt.Sprintf(`["%s"]`, node1IPv4), true)
+				node2 := newEgressTestNode(node2Name, "", node2IPv6, fmt.Sprintf(`["%s"]`, node2IPv6), true)
+				orphanNode := newEgressTestNode("orphan-node", "192.168.126.14/24", "", "", true)
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIPv4, egressIPv6},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&corev1.NodeList{
+						Items: []corev1.Node{node1, node2, orphanNode},
+					})
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(func() []egressipv1.EgressIPStatusItem {
+					eIP, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+					if err != nil {
+						return nil
+					}
+					return eIP.Status.Items
+				}).WithTimeout(2 * time.Second).Should(gomega.HaveLen(2))
+
+				finalEIP, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				assignedNodes := make(map[string]string)
+				for _, item := range finalEIP.Status.Items {
+					assignedNodes[item.Node] = item.EgressIP
+				}
+				gomega.Expect(assignedNodes).To(gomega.HaveKey(node1Name))
+				gomega.Expect(assignedNodes).To(gomega.HaveKey(node2Name))
+				gomega.Expect(assignedNodes[node1Name]).To(gomega.Equal(egressIPv4))
+				gomega.Expect(assignedNodes[node2Name]).To(gomega.Equal(egressIPv6))
+				gomega.Expect(assignedNodes).NotTo(gomega.HaveKey("orphan-node"))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.DescribeTable("should not assign EgressIP to a node with unusable host-cidrs",
+			func(badHostCIDRs string) {
+				app.Action = func(*cli.Context) error {
+					config.IPv4Mode = true
+
+					node1IPv4 := "192.168.126.12/24"
+					node1 := newEgressTestNode(node1Name, node1IPv4, "", fmt.Sprintf(`["%s"]`, node1IPv4), true)
+					node2 := newEgressTestNode(node2Name, "192.168.126.13/24", "", badHostCIDRs, true)
+
+					eIP := egressipv1.EgressIP{
+						ObjectMeta: newEgressIPMeta(egressIPName),
+						Spec: egressipv1.EgressIPSpec{
+							EgressIPs: []string{"192.168.126.101"},
+						},
+						Status: egressipv1.EgressIPStatus{
+							Items: []egressipv1.EgressIPStatusItem{},
+						},
+					}
+
+					fakeClusterManagerOVN.start(
+						&egressipv1.EgressIPList{
+							Items: []egressipv1.EgressIP{eIP},
+						},
+						&corev1.NodeList{
+							Items: []corev1.Node{node1, node2},
+						})
+
+					_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					getStatusItems := func() []egressipv1.EgressIPStatusItem {
+						eIP, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+						if err != nil {
+							return nil
+						}
+						return eIP.Status.Items
+					}
+
+					gomega.Eventually(getStatusItems).WithTimeout(2 * time.Second).Should(gomega.HaveLen(1))
+					gomega.Expect(getStatusItems()[0].Node).To(gomega.Equal(node1Name))
+					gomega.Consistently(getStatusItems).WithTimeout(500 * time.Millisecond).ShouldNot(
+						gomega.ContainElement(gomega.HaveField("Node", node2Name)))
+
+					return nil
+				}
+				err := app.Run([]string{app.Name})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			ginkgo.Entry("malformed annotation", "not-json"),
+			ginkgo.Entry("empty annotation", "[]"),
+		)
+
+		ginkgo.It("should retry cleanup of unassignable node via inRetryCache when both old and new have broken annotation", func() {
+			app.Action = func(*cli.Context) error {
+				config.IPv4Mode = true
+
+				node1IPv4 := "192.168.126.12/24"
+				node2IPv4 := "192.168.126.13/24"
+				node1 := newEgressTestNode(node1Name, node1IPv4, "", fmt.Sprintf(`["%s"]`, node1IPv4), true)
+				node2 := newEgressTestNode(node2Name, node2IPv4, "", fmt.Sprintf(`["%s"]`, node2IPv4), true)
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{"192.168.126.101"},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&corev1.NodeList{
+						Items: []corev1.Node{node1, node2},
+					})
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(func() string {
+					eIP, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+					if err != nil || len(eIP.Status.Items) == 0 {
+						return ""
+					}
+					return eIP.Status.Items[0].Node
+				}).WithTimeout(2 * time.Second).Should(gomega.Equal(node1Name))
+
+				brokenNode1 := node1.DeepCopy()
+				delete(brokenNode1.Annotations, util.OVNNodeHostCIDRs)
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(
+					context.TODO(), brokenNode1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				handler := &egressIPClusterControllerEventHandler{
+					objType: factory.EgressNodeType,
+					eIPC:    fakeClusterManagerOVN.eIPC,
+				}
+				err = handler.UpdateResource(brokenNode1, brokenNode1, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(func() string {
+					eIP, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+					if err != nil || len(eIP.Status.Items) == 0 {
+						return ""
+					}
+					return eIP.Status.Items[0].Node
+				}).WithTimeout(2 * time.Second).Should(gomega.Equal(node2Name))
+
+				gomega.Consistently(func() string {
+					eIP, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+					if err != nil || len(eIP.Status.Items) == 0 {
+						return ""
+					}
+					return eIP.Status.Items[0].Node
+				}).WithTimeout(500 * time.Millisecond).Should(gomega.Equal(node2Name))
+
+				return nil
+			}
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -57,7 +57,17 @@ func (h *egressIPClusterControllerEventHandler) AddResource(obj interface{}, _ b
 		nodeLabels := node.GetLabels()
 		_, hasEgressLabel := nodeLabels[nodeEgressLabel]
 		if hasEgressLabel {
-			h.eIPC.setNodeEgressAssignable(node.Name, true)
+			// A node is only assignable when its host-cidrs annotation is
+			// present, parseable, and non-empty; without addresses the
+			// conflict check has no data for this node.
+			hostCIDRs, err := util.ParseNodeHostCIDRsDropNetMask(node)
+			nodeIsAssignable := err == nil && hostCIDRs.Len() > 0
+			if err != nil {
+				klog.Warningf("Node %s is not egress-assignable: failed to parse host-cidrs: %v", node.Name, err)
+			} else if hostCIDRs.Len() == 0 {
+				klog.Warningf("Node %s is not egress-assignable: host-cidrs contains no host CIDRs", node.Name)
+			}
+			h.eIPC.setNodeEgressAssignable(node.Name, nodeIsAssignable)
 		}
 		isReady := h.eIPC.isEgressNodeReady(node)
 		if isReady {
@@ -85,7 +95,7 @@ func (h *egressIPClusterControllerEventHandler) AddResource(obj interface{}, _ b
 // UpdateResource updates the specified object in the cluster to its version in newObj according
 // to its type and returns the error, if any, yielded during the object update.
 // The inRetryCache boolean argument is to indicate if the given resource is in the retryCache or not.
-func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj interface{}, _ bool) error {
+func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
 	switch h.objType {
 	case factory.EgressIPType:
 		oldEIP := oldObj.(*egressipv1.EgressIP)
@@ -119,7 +129,44 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 		if !oldHadEgressLabel && !newHasEgressLabel {
 			return nil
 		}
-		h.eIPC.setNodeEgressAssignable(newNode.Name, newHasEgressLabel)
+		// A node is only assignable when it carries the egress-assignable label
+		// and its host-cidrs annotation is present, parseable, and non-empty.
+		// Without addresses the conflict check has no data for this node.
+		oldNodeIsAssignable := oldHadEgressLabel
+		if oldNodeIsAssignable {
+			hostCIDRs, err := util.ParseNodeHostCIDRsDropNetMask(oldNode)
+			oldNodeIsAssignable = err == nil && hostCIDRs.Len() > 0
+		}
+
+		nodeIsAssignable := newHasEgressLabel
+		if nodeIsAssignable {
+			hostCIDRs, err := util.ParseNodeHostCIDRsDropNetMask(newNode)
+			nodeIsAssignable = err == nil && hostCIDRs.Len() > 0
+			if err != nil {
+				klog.Warningf("Node %s is not egress-assignable: failed to parse host-cidrs: %v", newNode.Name, err)
+			} else if hostCIDRs.Len() == 0 {
+				klog.Warningf("Node %s is not egress-assignable: host-cidrs contains no host CIDRs", newNode.Name)
+			}
+		}
+		h.eIPC.setNodeEgressAssignable(newNode.Name, nodeIsAssignable)
+
+		// setNodeEgressAssignable clears the node's allocation cache when it
+		// turns a node unassignable, on the understanding that the caller then
+		// clears that node's assignments too. Release them here to keep the
+		// cache and status.items in agreement. A node that is genuinely gone is
+		// released anyway by the readiness and reachability handling below, so
+		// this only fires for a labelled, reachable node whose annotation stopped
+		// parsing.
+		if newHasEgressLabel && !nodeIsAssignable && (oldNodeIsAssignable || inRetryCache) {
+			klog.Infof("Node: %s is no longer assignable (host-cidrs annotation missing or invalid), "+
+				"deleting it from egress assignment", newNode.Name)
+			h.eIPC.setNodeEgressReady(newNode.Name, h.eIPC.isEgressNodeReady(newNode))
+			if err := h.eIPC.deleteEgressNode(newNode.Name); err != nil {
+				return fmt.Errorf("failed to delete egress assignments for node %s: %w", newNode.Name, err)
+			}
+			return nil
+		}
+
 		if oldHadEgressLabel && !newHasEgressLabel {
 			klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", newNode.Name)
 			return h.eIPC.deleteEgressNode(oldNode.Name)

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
@@ -36,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -400,6 +402,9 @@ type egressIPStatus struct {
 }
 
 type egressIP struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
 	Status struct {
 		Items []egressIPStatus `json:"items"`
 	} `json:"status"`
@@ -3788,6 +3793,176 @@ spec:
 			_, err = e2ekubectl.RunKubectl("", "annotate", "--overwrite", "egressip", egressIPName, fmt.Sprintf("%s-", util.EgressIPMarkAnnotation))
 			gomega.Expect(err).To(gomega.HaveOccurred(), "Should fail if k8s.ovn.org/egressip-mark is being removed")
 			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("The \"k8s.ovn.org/egressip-mark\" annotation cannot be modified or removed once set. This annotation is managed by the system.")))
+		})
+
+		ginkgo.It("Should skip orphaned nodes and assign EgressIPs to valid nodes", func() {
+			if isUserDefinedNetwork(netConfigParams) {
+				ginkgo.Skip("Unsupported for UDNs")
+			}
+
+			// Label two nodes for egress assignment
+			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, egress1Node.name, "k8s.ovn.org/egress-assignable", "dummy")
+			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, egress2Node.name, "k8s.ovn.org/egress-assignable", "dummy")
+
+			podNamespace := f.Namespace
+			nodeToOrphan := egress1Node.name
+
+			ginkgo.By("Allocating EgressIP addresses before orphaning node")
+			var egressIP1, egressIP2 net.IP
+			var err error
+			if utilnet.IsIPv6String(egress1Node.nodeIP) {
+				egressIP1, err = ipalloc.NewPrimaryIPv6()
+				framework.ExpectNoError(err, "Failed to allocate IPv6 for EgressIP1")
+				egressIP2, err = ipalloc.NewPrimaryIPv6()
+				framework.ExpectNoError(err, "Failed to allocate IPv6 for EgressIP2")
+			} else {
+				egressIP1, err = ipalloc.NewPrimaryIPv4()
+				framework.ExpectNoError(err, "Failed to allocate IPv4 for EgressIP1")
+				egressIP2, err = ipalloc.NewPrimaryIPv4()
+				framework.ExpectNoError(err, "Failed to allocate IPv4 for EgressIP2")
+			}
+
+			ginkgo.By("Removing host-cidrs annotation from one node to simulate orphan")
+			node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeToOrphan, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Failed to get node %s", nodeToOrphan)
+			originalHostCIDRs := node.Annotations[util.OVNNodeHostCIDRs]
+
+			// The node object is updated by ovnkube-node while the test runs, so
+			// every write here has to be retried on conflict.
+			setHostCIDRs := func(value string) error {
+				return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeToOrphan, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if value == "" {
+						delete(node.Annotations, util.OVNNodeHostCIDRs)
+					} else {
+						node.Annotations[util.OVNNodeHostCIDRs] = value
+					}
+					_, err = f.ClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+					return err
+				})
+			}
+
+			framework.ExpectNoError(setHostCIDRs(""), "Failed to remove host-cidrs annotation from node %s", nodeToOrphan)
+
+			// Register node annotation restore immediately
+			defer func() {
+				framework.ExpectNoError(setHostCIDRs(originalHostCIDRs),
+					"Failed to restore host-cidrs annotation on node %s", nodeToOrphan)
+			}()
+
+			egressIPConfig1 := fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: eip-test-1
+spec:
+    egressIPs:
+    - %s
+    podSelector:
+        matchLabels:
+            egress-pod: "true"
+    namespaceSelector:
+        matchLabels:
+            kubernetes.io/metadata.name: %s
+`, egressIP1.String(), podNamespace.Name)
+
+			egressIPConfig2 := fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: eip-test-2
+spec:
+    egressIPs:
+    - %s
+    podSelector:
+        matchLabels:
+            egress-pod: "true"
+    namespaceSelector:
+        matchLabels:
+            kubernetes.io/metadata.name: %s
+`, egressIP2.String(), podNamespace.Name)
+
+			tmpDir, err := os.MkdirTemp("", "egressip-test-")
+			if err != nil {
+				framework.Failf("Unable to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			egressIPYaml1 := filepath.Join(tmpDir, "eip-test-1.yaml")
+			if err := os.WriteFile(egressIPYaml1, []byte(egressIPConfig1), 0644); err != nil {
+				framework.Failf("Unable to write EgressIP YAML to disk: %v", err)
+			}
+
+			egressIPYaml2 := filepath.Join(tmpDir, "eip-test-2.yaml")
+			if err := os.WriteFile(egressIPYaml2, []byte(egressIPConfig2), 0644); err != nil {
+				framework.Failf("Unable to write EgressIP YAML to disk: %v", err)
+			}
+
+			framework.Logf("Create the EgressIP configurations")
+			e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml1)
+			providerCtx.AddCleanUpFn(func() error {
+				_, err := e2ekubectl.RunKubectl("default", "delete", "egressip", "eip-test-1", "--ignore-not-found=true")
+				return err
+			})
+
+			e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml2)
+			providerCtx.AddCleanUpFn(func() error {
+				_, err := e2ekubectl.RunKubectl("default", "delete", "egressip", "eip-test-2", "--ignore-not-found=true")
+				return err
+			})
+
+			// Returns the node each of the two test EgressIPs is assigned to.
+			// An EgressIP that has no assignment yet is absent from the map.
+			assignedNodes := func() map[string]string {
+				egressIPStdout, err := e2ekubectl.RunKubectl("default", "get", "eip", "-o", "json")
+				if err != nil {
+					framework.Logf("Error getting EgressIPs: %v", err)
+					return nil
+				}
+				var egressIPList egressIPs
+				if err := json.Unmarshal([]byte(egressIPStdout), &egressIPList); err != nil {
+					framework.Logf("Error unmarshaling EgressIP list: %v", err)
+					return nil
+				}
+				assigned := map[string]string{}
+				for _, eip := range egressIPList.Items {
+					if eip.Metadata.Name != "eip-test-1" && eip.Metadata.Name != "eip-test-2" {
+						continue
+					}
+					if len(eip.Status.Items) > 0 {
+						assigned[eip.Metadata.Name] = eip.Status.Items[0].Node
+					}
+				}
+				return assigned
+			}
+
+			// The orphaned state cannot be held open for a fixed window:
+			// ovnkube-node's address manager restores host-cidrs on any netlink
+			// address event, not only on its sync ticker, and IPv6 links produce
+			// enough address activity that the annotation can come back within
+			// seconds. So assert as soon as both EgressIPs are assigned, and
+			// re-check the annotation on every poll: if it returns before the
+			// assignments land, the run has not exercised the orphaned state and
+			// must fail loudly rather than pass without testing anything.
+			ginkgo.By("Verifying both EgressIPs are assigned while one node is orphaned")
+			var assigned map[string]string
+			err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+				orphanNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeToOrphan, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				if _, ok := orphanNode.Annotations[util.OVNNodeHostCIDRs]; ok {
+					return false, fmt.Errorf("node %s regained its host-cidrs annotation before both EgressIPs were assigned, so the orphaned state was not exercised", nodeToOrphan)
+				}
+				assigned = assignedNodes()
+				framework.Logf("Current EgressIP assignments: %v", assigned)
+				return len(assigned) == 2, nil
+			})
+			framework.ExpectNoError(err, "Both EgressIPs should have been assigned while node %s was orphaned", nodeToOrphan)
+
+			gomega.Expect(assigned).NotTo(gomega.ContainElement(nodeToOrphan),
+				"EgressIPs must not be assigned to node %s while its host-cidrs annotation is missing", nodeToOrphan)
 		})
 
 		ginkgo.DescribeTable("[OVN network] multiple namespaces with different primary networks", func(otherNetworkAttachParms networkAttachmentConfigParams) {


### PR DESCRIPTION
## 📑 Description

If a node's `k8s.ovn.org/host-cidrs` annotation is missing or unreadable, EgressIP assignment
currently fails for the **whole cluster**, not just that node: the conflict check returns an
error, `assignEgressIPs` aborts the pass, and every EgressIP object ends up with an empty
`status.items`. One bad node breaks egress traffic everywhere.

This skips such a node instead of aborting, so every other node is still assigned normally.

Fixes #

## Additional Information for reviewers

The annotation is the only source of a node's host addresses, so when it cannot be read there is
nothing to compare the requested egress IP against. Two areas change, both in
`go-controller/pkg/clustermanager`:

* `egressip_controller.go` — `isEgressIPAddrConflict` logs a warning and skips the node rather
  than returning an error.
* `egressip_event_handler.go` — because the node can no longer be vetted, it is also kept out of
  the assignment pool. A node is marked egress-assignable only when it has the
  `k8s.ovn.org/egress-assignable` label **and** a parseable `host-cidrs`. One that loses a usable
  annotation while keeping the label has its existing assignments released, so they move to
  healthy nodes.

Any parse failure is treated the same, not just `AnnotationNotSetError` — a malformed annotation
leaves the check exactly as blind as a missing one.

Deliberate trade-off: conflict protection is **not** enforced for a node in this state. The docs
change says so and tells operators to restore the annotation or remove the stale node. Failing
closed was the old behaviour and is what caused the cluster-wide outage.

Assisted-By: Claude Sonnet 4.5, Claude Opus 5

## ✅ Checks

- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests cover a node with a missing annotation and one with an unparseable annotation,
asserting the EgressIP is assigned to the healthy node and never to the bad one:

```console
cd go-controller
go test ./pkg/clustermanager/ -run TestClusterManager -args --ginkgo.focus="host-cidrs"
```

An e2e test labels two nodes, strips `host-cidrs` from one, creates two EgressIPs and checks both
are assigned and neither lands on the stripped node:

```console
make -C test control-plane WHAT="Should skip orphaned nodes and assign EgressIPs to valid nodes"
```

Both pass locally, as do `make lint` and `gofmt`. The e2e was run 3 times with
`FLAKE_ATTEMPTS=1` (the default retries twice, which would hide a flake) and passed every time.

Manually:

```console
# strip the annotation from a labelled egress node
kubectl annotate node <node> k8s.ovn.org/host-cidrs-
# EgressIPs stay assigned on the remaining eligible nodes instead of all going unassigned
kubectl get eip -o wide
# the cluster manager logs the skip
kubectl -n ovn-kubernetes logs -l name=ovnkube-control-plane -c ovnkube-cluster-manager | grep host-cidrs
```
