### PR TITLE
gateway: fix subnet masquerading SNAT for local gateway

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -98,6 +98,7 @@ add chain inet ovn-kubernetes ovn-kube-local-gw-masq { type nat hook postrouting
 add rule inet ovn-kubernetes ovn-kube-local-gw-masq ip saddr 169.254.169.1 masquerade
 add rule inet ovn-kubernetes ovn-kube-local-gw-masq jump ovn-kube-pod-subnet-masq
 add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq
+add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip daddr @mgmtport-no-snat-subnets-v4 return
 add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
 `
 

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -744,6 +744,26 @@ func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNCo
 	return rules
 }
 
+// getNoSNATSubnetsReturnRules returns nftables return rules for the pod subnet
+// masquerade chain that skip SNAT for traffic matching the no-snat subnet sets.
+// This allows preserving the original pod source IP for specific destinations.
+func getNoSNATSubnetsReturnRules() []*knftables.Rule {
+	var rules []*knftables.Rule
+	if config.IPv4Mode {
+		rules = append(rules, &knftables.Rule{
+			Chain: nftablesPodSubnetMasqChain,
+			Rule:  knftables.Concat("ip", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV4, "return"),
+		})
+	}
+	if config.IPv6Mode {
+		rules = append(rules, &knftables.Rule{
+			Chain: nftablesPodSubnetMasqChain,
+			Rule:  knftables.Concat("ip6", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV6, "return"),
+		})
+	}
+	return rules
+}
+
 func shouldAddUDNServiceMarkRules(netInfo util.NetInfo, nodeName string) bool {
 	if !netInfo.IsPrimaryNetwork() {
 		return false
@@ -886,12 +906,7 @@ func getLocalGatewayNATNFTRules(cidrs ...*net.IPNet) ([]*knftables.Rule, error) 
 	var rules []*knftables.Rule
 
 	// Skip masquerade for traffic destined to no-snat subnets
-	if config.IPv4Mode {
-		rules = append(rules, &knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV4, "return")})
-	}
-	if config.IPv6Mode {
-		rules = append(rules, &knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip6", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV6, "return")})
-	}
+	rules = append(rules, getNoSNATSubnetsReturnRules()...)
 
 	// Process each CIDR to support dual-stack
 	for _, cidr := range cidrs {
@@ -1111,11 +1126,8 @@ func addOrUpdateLocalGatewayPodSubnetNFTRules(isAdvertisedNetwork bool, cidrs ..
 	tx.Flush(podSubnetChain)
 
 	// Skip masquerade for traffic destined to no-snat subnets
-	if config.IPv4Mode {
-		tx.Add(&knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV4, "return")})
-	}
-	if config.IPv6Mode {
-		tx.Add(&knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip6", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV6, "return")})
+	for _, rule := range getNoSNATSubnetsReturnRules() {
+		tx.Add(rule)
 	}
 
 	// Add the new rules for each CIDR

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -885,6 +885,14 @@ func getLocalGatewayPodSubnetMasqueradeNFTRule(cidr *net.IPNet, isAdvertisedNetw
 func getLocalGatewayNATNFTRules(cidrs ...*net.IPNet) ([]*knftables.Rule, error) {
 	var rules []*knftables.Rule
 
+	// Skip masquerade for traffic destined to no-snat subnets
+	if config.IPv4Mode {
+		rules = append(rules, &knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV4, "return")})
+	}
+	if config.IPv6Mode {
+		rules = append(rules, &knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip6", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV6, "return")})
+	}
+
 	// Process each CIDR to support dual-stack
 	for _, cidr := range cidrs {
 		// Determine IP version and masquerade IP
@@ -1101,6 +1109,14 @@ func addOrUpdateLocalGatewayPodSubnetNFTRules(isAdvertisedNetwork bool, cidrs ..
 	// Flush the chain to remove all existing rules
 	// if network toggles between advertised and non-advertised, we need to flush the chain and re-add correct rules
 	tx.Flush(podSubnetChain)
+
+	// Skip masquerade for traffic destined to no-snat subnets
+	if config.IPv4Mode {
+		tx.Add(&knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV4, "return")})
+	}
+	if config.IPv6Mode {
+		tx.Add(&knftables.Rule{Chain: nftablesPodSubnetMasqChain, Rule: knftables.Concat("ip6", "daddr", "@", types.NFTMgmtPortNoSNATSubnetsV6, "return")})
+	}
 
 	// Add the new rules for each CIDR
 	for _, cidr := range cidrs {

--- a/test/e2e/local_gateway_masquerade.go
+++ b/test/e2e/local_gateway_masquerade.go
@@ -10,7 +10,9 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/feature"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
+	infraapi "github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,6 +20,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
@@ -215,8 +218,8 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 			"chain should have 'ip daddr @mgmtport-no-snat-subnets-v4 return' rule")
 	})
 
-	ginkgo.It("should populate mgmtport-no-snat-subnets-v4 set when annotation is added", func() {
-		ginkgo.By("Verifying mgmtport-no-snat-subnets-v4 set exists")
+	ginkgo.It("should populate nftables sets when SNAT exclude annotation is added", func() {
+		ginkgo.By("Verifying mgmtport-no-snat-subnets-v4 set exists and test subnets are not present")
 		var setElements string
 		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 			var err error
@@ -224,11 +227,13 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 			return err == nil, nil
 		})
 		framework.ExpectNoError(err, "mgmtport-no-snat-subnets-v4 set should exist")
-		ginkgo.By("Verifying test subnet is not in the set before adding annotation")
 		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_1),
-			"test subnet should not be in set before annotation is added")
+			"first test subnet should not be in set initially")
+		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_2),
+			"second test subnet should not be in set initially")
 
-		ginkgo.By(fmt.Sprintf("Adding SNAT exclude subnet annotation with %s", testSubnetV4_1))
+		// Test single IPv4 subnet
+		ginkgo.By(fmt.Sprintf("Adding single SNAT exclude subnet annotation with %s", testSubnetV4_1))
 		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV4_1})
 		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation")
 
@@ -252,6 +257,54 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
 		framework.ExpectNoError(err, "excluded subnet should be in mgmtport-no-snat-subnets-v4 set after annotation is added")
 
+		// Test multiple IPv4 subnets
+		ginkgo.By(fmt.Sprintf("Updating annotation to include multiple subnets: %s, %s", testSubnetV4_1, testSubnetV4_2))
+		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV4_1, testSubnetV4_2})
+		framework.ExpectNoError(err, "failed to update SNAT exclude subnets annotation")
+
+		ginkgo.By("Verifying both subnets are in the set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+		framework.ExpectNoError(err, "first subnet should be in set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
+		framework.ExpectNoError(err, "second subnet should be in set")
+
+		// Test IPv6 subnet (if dual-stack)
+		ginkgo.By("Checking if IPv6 set exists (indicates dual-stack)")
+		_, ipv6Err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
+		if ipv6Err == nil {
+			ginkgo.By("Verifying test IPv6 subnet is NOT in the set initially")
+			setElementsV6, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
+			framework.ExpectNoError(err, "should be able to list IPv6 set elements")
+			gomega.Expect(setElementsV6).NotTo(gomega.ContainSubstring(testSubnetV6),
+				"test IPv6 subnet should NOT be in set initially")
+
+			ginkgo.By(fmt.Sprintf("Adding IPv6 subnet to annotation: %s, %s, %s", testSubnetV4_1, testSubnetV4_2, testSubnetV6))
+			err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV4_1, testSubnetV4_2, testSubnetV6})
+			framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation with IPv6")
+
+			ginkgo.By("Verifying IPv6 subnet is in the v6 set")
+			err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+				nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
+			framework.ExpectNoError(err, "IPv6 subnet should be in mgmtport-no-snat-subnets-v6 set")
+
+			ginkgo.By("Verifying IPv6 subnet is NOT in the v4 set")
+			setElementsV4, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
+			framework.ExpectNoError(err, "should be able to list v4 set elements")
+			gomega.Expect(setElementsV4).NotTo(gomega.ContainSubstring(testSubnetV6),
+				"IPv6 subnet should NOT be in v4 set")
+
+			ginkgo.By("Verifying IPv4 subnets are still in the v4 set after adding IPv6")
+			gomega.Expect(setElementsV4).To(gomega.ContainSubstring(testSubnetV4_1),
+				"first IPv4 subnet should still be in v4 set")
+			gomega.Expect(setElementsV4).To(gomega.ContainSubstring(testSubnetV4_2),
+				"second IPv4 subnet should still be in v4 set")
+		} else {
+			framework.Logf("Skipping IPv6 portion - mgmtport-no-snat-subnets-v6 set does not exist (IPv4-only cluster)")
+		}
+
+		// Test removal
 		ginkgo.By("Removing the SNAT exclude subnet annotation")
 		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
 		framework.ExpectNoError(err, "failed to remove SNAT exclude subnets annotation")
@@ -266,78 +319,125 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		})
 		framework.ExpectNoError(err, "annotation should be removed from the node")
 
-		ginkgo.By("Verifying the excluded subnet is removed from mgmtport-no-snat-subnets-v4 set")
+		ginkgo.By("Verifying all IPv4 subnets are removed from mgmtport-no-snat-subnets-v4 set")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
 			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
-		framework.ExpectNoError(err, "excluded subnet should be removed from the set after annotation is removed")
-	})
-
-	ginkgo.It("should handle multiple subnets in annotation", func() {
-		ginkgo.By("Verifying test subnets are NOT in the set")
-		setElements, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
-		framework.ExpectNoError(err, "should be able to list set elements")
-		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_1),
-			"first test subnet should NOT be in set initially")
-		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_2),
-			"second test subnet should NOT be in set initially")
-
-		ginkgo.By(fmt.Sprintf("Adding multiple subnets to annotation: %s, %s", testSubnetV4_1, testSubnetV4_2))
-		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV4_1, testSubnetV4_2})
-		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation")
-
-		ginkgo.By("Verifying both subnets are in the set")
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
-		framework.ExpectNoError(err, "first subnet should be in set")
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+		framework.ExpectNoError(err, "first subnet should be removed from the set after annotation is removed")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
 			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
-		framework.ExpectNoError(err, "second subnet should be in set")
+		framework.ExpectNoError(err, "second subnet should be removed from the set after annotation is removed")
 
-		ginkgo.By("Cleaning up: removing annotation")
-		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
-		framework.ExpectNoError(err, "failed to remove annotation")
-
-		ginkgo.By("Verifying all subnets are removed")
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
-		framework.ExpectNoError(err, "first subnet should be removed after cleanup")
+		if ipv6Err == nil {
+			ginkgo.By("Verifying IPv6 subnet is removed from mgmtport-no-snat-subnets-v6 set")
+			err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+				nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
+			framework.ExpectNoError(err, "IPv6 subnet should be removed after cleanup")
+		}
 	})
 
-	ginkgo.It("should handle IPv6 subnets in dual-stack clusters", func() {
-		ginkgo.By("Checking if IPv6 set exists (indicates dual-stack)")
-		_, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
-		if err != nil {
-			e2eskipper.Skipf("Skipping IPv6 test - mgmtport-no-snat-subnets-v6 set does not exist (IPv4-only cluster)")
+	ginkgo.It("should preserve pod source IP when destination is in SNAT exclude list", func() {
+		const (
+			externalContainerName = "snat-test-server"
+			testPodName           = "snat-test-client"
+		)
+
+		// Create infrastructure provider context for external container management
+		providerCtx := infraprovider.Get().NewTestContext()
+
+		ginkgo.By("Creating external container running agnhost netexec")
+		primaryNetwork, err := infraprovider.Get().PrimaryNetwork()
+		framework.ExpectNoError(err, "failed to get primary network")
+		port := infraprovider.Get().GetExternalContainerPort()
+
+		externalContainer := infraapi.ExternalContainer{
+			Name:    externalContainerName,
+			Image:   images.AgnHost(),
+			Network: primaryNetwork,
+			CmdArgs: []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
+			ExtPort: port,
+		}
+		externalContainer, err = providerCtx.CreateExternalContainer(externalContainer)
+		framework.ExpectNoError(err, "failed to create external container")
+		framework.Logf("External container created with IPv4: %s, port: %d", externalContainer.GetIPv4(), port)
+
+		externalIP := externalContainer.GetIPv4()
+		if externalIP == "" {
+			e2eskipper.Skipf("External container has no IPv4 address")
 		}
 
-		ginkgo.By("Verifying test IPv6 subnet is NOT in the set")
-		setElements, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
-		framework.ExpectNoError(err, "should be able to list IPv6 set elements")
-		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV6),
-			"test IPv6 subnet should NOT be in set initially")
+		ginkgo.By(fmt.Sprintf("Adding external container IP %s/32 to SNAT exclude annotation", externalIP))
+		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{externalIP + "/32"})
+		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation")
 
-		ginkgo.By(fmt.Sprintf("Adding IPv6 subnet to annotation: %s", testSubnetV6))
-		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV6})
-		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation with IPv6")
-
-		ginkgo.By("Verifying IPv6 subnet is in the v6 set")
+		ginkgo.By("Waiting for nftables set to be updated")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-			nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
-		framework.ExpectNoError(err, "IPv6 subnet should be in mgmtport-no-snat-subnets-v6 set")
+			nodeName, mgmtportNoSNATSubnetsV4, externalIP))
+		framework.ExpectNoError(err, "external container IP should be in mgmtport-no-snat-subnets-v4 set")
 
-		ginkgo.By("Verifying IPv6 subnet is NOT in the v4 set")
-		setElementsV4, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
-		framework.ExpectNoError(err, "should be able to list v4 set elements")
-		gomega.Expect(setElementsV4).NotTo(gomega.ContainSubstring(testSubnetV6),
-			"IPv6 subnet should NOT be in v4 set")
+		ginkgo.By("Creating test pod on the same node")
+		pod := e2epod.NewAgnhostPod(f.Namespace.Name, testPodName, nil, nil, nil)
+		pod.Spec.NodeName = nodeName
+		pod, err = cs.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create test pod")
 
-		ginkgo.By("Cleaning up: removing annotation")
-		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
-		framework.ExpectNoError(err, "failed to remove annotation")
+		err = e2epod.WaitForPodRunningInNamespace(context.TODO(), cs, pod)
+		framework.ExpectNoError(err, "test pod did not reach Running state")
 
-		ginkgo.By("Verifying IPv6 subnet is removed from the set")
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-			nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
-		framework.ExpectNoError(err, "IPv6 subnet should be removed after cleanup")
+		// Refresh pod to get IP
+		pod, err = cs.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), testPodName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get test pod")
+		podIP := pod.Status.PodIP
+		framework.Logf("Test pod IP: %s", podIP)
+
+		// Get node IP to verify we're NOT seeing it (and to set up return route)
+		node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get node")
+		var nodeIP string
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == "InternalIP" {
+				nodeIP = addr.Address
+				break
+			}
+		}
+		framework.Logf("Node IP: %s", nodeIP)
+
+		// Add route on external container for return traffic to pod
+		// Since we're bypassing SNAT, the external container will see the pod IP as source
+		// and needs to know how to route the response back via the node
+		ginkgo.By(fmt.Sprintf("Adding route on external container for return traffic: %s via %s", podIP, nodeIP))
+		_, err = infraprovider.Get().ExecExternalContainerCommand(externalContainer,
+			[]string{"ip", "route", "add", podIP + "/32", "via", nodeIP})
+		framework.ExpectNoError(err, "failed to add return route on external container")
+
+		ginkgo.By("Curling external container from pod to verify source IP")
+		// agnhost netexec /clientip returns the client IP:port, e.g., "10.244.0.5:54321"
+		curlCmd := fmt.Sprintf("curl -s --max-time 10 http://%s:%d/clientip", externalIP, port)
+
+		var sourceIP string
+		gomega.Eventually(func() bool {
+			stdout, stderr, err := e2epod.ExecShellInPodWithFullOutput(context.TODO(), f, testPodName, curlCmd)
+			if err != nil {
+				framework.Logf("curl failed: %v, stderr: %s", err, stderr)
+				return false
+			}
+			framework.Logf("External container saw source: %s", stdout)
+			// Output format is "IP:port", extract just the IP
+			sourceIP = strings.Split(strings.TrimSpace(stdout), ":")[0]
+			return sourceIP != ""
+		}, 60*time.Second, 2*time.Second).Should(gomega.BeTrue(), "should be able to curl external container")
+
+		ginkgo.By("Verifying source IP is pod IP, not node IP")
+		framework.Logf("Source IP seen by external container: %s", sourceIP)
+		framework.Logf("Expected pod IP: %s", podIP)
+		framework.Logf("Should NOT be node IP: %s", nodeIP)
+
+		gomega.Expect(sourceIP).To(gomega.Equal(podIP),
+			fmt.Sprintf("source IP should be pod IP (%s), not node IP (%s)", podIP, nodeIP))
+		gomega.Expect(sourceIP).NotTo(gomega.Equal(nodeIP),
+			"source IP should NOT be node IP (SNAT should be bypassed)")
+
+		ginkgo.By("Cleaning up test pod")
+		err = cs.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testPodName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "failed to delete test pod")
 	})
 })

--- a/test/e2e/local_gateway_masquerade.go
+++ b/test/e2e/local_gateway_masquerade.go
@@ -1,0 +1,343 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/feature"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+const (
+	ovnKubePodSubnetMasqChain = "ovn-kube-pod-subnet-masq"
+	mgmtportNoSNATSubnetsV4   = "mgmtport-no-snat-subnets-v4"
+	mgmtportNoSNATSubnetsV6   = "mgmtport-no-snat-subnets-v6"
+
+	ovnNodeDontSNATSubnetsAnnotation = "k8s.ovn.org/node-ingress-snat-exclude-subnets"
+)
+
+func setNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName string, subnets []string) error {
+	subnetsJSON, err := json.Marshal(subnets)
+	if err != nil {
+		return fmt.Errorf("failed to marshal subnets: %w", err)
+	}
+
+	patch := struct {
+		Metadata map[string]interface{} `json:"metadata"`
+	}{
+		Metadata: map[string]interface{}{
+			"annotations": map[string]string{
+				ovnNodeDontSNATSubnetsAnnotation: string(subnetsJSON),
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(&patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch node %s: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+func removeNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName string) error {
+	patch := struct {
+		Metadata map[string]interface{} `json:"metadata"`
+	}{
+		Metadata: map[string]interface{}{
+			"annotations": map[string]*string{
+				ovnNodeDontSNATSubnetsAnnotation: nil,
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(&patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch node %s: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+func getNodeAnnotation(cs clientset.Interface, nodeName, annotation string) (string, bool, error) {
+	node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", false, err
+	}
+	value, ok := node.Annotations[annotation]
+	return value, ok, nil
+}
+
+func getNFTablesChainRules(nodeName, chainName string) (string, error) {
+	nftCmd := []string{"nft", "list", "chain", "inet", "ovn-kubernetes", chainName}
+	output, err := infraprovider.Get().ExecK8NodeCommand(nodeName, nftCmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to list chain %s on node %s: %w", chainName, nodeName, err)
+	}
+	return output, nil
+}
+
+func getNFTablesSetElements(nodeName, setName string) (string, error) {
+	nftCmd := []string{"nft", "list", "set", "inet", "ovn-kubernetes", setName}
+	output, err := infraprovider.Get().ExecK8NodeCommand(nodeName, nftCmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to list set %s on node %s: %w", setName, nodeName, err)
+	}
+	return output, nil
+}
+
+func checkNFTablesChainContainsRule(nodeName, chainName, rulePattern string) wait.ConditionFunc {
+	return func() (bool, error) {
+		rules, err := getNFTablesChainRules(nodeName, chainName)
+		if err != nil {
+			framework.Logf("Error getting chain rules: %v", err)
+			return false, nil
+		}
+		contains := strings.Contains(rules, rulePattern)
+		if !contains {
+			framework.Logf("Chain %s does not contain rule pattern %q. Current rules:\n%s", chainName, rulePattern, rules)
+		}
+		return contains, nil
+	}
+}
+
+func checkNFTablesSetContainsElement(nodeName, setName, element string) wait.ConditionFunc {
+	return func() (bool, error) {
+		output, err := getNFTablesSetElements(nodeName, setName)
+		if err != nil {
+			framework.Logf("Error getting set elements: %v", err)
+			return false, nil
+		}
+		contains := strings.Contains(output, element)
+		if !contains {
+			framework.Logf("Set %s does not contain element %q. Current elements:\n%s", setName, element, output)
+		}
+		return contains, nil
+	}
+}
+
+func checkNFTablesSetDoesNotContainElement(nodeName, setName, element string) wait.ConditionFunc {
+	containsFunc := checkNFTablesSetContainsElement(nodeName, setName, element)
+	return func() (bool, error) {
+		contains, err := containsFunc()
+		if err != nil {
+			return false, err
+		}
+		return !contains, nil
+	}
+}
+
+var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func() {
+	const (
+		retryInterval = 1 * time.Second
+		retryTimeout  = 60 * time.Second
+
+		testSubnetV4_1 = "198.51.100.0/24"
+		testSubnetV4_2 = "203.0.113.0/24"
+		testSubnetV6   = "2001:db8::/32"
+	)
+
+	f := wrappedTestFramework("local-gw-masq")
+	var cs clientset.Interface
+	var nodeName string
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+
+		if !IsGatewayModeLocal(cs) {
+			e2eskipper.Skipf("Skipping test - not in local gateway mode")
+		}
+
+		node, err := e2enode.GetRandomReadySchedulableNode(context.TODO(), cs)
+		framework.ExpectNoError(err, "failed to get a schedulable node")
+		nodeName = node.Name
+
+		framework.Logf("Using node %s for local gateway SNAT test", nodeName)
+		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
+		if err != nil {
+			framework.Logf("Note: failed to remove existing SNAT exclude subnets annotation (may not exist): %v", err)
+		}
+		_ = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+		_ = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
+	})
+
+	ginkgo.AfterEach(func() {
+		if nodeName != "" {
+			err := removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
+			if err != nil {
+				framework.Logf("Warning: failed to remove SNAT exclude subnets annotation: %v", err)
+			}
+		}
+	})
+
+	ginkgo.It("should have return rules for no-snat-subnets in ovn-kube-pod-subnet-masq chain", func() {
+		ginkgo.By("Verifying the ovn-kube-pod-subnet-masq chain exists")
+		var chainRules string
+		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			var err error
+			chainRules, err = getNFTablesChainRules(nodeName, ovnKubePodSubnetMasqChain)
+			if err != nil {
+				framework.Logf("Chain not ready: %v", err)
+				return false, nil
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "ovn-kube-pod-subnet-masq chain should exist on node %s", nodeName)
+		framework.Logf("Chain %s rules:\n%s", ovnKubePodSubnetMasqChain, chainRules)
+
+		ginkgo.By("Verifying the chain has return rule referencing mgmtport-no-snat-subnets-v4 set")
+		gomega.Expect(chainRules).To(gomega.MatchRegexp(`ip\s+daddr\s+@mgmtport-no-snat-subnets-v4\s+return`),
+			"chain should have 'ip daddr @mgmtport-no-snat-subnets-v4 return' rule")
+	})
+
+	ginkgo.It("should populate mgmtport-no-snat-subnets-v4 set when annotation is added", func() {
+		ginkgo.By("Verifying mgmtport-no-snat-subnets-v4 set exists")
+		var setElements string
+		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			var err error
+			setElements, err = getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
+			return err == nil, nil
+		})
+		framework.ExpectNoError(err, "mgmtport-no-snat-subnets-v4 set should exist")
+		ginkgo.By("Verifying test subnet is not in the set before adding annotation")
+		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_1),
+			"test subnet should not be in set before annotation is added")
+
+		ginkgo.By(fmt.Sprintf("Adding SNAT exclude subnet annotation with %s", testSubnetV4_1))
+		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV4_1})
+		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation")
+
+		ginkgo.By("Verifying annotation was set on the node")
+		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			value, ok, err := getNodeAnnotation(cs, nodeName, ovnNodeDontSNATSubnetsAnnotation)
+			if err != nil {
+				return false, nil
+			}
+			if !ok {
+				framework.Logf("Annotation not yet set on node")
+				return false, nil
+			}
+			framework.Logf("Annotation value on node: %s", value)
+			return strings.Contains(value, testSubnetV4_1), nil
+		})
+		framework.ExpectNoError(err, "annotation should be set on the node")
+
+		ginkgo.By("Verifying the excluded subnet is in mgmtport-no-snat-subnets-v4 set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+		framework.ExpectNoError(err, "excluded subnet should be in mgmtport-no-snat-subnets-v4 set after annotation is added")
+
+		ginkgo.By("Removing the SNAT exclude subnet annotation")
+		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
+		framework.ExpectNoError(err, "failed to remove SNAT exclude subnets annotation")
+
+		ginkgo.By("Verifying annotation was removed from the node")
+		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			_, ok, err := getNodeAnnotation(cs, nodeName, ovnNodeDontSNATSubnetsAnnotation)
+			if err != nil {
+				return false, nil
+			}
+			return !ok, nil
+		})
+		framework.ExpectNoError(err, "annotation should be removed from the node")
+
+		ginkgo.By("Verifying the excluded subnet is removed from mgmtport-no-snat-subnets-v4 set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+		framework.ExpectNoError(err, "excluded subnet should be removed from the set after annotation is removed")
+	})
+
+	ginkgo.It("should handle multiple subnets in annotation", func() {
+		ginkgo.By("Verifying test subnets are NOT in the set")
+		setElements, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
+		framework.ExpectNoError(err, "should be able to list set elements")
+		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_1),
+			"first test subnet should NOT be in set initially")
+		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV4_2),
+			"second test subnet should NOT be in set initially")
+
+		ginkgo.By(fmt.Sprintf("Adding multiple subnets to annotation: %s, %s", testSubnetV4_1, testSubnetV4_2))
+		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV4_1, testSubnetV4_2})
+		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation")
+
+		ginkgo.By("Verifying both subnets are in the set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+		framework.ExpectNoError(err, "first subnet should be in set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
+		framework.ExpectNoError(err, "second subnet should be in set")
+
+		ginkgo.By("Cleaning up: removing annotation")
+		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
+		framework.ExpectNoError(err, "failed to remove annotation")
+
+		ginkgo.By("Verifying all subnets are removed")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+		framework.ExpectNoError(err, "first subnet should be removed after cleanup")
+	})
+
+	ginkgo.It("should handle IPv6 subnets in dual-stack clusters", func() {
+		ginkgo.By("Checking if IPv6 set exists (indicates dual-stack)")
+		_, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
+		if err != nil {
+			e2eskipper.Skipf("Skipping IPv6 test - mgmtport-no-snat-subnets-v6 set does not exist (IPv4-only cluster)")
+		}
+
+		ginkgo.By("Verifying test IPv6 subnet is NOT in the set")
+		setElements, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
+		framework.ExpectNoError(err, "should be able to list IPv6 set elements")
+		gomega.Expect(setElements).NotTo(gomega.ContainSubstring(testSubnetV6),
+			"test IPv6 subnet should NOT be in set initially")
+
+		ginkgo.By(fmt.Sprintf("Adding IPv6 subnet to annotation: %s", testSubnetV6))
+		err = setNodeSNATExcludeSubnetsAnnotation(cs, nodeName, []string{testSubnetV6})
+		framework.ExpectNoError(err, "failed to set SNAT exclude subnets annotation with IPv6")
+
+		ginkgo.By("Verifying IPv6 subnet is in the v6 set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
+			nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
+		framework.ExpectNoError(err, "IPv6 subnet should be in mgmtport-no-snat-subnets-v6 set")
+
+		ginkgo.By("Verifying IPv6 subnet is NOT in the v4 set")
+		setElementsV4, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
+		framework.ExpectNoError(err, "should be able to list v4 set elements")
+		gomega.Expect(setElementsV4).NotTo(gomega.ContainSubstring(testSubnetV6),
+			"IPv6 subnet should NOT be in v4 set")
+
+		ginkgo.By("Cleaning up: removing annotation")
+		err = removeNodeSNATExcludeSubnetsAnnotation(cs, nodeName)
+		framework.ExpectNoError(err, "failed to remove annotation")
+
+		ginkgo.By("Verifying IPv6 subnet is removed from the set")
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+			nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
+		framework.ExpectNoError(err, "IPv6 subnet should be removed after cleanup")
+	})
+})

--- a/test/e2e/local_gateway_masquerade.go
+++ b/test/e2e/local_gateway_masquerade.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/feature"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -26,10 +28,6 @@ import (
 
 const (
 	ovnKubePodSubnetMasqChain = "ovn-kube-pod-subnet-masq"
-	mgmtportNoSNATSubnetsV4   = "mgmtport-no-snat-subnets-v4"
-	mgmtportNoSNATSubnetsV6   = "mgmtport-no-snat-subnets-v6"
-
-	ovnNodeDontSNATSubnetsAnnotation = "k8s.ovn.org/node-ingress-snat-exclude-subnets"
 )
 
 func setNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName string, subnets []string) error {
@@ -43,7 +41,7 @@ func setNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName string
 	}{
 		Metadata: map[string]interface{}{
 			"annotations": map[string]string{
-				ovnNodeDontSNATSubnetsAnnotation: string(subnetsJSON),
+				util.OvnNodeDontSNATSubnets: string(subnetsJSON),
 			},
 		},
 	}
@@ -53,7 +51,7 @@ func setNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName string
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), nodeName, k8stypes.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to patch node %s: %w", nodeName, err)
 	}
@@ -67,7 +65,7 @@ func removeNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName str
 	}{
 		Metadata: map[string]interface{}{
 			"annotations": map[string]*string{
-				ovnNodeDontSNATSubnetsAnnotation: nil,
+				util.OvnNodeDontSNATSubnets: nil,
 			},
 		},
 	}
@@ -77,7 +75,7 @@ func removeNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName str
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	_, err = cs.CoreV1().Nodes().Patch(context.TODO(), nodeName, k8stypes.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to patch node %s: %w", nodeName, err)
 	}
@@ -184,9 +182,9 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 			framework.Logf("Note: failed to remove existing SNAT exclude subnets annotation (may not exist): %v", err)
 		}
 		_ = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_1))
 		_ = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_2))
 	})
 
 	ginkgo.AfterEach(func() {
@@ -223,7 +221,7 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		var setElements string
 		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 			var err error
-			setElements, err = getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
+			setElements, err = getNFTablesSetElements(nodeName, types.NFTMgmtPortNoSNATSubnetsV4)
 			return err == nil, nil
 		})
 		framework.ExpectNoError(err, "mgmtport-no-snat-subnets-v4 set should exist")
@@ -239,7 +237,7 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 		ginkgo.By("Verifying annotation was set on the node")
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-			value, ok, err := getNodeAnnotation(cs, nodeName, ovnNodeDontSNATSubnetsAnnotation)
+			value, ok, err := getNodeAnnotation(cs, nodeName, util.OvnNodeDontSNATSubnets)
 			if err != nil {
 				return false, nil
 			}
@@ -254,7 +252,7 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 		ginkgo.By("Verifying the excluded subnet is in mgmtport-no-snat-subnets-v4 set")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_1))
 		framework.ExpectNoError(err, "excluded subnet should be in mgmtport-no-snat-subnets-v4 set after annotation is added")
 
 		// Test multiple IPv4 subnets
@@ -264,18 +262,18 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 		ginkgo.By("Verifying both subnets are in the set")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_1))
 		framework.ExpectNoError(err, "first subnet should be in set")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_2))
 		framework.ExpectNoError(err, "second subnet should be in set")
 
 		// Test IPv6 subnet (if dual-stack)
 		ginkgo.By("Checking if IPv6 set exists (indicates dual-stack)")
-		_, ipv6Err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
+		_, ipv6Err := getNFTablesSetElements(nodeName, types.NFTMgmtPortNoSNATSubnetsV6)
 		if ipv6Err == nil {
 			ginkgo.By("Verifying test IPv6 subnet is NOT in the set initially")
-			setElementsV6, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV6)
+			setElementsV6, err := getNFTablesSetElements(nodeName, types.NFTMgmtPortNoSNATSubnetsV6)
 			framework.ExpectNoError(err, "should be able to list IPv6 set elements")
 			gomega.Expect(setElementsV6).NotTo(gomega.ContainSubstring(testSubnetV6),
 				"test IPv6 subnet should NOT be in set initially")
@@ -286,11 +284,11 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 			ginkgo.By("Verifying IPv6 subnet is in the v6 set")
 			err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-				nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
+				nodeName, types.NFTMgmtPortNoSNATSubnetsV6, testSubnetV6))
 			framework.ExpectNoError(err, "IPv6 subnet should be in mgmtport-no-snat-subnets-v6 set")
 
 			ginkgo.By("Verifying IPv6 subnet is NOT in the v4 set")
-			setElementsV4, err := getNFTablesSetElements(nodeName, mgmtportNoSNATSubnetsV4)
+			setElementsV4, err := getNFTablesSetElements(nodeName, types.NFTMgmtPortNoSNATSubnetsV4)
 			framework.ExpectNoError(err, "should be able to list v4 set elements")
 			gomega.Expect(setElementsV4).NotTo(gomega.ContainSubstring(testSubnetV6),
 				"IPv6 subnet should NOT be in v4 set")
@@ -311,7 +309,7 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 		ginkgo.By("Verifying annotation was removed from the node")
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-			_, ok, err := getNodeAnnotation(cs, nodeName, ovnNodeDontSNATSubnetsAnnotation)
+			_, ok, err := getNodeAnnotation(cs, nodeName, util.OvnNodeDontSNATSubnets)
 			if err != nil {
 				return false, nil
 			}
@@ -321,16 +319,16 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 		ginkgo.By("Verifying all IPv4 subnets are removed from mgmtport-no-snat-subnets-v4 set")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_1))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_1))
 		framework.ExpectNoError(err, "first subnet should be removed from the set after annotation is removed")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-			nodeName, mgmtportNoSNATSubnetsV4, testSubnetV4_2))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_2))
 		framework.ExpectNoError(err, "second subnet should be removed from the set after annotation is removed")
 
 		if ipv6Err == nil {
 			ginkgo.By("Verifying IPv6 subnet is removed from mgmtport-no-snat-subnets-v6 set")
 			err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
-				nodeName, mgmtportNoSNATSubnetsV6, testSubnetV6))
+				nodeName, types.NFTMgmtPortNoSNATSubnetsV6, testSubnetV6))
 			framework.ExpectNoError(err, "IPv6 subnet should be removed after cleanup")
 		}
 	})
@@ -371,7 +369,7 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 
 		ginkgo.By("Waiting for nftables set to be updated")
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetContainsElement(
-			nodeName, mgmtportNoSNATSubnetsV4, externalIP))
+			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, externalIP))
 		framework.ExpectNoError(err, "external container IP should be in mgmtport-no-snat-subnets-v4 set")
 
 		ginkgo.By("Creating test pod on the same node")

--- a/test/e2e/local_gateway_masquerade.go
+++ b/test/e2e/local_gateway_masquerade.go
@@ -1,21 +1,26 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/ovn-org/ovn-kubernetes/test/e2e/feature"
-	"github.com/ovn-org/ovn-kubernetes/test/e2e/images"
-	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
-	infraapi "github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
+	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -86,7 +91,7 @@ func removeNodeSNATExcludeSubnetsAnnotation(cs clientset.Interface, nodeName str
 func getNodeAnnotation(cs clientset.Interface, nodeName, annotation string) (string, bool, error) {
 	node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("failed to get node %s: %w", nodeName, err)
 	}
 	value, ok := node.Annotations[annotation]
 	return value, ok, nil
@@ -145,7 +150,7 @@ func checkNFTablesSetDoesNotContainElement(nodeName, setName, element string) wa
 	return func() (bool, error) {
 		contains, err := containsFunc()
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("checking set %s on node %s does not contain %s: %w", setName, nodeName, element, err)
 		}
 		return !contains, nil
 	}
@@ -181,10 +186,12 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		if err != nil {
 			framework.Logf("Note: failed to remove existing SNAT exclude subnets annotation (may not exist): %v", err)
 		}
-		_ = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
 			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_1))
-		_ = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
+		framework.ExpectNoError(err, "timed out waiting for %s to be removed from %s — test environment is dirty", testSubnetV4_1, types.NFTMgmtPortNoSNATSubnetsV4)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNFTablesSetDoesNotContainElement(
 			nodeName, types.NFTMgmtPortNoSNATSubnetsV4, testSubnetV4_2))
+		framework.ExpectNoError(err, "timed out waiting for %s to be removed from %s — test environment is dirty", testSubnetV4_2, types.NFTMgmtPortNoSNATSubnetsV4)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -214,6 +221,16 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		ginkgo.By("Verifying the chain has return rule referencing mgmtport-no-snat-subnets-v4 set")
 		gomega.Expect(chainRules).To(gomega.MatchRegexp(`ip\s+daddr\s+@mgmtport-no-snat-subnets-v4\s+return`),
 			"chain should have 'ip daddr @mgmtport-no-snat-subnets-v4 return' rule")
+
+		ginkgo.By("Checking if IPv6 set exists (indicates dual-stack)")
+		_, ipv6Err := getNFTablesSetElements(nodeName, types.NFTMgmtPortNoSNATSubnetsV6)
+		if ipv6Err == nil {
+			ginkgo.By("Verifying the chain has return rule referencing mgmtport-no-snat-subnets-v6 set")
+			gomega.Expect(chainRules).To(gomega.MatchRegexp(`ip6\s+daddr\s+@mgmtport-no-snat-subnets-v6\s+return`),
+				"chain should have 'ip6 daddr @mgmtport-no-snat-subnets-v6 return' rule")
+		} else {
+			framework.Logf("Skipping IPv6 return rule check - mgmtport-no-snat-subnets-v6 set does not exist (IPv4-only cluster)")
+		}
 	})
 
 	ginkgo.It("should populate nftables sets when SNAT exclude annotation is added", func() {
@@ -377,6 +394,10 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		pod.Spec.NodeName = nodeName
 		pod, err = cs.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create test pod")
+		ginkgo.DeferCleanup(func() {
+			err := cs.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testPodName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete test pod")
+		})
 
 		err = e2epod.WaitForPodRunningInNamespace(context.TODO(), cs, pod)
 		framework.ExpectNoError(err, "test pod did not reach Running state")
@@ -392,7 +413,7 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		framework.ExpectNoError(err, "failed to get node")
 		var nodeIP string
 		for _, addr := range node.Status.Addresses {
-			if addr.Type == "InternalIP" {
+			if addr.Type == corev1.NodeInternalIP {
 				nodeIP = addr.Address
 				break
 			}
@@ -419,8 +440,13 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 				return false
 			}
 			framework.Logf("External container saw source: %s", stdout)
-			// Output format is "IP:port", extract just the IP
-			sourceIP = strings.Split(strings.TrimSpace(stdout), ":")[0]
+			// Output format is "IP:port" — use SplitHostPort to handle IPv6 addresses correctly
+			host, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+			if err != nil {
+				framework.Logf("Failed to parse client IP %q: %v", stdout, err)
+				return false
+			}
+			sourceIP = host
 			return sourceIP != ""
 		}, 60*time.Second, 2*time.Second).Should(gomega.BeTrue(), "should be able to curl external container")
 
@@ -434,8 +460,5 @@ var _ = ginkgo.Describe("Local Gateway Pod Subnet SNAT", feature.Service, func()
 		gomega.Expect(sourceIP).NotTo(gomega.Equal(nodeIP),
 			"source IP should NOT be node IP (SNAT should be bypassed)")
 
-		ginkgo.By("Cleaning up test pod")
-		err = cs.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), testPodName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err, "failed to delete test pod")
 	})
 })


### PR DESCRIPTION
## 📑 Description


  **Overview**
     
  By default, OVN-Kubernetes masquerades (SNATs) pod traffic to the node's IP address as it leaves the cluster. This is correct for most workloads, but some applications need to preserve the pod's original source IP.

 A key example is Submariner, a project that connects multiple Kubernetes clusters at the network level. Submariner relies on seeing the pod's real source IP to route return traffic back across clusters correctly. When OVN-K SNATs the traffic to the node IP,  Submariner loses the pod identity and cross-cluster communication breaks.

  #5113  addressed this by introducing the   **k8s.ovn.org/node-ingress-snat-exclude-subnets** node annotation, which lets users specify subnets that should bypass SNAT —  preserving the source IP for traffic destined to those subnets.

However, this annotation **is not honored** in local gateway mode, which is the issue this PR fixes.

  
When using local gateway mode combined with the node annotation **k8s.ovn.org/node-ingress-snat-exclude-subnets** (introduced in  #5113), traffic destined to the excluded subnets is still masqueraded by nftables, breaking source addresses.

**Root cause:** In local gateway mode, ovn-kube-local-gw-masq (priority 101) fires before mgmtport-snat (priority 100), so the  pod-subnet masquerade chain runs unconditionally regardless of the annotation. In shared gateway mode the annotation works
  correctly.

**Fix:** Add ip daddr @mgmtport-no-snat-subnets-v4 return (and the IPv6 equivalent) as the first rules in ovn-kube-pod-subnet-masq, so excluded-subnet traffic returns before being masqueraded.

This PR is a rebased version of #6030 by @pacevedom, updated to resolve merge conflicts with the current master.

This PR was validated end-to-end with Submariner deployed across two OVN-Kubernetes Kind clusters configured in local gateway mode.


 Fixes #6799



## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests: updated `nftablesRulesLocalGateway` constant in `gateway_init_linux_test.go` covers the new return rule.

E2E tests added in `test/e2e/local_gateway_masquerade.go`:
1. Verifies `ovn-kube-pod-subnet-masq` chain contains the return rule
2. Verifies the nftables set is populated/cleaned up when the annotation is set/removed
3. Verifies pod source IP is preserved (not SNATed) when destination is in the exclude list