### PR TITLE
clustermanager: test inactive L2 transit router nodes

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -791,9 +791,10 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 				selectedNetworks.networkTopology[network] == types.Layer2Topology &&
 				!c.nodeHasLayer2Allocation(nodeName, network) {
 				// Legacy layer2 topology uses the tunnel ID allocation as a
-				// signal that the network is rendered on the node. Transit-router
-				// topology intentionally has no such allocation, so NodeHasNetwork
-				// above is the available signal there.
+				// signal that the network is rendered on the node. The allocation
+				// is stored as a node annotation whose update triggers this
+				// reconcile. Transit-router topology intentionally has no such
+				// allocation, so NodeHasNetwork above is the available signal there.
 				// TODO: replace with a per-node network status once
 				// available, to know when the network is actually rendered.
 				continue
@@ -1832,8 +1833,8 @@ func nodeNeedsUpdate(oldObj, newObj *corev1.Node) bool {
 	return oldObj == nil || newObj == nil ||
 		!reflect.DeepEqual(oldObj.Labels, newObj.Labels) ||
 		util.NodeSubnetAnnotationChanged(oldObj, newObj) ||
-		// with dynamic UDN allocation, the tunnel ID allocation determines
-		// which nodes advertise a layer2 network
+		// With dynamic UDN allocation in legacy layer2 topology, the tunnel
+		// ID allocation determines which nodes advertise the network.
 		oldObj.Annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] != newObj.Annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] ||
 		oldObj.Annotations[util.OvnNodeIfAddr] != newObj.Annotations[util.OvnNodeIfAddr] ||
 		util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -2742,7 +2742,7 @@ exit
 			expectNADAnnotations: map[string]map[string]string{"green": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
 		},
 		{
-			name:                "with dynamic UDN allocation and transit router, advertises an active layer2 network without a tunnel ID allocation",
+			name:                "with dynamic UDN allocation and transit router, advertises an active layer2 network without a tunnel ID allocation and skips inactive nodes",
 			dynamicUDN:          true,
 			layer2TransitRouter: true,
 			ra:                  &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
@@ -2763,7 +2763,11 @@ exit
 			namespaces: []*testNamespace{{Name: "green"}},
 			pods:       []*testPod{{Name: "pod", Namespace: "green", Node: "node"}},
 			nodes: []*testNode{
+				// "node" runs a pod attached to the network; "node2" does not.
+				// Neither has a tunnel ID allocation, and only "node" must be
+				// advertised.
 				{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\"}"},
+				{Name: "node2", SubnetsAnnotation: "{\"default\":\"1.1.1.0/24\"}"},
 			},
 			reconcile:            "ra",
 			expectAcceptedStatus: metav1.ConditionTrue,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
  Follow-up to #6771 review feedback.

  Extend the transit-router Layer2 test with both an active and inactive node, verifying that bypassing the legacy tunnel-ID readiness check does not advertise the network from inactive nodes.

  Also clarify that tunnel-ID allocation and its Node annotation reconcile trigger apply only to legacy Layer2 topology.

  No production behavior change.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
