### PR TITLE
e2e: exclude machine network subnets from UDN/BGP allocators

### DIFF
--- a/test/e2e/allocators/bgp.go
+++ b/test/e2e/allocators/bgp.go
@@ -60,8 +60,9 @@ func AllocateBGP(f *framework.Framework, cleanup infraapi.ContextCleanUp) (BGPAl
 		bgpIPVRF6 = newSubnetSpec(ipvrfSubnets6, nil)
 		bgpVTEP4 = newSubnetSpec(vtepSubnets, nil)
 		bgpVTEP6 = newSubnetSpec(vtepSubnets6, nil)
-		bgpUDN4 = newSubnetSpec(udnSubnets, nil)
-		bgpUDN6 = newSubnetSpec(udnSubnets6, nil)
+		v4Exclusions, v6Exclusions := machineNetworkExclusions()
+		bgpUDN4 = newSubnetSpec(udnSubnets, v4Exclusions)
+		bgpUDN6 = newSubnetSpec(udnSubnets6, v6Exclusions)
 	})
 
 	maxUsable := min(

--- a/test/e2e/allocators/udn.go
+++ b/test/e2e/allocators/udn.go
@@ -4,7 +4,19 @@
 package allocators
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"os"
 	"sync"
+	"time"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var (
@@ -14,9 +26,19 @@ var (
 
 func initSubnetSpecs() {
 	udnOnce.Do(func() {
-		udnV4 = newSubnetSpec(udnSubnets, nil)
-		udnV6 = newSubnetSpec(udnSubnets6, nil)
+		v4Exclusions, v6Exclusions := machineNetworkExclusions()
+		udnV4 = newSubnetSpec(udnSubnets, v4Exclusions)
+		udnV6 = newSubnetSpec(udnSubnets6, v6Exclusions)
 	})
+}
+
+func machineNetworkExclusions() (ipv4, ipv6 []string) {
+	v4, v6, err := getMachineNetworkSubnets()
+	if err != nil {
+		framework.Logf("Warning: failed to get machine network subnets for exclusion: %v", err)
+		return nil, nil
+	}
+	return v4.UnsortedList(), v6.UnsortedList()
 }
 
 // GetFirstUDNSubnets always allocates the first UDN IPv4 and IPv6 subnet
@@ -48,4 +70,55 @@ func GetNthFirstUDNSubnets(n int) (ipv4, ipv6 []string) {
 		ipv6 = append(ipv6, udnV6.cidr(udnV6Idx))
 	}
 	return ipv4, ipv6
+}
+
+// getMachineNetworkSubnets retrieves the machine network subnets from node
+// annotations (k8s.ovn.org/node-primary-ifaddr). It returns the unique IPv4
+// and IPv6 CIDR networks found across all nodes. When KUBECONFIG is not set,
+// the call is a no-op and returns empty sets.
+func getMachineNetworkSubnets() (sets.Set[string], sets.Set[string], error) {
+	ipv4 := sets.New[string]()
+	ipv6 := sets.New[string]()
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if kubeConfig == "" {
+		return ipv4, ipv6, nil
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	if err != nil {
+		return ipv4, ipv6, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return ipv4, ipv6, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return ipv4, ipv6, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	for i := range nodes.Items {
+		ifAddr, err := util.GetNodeIfAddrAnnotation(&nodes.Items[i])
+		if err != nil {
+			return ipv4, ipv6, fmt.Errorf("failed to get interface address annotation for node %q: %w", nodes.Items[i].Name, err)
+		}
+		for _, addr := range []string{ifAddr.IPv4, ifAddr.IPv6} {
+			if addr == "" {
+				continue
+			}
+			_, cidr, err := net.ParseCIDR(addr)
+			if err != nil {
+				return ipv4, ipv6, fmt.Errorf("failed to parse CIDR %q for node %q: %w", addr, nodes.Items[i].Name, err)
+			}
+			if cidr == nil {
+				return ipv4, ipv6, fmt.Errorf("parsed nil CIDR from %q for node %q", addr, nodes.Items[i].Name)
+			}
+			if cidr.IP.To4() != nil {
+				ipv4.Insert(cidr.String())
+			} else {
+				ipv6.Insert(cidr.String())
+			}
+		}
+	}
+	return ipv4, ipv6, nil
 }


### PR DESCRIPTION
UDN test subnets (e.g. 10.0.0.0/10) can overlap with provider machine network subnets, causing connectivity failures. Retrieve machine network CIDRs from node annotations and pass them as exclusions to the subnet allocators to avoid collisions.