### PR TITLE
egressip: introduce nodeSelector for targeted allocation

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -1052,7 +1053,7 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 			eIPC.deleteAllocatorEgressIPAssignments(statusToRemove)
 		}
 		if len(ipsToAssign) > 0 {
-			statusToAdd = eIPC.assignEgressIPs(name, ipsToAssign.UnsortedList())
+			statusToAdd = eIPC.assignEgressIPs(newEIP, ipsToAssign.UnsortedList())
 			statusToKeep = append(statusToKeep, statusToAdd...)
 		}
 		// Add all assignments which are to be kept to the allocator cache,
@@ -1116,7 +1117,7 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 		// processing the answer from the requests we make here, and update OVN
 		// accordingly when we know what the outcome is.
 		if len(ipsToAssign) > 0 {
-			statusToAdd = eIPC.assignEgressIPs(name, ipsToAssign.UnsortedList())
+			statusToAdd = eIPC.assignEgressIPs(newEIP, ipsToAssign.UnsortedList())
 			statusToKeep = append(statusToKeep, statusToAdd...)
 		}
 		// Same as above: Add all assignments which are to be kept to the
@@ -1205,7 +1206,8 @@ func (eIPC *egressIPClusterController) getCloudPrivateIPConfigMap(objs []interfa
 // the IP cannot already be assigned and reference by another EgressIP object d)
 // no two egress IPs for the same EgressIP object can be assigned to the same
 // node e) (for public clouds) the amount of egress IPs assigned to one node
-// must respect its assignment capacity. Moreover there is a soft constraint:
+// must respect its assignment capacity f) the node must match the NodeSelector
+// defined in the EgressIP spec, if specified. Moreover there is a soft constraint:
 // the assignments need to be balanced across all cluster nodes, so that no node
 // becomes a bottleneck. The balancing is achieved by sorting the nodes in
 // ascending order following their existing amount of allocations, and trying to
@@ -1213,11 +1215,41 @@ func (eIPC *egressIPClusterController) getCloudPrivateIPConfigMap(objs []interfa
 // time, this does not guarantee complete balance, but mostly complete.
 // For Egress IPs that are hosted by secondary host networks, there must be at least
 // one node that hosts the network and exposed via the nodes host-cidrs annotation.
-func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []string) []egressipv1.EgressIPStatusItem {
+func (eIPC *egressIPClusterController) assignEgressIPs(eIPObj *egressipv1.EgressIP, egressIPs []string) []egressipv1.EgressIPStatusItem {
+	name := eIPObj.Name
 	eIPC.nodeAllocator.Lock()
 	defer eIPC.nodeAllocator.Unlock()
 	assignments := []egressipv1.EgressIPStatusItem{}
 	assignableNodes, existingAllocations := eIPC.getSortedEgressData()
+
+	if eIPObj.Spec.NodeSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(eIPObj.Spec.NodeSelector)
+		if err != nil {
+			klog.Errorf("Invalid nodeSelector for EgressIP %s: %v", name, err)
+			eIPRef := corev1.ObjectReference{
+				Kind:       "EgressIP",
+				Name:       name,
+				UID:        eIPObj.UID,
+				APIVersion: "k8s.ovn.org/v1",
+			}
+			eIPC.recorder.Eventf(&eIPRef, corev1.EventTypeWarning, "InvalidNodeSelector", "Invalid nodeSelector: %v", err)
+			return assignments
+		} else if !selector.Empty() {
+			var filteredNodes []*egressNode
+			for _, eNode := range assignableNodes {
+				nodeObj, nodeErr := eIPC.watchFactory.GetNode(eNode.name)
+				if nodeErr != nil {
+					klog.Warningf("Failed to get node %s while filtering for EgressIP %s: %v", eNode.name, name, nodeErr)
+					continue
+				}
+				if selector.Matches(labels.Set(nodeObj.Labels)) {
+					filteredNodes = append(filteredNodes, eNode)
+				}
+			}
+			assignableNodes = filteredNodes
+		}
+	}
+
 	if len(assignableNodes) == 0 {
 		eIPRef := corev1.ObjectReference{
 			Kind: "EgressIP",

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -2032,7 +2032,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 						EgressIPs: []string{egressIP},
 					},
 				}
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(egressNode2.name))
 				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP).String()))
@@ -2114,7 +2114,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(2))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(egressNode2.name))
 				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP1).String()))
@@ -2201,7 +2201,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node1)).To(gomega.Succeed())
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node2)).To(gomega.Succeed())
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(2))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(egressNode2.name))
 				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP1).String()))
@@ -2295,7 +2295,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node1)).To(gomega.Succeed())
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node2)).To(gomega.Succeed())
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(2))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(egressNode2.name))
 				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP1SecondaryHost).String()))
@@ -2381,10 +2381,10 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node1)).To(gomega.Succeed())
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node2)).To(gomega.Succeed())
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2Name))
-				assignedStatuses = fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses = fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2Name))
 				return nil
@@ -2466,7 +2466,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 
 				return nil
@@ -2549,7 +2549,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node1)).To(gomega.Succeed())
 				gomega.Expect(fakeClusterManagerOVN.eIPC.initEgressIPAllocator(&node2)).To(gomega.Succeed())
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 
 				return nil
@@ -2628,7 +2628,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
@@ -2707,7 +2707,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
@@ -2786,7 +2786,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(egressNode2.name))
 				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP).String()))
@@ -2867,7 +2867,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.BeEmpty())
 				return nil
 			}
@@ -3023,7 +3023,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.nodeAllocator.cache[egressNode2.name] = &egressNode2
 
-				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(&eIP, eIP.Spec.EgressIPs)
 				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
 				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(egressNode2.name))
 				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP).String()))
@@ -3033,6 +3033,124 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("When NodeSelector is specified in EgressIP", func() {
+
+		ginkgo.It("should assign and reassign egress IP exclusively to the node matching NodeSelector via API path", func() {
+			app.Action = func(*cli.Context) error {
+				egressIP := "192.168.126.20"
+				node1IPv4 := "192.168.126.11/24"
+				node2IPv4 := "192.168.126.12/24"
+				node3IPv4 := "192.168.126.13/24"
+
+				node1 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-a",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node1IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+							"zone":                          "dmz",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					},
+				}
+
+				node2 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-b",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node2IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node2IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta("egressip-dmz-test"),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+						NodeSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"zone": "dmz",
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&corev1.NodeList{Items: []corev1.Node{node1, node2}},
+					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
+				)
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to start watching Egress Nodes")
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to start watching Egress IPs")
+
+				gomega.Eventually(getEgressIPStatusLen(eIP.Name)).
+					WithTimeout(5*time.Second).
+					WithPolling(200*time.Millisecond).
+					Should(gomega.Equal(1), "Expected EgressIP to be assigned to exactly 1 node")
+
+				egressIPs, nodes := getEgressIPStatus(eIP.Name)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name), "Expected assigned node to be node-a")
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP), "Expected assigned IP to match")
+
+				node3 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-c",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node3IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node3IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+							"zone":                          "dmz",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					},
+				}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node3, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create node-c")
+
+				node1.Labels = map[string]string{"zone": "dmz"}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to update node-a to trigger reassignment")
+
+				gomega.Eventually(func() string {
+					_, currentNodes := getEgressIPStatus(eIP.Name)
+					if len(currentNodes) > 0 {
+						return currentNodes[0]
+					}
+					return ""
+				}).
+					WithTimeout(5*time.Second).
+					WithPolling(200*time.Millisecond).
+					Should(gomega.Equal(node3.Name), "Expected EgressIP to reassign exclusively to node-c after node-a lost assignable label")
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to run test app")
 		})
 	})
 

--- a/go-controller/pkg/crd/egressip/v1/apis/applyconfiguration/egressip/v1/egressipspec.go
+++ b/go-controller/pkg/crd/egressip/v1/apis/applyconfiguration/egressip/v1/egressipspec.go
@@ -28,6 +28,9 @@ type EgressIPSpecApplyConfiguration struct {
 	// (in the namespace(s) already matched by the NamespaceSelector) which
 	// match this pod selector.
 	PodSelector *metav1.LabelSelectorApplyConfiguration `json:"podSelector,omitempty"`
+	// NodeSelector applies the egress IP only to the egress-assignable nodes
+	// that are matched by this label selector.
+	NodeSelector *metav1.LabelSelectorApplyConfiguration `json:"nodeSelector,omitempty"`
 }
 
 // EgressIPSpecApplyConfiguration constructs a declarative configuration of the EgressIPSpec type for use with
@@ -59,5 +62,13 @@ func (b *EgressIPSpecApplyConfiguration) WithNamespaceSelector(value *metav1.Lab
 // If called multiple times, the PodSelector field is set to the value of the last call.
 func (b *EgressIPSpecApplyConfiguration) WithPodSelector(value *metav1.LabelSelectorApplyConfiguration) *EgressIPSpecApplyConfiguration {
 	b.PodSelector = value
+	return b
+}
+
+// WithNodeSelector sets the NodeSelector field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NodeSelector field is set to the value of the last call.
+func (b *EgressIPSpecApplyConfiguration) WithNodeSelector(value *metav1.LabelSelectorApplyConfiguration) *EgressIPSpecApplyConfiguration {
+	b.NodeSelector = value
 	return b
 }

--- a/go-controller/pkg/crd/egressip/v1/apis/applyconfiguration/internal/internal.go
+++ b/go-controller/pkg/crd/egressip/v1/apis/applyconfiguration/internal/internal.go
@@ -60,6 +60,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
       default: {}
+    - name: nodeSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
     - name: podSelector
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector

--- a/go-controller/pkg/crd/egressip/v1/openapi/zz_generated.openapi.go
+++ b/go-controller/pkg/crd/egressip/v1/openapi/zz_generated.openapi.go
@@ -264,6 +264,12 @@ func schema_pkg_crd_egressip_v1_EgressIPSpec(ref common.ReferenceCallback) commo
 							Ref:         ref(metav1.LabelSelector{}.OpenAPIModelName()),
 						},
 					},
+					"nodeSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeSelector applies the egress IP only to the egress-assignable nodes that are matched by this label selector.",
+							Ref:         ref(metav1.LabelSelector{}.OpenAPIModelName()),
+						},
+					},
 				},
 				Required: []string{"egressIPs", "namespaceSelector"},
 			},

--- a/go-controller/pkg/crd/egressip/v1/types.go
+++ b/go-controller/pkg/crd/egressip/v1/types.go
@@ -65,6 +65,12 @@ type EgressIPSpec struct {
 	// match this pod selector.
 	// +optional
 	PodSelector metav1.LabelSelector `json:"podSelector,omitempty"`
+	// NodeSelector applies the egress IP only to the egress-assignable nodes
+	// that are matched by this label selector.
+	// +kubebuilder:validation:XValidation:rule="!has(self.matchLabels) || size(self.matchLabels) <= 64",message="matchLabels must have 64 or fewer elements"
+	// +kubebuilder:validation:XValidation:rule="!has(self.matchExpressions) || size(self.matchExpressions) <= 32",message="matchExpressions must have 32 or fewer elements"
+	// +optional
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/go-controller/pkg/crd/egressip/v1/zz_generated.deepcopy.go
+++ b/go-controller/pkg/crd/egressip/v1/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -83,6 +84,11 @@ func (in *EgressIPSpec) DeepCopyInto(out *EgressIPSpec) {
 	}
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
 	in.PodSelector.DeepCopyInto(&out.PodSelector)
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_egressips.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_egressips.yaml
@@ -110,6 +110,60 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              nodeSelector:
+                description: |-
+                  NodeSelector applies the egress IP only to the egress-assignable nodes
+                  that are matched by this label selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: matchLabels must have 64 or fewer elements
+                  rule: '!has(self.matchLabels) || size(self.matchLabels) <= 64'
+                - message: matchExpressions must have 32 or fewer elements
+                  rule: '!has(self.matchExpressions) || size(self.matchExpressions)
+                    <= 32'
               podSelector:
                 description: |-
                   PodSelector applies the egress IP only to the pods whose label


### PR DESCRIPTION
## 📑 Description

    Currently, OVN-Kubernetes uses a global boolean label
    (`k8s.ovn.org/egress-assignable=""`) to define the egress node pool.
    This causes EgressIPs to float randomly across all tagged nodes
    cluster-wide. In enterprise environments with strict hardware firewall
    and macro-segmentation policies, this global floating behavior often
    causes traffic blackholes, as specific Egress IPs must be restricted
    to a dedicated subset of infrastructure nodes (e.g., a specific DMZ tier).
    
    This commit introduces an optional `nodeSelector` field to the
    EgressIP CRD (`v1/types.go`).
    
    In the cluster manager's allocation logic (`assignEgressIPs`), the
    global assignable node pool is now intersected with the provided
    `nodeSelector` before the IP allocation algorithm runs.
    
    This enhancement allows administrators to constrain EgressIP assignments
    to specific node groups, successfully bypassing underlying infrastructure
    limitations while fully preserving OVN-Kubernetes' native HA and
    load-balancing mechanics within that constrained pool.


## How to verify it

The test result is as follows:
```
$ go test ./pkg/clustermanager/ -v -count=1 -ginkgo.v -ginkgo.focus "NodeSelector" -run TestClusterManager
=== RUN   TestClusterManager
Running Suite: Cluster Manager Operations Suite - /project/ovn-kubernetes/go-controller/pkg/clustermanager
====================================================================================================================
Random Seed: 1786441495

Will run 1 of 105 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
OVN cluster-manager EgressIP Operations When NodeSelector is specified in EgressIP should assign egress IP exclusively to the node matching NodeSelector
/project/ovn-kubernetes/go-controller/pkg/clustermanager/egressip_controller_test.go:3041
I0811 17:44:55.347332   78430 factory.go:603] Starting watch factory
I0811 17:44:55.347469   78430 envvar.go:195] "Feature gate default state" feature="InformerResourceVersion" enabled=true
I0811 17:44:55.347480   78430 envvar.go:195] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0811 17:44:55.347484   78430 envvar.go:195] "Feature gate default state" feature="InOrderInformers" enabled=true
I0811 17:44:55.347488   78430 envvar.go:195] "Feature gate default state" feature="AtomicFIFO" enabled=true
I0811 17:44:55.347490   78430 envvar.go:195] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0811 17:44:55.347493   78430 envvar.go:195] "Feature gate default state" feature="InOrderInformersBatchProcess" enabled=true
I0811 17:44:55.347496   78430 envvar.go:195] "Feature gate default state" feature="UnlockWhileProcessingFIFO" enabled=true
I0811 17:44:55.347499   78430 envvar.go:192] "Feature gate updated state" feature="WatchListClient" enabled=false
I0811 17:44:55.347501   78430 envvar.go:195] "Feature gate default state" feature="ClientsAllowTLSCacheGC" enabled=true
I0811 17:44:55.347505   78430 envvar.go:195] "Feature gate default state" feature="ClientsAllowCARotation" enabled=true
I0811 17:44:55.347567   78430 reflector.go:425] "Starting reflector" type="*v1.EndpointSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347575   78430 reflector.go:472] "Listing and watching" type="*v1.EndpointSlice" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347632   78430 reflector.go:425] "Starting reflector" type="*v1.Service" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347646   78430 reflector.go:472] "Listing and watching" type="*v1.Service" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347702   78430 reflector.go:425] "Starting reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347713   78430 reflector.go:472] "Listing and watching" type="*v1.Node" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347715   78430 reflector.go:507] "Caches populated" type="*v1.EndpointSlice" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347757   78430 reflector.go:507] "Caches populated" type="*v1.Service" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.347833   78430 reflector.go:507] "Caches populated" type="*v1.Node" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.352608   78430 factory.go:2093] *v1.Service informer cache synced successfully
I0811 17:44:55.352621   78430 factory.go:2093] *v1.EndpointSlice informer cache synced successfully
I0811 17:44:55.352625   78430 factory.go:2093] *v1.Node informer cache synced successfully
I0811 17:44:55.352701   78430 reflector.go:425] "Starting reflector" type="*v1.EgressIP" resyncPeriod="0s" reflector="pkg/crd/egressip/v1/apis/informers/externalversions/factory.go:145"
I0811 17:44:55.352712   78430 reflector.go:472] "Listing and watching" type="*v1.EgressIP" reflector="pkg/crd/egressip/v1/apis/informers/externalversions/factory.go:145"
I0811 17:44:55.352786   78430 reflector.go:507] "Caches populated" type="*v1.EgressIP" reflector="pkg/crd/egressip/v1/apis/informers/externalversions/factory.go:145"
I0811 17:44:55.357727   78430 factory.go:2093] *v1.EgressIP informer cache synced successfully
I0811 17:44:55.357743   78430 factory.go:735] Watch Factory start up complete, took: 10.419696ms
I0811 17:44:55.357867   78430 egressip_controller.go:1248] Current assignments are: map[]
I0811 17:44:55.357874   78430 egressip_controller.go:1250] Will attempt assignment for egress IP: 192.168.126.20
I0811 17:44:55.357888   78430 egressip_controller.go:1358] Attempting assignment on egress node: &{egressIPConfig:0x1ad552d2c000 mgmtIPs:[[10 128 0 2]] allocations:map[] healthClient:0x1ad5501486e0 isReady:true isReachable:true isEgressAssignable:true name:node-a}
I0811 17:44:55.357905   78430 egressip_controller.go:1401] Successful assignment of egress IP: 192.168.126.20 to network 192.168.126.0/24 on node: &{egressIPConfig:0x1ad552d2c000 mgmtIPs:[[10 128 0 2]] allocations:map[192.168.126.20:egressip-dmz-test] healthClient:0x1ad5501486e0 isReady:true isReachable:true isEgressAssignable:true name:node-a}
I0811 17:44:55.358151   78430 watch.go:218] "Stopping fake watcher"
I0811 17:44:55.358186   78430 reflector.go:434] "Stopping reflector" type="*v1.EgressIP" resyncPeriod="0s" reflector="pkg/crd/egressip/v1/apis/informers/externalversions/factory.go:145"
I0811 17:44:55.358340   78430 watch.go:218] "Stopping fake watcher"
I0811 17:44:55.358358   78430 reflector.go:434] "Stopping reflector" type="*v1.EndpointSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.358365   78430 watch.go:218] "Stopping fake watcher"
I0811 17:44:55.358371   78430 reflector.go:434] "Stopping reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.358375   78430 watch.go:218] "Stopping fake watcher"
I0811 17:44:55.358380   78430 reflector.go:434] "Stopping reflector" type="*v1.Service" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0811 17:44:55.360058   78430 factory.go:741] Stopping watch factory
• [0.024 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 105 Specs in 0.025 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 104 Skipped
--- PASS: TestClusterManager (0.03s)
PASS
ok  	github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager	0.045s
```