### PR TITLE
libovsdb/ops: match port-to-br for bridge local ports

### DIFF
--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -127,9 +127,12 @@ func FindBridgesWithPredicate(ovsClient libovsdbclient.Client, p ovsBridgePredic
 }
 
 // GetPortBridge returns the OVS bridge that owns the named port.
-// Returns ErrNotFound if the port does not exist or no bridge references it
-// in its ports column. This is the libovsdb equivalent of
-// `ovs-vsctl port-to-br <port>`.
+// Returns ErrNotFound if the port does not exist, no bridge references it
+// in its ports column, or the port is the bridge's local port. This is the
+// libovsdb equivalent of `ovs-vsctl port-to-br <port>`.
+//
+// Like ovs-vsctl port-to-br / list-ports, a bridge's local port (the Port
+// created by add-br with the same name as the bridge) is not reported.
 func GetPortBridge(ovsClient libovsdbclient.Client, portName string) (*vswitchd.Bridge, error) {
 	port, err := GetOVSPort(ovsClient, portName)
 	if err != nil {
@@ -150,6 +153,11 @@ func GetPortBridge(ovsClient libovsdbclient.Client, portName string) (*vswitchd.
 		return nil, fmt.Errorf("OVSDB corruption: port %q is referenced by multiple bridges: %w", portName, errMultipleResults)
 	}
 	if len(bridges) == 1 {
+		// ovs-vsctl port-to-br does not resolve a bridge's own local port.
+		if bridges[0].Name == portName {
+			return nil, fmt.Errorf("port %q is the local port of bridge %q: %w",
+				portName, bridges[0].Name, libovsdbclient.ErrNotFound)
+		}
 		return bridges[0], nil
 	}
 	return nil, fmt.Errorf("no bridge contains port %q: %w", portName, libovsdbclient.ErrNotFound)

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -73,6 +73,17 @@ func TestGetPortBridge(t *testing.T) {
 				port.DeepCopy(),
 			}},
 		},
+		{
+			// Matches ovs-vsctl port-to-br / list-ports: the bridge local port is hidden.
+			desc:      "returns ErrNotFound for a bridge's local port",
+			portName:  "br-ex",
+			expectErr: libovsdbclient.ErrNotFound,
+			initialOvs: libovsdbtest.TestSetup{OVSData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeAUUID}},
+				&vswitchd.Bridge{UUID: bridgeAUUID, Name: "br-ex", Ports: []string{portUUID}},
+				&vswitchd.Port{UUID: portUUID, Name: "br-ex"},
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -504,6 +504,13 @@ func setManagementPortFakeCommands(fexec *ovntest.FakeExec, nodeName string) {
 func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 	// GetNicName lookups (list-ports / get Port Interfaces / get Interface Type)
 	// are now served by the libovsdb harness seeded in BeforeEach.
+	// getGatewayNextHops rewrites eth0 → breth0; GetPortBridge hides the
+	// bridge local port, so NewBridgeConfiguration takes the "is a bridge"
+	// path and getIntfName verifies eth0's ofport first.
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
+		Output: "7",
+	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 		Output: "00:00:00:55:66:99",
@@ -536,13 +543,13 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 		Output: "5",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 get interface breth0 ofport",
+		Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 		Output: "7",
 	})
 	// newNodePortWatcher() looks up the physical interface's ofport via exec;
 	// this is unrelated to checkPorts(), which now reads it from libovsdb.
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 ofport",
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface eth0 ofport",
 		Output: "7",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -820,9 +827,12 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 					Name:  "breth0",
 					Ports: []string{"breth0-port-uuid", "eth0-port-uuid"},
 				},
+				// Local port of the bridge (hidden by GetPortBridge / port-to-br).
 				&vswitchd.Port{UUID: "breth0-port-uuid", Name: "breth0", Interfaces: []string{"breth0-iface-uuid"}},
-				&vswitchd.Interface{UUID: "breth0-iface-uuid", Name: "breth0", Type: "system", Ofport: ptr.To(7)},
-				&vswitchd.Port{UUID: "eth0-port-uuid", Name: "eth0"},
+				&vswitchd.Interface{UUID: "breth0-iface-uuid", Name: "breth0", Type: "internal", Ofport: ptr.To(65534)},
+				// Physical uplink: system-typed so GetNicName resolves eth0.
+				&vswitchd.Port{UUID: "eth0-port-uuid", Name: "eth0", Interfaces: []string{"eth0-iface-uuid"}},
+				&vswitchd.Interface{UUID: "eth0-iface-uuid", Name: "eth0", Type: "system", Ofport: ptr.To(7)},
 			},
 		})
 		Expect(ovsErr).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -734,6 +734,12 @@ func checkPorts(ovsClient libovsdbclient.Client, netConfigs []*bridgeconfig.Brid
 		}
 	}
 
+	// With --allow-no-uplink, NewBridgeConfiguration may leave physIntf empty.
+	// There is then no physical ofport to track.
+	if config.Gateway.AllowNoUplink && physIntf == "" {
+		return nil
+	}
+
 	// it could be that someone removed the physical interface and added it back on the OVS host
 	// bridge, as a result the ofport number changed for that physical interface
 	curOfportPhys, err := getOfport(ovsClient, physIntf)

--- a/go-controller/pkg/node/openflow_manager_test.go
+++ b/go-controller/pkg/node/openflow_manager_test.go
@@ -251,3 +251,18 @@ patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
 		})
 	}
 }
+
+// --allow-no-uplink can leave physIntf empty. checkPorts must skip the phys
+// ofport check in that case (GetOVSInterface("") cannot look up a zero Name).
+func TestCheckPortsAllowNoUplink(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("PrepareTestConfig: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.Gateway.AllowNoUplink = true
+	if err := checkPorts(nil, nil, "", ""); err != nil {
+		t.Fatalf("checkPorts with AllowNoUplink and empty physIntf: %v", err)
+	}
+}

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -218,9 +218,12 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 					Name:  "breth0",
 					Ports: []string{"breth0-port-uuid", "eth0-port-uuid"},
 				},
+				// Local port of the bridge (hidden by GetPortBridge / port-to-br).
 				&vswitchd.Port{UUID: "breth0-port-uuid", Name: "breth0", Interfaces: []string{"breth0-iface-uuid"}},
-				&vswitchd.Interface{UUID: "breth0-iface-uuid", Name: "breth0", Type: "system"},
-				&vswitchd.Port{UUID: "eth0-port-uuid", Name: "eth0"},
+				&vswitchd.Interface{UUID: "breth0-iface-uuid", Name: "breth0", Type: "internal", Ofport: ptr.To(65534)},
+				// Physical uplink: system-typed so GetNicName resolves eth0.
+				&vswitchd.Port{UUID: "eth0-port-uuid", Name: "eth0", Interfaces: []string{"eth0-iface-uuid"}},
+				&vswitchd.Interface{UUID: "eth0-iface-uuid", Name: "eth0", Type: "system", Ofport: ptr.To(7)},
 			},
 		})
 		Expect(ovsErr).NotTo(HaveOccurred())


### PR DESCRIPTION
GetPortBridge, introduced when migrating off ovs-vsctl port-to-br in #6402 (65e3926d0, 2026-07-15), treated a bridge's same-named local port as a normal port. ovs-vsctl intentionally hides that port.

That made NewBridgeConfiguration treat br-ex as "a port on a bridge" instead of "the bridge itself". The port path calls GetNicName, which with no system uplink invents "-ex" from the "br" prefix and does not consult --allow-no-uplink (that flag is only handled on the bridge path). Gateway init then failed looking up ofport for "-ex".

Return ErrNotFound for local ports to restore the old behavior.

Link: https://github.com/openvswitch/ovs/blob/v3.5.0/utilities/ovs-vsctl.c#L952-L966

The second commit fixes a non-failing error in checkPorts.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
