### PR TITLE
Uplink: recreate UplinkStates deleted out of band

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -236,6 +236,7 @@ jobs:
           make -C test control-plane WHAT="Network Segmentation Uplink route advertisements uses the Uplink interface as the targetVRF auto BGP peering path"
           make -C test control-plane WHAT="Uplink route advertisements with Dynamic UDN allocation allows node-disjoint Dynamic CUDNs to share a targetVRF auto Uplink and rejects overlap"
           make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions keeps one writer per condition and recovers a missing host interface"
+          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions recreates an UplinkState deleted out of band"
 
       - name: Export kind logs on failure
         if: failure()

--- a/docs/features/user-defined-networks/uplinks.md
+++ b/docs/features/user-defined-networks/uplinks.md
@@ -269,6 +269,16 @@ metadata:
 When one or more CUDNs reference an `Uplink`, OVN-Kubernetes keeps a finalizer
 on the `Uplink` so it cannot be deleted while still selected by a CUDN.
 
+`UplinkState` objects are exclusively owned by OVN-Kubernetes and recover from
+out-of-band deletion: if an `UplinkState` is deleted directly (for example with
+`kubectl delete`), ovnkube-node recreates it without a restart, discovery
+republishes `Resolved=True`, a previously published `GatewayReady` condition is
+restored (on a brand-new `UplinkState` it still appears only once gateway
+programming has run), and the CUDN returns to `UplinksReady=True`. An `UplinkState` is not
+recreated when its `Uplink` is terminating (its `UplinkState` objects are
+deleted on purpose during teardown), no longer exists, or no longer selects the
+node.
+
 The CUDN reports a CUDN-specific `UplinksReady` condition. This condition is
 computed from the active nodes for that CUDN, not directly from aggregate
 `Uplink.status`. This matters with Dynamic UDN, where two CUDNs can reference

--- a/go-controller/pkg/clustermanager/uplink/controller.go
+++ b/go-controller/pkg/clustermanager/uplink/controller.go
@@ -574,19 +574,16 @@ func (c *Controller) uplinkNameForStateName(stateName string) (string, bool, err
 	if err != nil {
 		return "", false, fmt.Errorf("failed to list Nodes for UplinkState %s: %w", stateName, err)
 	}
-
-	var matchedUplink string
-	matches := 0
-	for _, uplink := range uplinks {
-		for _, node := range nodes {
-			if uplinkutil.StateName(uplink.Name, node.Name) != stateName {
-				continue
-			}
-			matchedUplink = uplink.Name
-			matches++
-		}
+	nodeNames := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		nodeNames = append(nodeNames, node.Name)
 	}
-	return matchedUplink, matches == 1, nil
+
+	uplink, found := uplinkutil.UplinkForState(uplinks, nodeNames, stateName)
+	if !found {
+		return "", false, nil
+	}
+	return uplink.Name, true, nil
 }
 
 // Node controllers normally remove their own UplinkStates, but the responsible

--- a/go-controller/pkg/controller/controller.go
+++ b/go-controller/pkg/controller/controller.go
@@ -251,7 +251,11 @@ func (c *controller[T]) onUpdate(oldObjInterface, newObjInterface interface{}) {
 }
 
 func (c *controller[T]) onDelete(objInterface interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(objInterface)
+	// A deletion that the watch missed (detected later by a relist) is
+	// delivered as a DeletedFinalStateUnknown wrapper, not as the object
+	// itself. This key func handles both; the plain one errors on the
+	// wrapper, which would silently drop the deletion.
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(objInterface)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("controller %s: couldn't get key for object %+v: %v", c.name, objInterface, err))
 		return

--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -323,12 +323,13 @@ func NewNodeControllerManager(ovnClient *util.OVNClientset, wf factory.NodeWatch
 		ncm.ruleManager = iprulemanager.NewController(config.IPv4Mode, config.IPv6Mode)
 	}
 	if util.IsUplinkEnabled() {
-		ncm.uplinkController = nodeuplink.NewController(name, wf, ncm.ovnNodeClient, ncm.ovsClient)
 		ncm.uplinkGatewayController = node.NewUplinkGatewayController(
 			name,
 			ncm.ovnNodeClient.UplinkClient,
 			wf.UplinkStateInformer().Lister(),
 		)
+		ncm.uplinkController = nodeuplink.NewController(name, wf, ncm.ovnNodeClient, ncm.ovsClient,
+			ncm.uplinkGatewayController)
 	}
 
 	return ncm, nil

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -442,32 +442,30 @@ func (c *Controller) reconcileUplinkState(key string) error {
 
 // reconcileOwnerOfDeletedUplinkState reacts to an UplinkState deletion: the deletion
 // generates no event on the Uplink that owns it, so reconcile that Uplink
-// here to recreate the UplinkState. UplinkState names are opaque keys (long
-// ones are hashed), so the owner is found by computing every Uplink's
-// UplinkState name for this node.
+// here to recreate the UplinkState.
 func (c *Controller) reconcileOwnerOfDeletedUplinkState(key string) error {
 	uplinks, err := c.uplinkLister.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list Uplinks: %w", err)
 	}
-	for _, uplink := range uplinks {
-		if uplinkutil.StateName(uplink.Name, c.nodeName) != key {
-			continue
-		}
-		// The cluster-manager finalizer flow deletes the UplinkStates of a
-		// terminating Uplink before releasing it; don't recreate them.
-		if !uplink.DeletionTimestamp.IsZero() {
-			if c.gatewayStateManager != nil {
-				c.gatewayStateManager.DeleteGatewayState(uplink.Name)
-			}
-			return nil
-		}
-		klog.Infof("UplinkState %s was deleted, reconciling Uplink %s to recreate it", key, uplink.Name)
-		// Rate-limited so recreation backs off while the informer cache still
-		// misses a just-created UplinkState, or against a persistent deleter.
-		c.uplinkController.ReconcileRateLimited(uplink.Name)
+	uplink, found := uplinkutil.UplinkForState(uplinks, []string{c.nodeName}, key)
+	if !found {
 		return nil
 	}
+	// The cluster-manager finalizer flow deletes the UplinkStates of a
+	// terminating Uplink before releasing it; don't recreate them.
+	if !uplink.DeletionTimestamp.IsZero() {
+		if c.gatewayStateManager != nil {
+			c.gatewayStateManager.DeleteGatewayState(uplink.Name)
+		}
+		return nil
+	}
+	klog.Infof("UplinkState %s was deleted, reconciling Uplink %s to recreate it", key, uplink.Name)
+	// Rate-limited so recreation backs off while the informer cache still
+	// misses a just-created UplinkState. Successful recreations reset the
+	// per-key backoff, so a persistent deleter is only throttled to the
+	// rate limiter's sustained token-bucket rate.
+	c.uplinkController.ReconcileRateLimited(uplink.Name)
 	return nil
 }
 

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -83,10 +83,12 @@ func newDiscoveryError(reason string, err error) error {
 	return &discoveryError{reason: reason, err: err}
 }
 
-// GatewayConditionPublisher restores a gateway-owned UplinkState condition
-// that an out-of-band deletion wiped.
-type GatewayConditionPublisher interface {
+// GatewayStateManager owns the node-local gateway cache and the GatewayReady
+// condition published from it.
+type GatewayStateManager interface {
 	RepublishGatewayCondition(uplinkName string) error
+	InvalidateGatewayState(uplinkName string)
+	DeleteGatewayState(uplinkName string)
 }
 
 // Controller publishes UplinkState discovery status for this node.
@@ -98,9 +100,9 @@ type Controller struct {
 	uplinkStateLister uplinklisters.UplinkStateLister
 	nodeLister        corelisters.NodeLister
 
-	hostDiscoverer   hostInterfaceDiscoverer
-	bridgeResolver   ovsBridgeResolver
-	gatewayPublisher GatewayConditionPublisher
+	hostDiscoverer      hostInterfaceDiscoverer
+	bridgeResolver      ovsBridgeResolver
+	gatewayStateManager GatewayStateManager
 
 	uplinkController      controllerutil.Controller
 	uplinkStateController controllerutil.Controller
@@ -120,17 +122,17 @@ func discoveryRateLimiter() workqueue.TypedRateLimiter[string] {
 
 // NewController creates an ovnkube-node Uplink controller.
 func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util.OVNNodeClientset, ovsClient libovsdbclient.Client,
-	gatewayPublisher GatewayConditionPublisher,
+	gatewayStateManager GatewayStateManager,
 ) *Controller {
 	c := &Controller{
-		nodeName:          nodeName,
-		uplinkClient:      ovnClient.UplinkClient,
-		uplinkLister:      wf.UplinkInformer().Lister(),
-		uplinkStateLister: wf.UplinkStateInformer().Lister(),
-		nodeLister:        wf.NodeCoreInformer().Lister(),
-		hostDiscoverer:    netlinkHostInterfaceDiscoverer{},
-		bridgeResolver:    defaultOVSBridgeResolver{ovsClient: ovsClient},
-		gatewayPublisher:  gatewayPublisher,
+		nodeName:            nodeName,
+		uplinkClient:        ovnClient.UplinkClient,
+		uplinkLister:        wf.UplinkInformer().Lister(),
+		uplinkStateLister:   wf.UplinkStateInformer().Lister(),
+		nodeLister:          wf.NodeCoreInformer().Lister(),
+		hostDiscoverer:      netlinkHostInterfaceDiscoverer{},
+		bridgeResolver:      defaultOVSBridgeResolver{ovsClient: ovsClient},
+		gatewayStateManager: gatewayStateManager,
 	}
 
 	uplinkCfg := &controllerutil.ControllerConfig[uplinkv1alpha1.Uplink]{
@@ -203,6 +205,9 @@ func (c *Controller) reconcileUplink(key string) error {
 	uplink, err := c.uplinkLister.Get(key)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			if c.gatewayStateManager != nil {
+				c.gatewayStateManager.DeleteGatewayState(key)
+			}
 			return c.deleteUplinkState(uplinkutil.StateName(key, c.nodeName))
 		}
 		return fmt.Errorf("failed to get Uplink %s: %w", key, err)
@@ -215,6 +220,9 @@ func (c *Controller) reconcileUplink(key string) error {
 
 	nodeConfig, nodeConfigErr := selectedNodeConfigForNode(uplink, node)
 	if nodeConfigErr == nil && nodeConfig == nil {
+		if c.gatewayStateManager != nil {
+			c.gatewayStateManager.InvalidateGatewayState(uplink.Name)
+		}
 		return c.deleteUplinkState(uplinkutil.StateName(uplink.Name, c.nodeName))
 	}
 
@@ -264,19 +272,12 @@ func (c *Controller) reconcileUplinkState(key string) error {
 	uplink, err := c.uplinkLister.Get(uplinkName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			if c.gatewayStateManager != nil {
+				c.gatewayStateManager.DeleteGatewayState(uplinkName)
+			}
 			return nil
 		}
 		return fmt.Errorf("failed to get Uplink %s: %w", uplinkName, err)
-	}
-
-	// An UplinkState recreated after an out-of-band deletion lost the
-	// GatewayReady condition, and nothing republishes it until a network event
-	// runs gateway reconciliation: restore it here.
-	if c.gatewayPublisher != nil &&
-		meta.FindStatusCondition(state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionGatewayReady) == nil {
-		if err := c.gatewayPublisher.RepublishGatewayCondition(uplinkName); err != nil {
-			return fmt.Errorf("failed to republish gateway condition for Uplink %s: %w", uplinkName, err)
-		}
 	}
 
 	node, err := c.nodeLister.Get(c.nodeName)
@@ -297,7 +298,22 @@ func (c *Controller) reconcileUplinkState(key string) error {
 		))
 	}
 	if nodeConfig == nil {
+		if c.gatewayStateManager != nil {
+			c.gatewayStateManager.InvalidateGatewayState(uplinkName)
+		}
 		return c.deleteUplinkState(state.Name)
+	}
+
+	// An UplinkState recreated after an out-of-band deletion lost the
+	// GatewayReady condition, and nothing republishes it until a network event
+	// runs gateway reconciliation: restore it only after confirming this
+	// Uplink still selects the node. Intentional deselection starts a new
+	// gateway lifecycle and must not restore cached readiness.
+	if c.gatewayStateManager != nil &&
+		meta.FindStatusCondition(state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionGatewayReady) == nil {
+		if err := c.gatewayStateManager.RepublishGatewayCondition(uplinkName); err != nil {
+			return fmt.Errorf("failed to republish gateway condition for Uplink %s: %w", uplinkName, err)
+		}
 	}
 
 	hostInterfaceName := string(nodeConfig.HostInterfaceName)
@@ -441,6 +457,9 @@ func (c *Controller) reconcileOwnerOfDeletedUplinkState(key string) error {
 		// The cluster-manager finalizer flow deletes the UplinkStates of a
 		// terminating Uplink before releasing it; don't recreate them.
 		if !uplink.DeletionTimestamp.IsZero() {
+			if c.gatewayStateManager != nil {
+				c.gatewayStateManager.DeleteGatewayState(uplink.Name)
+			}
 			return nil
 		}
 		klog.Infof("UplinkState %s was deleted, reconciling Uplink %s to recreate it", key, uplink.Name)

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -20,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -245,7 +246,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 	state, err := c.uplinkStateLister.Get(key)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil
+			return c.reconcileOwnerOfDeletedUplinkState(key)
 		}
 		return fmt.Errorf("failed to get UplinkState %s: %w", key, err)
 	}
@@ -402,6 +403,34 @@ func (c *Controller) reconcileUplinkState(key string) error {
 		bridgeName,
 		"Uplink discovery succeeded",
 	)
+}
+
+// reconcileOwnerOfDeletedUplinkState reacts to an UplinkState deletion: the deletion
+// generates no event on the Uplink that owns it, so reconcile that Uplink
+// here to recreate the UplinkState. UplinkState names are opaque keys (long
+// ones are hashed), so the owner is found by computing every Uplink's
+// UplinkState name for this node.
+func (c *Controller) reconcileOwnerOfDeletedUplinkState(key string) error {
+	uplinks, err := c.uplinkLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list Uplinks: %w", err)
+	}
+	for _, uplink := range uplinks {
+		if uplinkutil.StateName(uplink.Name, c.nodeName) != key {
+			continue
+		}
+		// The cluster-manager finalizer flow deletes the UplinkStates of a
+		// terminating Uplink before releasing it; don't recreate them.
+		if !uplink.DeletionTimestamp.IsZero() {
+			return nil
+		}
+		klog.Infof("UplinkState %s was deleted, reconciling Uplink %s to recreate it", key, uplink.Name)
+		// Rate-limited so recreation backs off while the informer cache still
+		// misses a just-created UplinkState, or against a persistent deleter.
+		c.uplinkController.ReconcileRateLimited(uplink.Name)
+		return nil
+	}
+	return nil
 }
 
 func selectedNodeConfigForNode(

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -83,6 +83,12 @@ func newDiscoveryError(reason string, err error) error {
 	return &discoveryError{reason: reason, err: err}
 }
 
+// GatewayConditionPublisher restores a gateway-owned UplinkState condition
+// that an out-of-band deletion wiped.
+type GatewayConditionPublisher interface {
+	RepublishGatewayCondition(uplinkName string) error
+}
+
 // Controller publishes UplinkState discovery status for this node.
 type Controller struct {
 	nodeName string
@@ -92,8 +98,9 @@ type Controller struct {
 	uplinkStateLister uplinklisters.UplinkStateLister
 	nodeLister        corelisters.NodeLister
 
-	hostDiscoverer hostInterfaceDiscoverer
-	bridgeResolver ovsBridgeResolver
+	hostDiscoverer   hostInterfaceDiscoverer
+	bridgeResolver   ovsBridgeResolver
+	gatewayPublisher GatewayConditionPublisher
 
 	uplinkController      controllerutil.Controller
 	uplinkStateController controllerutil.Controller
@@ -113,6 +120,7 @@ func discoveryRateLimiter() workqueue.TypedRateLimiter[string] {
 
 // NewController creates an ovnkube-node Uplink controller.
 func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util.OVNNodeClientset, ovsClient libovsdbclient.Client,
+	gatewayPublisher GatewayConditionPublisher,
 ) *Controller {
 	c := &Controller{
 		nodeName:          nodeName,
@@ -122,6 +130,7 @@ func NewController(nodeName string, wf factory.NodeWatchFactory, ovnClient *util
 		nodeLister:        wf.NodeCoreInformer().Lister(),
 		hostDiscoverer:    netlinkHostInterfaceDiscoverer{},
 		bridgeResolver:    defaultOVSBridgeResolver{ovsClient: ovsClient},
+		gatewayPublisher:  gatewayPublisher,
 	}
 
 	uplinkCfg := &controllerutil.ControllerConfig[uplinkv1alpha1.Uplink]{
@@ -258,6 +267,16 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			return nil
 		}
 		return fmt.Errorf("failed to get Uplink %s: %w", uplinkName, err)
+	}
+
+	// An UplinkState recreated after an out-of-band deletion lost the
+	// GatewayReady condition, and nothing republishes it until a network event
+	// runs gateway reconciliation: restore it here.
+	if c.gatewayPublisher != nil &&
+		meta.FindStatusCondition(state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionGatewayReady) == nil {
+		if err := c.gatewayPublisher.RepublishGatewayCondition(uplinkName); err != nil {
+			return fmt.Errorf("failed to republish gateway condition for Uplink %s: %w", uplinkName, err)
+		}
 	}
 
 	node, err := c.nodeLister.Get(c.nodeName)

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -934,12 +934,60 @@ func TestNodeUplinkControllerDeletesUnselectedNodeState(t *testing.T) {
 		newUplink("br-blue", "role", "blue", "breth0"),
 		newUplinkState(stateName, "br-blue", "node-a"),
 	)
+	gatewayStateManager := &fakeGatewayStateManager{}
+	controller.gatewayStateManager = gatewayStateManager
 
 	g.Expect(controller.reconcileUplinkState(stateName)).To(gomega.Succeed())
 
 	_, err := client.UplinkClient.K8sV1alpha1().UplinkStates().Get(
 		context.Background(), stateName, metav1.GetOptions{})
 	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+	g.Expect(gatewayStateManager.invalidated).To(gomega.ConsistOf("br-blue"))
+	g.Expect(gatewayStateManager.republished).To(gomega.BeEmpty())
+}
+
+func TestNodeUplinkControllerInvalidatesUnselectedUplinkGatewayState(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	stateName := uplinkutil.StateName("br-blue", "node-a")
+	controller, client := newTestController(t,
+		fakeHostDiscoverer{},
+		fakeBridgeResolver{},
+		newNode("node-a", map[string]string{"role": "red"}),
+		newUplink("br-blue", "role", "blue", "breth0"),
+		newUplinkState(stateName, "br-blue", "node-a"),
+	)
+	gatewayStateManager := &fakeGatewayStateManager{}
+	controller.gatewayStateManager = gatewayStateManager
+
+	g.Expect(controller.reconcileUplink("br-blue")).To(gomega.Succeed())
+
+	_, err := client.UplinkClient.K8sV1alpha1().UplinkStates().Get(
+		context.Background(), stateName, metav1.GetOptions{})
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+	g.Expect(gatewayStateManager.invalidated).To(gomega.ConsistOf("br-blue"))
+}
+
+func TestNodeUplinkControllerDeletesRemovedUplinkGatewayState(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	stateName := uplinkutil.StateName("br-blue", "node-a")
+	controller, client := newTestController(t,
+		fakeHostDiscoverer{},
+		fakeBridgeResolver{},
+		newNode("node-a", map[string]string{"role": "blue"}),
+		newUplinkState(stateName, "br-blue", "node-a"),
+		// No Uplink: reconciling its key models an Uplink delete event.
+	)
+	gatewayStateManager := &fakeGatewayStateManager{}
+	controller.gatewayStateManager = gatewayStateManager
+
+	g.Expect(controller.reconcileUplink("br-blue")).To(gomega.Succeed())
+
+	_, err := client.UplinkClient.K8sV1alpha1().UplinkStates().Get(
+		context.Background(), stateName, metav1.GetOptions{})
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+	g.Expect(gatewayStateManager.deleted).To(gomega.ConsistOf("br-blue"))
 }
 
 func TestNodeUplinkControllerRecreatesDeletedState(t *testing.T) {
@@ -1004,11 +1052,14 @@ func TestNodeUplinkControllerRecreatesDeletedState(t *testing.T) {
 			newNode("node-a", map[string]string{"role": "blue"}),
 			uplink,
 		)
+		gatewayStateManager := &fakeGatewayStateManager{}
+		controller.gatewayStateManager = gatewayStateManager
 
 		g.Expect(controller.reconcileUplinkState(
 			uplinkutil.StateName("br-blue", "node-a"))).To(gomega.Succeed())
 		g.Expect(controller.uplinkController.(*controllerutil.FakeController).Reconciles).To(
 			gomega.BeEmpty())
+		g.Expect(gatewayStateManager.deleted).To(gomega.ConsistOf("br-blue"))
 	})
 
 	// A key no Uplink owns (remote node's UplinkState, or deleted Uplink)
@@ -1030,21 +1081,31 @@ func TestNodeUplinkControllerRecreatesDeletedState(t *testing.T) {
 	})
 }
 
-type fakeGatewayPublisher struct {
+type fakeGatewayStateManager struct {
 	republished []string
+	invalidated []string
+	deleted     []string
 	err         error
 }
 
-func (f *fakeGatewayPublisher) RepublishGatewayCondition(uplinkName string) error {
+func (f *fakeGatewayStateManager) RepublishGatewayCondition(uplinkName string) error {
 	f.republished = append(f.republished, uplinkName)
 	return f.err
+}
+
+func (f *fakeGatewayStateManager) InvalidateGatewayState(uplinkName string) {
+	f.invalidated = append(f.invalidated, uplinkName)
+}
+
+func (f *fakeGatewayStateManager) DeleteGatewayState(uplinkName string) {
+	f.deleted = append(f.deleted, uplinkName)
 }
 
 // A recreated UplinkState lost the gateway-owned GatewayReady condition, which
 // only network events republish: the reconciler must restore it via the
 // gateway publisher, and only when it is missing.
 func TestNodeUplinkControllerRepublishesGatewayCondition(t *testing.T) {
-	newController := func(g gomega.Gomega, state *uplinkv1alpha1.UplinkState) (*Controller, *fakeGatewayPublisher) {
+	newController := func(g gomega.Gomega, state *uplinkv1alpha1.UplinkState) (*Controller, *fakeGatewayStateManager) {
 		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		controller, _ := newTestController(t,
 			fakeHostDiscoverer{state: newStatusTestHostState()},
@@ -1053,8 +1114,8 @@ func TestNodeUplinkControllerRepublishesGatewayCondition(t *testing.T) {
 			newUplink("br-blue", "role", "blue", "breth0"),
 			state,
 		)
-		publisher := &fakeGatewayPublisher{}
-		controller.gatewayPublisher = publisher
+		publisher := &fakeGatewayStateManager{}
+		controller.gatewayStateManager = publisher
 		return controller, publisher
 	}
 

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -942,6 +942,94 @@ func TestNodeUplinkControllerDeletesUnselectedNodeState(t *testing.T) {
 	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
 }
 
+func TestNodeUplinkControllerRecreatesDeletedState(t *testing.T) {
+	// Deleting an UplinkState generates no event on the owning Uplink, so the
+	// UplinkState reconciler must requeue the owner to recreate the
+	// UplinkState. A delete event reconciles the UplinkState's key with the
+	// object gone from the lister, so it is simulated by not seeding the
+	// UplinkState at all.
+	t.Run("requeues the owning Uplink", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{},
+			fakeBridgeResolver{},
+			newNode("node-a", map[string]string{"role": "blue"}),
+			newUplink("br-blue", "role", "blue", "breth0"),
+			// no UplinkState: reconciling its key simulates its deletion
+		)
+
+		stateName := uplinkutil.StateName("br-blue", "node-a")
+		g.Expect(controller.reconcileUplinkState(stateName)).To(gomega.Succeed())
+		// The fake Uplink controller records the requeue that would recreate
+		// the UplinkState (creation itself is covered by
+		// TestNodeUplinkControllerCreatesSelectedNodeState).
+		g.Expect(controller.uplinkController.(*controllerutil.FakeController).Reconciles).To(
+			gomega.ConsistOf("RateLimited:br-blue"))
+	})
+
+	// The delete handler must not filter on node selection: its node labels
+	// may be stale, and a stale "not selected" would skip a needed recovery.
+	// The owner is requeued unconditionally and its reconcile decides; for an
+	// unselected node it settles by deleting nothing
+	// (TestNodeUplinkControllerDeletesUnselectedNodeState).
+	t.Run("requeues the owning Uplink when it no longer selects the node", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{},
+			fakeBridgeResolver{},
+			newNode("node-a", map[string]string{"role": "red"}),
+			newUplink("br-blue", "role", "blue", "breth0"),
+		)
+
+		g.Expect(controller.reconcileUplinkState(
+			uplinkutil.StateName("br-blue", "node-a"))).To(gomega.Succeed())
+		g.Expect(controller.uplinkController.(*controllerutil.FakeController).Reconciles).To(
+			gomega.ConsistOf("RateLimited:br-blue"))
+	})
+
+	// The cluster-manager deletes the UplinkStates of a terminating Uplink
+	// before releasing its finalizer; recreating them would fight that
+	// teardown.
+	t.Run("does not requeue a terminating Uplink", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		uplink := newUplink("br-blue", "role", "blue", "breth0")
+		now := metav1.Now()
+		uplink.DeletionTimestamp = &now
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{},
+			fakeBridgeResolver{},
+			newNode("node-a", map[string]string{"role": "blue"}),
+			uplink,
+		)
+
+		g.Expect(controller.reconcileUplinkState(
+			uplinkutil.StateName("br-blue", "node-a"))).To(gomega.Succeed())
+		g.Expect(controller.uplinkController.(*controllerutil.FakeController).Reconciles).To(
+			gomega.BeEmpty())
+	})
+
+	// A key no Uplink owns (remote node's UplinkState, or deleted Uplink)
+	// must not requeue anything.
+	t.Run("ignores UplinkStates not owned by any Uplink", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{},
+			fakeBridgeResolver{},
+			newNode("node-a", map[string]string{"role": "blue"}),
+			newUplink("br-blue", "role", "blue", "breth0"),
+		)
+
+		g.Expect(controller.reconcileUplinkState(
+			uplinkutil.StateName("br-red", "node-a"))).To(gomega.Succeed())
+		g.Expect(controller.uplinkController.(*controllerutil.FakeController).Reconciles).To(
+			gomega.BeEmpty())
+	})
+}
+
 func TestEnsureUplinkStateGetsExistingObjectAfterCreateRace(t *testing.T) {
 	g := gomega.NewWithT(t)
 	uplink := newUplink("br-blue", "role", "blue", "breth0")

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -1030,6 +1030,67 @@ func TestNodeUplinkControllerRecreatesDeletedState(t *testing.T) {
 	})
 }
 
+type fakeGatewayPublisher struct {
+	republished []string
+	err         error
+}
+
+func (f *fakeGatewayPublisher) RepublishGatewayCondition(uplinkName string) error {
+	f.republished = append(f.republished, uplinkName)
+	return f.err
+}
+
+// A recreated UplinkState lost the gateway-owned GatewayReady condition, which
+// only network events republish: the reconciler must restore it via the
+// gateway publisher, and only when it is missing.
+func TestNodeUplinkControllerRepublishesGatewayCondition(t *testing.T) {
+	newController := func(g gomega.Gomega, state *uplinkv1alpha1.UplinkState) (*Controller, *fakeGatewayPublisher) {
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		controller, _ := newTestController(t,
+			fakeHostDiscoverer{state: newStatusTestHostState()},
+			fakeBridgeResolver{bridgeName: "br-blue", bridgeUplink: "eth0"},
+			newNode("node-a", map[string]string{"role": "blue"}),
+			newUplink("br-blue", "role", "blue", "breth0"),
+			state,
+		)
+		publisher := &fakeGatewayPublisher{}
+		controller.gatewayPublisher = publisher
+		return controller, publisher
+	}
+
+	t.Run("republishes when the condition is missing", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		controller, publisher := newController(g, newUplinkState("br-blue.node-a", "br-blue", "node-a"))
+
+		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+		g.Expect(publisher.republished).To(gomega.ConsistOf("br-blue"))
+	})
+
+	t.Run("does not republish a present condition", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		state := newUplinkState("br-blue.node-a", "br-blue", "node-a")
+		state.Status.Conditions = []metav1.Condition{{
+			Type:   uplinkv1alpha1.UplinkStateConditionGatewayReady,
+			Status: metav1.ConditionTrue,
+			Reason: uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
+		}}
+		controller, publisher := newController(g, state)
+
+		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+		g.Expect(publisher.republished).To(gomega.BeEmpty())
+	})
+
+	// A failed republish must fail the reconcile so it is retried.
+	t.Run("propagates a republish failure", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		controller, publisher := newController(g, newUplinkState("br-blue.node-a", "br-blue", "node-a"))
+		publisher.err = fmt.Errorf("apply failed")
+
+		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.MatchError(
+			gomega.ContainSubstring("failed to republish gateway condition for Uplink br-blue")))
+	})
+}
+
 func TestEnsureUplinkStateGetsExistingObjectAfterCreateRace(t *testing.T) {
 	g := gomega.NewWithT(t)
 	uplink := newUplink("br-blue", "role", "blue", "breth0")

--- a/go-controller/pkg/node/uplink_gateway_controller.go
+++ b/go-controller/pkg/node/uplink_gateway_controller.go
@@ -187,6 +187,59 @@ func (c *UplinkGatewayController) DeleteNetwork(network util.NetInfo, reconcile 
 	return utilerrors.Join(reconcileErr, statusErr)
 }
 
+// InvalidateGatewayState starts a new node-local gateway lifecycle for an
+// Uplink that still exists but no longer selects this node. Preserve the
+// active network set so aggregate readiness cannot become true until every
+// affected CUDN has reconciled again.
+func (c *UplinkGatewayController) InvalidateGatewayState(uplinkName string) {
+	c.mutex.Lock()
+	uplinkState := c.uplinks[uplinkName]
+	if uplinkState != nil {
+		for _, networkState := range uplinkState.networks {
+			networkState.generation++
+			networkState.phase = uplinkGatewayNetworkPending
+			networkState.reason = uplinkv1alpha1.UplinkStateReasonGatewayConfigurationPending
+			networkState.message = "gateway reconciliation is pending"
+		}
+	}
+	c.mutex.Unlock()
+
+	if uplinkState == nil {
+		return
+	}
+	// Wait for an already-started publish before clearing lastCondition. The
+	// caller deletes the UplinkState only after this method returns, so no old
+	// publish can race with recreation of the node-local state.
+	uplinkState.conditionMutex.Lock()
+	uplinkState.lastCondition = nil
+	uplinkState.conditionMutex.Unlock()
+}
+
+// DeleteGatewayState forgets all cached state for an Uplink resource that no
+// longer exists. A later Uplink with the same name must start with a fresh
+// gateway lifecycle.
+func (c *UplinkGatewayController) DeleteGatewayState(uplinkName string) {
+	c.mutex.Lock()
+	uplinkState := c.uplinks[uplinkName]
+	delete(c.uplinks, uplinkName)
+	for networkName, networkUplinkName := range c.uplinkByNetworkName {
+		if networkUplinkName == uplinkName {
+			delete(c.uplinkByNetworkName, networkName)
+		}
+	}
+	c.mutex.Unlock()
+
+	if uplinkState == nil {
+		return
+	}
+	// Drain any status publish that captured the old cache entry before it was
+	// removed. Subsequent publishers revalidate the entry and return without
+	// applying a condition for the deleted lifecycle.
+	uplinkState.conditionMutex.Lock()
+	uplinkState.lastCondition = nil
+	uplinkState.conditionMutex.Unlock()
+}
+
 func (c *UplinkGatewayController) markNetworkPending(
 	network util.NetInfo,
 ) (*uplinkGatewayState, uint64, []string) {
@@ -195,7 +248,9 @@ func (c *UplinkGatewayController) markNetworkPending(
 
 	previousUplink := c.uplinkByNetworkName[network.GetNetworkName()]
 	if previousUplink != "" && previousUplink != network.Uplink() {
-		delete(c.uplinks[previousUplink].networks, network.GetNetworkName())
+		if previousUplinkState := c.uplinks[previousUplink]; previousUplinkState != nil {
+			delete(previousUplinkState.networks, network.GetNetworkName())
+		}
 	}
 
 	uplinkState, generation := c.markNetworkPendingLocked(network.GetNetworkName(), network.Uplink())
@@ -234,6 +289,10 @@ func (c *UplinkGatewayController) completeNetworkReconcile(
 ) error {
 	c.mutex.Lock()
 	uplinkState := c.uplinks[network.Uplink()]
+	if uplinkState == nil {
+		c.mutex.Unlock()
+		return nil
+	}
 	networkState := uplinkState.networks[network.GetNetworkName()]
 	if networkState != nil && networkState.generation == generation {
 		if reconcileErr == nil {
@@ -257,6 +316,10 @@ func (c *UplinkGatewayController) completeNetworkDelete(
 ) error {
 	c.mutex.Lock()
 	uplinkState := c.uplinks[network.Uplink()]
+	if uplinkState == nil {
+		c.mutex.Unlock()
+		return nil
+	}
 	networkState := uplinkState.networks[network.GetNetworkName()]
 	if networkState != nil && networkState.generation == generation {
 		if reconcileErr == nil {
@@ -316,11 +379,24 @@ func (c *UplinkGatewayController) publishGatewayCondition(uplinkName string) err
 	c.mutex.Lock()
 	uplinkState := c.uplinks[uplinkName]
 	c.mutex.Unlock()
+	if uplinkState == nil {
+		return nil
+	}
 
 	// Serialize the read, merge, and apply sequence and access to
 	// lastCondition for this Uplink.
 	uplinkState.conditionMutex.Lock()
 	defer uplinkState.conditionMutex.Unlock()
+
+	// DeleteGatewayState may have removed the entry after this publisher read
+	// it but before it acquired conditionMutex. Do not publish readiness from a
+	// superseded Uplink lifecycle.
+	c.mutex.Lock()
+	current := c.uplinks[uplinkName]
+	c.mutex.Unlock()
+	if current != uplinkState {
+		return nil
+	}
 
 	stateName := uplinkutil.StateName(uplinkName, c.nodeName)
 	state, err := uplinkutil.GetState(c.uplinkStateLister, uplinkName, c.nodeName)
@@ -328,7 +404,10 @@ func (c *UplinkGatewayController) publishGatewayCondition(uplinkName string) err
 		return fmt.Errorf("failed to get UplinkState %s from cache: %w", stateName, err)
 	}
 
-	desiredCondition := c.gatewayCondition(uplinkName)
+	desiredCondition, found := c.gatewayCondition(uplinkName, uplinkState)
+	if !found {
+		return nil
+	}
 	cachedCondition := meta.FindStatusCondition(state.Status.Conditions, desiredCondition.Type)
 	if conditionsEqual(uplinkState.lastCondition, desiredCondition) && conditionsEqual(cachedCondition, desiredCondition) {
 		return nil
@@ -360,18 +439,24 @@ func (c *UplinkGatewayController) publishGatewayCondition(uplinkName string) err
 
 // gatewayCondition aggregates gateway programming for every active CUDN using
 // the Uplink. GatewayReady remains false while any CUDN is pending or failed.
-func (c *UplinkGatewayController) gatewayCondition(uplinkName string) metav1.Condition {
+func (c *UplinkGatewayController) gatewayCondition(
+	uplinkName string,
+	expectedUplinkState *uplinkGatewayState,
+) (metav1.Condition, bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	uplinkState := c.uplinks[uplinkName]
+	if uplinkState != expectedUplinkState {
+		return metav1.Condition{}, false
+	}
 	if len(uplinkState.networks) == 0 {
 		return metav1.Condition{
 			Type:    uplinkv1alpha1.UplinkStateConditionGatewayReady,
 			Status:  metav1.ConditionTrue,
 			Reason:  uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
 			Message: "No active CUDNs require Uplink gateway programming",
-		}
+		}, true
 	}
 
 	networkNames := make([]string, 0, len(uplinkState.networks))
@@ -404,7 +489,7 @@ func (c *UplinkGatewayController) gatewayCondition(uplinkName string) metav1.Con
 			Status:  metav1.ConditionTrue,
 			Reason:  uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
 			Message: fmt.Sprintf("Uplink gateway programming succeeded for %d active CUDN(s)", len(networkNames)),
-		}
+		}, true
 	}
 
 	return metav1.Condition{
@@ -417,7 +502,7 @@ func (c *UplinkGatewayController) gatewayCondition(uplinkName string) metav1.Con
 			len(networkNames),
 			strings.Join(examples, ", "),
 		),
-	}
+	}, true
 }
 
 func aggregateGatewayFailureReason(reasons map[string]struct{}) string {

--- a/go-controller/pkg/node/uplink_gateway_controller.go
+++ b/go-controller/pkg/node/uplink_gateway_controller.go
@@ -272,6 +272,26 @@ func (c *UplinkGatewayController) completeNetworkDelete(
 	return c.publishGatewayCondition(network.Uplink())
 }
 
+// RepublishGatewayCondition restores this controller's GatewayReady condition
+// on an UplinkState recreated after an out-of-band deletion. It only restores
+// a condition that was already published once: on a first creation the
+// condition is published by network reconciliation.
+func (c *UplinkGatewayController) RepublishGatewayCondition(uplinkName string) error {
+	c.mutex.Lock()
+	uplinkState := c.uplinks[uplinkName]
+	c.mutex.Unlock()
+	if uplinkState == nil {
+		return nil
+	}
+	uplinkState.conditionMutex.Lock()
+	published := uplinkState.lastCondition != nil
+	uplinkState.conditionMutex.Unlock()
+	if !published {
+		return nil
+	}
+	return c.publishGatewayCondition(uplinkName)
+}
+
 func (c *UplinkGatewayController) publishGatewayConditions(uplinkNames []string) error {
 	var errs []error
 	sort.Strings(uplinkNames)

--- a/go-controller/pkg/node/uplink_gateway_controller_test.go
+++ b/go-controller/pkg/node/uplink_gateway_controller_test.go
@@ -103,6 +103,68 @@ func getUplinkGatewayCondition(
 		meta.FindStatusCondition(state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionResolved)
 }
 
+func TestUplinkGatewayControllerRepublishesWipedCondition(t *testing.T) {
+	prepareUplinkGatewayControllerTest(t)
+	const (
+		uplinkName = "uplink1"
+		nodeName   = "node-a"
+	)
+	controller, client := newUplinkGatewayControllerForTest(t, uplinkName, nodeName)
+	network := uplinkGatewayNetInfo(t, "red", uplinkName)
+
+	// Nothing published yet: republish must not invent a condition.
+	if err := controller.RepublishGatewayCondition(uplinkName); err != nil {
+		t.Fatalf("failed to republish before first publish: %v", err)
+	}
+	gatewayReady, _ := getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady != nil {
+		t.Fatalf("expected no GatewayReady condition before first publish, got %#v", gatewayReady)
+	}
+
+	if err := controller.ReconcileNetwork(network, func() error { return nil }); err != nil {
+		t.Fatalf("failed to reconcile network: %v", err)
+	}
+	gatewayReady, _ = getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady == nil || gatewayReady.Status != metav1.ConditionTrue {
+		t.Fatalf("expected published GatewayReady condition, got %#v", gatewayReady)
+	}
+
+	// Simulate an out-of-band deletion and recreation: the recreated object
+	// carries only the discovery condition. The lister already reflects that
+	// shape (it was never updated with the published condition).
+	recreated := &uplinkv1alpha1.UplinkState{
+		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
+		Spec: uplinkv1alpha1.UplinkStateSpec{
+			UplinkName: uplinkName,
+			NodeName:   nodeName,
+		},
+		Status: uplinkv1alpha1.UplinkStateStatus{
+			Conditions: []metav1.Condition{{
+				Type:   uplinkv1alpha1.UplinkStateConditionResolved,
+				Status: metav1.ConditionTrue,
+				Reason: uplinkv1alpha1.UplinkStateReasonResolved,
+			}},
+		},
+	}
+	if _, err := client.K8sV1alpha1().UplinkStates().Update(
+		context.Background(), recreated, metav1.UpdateOptions{},
+	); err != nil {
+		t.Fatalf("failed to wipe GatewayReady condition: %v", err)
+	}
+
+	if err := controller.RepublishGatewayCondition(uplinkName); err != nil {
+		t.Fatalf("failed to republish after wipe: %v", err)
+	}
+	gatewayReady, resolved := getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady == nil || gatewayReady.Status != metav1.ConditionTrue ||
+		gatewayReady.Reason != uplinkv1alpha1.UplinkStateReasonGatewayConfigured {
+		t.Fatalf("expected restored GatewayReady condition, got %#v", gatewayReady)
+	}
+	if resolved == nil || resolved.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Resolved to remain true, got %#v", resolved)
+	}
+}
+
 func TestUplinkGatewayControllerAggregatesActiveNetworks(t *testing.T) {
 	prepareUplinkGatewayControllerTest(t)
 	const (

--- a/go-controller/pkg/node/uplink_gateway_controller_test.go
+++ b/go-controller/pkg/node/uplink_gateway_controller_test.go
@@ -165,6 +165,141 @@ func TestUplinkGatewayControllerRepublishesWipedCondition(t *testing.T) {
 	}
 }
 
+func TestUplinkGatewayControllerInvalidatesIntentionalStateDeletion(t *testing.T) {
+	prepareUplinkGatewayControllerTest(t)
+	const (
+		uplinkName = "uplink1"
+		nodeName   = "node-a"
+	)
+	controller, client := newUplinkGatewayControllerForTest(t, uplinkName, nodeName)
+	network := uplinkGatewayNetInfo(t, "red", uplinkName)
+
+	if err := controller.ReconcileNetwork(network, func() error { return nil }); err != nil {
+		t.Fatalf("failed to reconcile network: %v", err)
+	}
+	controller.InvalidateGatewayState(uplinkName)
+
+	// Model the UplinkState created after the node is selected again. Unlike an
+	// out-of-band deletion, an intentional deletion invalidated the old
+	// GatewayReady condition, so it must not be restored.
+	recreated := &uplinkv1alpha1.UplinkState{
+		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
+		Spec: uplinkv1alpha1.UplinkStateSpec{
+			UplinkName: uplinkName,
+			NodeName:   nodeName,
+		},
+	}
+	if _, err := client.K8sV1alpha1().UplinkStates().Update(
+		context.Background(), recreated, metav1.UpdateOptions{},
+	); err != nil {
+		t.Fatalf("failed to recreate UplinkState: %v", err)
+	}
+
+	if err := controller.RepublishGatewayCondition(uplinkName); err != nil {
+		t.Fatalf("failed to check invalidated gateway condition: %v", err)
+	}
+	gatewayReady, _ := getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady != nil {
+		t.Fatalf("expected invalidated GatewayReady not to be restored, got %#v", gatewayReady)
+	}
+
+	controller.mutex.Lock()
+	networkState := controller.uplinks[uplinkName].networks[network.GetNetworkName()]
+	phase := networkState.phase
+	controller.mutex.Unlock()
+	if phase != uplinkGatewayNetworkPending {
+		t.Fatalf("expected cached network readiness to be pending, got %q", phase)
+	}
+
+	if err := controller.ReconcileNetwork(network, func() error { return nil }); err != nil {
+		t.Fatalf("failed to reconcile network in the new lifecycle: %v", err)
+	}
+	gatewayReady, _ = getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady == nil || gatewayReady.Status != metav1.ConditionTrue {
+		t.Fatalf("expected GatewayReady after fresh reconciliation, got %#v", gatewayReady)
+	}
+}
+
+func TestUplinkGatewayControllerDeletesRemovedUplinkCache(t *testing.T) {
+	prepareUplinkGatewayControllerTest(t)
+	const (
+		uplinkName = "uplink1"
+		nodeName   = "node-a"
+	)
+	controller, client := newUplinkGatewayControllerForTest(t, uplinkName, nodeName)
+	network := uplinkGatewayNetInfo(t, "red", uplinkName)
+
+	if err := controller.ReconcileNetwork(network, func() error { return nil }); err != nil {
+		t.Fatalf("failed to reconcile network: %v", err)
+	}
+	controller.DeleteGatewayState(uplinkName)
+
+	controller.mutex.Lock()
+	_, uplinkFound := controller.uplinks[uplinkName]
+	_, networkFound := controller.uplinkByNetworkName[network.GetNetworkName()]
+	controller.mutex.Unlock()
+	if uplinkFound || networkFound {
+		t.Fatalf("expected deleted Uplink cache to be removed, uplinkFound=%t networkFound=%t",
+			uplinkFound, networkFound)
+	}
+
+	// A same-name Uplink created later is a new lifecycle and must not inherit
+	// readiness from the deleted resource.
+	recreated := &uplinkv1alpha1.UplinkState{
+		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
+		Spec: uplinkv1alpha1.UplinkStateSpec{
+			UplinkName: uplinkName,
+			NodeName:   nodeName,
+		},
+	}
+	if _, err := client.K8sV1alpha1().UplinkStates().Update(
+		context.Background(), recreated, metav1.UpdateOptions{},
+	); err != nil {
+		t.Fatalf("failed to recreate UplinkState: %v", err)
+	}
+	if err := controller.RepublishGatewayCondition(uplinkName); err != nil {
+		t.Fatalf("failed to check deleted gateway cache: %v", err)
+	}
+	gatewayReady, _ := getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady != nil {
+		t.Fatalf("expected no GatewayReady from deleted Uplink cache, got %#v", gatewayReady)
+	}
+}
+
+func TestUplinkGatewayControllerInvalidationDiscardsInFlightCompletion(t *testing.T) {
+	prepareUplinkGatewayControllerTest(t)
+	const (
+		uplinkName = "uplink1"
+		nodeName   = "node-a"
+	)
+	controller, client := newUplinkGatewayControllerForTest(t, uplinkName, nodeName)
+	network := uplinkGatewayNetInfo(t, "red", uplinkName)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+
+	go func() {
+		done <- controller.ReconcileNetwork(network, func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	controller.InvalidateGatewayState(uplinkName)
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("failed to finish invalidated reconciliation: %v", err)
+	}
+
+	gatewayReady, _ := getUplinkGatewayCondition(t, client, uplinkName, nodeName)
+	if gatewayReady == nil || gatewayReady.Status != metav1.ConditionFalse ||
+		gatewayReady.Reason != uplinkv1alpha1.UplinkStateReasonGatewayConfigurationPending {
+		t.Fatalf("expected old completion to leave GatewayReady pending, got %#v", gatewayReady)
+	}
+}
+
 func TestUplinkGatewayControllerAggregatesActiveNetworks(t *testing.T) {
 	prepareUplinkGatewayControllerTest(t)
 	const (

--- a/go-controller/pkg/node/uplink_gateway_controller_test.go
+++ b/go-controller/pkg/node/uplink_gateway_controller_test.go
@@ -25,25 +25,33 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
-func newUplinkGatewayControllerForTest(
-	t *testing.T,
-	uplinkName, nodeName string,
-) (*UplinkGatewayController, *uplinkfake.Clientset) {
-	t.Helper()
-	state := &uplinkv1alpha1.UplinkState{
+func newUplinkStateFixture(
+	uplinkName, nodeName string, conditions ...metav1.Condition,
+) *uplinkv1alpha1.UplinkState {
+	return &uplinkv1alpha1.UplinkState{
 		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
 		Spec: uplinkv1alpha1.UplinkStateSpec{
 			UplinkName: uplinkName,
 			NodeName:   nodeName,
 		},
-		Status: uplinkv1alpha1.UplinkStateStatus{
-			Conditions: []metav1.Condition{{
-				Type:   uplinkv1alpha1.UplinkStateConditionResolved,
-				Status: metav1.ConditionTrue,
-				Reason: uplinkv1alpha1.UplinkStateReasonResolved,
-			}},
-		},
+		Status: uplinkv1alpha1.UplinkStateStatus{Conditions: conditions},
 	}
+}
+
+func resolvedTrueCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:   uplinkv1alpha1.UplinkStateConditionResolved,
+		Status: metav1.ConditionTrue,
+		Reason: uplinkv1alpha1.UplinkStateReasonResolved,
+	}
+}
+
+func newUplinkGatewayControllerForTest(
+	t *testing.T,
+	uplinkName, nodeName string,
+) (*UplinkGatewayController, *uplinkfake.Clientset) {
+	t.Helper()
+	state := newUplinkStateFixture(uplinkName, nodeName, resolvedTrueCondition())
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	if err := indexer.Add(state); err != nil {
 		t.Fatalf("failed to add UplinkState: %v", err)
@@ -132,20 +140,7 @@ func TestUplinkGatewayControllerRepublishesWipedCondition(t *testing.T) {
 	// Simulate an out-of-band deletion and recreation: the recreated object
 	// carries only the discovery condition. The lister already reflects that
 	// shape (it was never updated with the published condition).
-	recreated := &uplinkv1alpha1.UplinkState{
-		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
-		Spec: uplinkv1alpha1.UplinkStateSpec{
-			UplinkName: uplinkName,
-			NodeName:   nodeName,
-		},
-		Status: uplinkv1alpha1.UplinkStateStatus{
-			Conditions: []metav1.Condition{{
-				Type:   uplinkv1alpha1.UplinkStateConditionResolved,
-				Status: metav1.ConditionTrue,
-				Reason: uplinkv1alpha1.UplinkStateReasonResolved,
-			}},
-		},
-	}
+	recreated := newUplinkStateFixture(uplinkName, nodeName, resolvedTrueCondition())
 	if _, err := client.K8sV1alpha1().UplinkStates().Update(
 		context.Background(), recreated, metav1.UpdateOptions{},
 	); err != nil {
@@ -182,13 +177,7 @@ func TestUplinkGatewayControllerInvalidatesIntentionalStateDeletion(t *testing.T
 	// Model the UplinkState created after the node is selected again. Unlike an
 	// out-of-band deletion, an intentional deletion invalidated the old
 	// GatewayReady condition, so it must not be restored.
-	recreated := &uplinkv1alpha1.UplinkState{
-		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
-		Spec: uplinkv1alpha1.UplinkStateSpec{
-			UplinkName: uplinkName,
-			NodeName:   nodeName,
-		},
-	}
+	recreated := newUplinkStateFixture(uplinkName, nodeName)
 	if _, err := client.K8sV1alpha1().UplinkStates().Update(
 		context.Background(), recreated, metav1.UpdateOptions{},
 	); err != nil {
@@ -245,13 +234,7 @@ func TestUplinkGatewayControllerDeletesRemovedUplinkCache(t *testing.T) {
 
 	// A same-name Uplink created later is a new lifecycle and must not inherit
 	// readiness from the deleted resource.
-	recreated := &uplinkv1alpha1.UplinkState{
-		ObjectMeta: metav1.ObjectMeta{Name: uplinkutil.StateName(uplinkName, nodeName)},
-		Spec: uplinkv1alpha1.UplinkStateSpec{
-			UplinkName: uplinkName,
-			NodeName:   nodeName,
-		},
-	}
+	recreated := newUplinkStateFixture(uplinkName, nodeName)
 	if _, err := client.K8sV1alpha1().UplinkStates().Update(
 		context.Background(), recreated, metav1.UpdateOptions{},
 	); err != nil {

--- a/go-controller/pkg/uplink/names.go
+++ b/go-controller/pkg/uplink/names.go
@@ -27,6 +27,31 @@ func StateIdentity(state *uplinkv1alpha1.UplinkState) (uplinkName, nodeName stri
 	return state.Spec.UplinkName, state.Spec.NodeName
 }
 
+// UplinkForState finds the Uplink owning the UplinkState named stateName on
+// one of the given nodes. UplinkState names are opaque keys that cannot be
+// parsed back into an identity, so the owner is found by forward-computing
+// every candidate's state name. The boolean reports whether exactly one
+// Uplink/node pair matched.
+func UplinkForState(
+	uplinks []*uplinkv1alpha1.Uplink, nodeNames []string, stateName string,
+) (*uplinkv1alpha1.Uplink, bool) {
+	var matched *uplinkv1alpha1.Uplink
+	matches := 0
+	for _, uplink := range uplinks {
+		for _, nodeName := range nodeNames {
+			if StateName(uplink.Name, nodeName) != stateName {
+				continue
+			}
+			matched = uplink
+			matches++
+		}
+	}
+	if matches != 1 {
+		return nil, false
+	}
+	return matched, true
+}
+
 // GetState returns the UplinkState for an Uplink and node after validating that
 // the identity stored in its spec matches the requested identity.
 func GetState(

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -184,7 +184,138 @@ var _ = ginkgo.Describe("Network Segmentation Uplink default-VRF egress", featur
 			}
 		}
 	})
+
+	ginkgo.It("recreates an UplinkState deleted out of band", func() {
+		env := provisionUplinkWithActiveCUDN(f, ictx, ipFamilySet, testSuffix, "updel")
+		node, uplinkName, bridgeName, networkName := env.node, env.uplinkName, env.bridgeName, env.networkName
+
+		ginkgo.By("deleting the UplinkState out of band")
+		state, err := getUplinkState(f, uplinkName, node.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deletedUID := state.GetUID()
+		gomega.Expect(f.DynamicClient.Resource(uplinkStateGVR).Delete(
+			context.Background(),
+			state.GetName(),
+			metav1.DeleteOptions{},
+		)).To(gomega.Succeed())
+
+		ginkgo.By("waiting for a new UplinkState without restarting ovnkube-node")
+		gomega.Eventually(func() error {
+			state, err := getUplinkState(f, uplinkName, node.Name)
+			if err != nil {
+				return err
+			}
+			if state.GetUID() == deletedUID {
+				return fmt.Errorf("UplinkState %s still carries the deleted object's UID %s",
+					state.GetName(), deletedUID)
+			}
+			return nil
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the UplinkState for uplink %q on node %q to be recreated",
+			uplinkName,
+			node.Name,
+		)
+
+		ginkgo.By("waiting for the recreated UplinkState to recover discovery and gateway readiness")
+		waitForUplinkStatesResolved(f, uplinkName, bridgeName, []corev1.Node{node})
+		waitForUplinkStateGatewayCondition(
+			f,
+			uplinkName,
+			node.Name,
+			metav1.ConditionTrue,
+			uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
+		)
+		waitForCUDNUplinksReady(f, networkName)
+	})
 })
+
+// uplinkRecoveryEnv is the provisioning shared by the UplinkState recovery
+// tests: one Uplink resolved on every node, and one CUDN activated on a single
+// schedulable node with gateway readiness published for it.
+type uplinkRecoveryEnv struct {
+	node        corev1.Node
+	uplinkName  string
+	bridgeName  string
+	networkName string
+}
+
+func provisionUplinkWithActiveCUDN(
+	f *framework.Framework,
+	ictx infraapi.Context,
+	ipFamilySet sets.Set[utilnet.IPFamily],
+	testSuffix string,
+	prefix string,
+) uplinkRecoveryEnv {
+	ginkgo.GinkgoHelper()
+
+	nodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	schedulableNodes, err := e2enode.GetBoundedReadySchedulableNodes(context.Background(), f.ClientSet, 1)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(schedulableNodes.Items).NotTo(gomega.BeEmpty())
+	node := schedulableNodes.Items[0]
+
+	uplinkAlloc, err := allocators.AllocateBGP(f, ictx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	_, nodeIfaces := setupUplinkNetwork(
+		ictx,
+		nodes.Items,
+		ipFamilySet,
+		"upnet"+testSuffix,
+		[]string{uplinkAlloc.BGPPeerSubnet, uplinkAlloc.BGPPeerSubnet6},
+	)
+
+	bridgeName := uplinkBridgeName(prefix + testSuffix)
+	gomega.Expect(configureUplinkBridge(f, ictx, bridgeName, nodeIfaces)).To(gomega.Succeed())
+	gomega.Expect(configureUplinkBridgeDefaultRoutes(
+		ictx,
+		bridgeName,
+		nodeIfaces,
+	)).To(gomega.Succeed())
+
+	uplinkName := prefix + testSuffix
+	createUplink(f, ictx, uplinkName, nodes.Items, nodeIfaces, bridgeName)
+	waitForUplinkStatesResolved(f, uplinkName, bridgeName, nodes.Items)
+
+	ginkgo.By("activating a CUDN on the Uplink so GatewayReady is published")
+	networkName := prefix + "net" + testSuffix
+	bgpAlloc, err := allocators.AllocateBGP(f, ictx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	networkSpec := uplinkLayer3NetworkSpec(ipFamilySet, bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6)
+	namespace, err := createUplinkNamespace(
+		f,
+		ictx,
+		"uplink-default",
+		networkName,
+	)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(createUplinkCUDN(
+		f,
+		ictx,
+		namespace,
+		networkName,
+		networkSpec,
+		nil,
+		uplinkName,
+	)).To(gomega.Succeed())
+	createUplinkNetexecPod(f, namespace.Name, "client-"+networkName, node.Name)
+	waitForUplinkStateGatewayCondition(
+		f,
+		uplinkName,
+		node.Name,
+		metav1.ConditionTrue,
+		uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
+	)
+	waitForCUDNUplinksReady(f, networkName)
+
+	return uplinkRecoveryEnv{
+		node:        node,
+		uplinkName:  uplinkName,
+		bridgeName:  bridgeName,
+		networkName: networkName,
+	}
+}
 
 var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feature.NetworkSegmentation, feature.RouteAdvertisements, func() {
 	f := wrappedTestFramework("uplink-bgp")
@@ -932,6 +1063,65 @@ var _ = ginkgo.Describe("Network Segmentation Uplink split DPU status conditions
 			gomega.Succeed(),
 			"expected the host-owned data fields to be pruned once discovery fails",
 		)
+	})
+
+	ginkgo.It("recreates an UplinkState deleted out of band", func() {
+		schedulableNodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		dpuHostNodes := filterNodesByLabel(schedulableNodes.Items, uplinkDPUHostNodeLabel)
+		gomega.Expect(dpuHostNodes).NotTo(gomega.BeEmpty(), "expected at least one ready schedulable DPU host node")
+		nodeIfaces := collectDPUHostUplinkInterfaces(dpuHostNodes)
+		node := dpuHostNodes[0]
+
+		ginkgo.By("resolving an Uplink on the provisioned host interface")
+		uplinkName := "updel" + testSuffix
+		createUplink(f, ictx, uplinkName, []corev1.Node{node}, nodeIfaces, "")
+		waitForUplinkStatesResolved(f, uplinkName, os.Getenv(uplinkDPUExpectedBridgeEnv), []corev1.Node{node})
+
+		ginkgo.By("deleting the UplinkState out of band")
+		state, err := getUplinkState(f, uplinkName, node.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deletedUID := state.GetUID()
+		gomega.Expect(f.DynamicClient.Resource(uplinkStateGVR).Delete(
+			context.Background(),
+			state.GetName(),
+			metav1.DeleteOptions{},
+		)).To(gomega.Succeed())
+
+		ginkgo.By("waiting for both DPU sides to republish their status on a recreated UplinkState")
+		gomega.Eventually(func() error {
+			state, err := getUplinkState(f, uplinkName, node.Name)
+			if err != nil {
+				return err
+			}
+			// A new UID proves recreation rather than a surviving object.
+			if state.GetUID() == deletedUID {
+				return fmt.Errorf("UplinkState %s still carries the deleted object's UID %s",
+					state.GetName(), deletedUID)
+			}
+			// The DPU-host republished the host interface data on the new
+			// object...
+			if err := checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				metav1.ConditionTrue,
+				uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			); err != nil {
+				return err
+			}
+			// ...and the DPU consumed it and re-resolved its bridge, having
+			// survived the create race between the two sides.
+			return checkUplinkStateCondition(state,
+				uplinkv1alpha1.UplinkStateConditionResolved,
+				metav1.ConditionTrue,
+				uplinkv1alpha1.UplinkStateReasonResolved,
+			)
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the deleted UplinkState to be recreated and re-resolved without a restart",
+		)
+		// Full status recovery: the resolved bridge and the host IPs were
+		// republished on the recreated object, not just the conditions.
+		waitForUplinkStatesResolved(f, uplinkName, os.Getenv(uplinkDPUExpectedBridgeEnv), []corev1.Node{node})
 	})
 })
 

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -64,6 +64,10 @@ const (
 	uplinkDefaultBGPServerIPv6CIDR  = "fc00:f853:ccd:e797::/64"
 )
 
+// errUplinkStateNotFound distinguishes "the UplinkState does not exist" from
+// transient API errors in getUplinkState results.
+var errUplinkStateNotFound = errors.New("no matching UplinkState")
+
 var uplinkGVR = schema.GroupVersionResource{
 	Group:    "k8s.ovn.org",
 	Version:  "v1alpha1",
@@ -227,6 +231,97 @@ var _ = ginkgo.Describe("Network Segmentation Uplink default-VRF egress", featur
 			uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
 		)
 		waitForCUDNUplinksReady(f, networkName)
+	})
+
+	// GatewayReady is restored from the node's gateway cache only after an
+	// out-of-band deletion, where the programmed gateway is untouched. An
+	// intentional deselection ends that gateway lifecycle: the UplinkState
+	// recreated on reselection must not inherit the previous lifecycle's
+	// readiness, which nothing has re-verified.
+	ginkgo.It("does not restore gateway readiness on an UplinkState recreated after deselection", func() {
+		env := provisionUplinkWithActiveCUDN(f, ictx, ipFamilySet, testSuffix, "updesel")
+		node, uplinkName, bridgeName := env.node, env.uplinkName, env.bridgeName
+		hostname, ok := node.Labels[corev1.LabelHostname]
+		gomega.Expect(ok).To(gomega.BeTrue(), "expected node %s to have label %q", node.Name, corev1.LabelHostname)
+
+		state, err := getUplinkState(f, uplinkName, node.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deselectedUID := state.GetUID()
+		gatewayReady, err := uplinkStateCondition(state, uplinkv1alpha1.UplinkStateConditionGatewayReady)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		previousTransition := gatewayReady.LastTransitionTime
+
+		ginkgo.By("deselecting the node from the Uplink")
+		deselectedHostname := "deselected-" + testSuffix
+		setUplinkNodeConfigHostname(f, uplinkName, hostname, deselectedHostname)
+		gomega.Eventually(func() error {
+			_, err := getUplinkState(f, uplinkName, node.Name)
+			if errors.Is(err, errUplinkStateNotFound) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("UplinkState for uplink %q on node %q still exists", uplinkName, node.Name)
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the UplinkState for uplink %q on node %q to be deleted after deselection",
+			uplinkName,
+			node.Name,
+		)
+
+		ginkgo.By("reselecting the node and waiting for a new UplinkState to resolve")
+		setUplinkNodeConfigHostname(f, uplinkName, deselectedHostname, hostname)
+		gomega.Eventually(func() error {
+			state, err := getUplinkState(f, uplinkName, node.Name)
+			if err != nil {
+				return err
+			}
+			if state.GetUID() == deselectedUID {
+				return fmt.Errorf("UplinkState %s still carries the deselected object's UID %s",
+					state.GetName(), deselectedUID)
+			}
+			return nil
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the UplinkState for uplink %q on node %q to be recreated after reselection",
+			uplinkName,
+			node.Name,
+		)
+		waitForUplinkStatesResolved(f, uplinkName, bridgeName, []corev1.Node{node})
+
+		ginkgo.By("verifying the recreated UplinkState does not inherit the previous GatewayReady")
+		gomega.Consistently(func() error {
+			state, err := getUplinkState(f, uplinkName, node.Name)
+			if err != nil {
+				return err
+			}
+			conditions, err := getConditions(state)
+			if err != nil {
+				return err
+			}
+			for _, condition := range conditions {
+				if condition.Type != uplinkv1alpha1.UplinkStateConditionGatewayReady ||
+					condition.Status != metav1.ConditionTrue {
+					continue
+				}
+				// A GatewayReady=True earned by gateway reconciliation in the
+				// new lifecycle transitions after the deselection. A condition
+				// restored from the previous lifecycle's cache keeps its old
+				// transition time.
+				if !condition.LastTransitionTime.After(previousTransition.Time) {
+					return fmt.Errorf(
+						"UplinkState %s carries GatewayReady=True from before the deselection (transitioned %s)",
+						state.GetName(),
+						condition.LastTransitionTime,
+					)
+				}
+			}
+			return nil
+		}).WithTimeout(uplinkConditionStableWindow).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected the recreated UplinkState not to inherit gateway readiness from the previous lifecycle",
+		)
 	})
 })
 
@@ -1874,9 +1969,63 @@ func getUplinkState(f *framework.Framework, uplinkName string, nodeName string) 
 		return nil, err
 	}
 	if len(stateList.Items) == 0 {
-		return nil, fmt.Errorf("failed to find UplinkState for uplink %q on node %q", uplinkName, nodeName)
+		return nil, fmt.Errorf("failed to find UplinkState for uplink %q on node %q: %w",
+			uplinkName, nodeName, errUplinkStateNotFound)
 	}
 	return &stateList.Items[0], nil
+}
+
+// setUplinkNodeConfigHostname rewrites the hostname selector of the Uplink
+// nodeConfig currently selecting fromHostname, selecting (or deselecting) the
+// matching node without touching the other nodeConfigs.
+func setUplinkNodeConfigHostname(f *framework.Framework, uplinkName, fromHostname, toHostname string) {
+	ginkgo.GinkgoHelper()
+
+	gomega.Eventually(func() error {
+		uplink, err := f.DynamicClient.Resource(uplinkGVR).Get(context.Background(), uplinkName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		nodeConfigs, _, err := unstructured.NestedSlice(uplink.Object, "spec", "nodeConfigs")
+		if err != nil {
+			return err
+		}
+		found := false
+		for i := range nodeConfigs {
+			nodeConfig, ok := nodeConfigs[i].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			hostname, _, err := unstructured.NestedString(nodeConfig, "nodeSelector", "matchLabels", corev1.LabelHostname)
+			if err != nil {
+				return err
+			}
+			if hostname != fromHostname {
+				continue
+			}
+			if err := unstructured.SetNestedField(
+				nodeConfig, toHostname, "nodeSelector", "matchLabels", corev1.LabelHostname,
+			); err != nil {
+				return err
+			}
+			nodeConfigs[i] = nodeConfig
+			found = true
+		}
+		if !found {
+			return fmt.Errorf("Uplink %s has no nodeConfig selecting hostname %q", uplinkName, fromHostname)
+		}
+		if err := unstructured.SetNestedSlice(uplink.Object, nodeConfigs, "spec", "nodeConfigs"); err != nil {
+			return err
+		}
+		_, err = f.DynamicClient.Resource(uplinkGVR).Update(context.Background(), uplink, metav1.UpdateOptions{})
+		return err
+	}).WithTimeout(uplinkShortTimeout).WithPolling(uplinkPoll).Should(
+		gomega.Succeed(),
+		"expected to update Uplink %q nodeConfig selector from %q to %q",
+		uplinkName,
+		fromHostname,
+		toHostname,
+	)
 }
 
 func createNodeScopedUplinkFRRConfiguration(


### PR DESCRIPTION
## 📑 Description

Only the Uplink reconciler creates UplinkStates, but deleting an UplinkState generates no event on the Uplink that owns it: the UplinkState reconciler saw NotFound and returned, so a state deleted out of band (e.g. an admin removing an unhealthy one with kubectl) was only recreated when a restarted ovnkube-node replayed its initial sync.

Three commits:
1. **Uplink: recreate UplinkState deleted out of band** — on NotFound, requeue (rate-limited) the Uplink whose computed state name matches the deleted key so it recreates the state. A terminating Uplink is not requeued: the cluster-manager finalizer flow deletes its states on purpose. This is the delete-event owner derivation the OKEP already describes (okep-6019, UplinkState naming section).
2. **Uplink: restore GatewayReady on recreated UplinkStates** — a recreated state regains discovery status but not the GatewayReady condition, which UplinkGatewayController only publishes from network reconciliation; the CUDN then reports UplinksReady=False until an unrelated network event. The UplinkState reconciler now asks UplinkGatewayController to recompute and publish the aggregate condition when it sees it missing; only conditions published once before are restored, so first creations and the DPU-host (non-owner) are unaffected.
3. **Uplink e2e: cover out-of-band UplinkState deletion recovery** — full-mode lane: recreation with a new UID, Resolved and GatewayReady recovered, CUDN UplinksReady back to True; split-DPU lane: both sides republish their owned status onto the recreated object (HostDataReady from the DPU-host, Resolved and the bridge from the DPU).

## ✅ Checks
- [ ] My code requires changes to the documentation
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI
