### PR TITLE
DPU host mode: recover pod interfaces after DPU reboot

### DIFF
--- a/docs/features/hardware-offload/dpu-support.md
+++ b/docs/features/hardware-offload/dpu-support.md
@@ -78,3 +78,19 @@ Two ovnkube-node options control this behavior:
 
 If the lease expires, the DPU host CNI server fails `ADD` requests immediately with `DPU Not Ready` and the `STATUS` command returns a CNI error with code `50` (The plugin is not available).
 This causes the container runtime to report `NetworkReady=false`, preventing new workloads from landing on the affected host until the DPU becomes healthy again.
+
+### Pod interface recovery
+
+When a DPU reboots, SR-IOV VFs disappear from the host. After the DPU is healthy again,
+ovnkube-node on the DPU host restores **default-network `eth0`** by moving the VF back into
+the pod network namespace and reconciling MAC, MTU, link state, addresses, and routes.
+Recovery is retried for five minutes at a 30s interval, then continues at a longer interval
+until the process exits or every recoverable pod succeeds.
+
+Limitations:
+
+- Pods created before this support do not store `netnsPath` in the DPU connection-details
+  annotation and cannot be recovered in place. Recreate those pods.
+- Secondary-network and User Defined Network interfaces are not recovered
+  ([#6823](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6823)).
+- VFIO, DPDK, bonding, and other cases where the application owns the netdev are not recovered.

--- a/go-controller/pkg/cni/cni_dpu.go
+++ b/go-controller/pkg/cni/cni_dpu.go
@@ -50,5 +50,6 @@ func (pr *PodRequest) allocateDPUConnectionDetails(vfNetdevName string) (*util.D
 		VfId:         fmt.Sprint(details.FuncId),
 		SandboxId:    pr.SandboxID,
 		VfNetdevName: vfNetdevName,
+		NetnsPath:    pr.Netns,
 	}, nil
 }

--- a/go-controller/pkg/cni/cni_dpu_test.go
+++ b/go-controller/pkg/cni/cni_dpu_test.go
@@ -76,6 +76,7 @@ var _ = Describe("cni_dpu tests", func() {
 				VfId:         "2",
 				SandboxId:    pr.SandboxID,
 				VfNetdevName: "ens1f0v2",
+				NetnsPath:    pr.Netns,
 			}))
 		})
 

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -840,6 +840,7 @@ var _ = Describe("DHCP IPAM workload differentiation", func() {
 				VfId:         "2",
 				SandboxId:    pr.SandboxID,
 				VfNetdevName: "ens1f0v2",
+				NetnsPath:    pr.Netns,
 			}))
 
 			By("the DHCP delegation still ran and patched the lease, keeping the entry's MAC")

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -73,6 +73,7 @@ func NewCNIServer(
 	networkManager networkmanager.Interface,
 	ovsClient client.Client,
 	dpuHealth DPUStatusProvider,
+	nodeName string,
 ) (*Server, error) {
 	var nadLister nadv1Listers.NetworkAttachmentDefinitionLister
 
@@ -106,6 +107,7 @@ func NewCNIServer(
 		networkManager: networkManager,
 		ovsClient:      ovsClient,
 		dpuHealth:      dpuHealth,
+		nodeName:       nodeName,
 	}
 
 	if len(config.Kubernetes.CAData) > 0 {

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -121,7 +121,7 @@ func TestCNIServer(t *testing.T) {
 		t.Fatalf("failed to call newOVSClientWithExternalIDs: %v", err)
 	}
 	t.Cleanup(ovsCleanup.Cleanup)
-	s, err := NewCNIServer(wf, fakeClient, networkmanager.Default().Interface(), ovsClient, nil)
+	s, err := NewCNIServer(wf, fakeClient, networkmanager.Default().Interface(), ovsClient, nil, "test-node")
 	if err != nil {
 		t.Fatalf("error creating CNI server: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestCNIServerStatusNotReady(t *testing.T) {
 	}
 	t.Cleanup(ovsCleanup.Cleanup)
 	dpuHealth := &fakeDPUHealth{ready: false, reason: "lease expired"}
-	s, err := NewCNIServer(wf, fakeClient, networkmanager.Default().Interface(), ovsClient, dpuHealth)
+	s, err := NewCNIServer(wf, fakeClient, networkmanager.Default().Interface(), ovsClient, dpuHealth, "test-node")
 	if err != nil {
 		t.Fatalf("error creating CNI server: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestNewCNIServerRequiresOVSClientInPrivilegedMode(t *testing.T) {
 			config.OvnKubeNode.Mode = tt.mode
 			config.UnprivilegedMode = tt.unprivilegedMode
 
-			_, err := NewCNIServer(wf, fakeClient, networkmanager.Default().Interface(), nil, nil)
+			_, err := NewCNIServer(wf, fakeClient, networkmanager.Default().Interface(), nil, nil, "test-node")
 			if tt.wantErr {
 				if err == nil || !strings.Contains(err.Error(), "OVS client is required in privileged mode") {
 					t.Fatalf("expected OVS client error, got %v", err)

--- a/go-controller/pkg/cni/dpu_recovery_linux.go
+++ b/go-controller/pkg/cni/dpu_recovery_linux.go
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package cni
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// dpuRecoveryMu serializes recovery scans to prevent concurrent scans
+// from racing to move/configure the same VF (e.g., lease flap + startup).
+var dpuRecoveryMu sync.Mutex
+
+// testable function variables for unit test injection
+var (
+	openNetNS      = ns.GetNS
+	recoverSriovIf func(s *Server, pod *corev1.Pod, nadKey string, dcd util.DPUConnectionDetails, ifName string) error
+)
+
+const (
+	dpuRecoveryRetryInterval = 30 * time.Second
+	dpuRecoveryTimeout       = 5 * time.Minute
+	dpuRecoverySlowInterval  = 2 * time.Minute
+	dpuDefaultIfName         = "eth0"
+)
+
+// RecoverPodInterfaces scans all pods on this node that have DPU connection-details
+// and re-configures any pod whose interface has disappeared. This is intended to be
+// called when the DPU transitions from unhealthy to healthy.
+func (s *Server) RecoverPodInterfaces(stopCh <-chan struct{}) {
+	if !config.IsModeDPUHost() {
+		return
+	}
+
+	ctx := wait.ContextForChannel(stopCh)
+	poll := func(_ context.Context) (bool, error) {
+		return s.recoverPodInterfacesScan() == 0, nil
+	}
+	err := wait.PollUntilContextTimeout(ctx, dpuRecoveryRetryInterval, dpuRecoveryTimeout, true, poll)
+	if ctx.Err() != nil {
+		return
+	}
+	if err != nil {
+		klog.Errorf("DPU recovery: still failing after %s, continuing at %s interval: %v",
+			dpuRecoveryTimeout, dpuRecoverySlowInterval, err)
+		_ = wait.PollUntilContextCancel(ctx, dpuRecoverySlowInterval, false, poll)
+	}
+	klog.Infof("DPU recovery: all recoverable pod interfaces have been restored")
+}
+
+func (s *Server) recoverPodInterfacesScan() int {
+	dpuRecoveryMu.Lock()
+	defer dpuRecoveryMu.Unlock()
+
+	klog.Infof("DPU recovery: starting pod interface recovery scan")
+
+	pods, err := s.clientSet.podLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("DPU recovery: failed to list pods: %v", err)
+		return 1
+	}
+
+	var failed, scanned int
+	for _, pod := range pods {
+		if pod.Spec.NodeName != s.nodeName {
+			continue
+		}
+		scanned++
+		if err := s.recoverPodInterface(pod); err != nil {
+			klog.Errorf("DPU recovery: pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			failed++
+		}
+	}
+
+	klog.Infof("DPU recovery: scan complete (pods_on_node=%d, failed=%d)", scanned, failed)
+	return failed
+}
+
+func (s *Server) recoverPodInterface(pod *corev1.Pod) error {
+	if util.PodWantsHostNetwork(pod) {
+		klog.V(5).Infof("DPU recovery: pod %s/%s uses host networking, skipping", pod.Namespace, pod.Name)
+		return nil
+	}
+
+	dcds, err := util.UnmarshalPodDPUConnDetailsAllNetworks(pod.Annotations)
+	if err != nil {
+		return fmt.Errorf("failed to parse DPU connection details: %v", err)
+	}
+	if len(dcds) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for nadKey, dcd := range dcds {
+		if nadKey != types.DefaultNetworkName {
+			klog.V(5).Infof("DPU recovery: pod %s/%s NAD %s is not default network, skipping", pod.Namespace, pod.Name, nadKey)
+			continue
+		}
+		if dcd.NetnsPath == "" {
+			klog.Warningf("DPU recovery: pod %s/%s NAD %s missing netnsPath (created before DPU recovery support); recreate the pod", pod.Namespace, pod.Name, nadKey)
+			continue
+		}
+		if dcd.VfNetdevName == "" {
+			klog.Warningf("DPU recovery: pod %s/%s NAD %s has empty VfNetdevName; cannot recover VFIO or non-netdev interfaces", pod.Namespace, pod.Name, nadKey)
+			continue
+		}
+
+		recoverFn := recoverSriovIf
+		if recoverFn == nil {
+			recoverFn = (*Server).recoverSriovInterface
+		}
+		klog.Infof("DPU recovery: pod %s/%s NAD %s: recovering interface %s", pod.Namespace, pod.Name, nadKey, dpuDefaultIfName)
+		if err := recoverFn(s, pod, nadKey, dcd, dpuDefaultIfName); err != nil {
+			klog.Errorf("DPU recovery: pod %s/%s NAD %s: recovery failed: %v", pod.Namespace, pod.Name, nadKey, err)
+			errs = append(errs, fmt.Errorf("NAD %s: %w", nadKey, err))
+		} else {
+			klog.Infof("DPU recovery: pod %s/%s NAD %s: interface %s recovered successfully", pod.Namespace, pod.Name, nadKey, dpuDefaultIfName)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// recoverSriovInterface restores the default-network VF into the pod netns and
+// reconciles MAC, MTU, link state, addresses, and routes. It is idempotent so a
+// partial previous attempt (VF already moved, renamed, or configured) can resume.
+func (s *Server) recoverSriovInterface(pod *corev1.Pod, nadKey string, dcd util.DPUConnectionDetails, ifName string) error {
+	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadKey)
+	if err != nil {
+		return fmt.Errorf("failed to get pod annotation for NAD %s: %v", nadKey, err)
+	}
+
+	netNS, err := openNetNS(dcd.NetnsPath)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %s: %v", dcd.NetnsPath, err)
+	}
+	defer netNS.Close()
+
+	currentName, err := ensureVFInPodNetns(netNS, dcd, ifName)
+	if err != nil {
+		return err
+	}
+
+	return netNS.Do(func(_ ns.NetNS) error {
+		if currentName != ifName {
+			if err := renameLink(currentName, ifName); err != nil {
+				return fmt.Errorf("failed to rename %s to %s: %v", currentName, ifName, err)
+			}
+		}
+		link, err := util.GetNetLinkOps().LinkByName(ifName)
+		if err != nil {
+			return fmt.Errorf("failed to lookup %s: %v", ifName, err)
+		}
+		return reconcilePodLink(link, pod, podAnnotation)
+	})
+}
+
+// ensureVFInPodNetns checks if the VF is already in the pod netns (as ifName
+// or VfNetdevName from a partial previous recovery). If not, it looks up the
+// VF on the host and moves it into the pod netns. Returns the current name of
+// the link inside the pod netns.
+func ensureVFInPodNetns(netNS ns.NetNS, dcd util.DPUConnectionDetails, ifName string) (string, error) {
+	// Check inside the pod netns: the VF may already be there as ifName (fully
+	// recovered) or as VfNetdevName (moved by a previous attempt but not renamed).
+	var currentName string
+	err := netNS.Do(func(_ ns.NetNS) error {
+		for _, name := range []string{ifName, dcd.VfNetdevName} {
+			if _, err := util.GetNetLinkOps().LinkByName(name); err == nil {
+				currentName = name
+				return nil
+			} else if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect pod netns %s: %v", dcd.NetnsPath, err)
+	}
+	if currentName != "" {
+		return currentName, nil
+	}
+
+	// VF not in pod netns — look it up on the host and move it in.
+	if _, err := util.GetNetLinkOps().LinkByName(dcd.VfNetdevName); err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return "", fmt.Errorf("VF %s not found on host or in pod netns (DPU may not be fully recovered)", dcd.VfNetdevName)
+		}
+		return "", fmt.Errorf("failed to lookup VF %s on host: %v", dcd.VfNetdevName, err)
+	}
+
+	name, moveErr := safeMoveIfToNetns(dcd.VfNetdevName, netNS, dcd.SandboxId)
+	if moveErr != nil {
+		return "", fmt.Errorf("failed to move VF %s to netns: %v", dcd.VfNetdevName, moveErr)
+	}
+	return name, nil
+}
+
+func reconcilePodLink(link netlink.Link, pod *corev1.Pod, podAnnotation *util.PodAnnotation) error {
+	if err := util.GetNetLinkOps().LinkSetHardwareAddr(link, podAnnotation.MAC); err != nil {
+		return fmt.Errorf("failed to set MAC: %v", err)
+	}
+	if err := util.GetNetLinkOps().LinkSetMTU(link, config.Default.MTU); err != nil {
+		return fmt.Errorf("failed to set MTU: %v", err)
+	}
+	if err := util.GetNetLinkOps().LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed to set link up: %v", err)
+	}
+	if kubevirt.IsPodLiveMigratable(pod) {
+		klog.Infof("DPU recovery: skipping IP/route configuration for live-migratable pod %s/%s", pod.Namespace, pod.Name)
+		return nil
+	}
+	return setupNetworkRecovery(link, podAnnotation)
+}
+
+// setupNetworkRecovery configures IPs and routes on a recovered interface.
+// Unlike setupNetwork, it tolerates existing state (EEXIST) to handle
+// partial recovery retries gracefully.
+func setupNetworkRecovery(link netlink.Link, podAnnotation *util.PodAnnotation) error {
+	for _, ip := range podAnnotation.IPs {
+		addr := &netlink.Addr{IPNet: ip}
+		if err := util.GetNetLinkOps().AddrAdd(link, addr); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to add IP addr %s to %s: %v", ip, link.Attrs().Name, err)
+		}
+	}
+
+	for _, gw := range podAnnotation.Gateways {
+		if err := addRouteIdempotent(nil, gw, link, config.Default.RoutableMTU); err != nil {
+			return fmt.Errorf("failed to add gateway route: %v", err)
+		}
+	}
+
+	for _, route := range podAnnotation.Routes {
+		if err := addRouteIdempotent(route.Dest, route.NextHop, link, config.Default.RoutableMTU); err != nil {
+			return fmt.Errorf("failed to add route %v via %v: %v", route.Dest, route.NextHop, err)
+		}
+	}
+
+	return nil
+}
+
+func addRouteIdempotent(ipn *net.IPNet, gw net.IP, dev netlink.Link, mtu int) error {
+	return util.GetNetLinkOps().RouteReplace(&netlink.Route{
+		LinkIndex: dev.Attrs().Index,
+		Scope:     netlink.SCOPE_UNIVERSE,
+		Dst:       ipn,
+		Gw:        gw,
+		MTU:       mtu,
+	})
+}

--- a/go-controller/pkg/cni/dpu_recovery_linux_test.go
+++ b/go-controller/pkg/cni/dpu_recovery_linux_test.go
@@ -1,0 +1,665 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package cni
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/mock"
+	"github.com/vishvananda/netlink"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	cni_ns_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/containernetworking/plugins/pkg/ns"
+	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
+	v1mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
+	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func podWithDPUAnnotation(name, namespace string, dcd *util.DPUConnectionDetails, nadKey string) *corev1.Pod {
+	annotations := map[string]string{}
+	if dcd != nil {
+		var err error
+		annotations, err = util.MarshalPodDPUConnDetails(annotations, dcd, nadKey)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+func withOVNPodAnnotation(pod *corev1.Pod, nadKey string, ann *util.PodAnnotation) *corev1.Pod {
+	var err error
+	pod.Annotations, err = util.MarshalPodAnnotation(pod.Annotations, ann, nadKey)
+	Expect(err).NotTo(HaveOccurred())
+	return pod
+}
+
+func testPodAnnotation() *util.PodAnnotation {
+	return &util.PodAnnotation{
+		MAC:      ovntest.MustParseMAC("0a:58:0a:00:00:05"),
+		IPs:      ovntest.MustParseIPNets("192.168.0.5/24"),
+		Gateways: []net.IP{net.ParseIP("192.168.0.1")},
+	}
+}
+
+func forwardingNetNS() *cni_ns_mocks.NetNS {
+	mockNS := &cni_ns_mocks.NetNS{}
+	mockNS.On("Close").Return(nil)
+	mockNS.On("Fd").Return(uintptr(123456)).Maybe()
+	mockNS.On("Do", mock.AnythingOfType("func(ns.NetNS) error")).Return(
+		func(toRun func(ns.NetNS) error) error {
+			return toRun(nil)
+		},
+	)
+	return mockNS
+}
+
+var _ = Describe("DPU pod interface recovery", func() {
+	var (
+		podLister v1mocks.PodLister
+		server    *Server
+	)
+
+	BeforeEach(func() {
+		origMode := config.OvnKubeNode.Mode
+		origMTU := config.Default.RoutableMTU
+		DeferCleanup(func() {
+			config.OvnKubeNode.Mode = origMode
+			config.Default.RoutableMTU = origMTU
+			recoverSriovIf = nil
+		})
+
+		podLister = v1mocks.PodLister{}
+		server = &Server{
+			clientSet: &ClientSet{
+				podLister: &podLister,
+			},
+			nodeName: "test-node",
+		}
+		config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
+	})
+
+	Context("recoverPodInterface", func() {
+		It("skips pod with no DPU annotations", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod",
+					Namespace:   "test-ns",
+					Annotations: map[string]string{},
+				},
+			}
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("skips pod with nil annotations", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-ns",
+				},
+			}
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("skips host-network pods", func() {
+			pod := podWithDPUAnnotation("test-pod", "test-ns", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "2",
+				SandboxId:    "abc123",
+				VfNetdevName: "enp3s0f0v2",
+				NetnsPath:    "/var/run/netns/pod-abc",
+			}, ovntypes.DefaultNetworkName)
+			pod.Spec.HostNetwork = true
+
+			recoverSriovIf = func(_ *Server, _ *corev1.Pod, _ string, _ util.DPUConnectionDetails, _ string) error {
+				Fail("recovery should not be invoked for host-network pods")
+				return nil
+			}
+
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("skips pod when netnsPath is empty", func() {
+			pod := podWithDPUAnnotation("test-pod", "test-ns", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "2",
+				SandboxId:    "abc123",
+				VfNetdevName: "enp3s0f0v2",
+			}, ovntypes.DefaultNetworkName)
+
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("skips pod when VfNetdevName is empty", func() {
+			pod := podWithDPUAnnotation("test-pod", "test-ns", &util.DPUConnectionDetails{
+				PfId:      "0",
+				VfId:      "2",
+				SandboxId: "abc123",
+				NetnsPath: "/var/run/netns/pod-abc",
+			}, ovntypes.DefaultNetworkName)
+
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("skips non-default network NADs", func() {
+			pod := podWithDPUAnnotation("test-pod", "test-ns", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "2",
+				SandboxId:    "abc123",
+				VfNetdevName: "enp3s0f0v2",
+				NetnsPath:    "/var/run/netns/test",
+			}, "test-ns/my-secondary-net")
+
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("setupNetworkRecovery", func() {
+		var (
+			netlinkOpsMock *utilMocks.NetLinkOps
+			mockLink       *netlink_mocks.Link
+		)
+
+		BeforeEach(func() {
+			netlinkOpsMock = &utilMocks.NetLinkOps{}
+			mockLink = &netlink_mocks.Link{}
+			util.SetNetLinkOpMockInst(netlinkOpsMock)
+		})
+
+		AfterEach(func() {
+			util.ResetNetLinkOpMockInst()
+		})
+
+		It("configures IPs and routes", func() {
+			podAnnotation := &util.PodAnnotation{
+				IPs:      ovntest.MustParseIPNets("192.168.0.5/24"),
+				Gateways: []net.IP{net.ParseIP("192.168.0.1")},
+				Routes: []util.PodRoute{
+					{
+						Dest:    ovntest.MustParseIPNet("10.0.0.0/8"),
+						NextHop: net.ParseIP("192.168.0.1"),
+					},
+				},
+			}
+
+			config.Default.RoutableMTU = 1400
+
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "eth0", Index: 7})
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(nil)
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).NotTo(HaveOccurred())
+
+			netlinkOpsMock.AssertNumberOfCalls(GinkgoT(), "AddrAdd", 1)
+			netlinkOpsMock.AssertNumberOfCalls(GinkgoT(), "RouteReplace", 2)
+		})
+
+		It("configures dual-stack IPs and routes", func() {
+			podAnnotation := &util.PodAnnotation{
+				IPs: ovntest.MustParseIPNets("192.168.0.5/24", "fd00::5/64"),
+				Gateways: []net.IP{
+					net.ParseIP("192.168.0.1"),
+					net.ParseIP("fd00::1"),
+				},
+			}
+
+			config.Default.RoutableMTU = 1400
+
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "eth0", Index: 7})
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(nil)
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).NotTo(HaveOccurred())
+
+			netlinkOpsMock.AssertNumberOfCalls(GinkgoT(), "AddrAdd", 2)
+			netlinkOpsMock.AssertNumberOfCalls(GinkgoT(), "RouteReplace", 2)
+		})
+
+		It("tolerates EEXIST on AddrAdd", func() {
+			podAnnotation := &util.PodAnnotation{
+				IPs:      ovntest.MustParseIPNets("192.168.0.5/24"),
+				Gateways: []net.IP{net.ParseIP("192.168.0.1")},
+			}
+
+			config.Default.RoutableMTU = 1400
+
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "eth0", Index: 7})
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(os.ErrExist)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(nil)
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error on non-EEXIST AddrAdd failure", func() {
+			podAnnotation := &util.PodAnnotation{
+				IPs: ovntest.MustParseIPNets("192.168.0.5/24"),
+			}
+
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "eth0", Index: 7})
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(fmt.Errorf("permission denied"))
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("permission denied"))
+		})
+
+		It("returns error on RouteReplace failure for gateway", func() {
+			podAnnotation := &util.PodAnnotation{
+				IPs:      ovntest.MustParseIPNets("192.168.0.5/24"),
+				Gateways: []net.IP{net.ParseIP("192.168.0.1")},
+			}
+
+			config.Default.RoutableMTU = 1400
+
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "eth0", Index: 7})
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(fmt.Errorf("network unreachable"))
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("network unreachable"))
+		})
+
+		It("returns error on RouteReplace failure for pod route", func() {
+			podAnnotation := &util.PodAnnotation{
+				IPs: ovntest.MustParseIPNets("192.168.0.5/24"),
+				Routes: []util.PodRoute{
+					{
+						Dest:    ovntest.MustParseIPNet("10.0.0.0/8"),
+						NextHop: net.ParseIP("192.168.0.1"),
+					},
+				},
+			}
+
+			config.Default.RoutableMTU = 1400
+
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "eth0", Index: 7})
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(fmt.Errorf("route error"))
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("route error"))
+		})
+
+		It("succeeds with no IPs, gateways, or routes", func() {
+			podAnnotation := &util.PodAnnotation{}
+
+			err := setupNetworkRecovery(mockLink, podAnnotation)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("recoverPodInterface with recoverSriovIf injection", func() {
+		var origRecoverFn func(*Server, *corev1.Pod, string, util.DPUConnectionDetails, string) error
+
+		BeforeEach(func() {
+			origRecoverFn = recoverSriovIf
+		})
+
+		AfterEach(func() {
+			recoverSriovIf = origRecoverFn
+		})
+
+		It("triggers VF recovery for a default-network pod", func() {
+			var recoveredPod string
+			var recoveredNAD string
+			var recoveredDCD util.DPUConnectionDetails
+			recoverSriovIf = func(_ *Server, pod *corev1.Pod, nadKey string, dcd util.DPUConnectionDetails, ifName string) error {
+				recoveredPod = pod.Namespace + "/" + pod.Name
+				recoveredNAD = nadKey
+				recoveredDCD = dcd
+				Expect(ifName).To(Equal("eth0"))
+				return nil
+			}
+
+			dcd := &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "2",
+				SandboxId:    "abc123",
+				VfNetdevName: "enp3s0f0v2",
+				NetnsPath:    "/var/run/netns/pod-abc",
+			}
+			pod := podWithDPUAnnotation("test-pod", "test-ns", dcd, ovntypes.DefaultNetworkName)
+
+			err := server.recoverPodInterface(pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recoveredPod).To(Equal("test-ns/test-pod"))
+			Expect(recoveredNAD).To(Equal(ovntypes.DefaultNetworkName))
+			Expect(recoveredDCD.VfNetdevName).To(Equal("enp3s0f0v2"))
+			Expect(recoveredDCD.SandboxId).To(Equal("abc123"))
+			Expect(recoveredDCD.NetnsPath).To(Equal("/var/run/netns/pod-abc"))
+		})
+
+		It("returns recovery failure from recoverPodInterface", func() {
+			recoverSriovIf = func(_ *Server, _ *corev1.Pod, _ string, _ util.DPUConnectionDetails, _ string) error {
+				return fmt.Errorf("VF not found on host")
+			}
+
+			pod := podWithDPUAnnotation("test-pod", "test-ns", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "2",
+				SandboxId:    "abc123",
+				VfNetdevName: "enp3s0f0v2",
+				NetnsPath:    "/var/run/netns/pod-abc",
+			}, ovntypes.DefaultNetworkName)
+
+			err := server.recoverPodInterface(pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("VF not found on host"))
+		})
+
+		It("full scan detects missing interface and triggers recovery", func() {
+			recoverCount := 0
+			recoverSriovIf = func(_ *Server, _ *corev1.Pod, _ string, _ util.DPUConnectionDetails, _ string) error {
+				recoverCount++
+				return nil
+			}
+
+			pod := podWithDPUAnnotation("pod1", "ns1", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "3",
+				SandboxId:    "sandbox1",
+				VfNetdevName: "enp3s0f0v3",
+				NetnsPath:    "/var/run/netns/pod1",
+			}, ovntypes.DefaultNetworkName)
+			pod.Spec.NodeName = "test-node"
+
+			podLister.On("List", labels.Everything()).Return([]*corev1.Pod{pod}, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(0))
+			Expect(recoverCount).To(Equal(1))
+		})
+
+		It("full scan still recovers when interface is already present", func() {
+			recoverCount := 0
+			recoverSriovIf = func(_ *Server, _ *corev1.Pod, _ string, _ util.DPUConnectionDetails, _ string) error {
+				recoverCount++
+				return nil
+			}
+
+			pod := podWithDPUAnnotation("pod1", "ns1", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "3",
+				SandboxId:    "sandbox1",
+				VfNetdevName: "enp3s0f0v3",
+				NetnsPath:    "/var/run/netns/pod1",
+			}, ovntypes.DefaultNetworkName)
+			pod.Spec.NodeName = "test-node"
+
+			podLister.On("List", labels.Everything()).Return([]*corev1.Pod{pod}, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(0))
+			Expect(recoverCount).To(Equal(1), "recovery should reconcile even when eth0 may already be present")
+		})
+
+		It("full scan increments failed when recovery returns an error", func() {
+			recoverSriovIf = func(_ *Server, _ *corev1.Pod, _ string, _ util.DPUConnectionDetails, _ string) error {
+				return fmt.Errorf("VF not found on host")
+			}
+
+			pod := podWithDPUAnnotation("pod1", "ns1", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "3",
+				SandboxId:    "sandbox1",
+				VfNetdevName: "enp3s0f0v3",
+				NetnsPath:    "/var/run/netns/pod1",
+			}, ovntypes.DefaultNetworkName)
+			pod.Spec.NodeName = "test-node"
+
+			podLister.On("List", labels.Everything()).Return([]*corev1.Pod{pod}, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(1))
+		})
+
+		It("full scan does not increment failed for skipped pods (missing netnsPath)", func() {
+			recoverCalled := false
+			recoverSriovIf = func(_ *Server, _ *corev1.Pod, _ string, _ util.DPUConnectionDetails, _ string) error {
+				recoverCalled = true
+				return nil
+			}
+
+			pod := podWithDPUAnnotation("pod1", "ns1", &util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "3",
+				SandboxId:    "sandbox1",
+				VfNetdevName: "enp3s0f0v3",
+			}, ovntypes.DefaultNetworkName)
+			pod.Spec.NodeName = "test-node"
+
+			podLister.On("List", labels.Everything()).Return([]*corev1.Pod{pod}, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(0))
+			Expect(recoverCalled).To(BeFalse())
+		})
+	})
+
+	Context("recoverPodInterfacesScan", func() {
+		It("returns 0 when no pods have DPU annotations", func() {
+			pods := []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "pod1",
+						Namespace:   "ns1",
+						Annotations: map[string]string{},
+					},
+					Spec: corev1.PodSpec{NodeName: "test-node"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "pod2",
+						Namespace:   "ns2",
+						Annotations: map[string]string{"other-annotation": "value"},
+					},
+					Spec: corev1.PodSpec{NodeName: "test-node"},
+				},
+			}
+
+			podLister.On("List", labels.Everything()).Return(pods, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(0))
+		})
+
+		It("skips pods on other nodes", func() {
+			pods := []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "pod1",
+						Namespace:   "ns1",
+						Annotations: map[string]string{},
+					},
+					Spec: corev1.PodSpec{NodeName: "other-node"},
+				},
+			}
+
+			podLister.On("List", labels.Everything()).Return(pods, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(0))
+		})
+
+		It("returns 0 when pod list is empty", func() {
+			podLister.On("List", labels.Everything()).Return([]*corev1.Pod{}, nil)
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(0))
+		})
+
+		It("returns 1 when pod listing fails", func() {
+			podLister.On("List", labels.Everything()).Return(nil, fmt.Errorf("lister error"))
+
+			failed := server.recoverPodInterfacesScan()
+			Expect(failed).To(Equal(1))
+		})
+	})
+
+	Context("recoverSriovInterface", func() {
+		const vfName = "enp3s0f0v2"
+
+		var (
+			netlinkOpsMock *utilMocks.NetLinkOps
+			mockLink       *netlink_mocks.Link
+			mockNS         *cni_ns_mocks.NetNS
+			origOpenNetNS  func(string) (ns.NetNS, error)
+			linkNotFound   = errors.New("link not found")
+			pod            *corev1.Pod
+			dcd            util.DPUConnectionDetails
+		)
+
+		BeforeEach(func() {
+			netlinkOpsMock = &utilMocks.NetLinkOps{}
+			mockLink = &netlink_mocks.Link{}
+			mockNS = forwardingNetNS()
+			util.SetNetLinkOpMockInst(netlinkOpsMock)
+			origOpenNetNS = openNetNS
+			openNetNS = func(path string) (ns.NetNS, error) {
+				Expect(path).To(Equal("/var/run/netns/pod-abc"))
+				return mockNS, nil
+			}
+
+			config.Default.MTU = 1500
+			config.Default.RoutableMTU = 1400
+
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(func(err error) bool {
+				return errors.Is(err, linkNotFound)
+			})
+
+			ann := testPodAnnotation()
+			mockLink.On("Attrs").Return(&netlink.LinkAttrs{
+				Name:         "eth0",
+				Index:        7,
+				HardwareAddr: ann.MAC,
+			})
+
+			dcd = util.DPUConnectionDetails{
+				PfId:         "0",
+				VfId:         "2",
+				SandboxId:    "abc123",
+				VfNetdevName: vfName,
+				NetnsPath:    "/var/run/netns/pod-abc",
+			}
+			pod = withOVNPodAnnotation(podWithDPUAnnotation("test-pod", "test-ns", &dcd, ovntypes.DefaultNetworkName),
+				ovntypes.DefaultNetworkName, ann)
+		})
+
+		AfterEach(func() {
+			openNetNS = origOpenNetNS
+			util.ResetNetLinkOpMockInst()
+		})
+
+		It("moves the VF from the host and reconciles network config", func() {
+			netlinkOpsMock.On("LinkByName", "eth0").Return(nil, linkNotFound).Once()
+			netlinkOpsMock.On("LinkByName", vfName).Return(nil, linkNotFound).Once()
+			netlinkOpsMock.On("LinkByName", vfName).Return(mockLink, nil)
+			netlinkOpsMock.On("LinkSetNsFd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("LinkSetDown", mockLink).Return(nil)
+			netlinkOpsMock.On("LinkSetName", mockLink, "eth0").Return(nil)
+			netlinkOpsMock.On("LinkSetUp", mockLink).Return(nil)
+			netlinkOpsMock.On("LinkByName", "eth0").Return(mockLink, nil)
+			netlinkOpsMock.On("LinkSetHardwareAddr", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", mockLink, 1500).Return(nil)
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(nil)
+
+			err := server.recoverSriovInterface(pod, ovntypes.DefaultNetworkName, dcd, "eth0")
+			Expect(err).NotTo(HaveOccurred())
+			netlinkOpsMock.AssertCalled(GinkgoT(), "LinkSetNsFd", mockLink, mock.Anything)
+			netlinkOpsMock.AssertCalled(GinkgoT(), "LinkSetName", mockLink, "eth0")
+			netlinkOpsMock.AssertCalled(GinkgoT(), "AddrAdd", mockLink, mock.Anything)
+		})
+
+		It("renames an already-moved VF and reconciles", func() {
+			netlinkOpsMock.On("LinkByName", "eth0").Return(nil, linkNotFound).Once()
+			netlinkOpsMock.On("LinkByName", vfName).Return(mockLink, nil)
+			netlinkOpsMock.On("LinkSetDown", mockLink).Return(nil)
+			netlinkOpsMock.On("LinkSetName", mockLink, "eth0").Return(nil)
+			netlinkOpsMock.On("LinkSetUp", mockLink).Return(nil)
+			netlinkOpsMock.On("LinkByName", "eth0").Return(mockLink, nil)
+			netlinkOpsMock.On("LinkSetHardwareAddr", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", mockLink, 1500).Return(nil)
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(nil)
+
+			err := server.recoverSriovInterface(pod, ovntypes.DefaultNetworkName, dcd, "eth0")
+			Expect(err).NotTo(HaveOccurred())
+			netlinkOpsMock.AssertNotCalled(GinkgoT(), "LinkSetNsFd")
+			netlinkOpsMock.AssertCalled(GinkgoT(), "LinkSetName", mockLink, "eth0")
+		})
+
+		It("reconciles when eth0 is already present", func() {
+			netlinkOpsMock.On("LinkByName", "eth0").Return(mockLink, nil)
+			netlinkOpsMock.On("LinkSetHardwareAddr", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", mockLink, 1500).Return(nil)
+			netlinkOpsMock.On("LinkSetUp", mockLink).Return(nil)
+			netlinkOpsMock.On("AddrAdd", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("RouteReplace", mock.Anything).Return(nil)
+
+			err := server.recoverSriovInterface(pod, ovntypes.DefaultNetworkName, dcd, "eth0")
+			Expect(err).NotTo(HaveOccurred())
+			netlinkOpsMock.AssertNotCalled(GinkgoT(), "LinkSetNsFd")
+			netlinkOpsMock.AssertNotCalled(GinkgoT(), "LinkSetName")
+			netlinkOpsMock.AssertCalled(GinkgoT(), "LinkSetHardwareAddr", mockLink, mock.Anything)
+			netlinkOpsMock.AssertCalled(GinkgoT(), "AddrAdd", mockLink, mock.Anything)
+		})
+
+		It("skips IP and route configuration for live-migratable pods", func() {
+			pod.Annotations[kubevirtv1.AllowPodBridgeNetworkLiveMigrationAnnotation] = ""
+
+			netlinkOpsMock.On("LinkByName", "eth0").Return(mockLink, nil)
+			netlinkOpsMock.On("LinkSetHardwareAddr", mockLink, mock.Anything).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", mockLink, 1500).Return(nil)
+			netlinkOpsMock.On("LinkSetUp", mockLink).Return(nil)
+
+			err := server.recoverSriovInterface(pod, ovntypes.DefaultNetworkName, dcd, "eth0")
+			Expect(err).NotTo(HaveOccurred())
+			netlinkOpsMock.AssertNotCalled(GinkgoT(), "AddrAdd")
+			netlinkOpsMock.AssertNotCalled(GinkgoT(), "RouteReplace")
+		})
+
+		It("returns a retryable error when the VF is missing from host and pod netns", func() {
+			netlinkOpsMock.On("LinkByName", "eth0").Return(nil, linkNotFound)
+			netlinkOpsMock.On("LinkByName", vfName).Return(nil, linkNotFound)
+
+			err := server.recoverSriovInterface(pod, ovntypes.DefaultNetworkName, dcd, "eth0")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found on host or in pod netns"))
+		})
+	})
+})

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -219,4 +219,5 @@ type Server struct {
 	networkManager networkmanager.Interface
 	ovsClient      client.Client
 	dpuHealth      DPUStatusProvider
+	nodeName       string
 }

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -833,11 +833,18 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		if nc.dpuNodeLeaseManager != nil {
 			dpuHealth = nc.dpuNodeLeaseManager
 		}
-		cniServer, err = cni.NewCNIServer(nc.watchFactory, kclient.KClient, nc.networkManager, nc.ovsClient, dpuHealth)
+		cniServer, err = cni.NewCNIServer(nc.watchFactory, kclient.KClient, nc.networkManager, nc.ovsClient, dpuHealth, nc.name)
 		if err != nil {
 			return err
 		}
 		nc.cniServer = cniServer
+
+		if nc.dpuNodeLeaseManager != nil && config.IsModeDPUHost() {
+			klog.Infof("DPU recovery: registering pod interface recovery handler on DPU lease manager")
+			nc.dpuNodeLeaseManager.SetRecoveryHandler(func() {
+				cniServer.RecoverPodInterfaces(nc.stopChan)
+			})
+		}
 	}
 
 	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
@@ -1122,6 +1129,10 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		}()
 		ovspinning.Run(ctx, stopCh, podResClient, nc.ovsClient)
 	}(nc.stopChan)
+
+	if config.IsModeDPUHost() && nc.cniServer != nil {
+		go nc.cniServer.RecoverPodInterfaces(nc.stopChan)
+	}
 
 	klog.Infof("Default node network controller initialized and ready.")
 	return nil

--- a/go-controller/pkg/node/dpulease/manager.go
+++ b/go-controller/pkg/node/dpulease/manager.go
@@ -36,9 +36,10 @@ type Manager struct {
 	renewInterval time.Duration
 	leaseDuration time.Duration
 
-	statusMu sync.RWMutex
-	ready    bool
-	reason   string
+	statusMu        sync.RWMutex
+	ready           bool
+	reason          string
+	recoveryHandler func()
 }
 
 // NewManager builds a new Manager.
@@ -62,6 +63,15 @@ func (m *Manager) Ready() (bool, string) {
 	m.statusMu.RLock()
 	defer m.statusMu.RUnlock()
 	return m.ready, m.reason
+}
+
+// SetRecoveryHandler registers a function to be called when the DPU
+// transitions from unhealthy to healthy. This allows consumers (e.g. the CNI
+// server) to trigger pod network recovery after a DPU outage.
+func (m *Manager) SetRecoveryHandler(fn func()) {
+	m.statusMu.Lock()
+	defer m.statusMu.Unlock()
+	m.recoveryHandler = fn
 }
 
 // EnsureLease creates or updates the DPU lease.
@@ -201,16 +211,22 @@ func (m *Manager) monitorPeriod() time.Duration {
 
 func (m *Manager) setStatus(reason string, ready bool) {
 	m.statusMu.Lock()
-	defer m.statusMu.Unlock()
 
 	prevReady := m.ready
 	prevReason := m.reason
+	var handler func()
 	if prevReady != ready || prevReason != reason {
 		if ready && !prevReady && prevReason != "" {
 			klog.V(4).Infof("DPU lease %s marked healthy", m.leaseName())
+			handler = m.recoveryHandler
 		}
 		m.ready = ready
 		m.reason = reason
+	}
+	m.statusMu.Unlock()
+
+	if handler != nil {
+		go handler()
 	}
 }
 

--- a/go-controller/pkg/util/dpu_annotations.go
+++ b/go-controller/pkg/util/dpu_annotations.go
@@ -60,6 +60,7 @@ type DPUConnectionDetails struct {
 	VfId         string `json:"vfId"`
 	SandboxId    string `json:"sandboxId"`
 	VfNetdevName string `json:"vfNetdevName,omitempty"`
+	NetnsPath    string `json:"netnsPath,omitempty"`
 }
 
 type DPUConnectionStatus struct {


### PR DESCRIPTION
## 📑 Description

When running in DPU host mode, a DPU reboot causes all VFs to disappear from the host. Pods lose their `eth0` interface and `ovnkube-node` crashes (management port VF gone). After the DPU recovers, VFs reappear but are not automatically moved back into pod network namespaces — pods remain without networking.

This PR adds a recovery mechanism that detects pods with missing interfaces and restores connectivity by moving the VF back into the pod netns and reconfiguring IPs/routes.

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6786

## Additional Information for reviewers

**Key changes:**

1. **`pkg/util/dpu_annotations.go`** — Added `NetnsPath` field to `DPUConnectionDetails` so we can find the pod's netns after restart.
2. **`pkg/cni/cni_dpu.go`** — Store `NetnsPath` during CNI ADD.
3. **`pkg/cni/dpu_recovery_linux.go`** (new) — Recovery logic: scans pods, checks for missing interfaces in netns, moves VF back, reconfigures IP/MAC/routes.
4. **`pkg/node/dpulease/manager.go`** — Added `SetRecoveryHandler` to trigger recovery when DPU transitions from unhealthy→healthy.
5. **`pkg/node/default_node_network_controller.go`** — Wires recovery handler into lease manager + triggers recovery at startup (handles ovnkube-node crash/restart case).

**Design decisions:**
- Recovery is triggered both on DPU lease health transition AND at startup (because ovnkube-node crashes when DPU reboots, so it never observes the transition).
- IP/route configuration in recovery path uses `RouteReplace` and tolerates `EEXIST` for idempotency.
- `NetnsPath` uses `omitempty` for backward compatibility with existing annotations.

**Known limitation:**
- The stored `VfNetdevName` can be stale if captured during a udev rename race (many VFs appearing simultaneously). A follow-up PR will add fallback resolution by PCI address via kubelet checkpoint.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [x] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

1. Deploy a DPU host mode cluster with SR-IOV workload pods
2. Verify pods have networking (`oc exec <pod> -- ip addr show eth0`)
3. Reboot the DPU (e.g., `mlxfwreset` or power cycle the BlueField)
4. Wait for DPU to recover and `ovnkube-node` to restart
5. Verify pods regain networking without manual restart
6. Check logs: `oc logs -n openshift-ovn-kubernetes <ovnkube-node-dpu-host-pod> | grep "DPU recovery"`

Made with [Cursor](https://cursor.com)