### PR TITLE
vrfmanager: preserve slave interface routes across VRF enslavement

### DIFF
--- a/docs/features/user-defined-networks/uplinks.md
+++ b/docs/features/user-defined-networks/uplinks.md
@@ -226,7 +226,10 @@ attachment. When the active CUDN set changes, `GatewayReady` first becomes
 `False` with reason `GatewayConfigurationPending` and returns to `True` only
 after the complete active set converges. A gateway programming failure does not
 change discovery `Resolved`; the CUDN-specific `UplinksReady` condition reflects
-both states.
+both states. In split DPU mode the host-side share of gateway programming, the
+VRF attachment of the Uplink gateway interface on the DPU-Host, is reported
+separately on the `HostGatewayReady` condition, and the CUDN `UplinksReady`
+condition requires both.
 
 The `Uplink` object reports aggregate status:
 
@@ -438,6 +441,11 @@ Common problems:
 * `UplinkState` with `GatewayReady` condition status `False` and reason
   `UplinkConfigurationConflict`: the resolved Uplink bridge is already
   attached to a different VRF on this node.
+* `UplinkState` with `HostGatewayReady` condition status `False` (split DPU
+  mode only): host-side gateway programming failed on the DPU-Host, for
+  example reason `UplinkVRFAttachmentFailed` when the Uplink gateway
+  interface could not be attached to or detached from the CUDN routing
+  domain on the DPU-Host.
 * CUDN with `UplinksReady` condition status `False` and reason
   `UplinkNotResolvedForNode`: at least one active node for the CUDN does not have
   a matching `UplinkState` with `Resolved=True`.
@@ -458,10 +466,35 @@ Common problems:
   supported with Uplinks.
 
 In split DPU mode each `UplinkState` condition has a single writer: the
-DPU-Host publishes the host interface data and the `HostDataReady` condition,
-while ovnkube-node on the DPU publishes `Resolved` and `GatewayReady`. Bridge
-reasons (`BridgeNotFound`, `BridgeUplinkNotFound`) therefore always describe
-OVS on the DPU, and `HostDataReady` reasons always describe the DPU-Host.
+DPU-Host publishes the host interface data and the `HostDataReady` and
+`HostGatewayReady` conditions, while ovnkube-node on the DPU publishes
+`Resolved` and `GatewayReady`. Bridge reasons (`BridgeNotFound`,
+`BridgeUplinkNotFound`) therefore always describe OVS on the DPU, and
+`HostDataReady`/`HostGatewayReady` reasons always describe the DPU-Host.
+
+In DPU deployments, FRR peering and route import happen on the DPU:
+BGP-learned routes are not propagated to the DPU-Host's CUDN VRF.
+Host-originated traffic toward the Uplink therefore requires a default
+gateway route on the selected host interface (preserved into the CUDN VRF
+across enslavement) or a host-side FRR setup; pod traffic toward the Uplink
+is unaffected, since its routes are imported into the gateway router on the
+DPU.
+
+```text
+             DPU                                DPU-Host
+ +---------------------------+      +----------------------------+
+ | FRR --- BGP peering       |      | CUDN VRF                   |
+ |          |                |      |  - no BGP-learned routes   |
+ |          v                |      |  - preserved default       |
+ | CUDN route-import VRF     |      |    gateway route           |
+ |          | imported       |      |    (or host-side FRR)      |
+ |          v                |      +-------------+--------------+
+ | CUDN gateway router (OVN) |                    |
+ +-------------+-------------+                    | host-originated
+               | pod traffic                      | traffic
+               v                                  v
+             Uplink <-----------------------------+
+```
 
 ## References
 

--- a/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
+++ b/docs/okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
@@ -399,7 +399,8 @@ stored per `UplinkState`. `UplinkState` stores only reusable per-node host gatew
 
 `UplinkState.status.conditions` reports independent node-local conditions, and each condition has a single writer.
 The Uplink discovery reconciler owns `Resolved` (published by the DPU side in split DPU mode), the DPU-Host discovery
-reconciler owns `HostDataReady` (split DPU mode only), and a node-level Uplink gateway coordinator owns `GatewayReady`;
+reconciler owns `HostDataReady` (split DPU mode only), a node-level Uplink gateway coordinator owns `GatewayReady`, and
+its DPU-Host counterpart owns `HostGatewayReady` (split DPU mode only);
 a gateway programming failure does not overwrite successful Uplink resolution. Individual CUDN gateway reconcilers do
 not write `GatewayReady` directly.
 
@@ -432,6 +433,14 @@ address for each enabled IP family, so the DPU side can consume the data), and `
 discovery reason (`HostInterfaceNotFound`, `InvalidHostInterface`, `GatewayInfoUnavailable`, `NodeSelectorOverlap`)
 otherwise. Full mode does not publish this condition.
 
+In split DPU mode the `HostGatewayReady` condition reports host-side gateway programming on the DPU-Host, mirroring
+`GatewayReady` on the DPU: the attachment of the selected host interface to the host-side CUDN VRF, including the
+migration of its pre-existing routes into the VRF table, for the complete set of CUDNs active on the Uplink.
+`HostGatewayReady=True` with reason `GatewayConfigured` once host-side programming succeeded for every active CUDN, and
+`HostGatewayReady=False` with the same reasons `GatewayReady` uses (e.g. `UplinkVRFAttachmentFailed` when the interface
+cannot be attached or its routes cannot be migrated) otherwise. Full mode does not publish this condition: the single
+node-level coordinator reports everything through `GatewayReady`.
+
 The `GatewayReady` condition reports aggregate gateway programming for the complete set of CUDNs active on the resolved
 Uplink path on this node. The node-level coordinator is the sole writer of this condition and serializes reconciliation
 of the shared gateway interface, bridge mappings, and OpenFlow state for the aggregate desired configuration.
@@ -461,7 +470,8 @@ The condition uses the following reasons:
 For pending or failure states, `GatewayReady=False` while `Resolved` can remain `True`. Its message contains the number of
 affected active CUDNs and a bounded sample of CUDN names and underlying reasons; full reconciliation errors remain
 available in node logs. Because the programmed gateway is shared state, cluster-manager maps the aggregate non-ready
-state into `UplinksReady=False` for every active CUDN using that Uplink/node pair. When the complete desired configuration
+state of `GatewayReady`, and of `HostGatewayReady` where present, into `UplinksReady=False` for every active CUDN using
+that Uplink/node pair. When the complete desired configuration
 succeeds again, `GatewayReady=True` with reason `GatewayConfigured`. Dynamic CUDNs using the same Uplink on disjoint nodes
 have independent `GatewayReady` conditions in their node-scoped `UplinkState` objects.
 
@@ -675,6 +685,11 @@ then reflects those routes into the CUDN gateway router. This DPU-local VRF is s
 nftables state. For `targetVRF: default` or CUDNs without matching `RouteAdvertisements`, the DPU bridge `LOCAL` interface
 remains in the default VRF and no DPU-local CUDN route-import VRF is created for that CUDN.
 
+In DPU deployments, FRR peering and route import happen on the DPU: BGP-learned routes are not propagated to the
+DPU-Host's CUDN VRF. Host-originated traffic toward the Uplink therefore requires a default gateway route on the
+selected host interface (preserved into the CUDN VRF across enslavement) or a host-side FRR setup; pod traffic toward
+the Uplink is unaffected, since its routes are imported into the gateway router on the DPU.
+
 The DPU-local FRR peering IP is not stored in `UplinkState`. For `targetVRF: auto`, it is expected to be configured on the
 resolved OVS bridge's `LOCAL` interface as local DPU state. OVNKube on the DPU enslaves that `LOCAL` interface to the
 DPU-local route-import VRF and uses that interface for FRR peering. The advertised next-hop for pod routes remains the
@@ -786,7 +801,9 @@ DPU-Host reconciler:
    gateways.
 4. Determine the CUDN's effective routing domain from matching `RouteAdvertisements`. Attach the selected host interface
    to the host-side CUDN VRF only for per-CUDN VRF-Lite isolation; otherwise leave it in the default VRF.
-5. Update this node's `UplinkState.status` with `hostInterfaceName`, `macAddress`, `ipAddresses`, `defaultGateways`, and
+5. Report the aggregate host-side gateway programming, including the VRF attachment and the migration of the interface's
+   pre-existing routes, through the `HostGatewayReady` condition.
+6. Update this node's `UplinkState.status` with `hostInterfaceName`, `macAddress`, `ipAddresses`, `defaultGateways`, and
    the `HostDataReady` condition. The DPU-Host does not write the `Resolved` condition; the DPU side owns it.
 
 DPU-side reconciler:
@@ -813,7 +830,7 @@ Although both DPU-Host and DPU-side reconcilers update the same `UplinkState`, u
 frequency. The DPU side waits for the DPU-Host to publish host-side gateway data, especially `status.macAddress`, before
 resolving and publishing DPU-local bridge data such as `status.ovsBridge.name`. Implementations should use status patches
 or server-side apply field ownership for the fields each side owns, and each status condition has a single writer
-(`HostDataReady` on the DPU-Host, `Resolved` and `GatewayReady` on the DPU), so normal retry-on-conflict handling is
+(`HostDataReady` and `HostGatewayReady` on the DPU-Host, `Resolved` and `GatewayReady` on the DPU), so normal retry-on-conflict handling is
 sufficient and the object cannot become a hot write target.
 
 This avoids publishing PF IDs, host PCI addresses, or DPU-local bridge names in the `Uplink` spec. The DPU-Host publishes

--- a/go-controller/pkg/clustermanager/uplink/controller.go
+++ b/go-controller/pkg/clustermanager/uplink/controller.go
@@ -827,9 +827,24 @@ func uplinkNodeFailureMessage(failures []uplinkNodeFailure, selectedNodes int) s
 }
 
 func cudnUplinkStateGatewayNotReadyReason(state *uplinkv1alpha1.UplinkState) string {
+	if reason := cudnUplinkStateGatewayConditionNotReadyReason(
+		state, uplinkv1alpha1.UplinkStateConditionGatewayReady); reason != "" {
+		return reason
+	}
+	// In split-DPU deployments, recognizable by the DPU-host-owned
+	// HostDataReady condition, host-side gateway programming is reported
+	// separately through HostGatewayReady and must be ready as well.
+	if meta.FindStatusCondition(state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionHostDataReady) != nil {
+		return cudnUplinkStateGatewayConditionNotReadyReason(
+			state, uplinkv1alpha1.UplinkStateConditionHostGatewayReady)
+	}
+	return ""
+}
+
+func cudnUplinkStateGatewayConditionNotReadyReason(state *uplinkv1alpha1.UplinkState, conditionType string) string {
 	condition := meta.FindStatusCondition(
 		state.Status.Conditions,
-		uplinkv1alpha1.UplinkStateConditionGatewayReady,
+		conditionType,
 	)
 	if condition == nil {
 		return reasonUplinksNotReady

--- a/go-controller/pkg/clustermanager/uplink/controller_test.go
+++ b/go-controller/pkg/clustermanager/uplink/controller_test.go
@@ -747,6 +747,85 @@ func TestUplinkControllerReportsCUDNUplinkTerminating(t *testing.T) {
 	))
 }
 
+func TestUplinkControllerRequiresHostGatewayReadyInSplitDPUMode(t *testing.T) {
+	// A DPU-host-owned HostDataReady condition identifies a split-DPU
+	// UplinkState: host-side gateway programming is then reported separately
+	// through HostGatewayReady and is required for CUDN uplink readiness.
+	cases := []struct {
+		name            string
+		extraConditions []metav1.Condition
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+	}{
+		{
+			name: "not ready while HostGatewayReady is missing",
+			extraConditions: []metav1.Condition{{
+				Type:   uplinkv1alpha1.UplinkStateConditionHostDataReady,
+				Status: metav1.ConditionTrue,
+				Reason: uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+			}},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: reasonUplinksNotReady,
+		},
+		{
+			name: "not ready on host-side VRF attachment failure",
+			extraConditions: []metav1.Condition{
+				{
+					Type:   uplinkv1alpha1.UplinkStateConditionHostDataReady,
+					Status: metav1.ConditionTrue,
+					Reason: uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+				},
+				{
+					Type:   uplinkv1alpha1.UplinkStateConditionHostGatewayReady,
+					Status: metav1.ConditionFalse,
+					Reason: uplinkv1alpha1.UplinkStateReasonVRFAttachmentFailed,
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: reasonUplinkVRFAttachmentFailed,
+		},
+		{
+			name: "ready once both sides report gateway programming",
+			extraConditions: []metav1.Condition{
+				{
+					Type:   uplinkv1alpha1.UplinkStateConditionHostDataReady,
+					Status: metav1.ConditionTrue,
+					Reason: uplinkv1alpha1.UplinkStateReasonHostDataDiscovered,
+				},
+				{
+					Type:   uplinkv1alpha1.UplinkStateConditionHostGatewayReady,
+					Status: metav1.ConditionTrue,
+					Reason: uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
+				},
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: reasonUplinksReady,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			setSharedGatewayMode(t)
+			state := newResolvedUplinkState("br-blue", "node-a", "br-blue")
+			state.Status.Conditions = append(state.Status.Conditions, tc.extraConditions...)
+			controller, client := newTestController(t,
+				newNode("node-a", map[string]string{"role": "blue"}),
+				newUplink("br-blue", "role", "blue", "br-blue"),
+				state,
+				newCUDN("blue", "br-blue"),
+			)
+
+			g.Expect(controller.reconcileCUDN("blue")).To(gomega.Succeed())
+
+			cond := getCUDNCondition(g, client, "blue", conditionTypeUplinksReady)
+			g.Expect(cond).To(gomega.And(
+				gomega.HaveField("Status", tc.expectedStatus),
+				gomega.HaveField("Reason", tc.expectedReason),
+			))
+		})
+	}
+}
+
 func TestUplinkControllerPropagatesCUDNUplinkStateGatewayFailure(t *testing.T) {
 	g := gomega.NewWithT(t)
 	setSharedGatewayMode(t)

--- a/go-controller/pkg/crd/uplink/v1alpha1/types.go
+++ b/go-controller/pkg/crd/uplink/v1alpha1/types.go
@@ -16,13 +16,15 @@ const (
 )
 
 // Each UplinkState condition has a single writer per node: in split DPU mode
-// the DPU-host owns HostDataReady, the DPU owns Resolved, and the DPU-side
-// gateway coordinator owns GatewayReady. In full mode the discovery
-// reconciler owns Resolved and HostDataReady is not published.
+// the DPU-host owns HostDataReady and HostGatewayReady, the DPU owns Resolved,
+// and the DPU-side gateway coordinator owns GatewayReady. In full mode the
+// discovery reconciler owns Resolved and the host conditions are not
+// published.
 const (
-	UplinkStateConditionResolved      = "Resolved"
-	UplinkStateConditionGatewayReady  = "GatewayReady"
-	UplinkStateConditionHostDataReady = "HostDataReady"
+	UplinkStateConditionResolved         = "Resolved"
+	UplinkStateConditionGatewayReady     = "GatewayReady"
+	UplinkStateConditionHostDataReady    = "HostDataReady"
+	UplinkStateConditionHostGatewayReady = "HostGatewayReady"
 )
 
 const (

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -1348,7 +1348,28 @@ func (udng *UserDefinedNetworkGateway) reconcileUplinkGatewayVRFSlave(vrfDeviceN
 	}
 
 	if udng.shouldEnslaveUplinkGatewayToVRF() {
-		if config.IPv6Mode {
+		// Remove the managed default routes before enslaving the Uplink
+		// gateway interface: enslavement preserves the interface's
+		// pre-existing routes into the VRF table, and a still-managed
+		// default route with the same key would otherwise clobber the
+		// preserved default route, or absorb its addition only to be
+		// removed right after. Managed default routes only exist on the
+		// host side, so this does not apply to DPU mode.
+		if config.IsModeDPUHost() || config.IsModeFull() {
+			if err := udng.removeManagedDefaultRoutesFromVRF(); err != nil {
+				return newUplinkGatewayError(
+					uplinkv1alpha1.UplinkStateReasonVRFAttachmentFailed,
+					fmt.Errorf("could not remove managed default routes from VRF %s for network %s: %w",
+						vrfDeviceName, udng.GetNetworkName(), err),
+				)
+			}
+		}
+		// Whenever the kernel supports IPv6, regardless of the cluster IP
+		// families: enslavement captures and restores routes of both
+		// families, and without this sysctl the kernel flushes the
+		// interface's IPv6 addresses on the master change, making any
+		// captured IPv6 route fail its restore.
+		if util.IsIPv6SysctlSupported() {
 			if err := util.SetIPv6KeepAddrOnDownForInterface(udng.gwInterfaceName); err != nil {
 				return newUplinkGatewayError(
 					uplinkv1alpha1.UplinkStateReasonVRFAttachmentFailed,
@@ -1414,7 +1435,7 @@ func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRoute() error {
 	switch {
 	case udng.isNetworkAdvertised && !udng.isNetworkAdvertisedToDefaultVRF:
 		// Remove default route for networks advertised to non-default VRF
-		if err := udng.removeDefaultRouteFromVRF(); err != nil {
+		if err := udng.removeManagedDefaultRoutesFromVRF(); err != nil {
 			return fmt.Errorf("failed to remove default route from VRF %s for network %s: %v",
 				vrfName, udng.GetNetworkName(), err)
 		}
@@ -1438,13 +1459,48 @@ func (udng *UserDefinedNetworkGateway) updateUDNVRFIPRoute() error {
 	return nil
 }
 
-func (udng *UserDefinedNetworkGateway) removeDefaultRouteFromVRF() error {
+// removeManagedDefaultRoutesFromVRF removes the OVN-Kubernetes-managed
+// default routes from the network's VRF table. A managed default route only
+// belongs in the VRF while the network follows the default routing domain:
+//
+//   - The host's own default route (typically DHCP-provided, not ours) is the
+//     next hop OVN uses to leave via the gateway bridge.
+//   - Networks that follow the default routing domain get a managed *copy* of
+//     that route in their VRF table, so their traffic leaks into it.
+//   - Networks advertised to their own VRF with an Uplink instead have the
+//     Uplink interface's own default route *migrated* into the VRF table by
+//     the enslavement, unmanaged; the managed copy must be removed first so
+//     that it cannot clobber the migrated route.
+//
+// The routes to remove are matched in the kernel by the OVN-Kubernetes
+// protocol rather than recomputed from the current gateway interface, so that
+// a route installed for a previous gateway interface is removed as well.
+func (udng *UserDefinedNetworkGateway) removeManagedDefaultRoutesFromVRF() error {
 	vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
-	defaultRoute, err := udng.getDefaultRoute()
+	filter := &netlink.Route{Table: udng.vrfTableId}
+	routes, err := util.GetNetLinkOps().RouteListFiltered(netlink.FAMILY_ALL, filter, netlink.RT_FILTER_TABLE)
 	if err != nil {
-		return fmt.Errorf("unable to get default route for network %s, err: %v", udng.GetNetworkName(), err)
+		return fmt.Errorf("unable to list routes of VRF table %d for network %s, err: %v",
+			udng.vrfTableId, udng.GetNetworkName(), err)
 	}
-	if err = udng.vrfManager.DeleteVRFRoutes(vrfDeviceName, defaultRoute); err != nil {
+	var managedDefaultRoutes []netlink.Route
+	for _, route := range routes {
+		if int(route.Protocol) != types.OVNKProtocol || len(route.Gw) == 0 || route.Dst != nil && route.Dst.IP != nil && !route.Dst.IP.IsUnspecified() {
+			continue
+		}
+		// The kernel reports a default route with a nil destination; the
+		// tracked routes carry the explicit any CIDR of their family.
+		_, anyCIDR, _ := net.ParseCIDR("0.0.0.0/0")
+		if utilnet.IsIPv6(route.Gw) {
+			_, anyCIDR, _ = net.ParseCIDR("::/0")
+		}
+		route.Dst = anyCIDR
+		managedDefaultRoutes = append(managedDefaultRoutes, route)
+	}
+	if len(managedDefaultRoutes) == 0 {
+		return nil
+	}
+	if err = udng.vrfManager.DeleteVRFRoutes(vrfDeviceName, managedDefaultRoutes); err != nil {
 		return fmt.Errorf("unable to delete routes for network %s, err: %v", udng.GetNetworkName(), err)
 	}
 	return nil

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -100,7 +100,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get routing table in node: %w", err)
 	}
-	routes := filterRoutesByIfIndex(routeList, gwIfIdx)
+	routes := util.FilterRoutesByIfIndex(routeList, gwIfIdx)
 	// use the first valid default gateway
 	for _, r := range routes {
 		// no multipath
@@ -154,49 +154,4 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 		}
 	}
 	return "", net.IP{}, nil
-}
-
-// filterRoutesByIfIndex is a helper function that will sieve the provided routes and check
-// if they match the provided index. This used to be implemented with netlink.RT_FILTER_OIF,
-// however the problem is that this filtered out MultiPath IPv6 routes which have a LinkIndex of 0.
-// filterRoutesByIfIndex will return:
-//
-//	a) if ifidx <= 0: routesUnfiltered
-//	b) else: a filtered list of routes
-//
-// The filter works as follows:
-//
-//	i)  return routes with LinkIndex == ifIdx
-//	ii) return routes with LinkIndex == 0 and where *all* MultiPaths have LinkIndex == ifIdx
-//
-// That also means: If a MultiPath route points out different interfaces, then skip that route and
-// do not return it.
-func filterRoutesByIfIndex(routesUnfiltered []netlink.Route, ifIdx int) []netlink.Route {
-	if ifIdx <= 0 {
-		return routesUnfiltered
-	}
-	var routes []netlink.Route
-	for _, r := range routesUnfiltered {
-		if r.LinkIndex == ifIdx ||
-			multipathRouteMatchesIfIndex(r, ifIdx) {
-			routes = append(routes, r)
-		}
-	}
-	return routes
-}
-
-// multipathRouteMatchesIfIndex is a helper for filterRoutesByIfIndex.
-func multipathRouteMatchesIfIndex(r netlink.Route, ifIdx int) bool {
-	if r.LinkIndex != 0 {
-		return false
-	}
-	if len(r.MultiPath) == 0 {
-		return false
-	}
-	for _, mr := range r.MultiPath {
-		if mr.LinkIndex != ifIdx {
-			return false
-		}
-	}
-	return true
 }

--- a/go-controller/pkg/node/helper_linux_test.go
+++ b/go-controller/pkg/node/helper_linux_test.go
@@ -178,7 +178,7 @@ func TestFilterRoutesByIfIndex(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		routesFiltered := filterRoutesByIfIndex(tc.routesUnfiltered, tc.gwIfIdx)
+		routesFiltered := util.FilterRoutesByIfIndex(tc.routesUnfiltered, tc.gwIfIdx)
 		if !reflect.DeepEqual(tc.routesFiltered, routesFiltered) {
 			t.Fatalf("TestFilterRoutesByIfIndex(%d): Filtering '%v' by index '%d' should have yielded '%v' but got '%v'",
 				i, tc.routesUnfiltered, tc.gwIfIdx, tc.routesFiltered, routesFiltered)

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -96,10 +96,13 @@ func newDiscoveryError(reason string, err error) error {
 	return &discoveryError{reason: reason, err: err}
 }
 
-// GatewayStateManager owns the node-local gateway cache and the GatewayReady
+// GatewayStateManager owns the node-local gateway cache and the gateway
 // condition published from it.
 type GatewayStateManager interface {
 	RepublishGatewayCondition(uplinkName string) error
+	// ConditionType is the UplinkState condition this manager publishes:
+	// GatewayReady, or HostGatewayReady on the DPU-host.
+	ConditionType() string
 	InvalidateGatewayState(uplinkName string)
 	DeleteGatewayState(uplinkName string)
 }
@@ -317,13 +320,16 @@ func (c *Controller) reconcileUplinkState(key string) error {
 		return c.deleteUplinkState(state.Name)
 	}
 
-	// An UplinkState recreated after an out-of-band deletion lost the
-	// GatewayReady condition, and nothing republishes it until a network event
-	// runs gateway reconciliation: restore it only after confirming this
-	// Uplink still selects the node. Intentional deselection starts a new
-	// gateway lifecycle and must not restore cached readiness.
+	// An UplinkState recreated after an out-of-band deletion lost the gateway
+	// condition this node publishes, and nothing republishes it until a
+	// network event runs gateway reconciliation: restore it only after
+	// confirming this Uplink still selects the node. Intentional deselection
+	// starts a new gateway lifecycle and must not restore cached readiness.
+	// The gate checks the manager's own condition type: on a DPU-host that is
+	// HostGatewayReady, while GatewayReady on the same UplinkState belongs to
+	// the DPU and says nothing about the host-side condition.
 	if c.gatewayStateManager != nil &&
-		meta.FindStatusCondition(state.Status.Conditions, uplinkv1alpha1.UplinkStateConditionGatewayReady) == nil {
+		meta.FindStatusCondition(state.Status.Conditions, c.gatewayStateManager.ConditionType()) == nil {
 		if err := c.gatewayStateManager.RepublishGatewayCondition(uplinkName); err != nil {
 			return fmt.Errorf("failed to republish gateway condition for Uplink %s: %w", uplinkName, err)
 		}

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -1208,15 +1208,23 @@ func TestNodeUplinkControllerRecreatesDeletedState(t *testing.T) {
 }
 
 type fakeGatewayStateManager struct {
-	republished []string
-	invalidated []string
-	deleted     []string
-	err         error
+	republished   []string
+	invalidated   []string
+	deleted       []string
+	err           error
+	conditionType string
 }
 
 func (f *fakeGatewayStateManager) RepublishGatewayCondition(uplinkName string) error {
 	f.republished = append(f.republished, uplinkName)
 	return f.err
+}
+
+func (f *fakeGatewayStateManager) ConditionType() string {
+	if f.conditionType != "" {
+		return f.conditionType
+	}
+	return uplinkv1alpha1.UplinkStateConditionGatewayReady
 }
 
 func (f *fakeGatewayStateManager) InvalidateGatewayState(uplinkName string) {
@@ -1265,6 +1273,24 @@ func TestNodeUplinkControllerRepublishesGatewayCondition(t *testing.T) {
 
 		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
 		g.Expect(publisher.republished).To(gomega.BeEmpty())
+	})
+
+	// On a DPU-host the manager publishes HostGatewayReady: a GatewayReady
+	// republished by the DPU on the recreated UplinkState must not close the
+	// gate for the manager's own condition.
+	t.Run("gates on the manager's own condition type", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		state := newUplinkState("br-blue.node-a", "br-blue", "node-a")
+		state.Status.Conditions = []metav1.Condition{{
+			Type:   uplinkv1alpha1.UplinkStateConditionGatewayReady,
+			Status: metav1.ConditionTrue,
+			Reason: uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
+		}}
+		controller, publisher := newController(g, state)
+		publisher.conditionType = uplinkv1alpha1.UplinkStateConditionHostGatewayReady
+
+		g.Expect(controller.reconcileUplinkState("br-blue.node-a")).To(gomega.Succeed())
+		g.Expect(publisher.republished).To(gomega.ConsistOf("br-blue"))
 	})
 
 	// A failed republish must fail the reconcile so it is retried.

--- a/go-controller/pkg/node/uplink_gateway_controller.go
+++ b/go-controller/pkg/node/uplink_gateway_controller.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	uplinkGatewayFieldManager      = "ovnkube-node-uplink-gateway-controller"
+	uplinkHostGatewayFieldManager  = "ovnkube-node-uplink-host-gateway-controller"
 	maxGatewayConditionExamples    = 3
 	maxGatewayConditionErrorLength = 160
 )
@@ -62,9 +63,12 @@ type UplinkGatewayController struct {
 	uplinkStateLister uplinklisters.UplinkStateLister
 	// The DPU owns GatewayReady in split-DPU deployments because it is the
 	// component that waits for OVN patch ports and programs OVS/OpenFlow.
-	// DPU-host gateway reconciliation still runs, but must not race the DPU
+	// DPU-host gateway reconciliation covers the host side, the VRF
+	// attachment of the Uplink gateway interface, and publishes it through
+	// its own HostGatewayReady condition so that it does not race the DPU
 	// for ownership of the shared condition.
-	publishStatus       bool
+	conditionType       string
+	fieldManager        string
 	mutex               sync.Mutex
 	uplinks             map[string]*uplinkGatewayState
 	uplinkByNetworkName map[string]string
@@ -76,11 +80,18 @@ func NewUplinkGatewayController(
 	uplinkClient uplinkclientset.Interface,
 	uplinkStateLister uplinklisters.UplinkStateLister,
 ) *UplinkGatewayController {
+	conditionType := uplinkv1alpha1.UplinkStateConditionGatewayReady
+	fieldManager := uplinkGatewayFieldManager
+	if config.IsModeDPUHost() {
+		conditionType = uplinkv1alpha1.UplinkStateConditionHostGatewayReady
+		fieldManager = uplinkHostGatewayFieldManager
+	}
 	return &UplinkGatewayController{
 		nodeName:            nodeName,
 		uplinkClient:        uplinkClient,
 		uplinkStateLister:   uplinkStateLister,
-		publishStatus:       !config.IsModeDPUHost(),
+		conditionType:       conditionType,
+		fieldManager:        fieldManager,
 		uplinks:             map[string]*uplinkGatewayState{},
 		uplinkByNetworkName: map[string]string{},
 	}
@@ -335,9 +346,15 @@ func (c *UplinkGatewayController) completeNetworkDelete(
 	return c.publishGatewayCondition(network.Uplink())
 }
 
-// RepublishGatewayCondition restores this controller's GatewayReady condition
-// on an UplinkState recreated after an out-of-band deletion. It only restores
-// a condition that was already published once: on a first creation the
+// ConditionType is the UplinkState condition this controller publishes:
+// GatewayReady, or HostGatewayReady on the DPU-host.
+func (c *UplinkGatewayController) ConditionType() string {
+	return c.conditionType
+}
+
+// RepublishGatewayCondition restores this controller's gateway condition on
+// an UplinkState recreated after an out-of-band deletion. It only restores a
+// condition that was already published once: on a first creation the
 // condition is published by network reconciliation.
 func (c *UplinkGatewayController) RepublishGatewayCondition(uplinkName string) error {
 	c.mutex.Lock()
@@ -369,13 +386,10 @@ func (c *UplinkGatewayController) publishGatewayConditions(uplinkNames []string)
 	return utilerrors.Join(errs...)
 }
 
-// publishGatewayCondition writes the aggregate GatewayReady condition for all
+// publishGatewayCondition writes this controller's aggregate gateway
+// condition (GatewayReady, or HostGatewayReady on the DPU-host) for all
 // active CUDNs using the node-local UplinkState.
 func (c *UplinkGatewayController) publishGatewayCondition(uplinkName string) error {
-	if !c.publishStatus {
-		return nil
-	}
-
 	c.mutex.Lock()
 	uplinkState := c.uplinks[uplinkName]
 	c.mutex.Unlock()
@@ -426,7 +440,7 @@ func (c *UplinkGatewayController) publishGatewayCondition(uplinkName string) err
 			uplinkapply.UplinkStateStatus().WithConditions(util.ConditionToApply(condition)),
 		),
 		metav1.ApplyOptions{
-			FieldManager: uplinkGatewayFieldManager,
+			FieldManager: c.fieldManager,
 			Force:        true,
 		},
 	)
@@ -452,7 +466,7 @@ func (c *UplinkGatewayController) gatewayCondition(
 	}
 	if len(uplinkState.networks) == 0 {
 		return metav1.Condition{
-			Type:    uplinkv1alpha1.UplinkStateConditionGatewayReady,
+			Type:    c.conditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
 			Message: "No active CUDNs require Uplink gateway programming",
@@ -485,7 +499,7 @@ func (c *UplinkGatewayController) gatewayCondition(
 	}
 	if incomplete == 0 {
 		return metav1.Condition{
-			Type:    uplinkv1alpha1.UplinkStateConditionGatewayReady,
+			Type:    c.conditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  uplinkv1alpha1.UplinkStateReasonGatewayConfigured,
 			Message: fmt.Sprintf("Uplink gateway programming succeeded for %d active CUDN(s)", len(networkNames)),
@@ -493,7 +507,7 @@ func (c *UplinkGatewayController) gatewayCondition(
 	}
 
 	return metav1.Condition{
-		Type:   uplinkv1alpha1.UplinkStateConditionGatewayReady,
+		Type:   c.conditionType,
 		Status: metav1.ConditionFalse,
 		Reason: aggregateGatewayFailureReason(failureReasons),
 		Message: fmt.Sprintf(

--- a/go-controller/pkg/node/uplink_gateway_controller_test.go
+++ b/go-controller/pkg/node/uplink_gateway_controller_test.go
@@ -14,6 +14,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -437,7 +438,7 @@ func TestUplinkGatewayControllerSerializesSharedUplinkProgramming(t *testing.T) 
 	wg.Wait()
 }
 
-func TestUplinkGatewayControllerDPUHostDoesNotPublishGatewayReady(t *testing.T) {
+func TestUplinkGatewayControllerDPUHostPublishesHostGatewayReady(t *testing.T) {
 	prepareUplinkGatewayControllerTest(t)
 	config.OvnKubeNode.Mode = types.NodeModeDPUHost
 	const (
@@ -457,8 +458,24 @@ func TestUplinkGatewayControllerDPUHostDoesNotPublishGatewayReady(t *testing.T) 
 	if !reconciled {
 		t.Fatal("expected DPU-host gateway reconciliation to run")
 	}
-	if len(client.Actions()) != 0 {
-		t.Fatalf("expected DPU host not to publish GatewayReady, got actions %v", client.Actions())
+	// The DPU-host reports its side of the gateway programming through its
+	// own HostGatewayReady condition, leaving GatewayReady to the DPU.
+	actions := client.Actions()
+	if len(actions) == 0 {
+		t.Fatal("expected DPU host to publish HostGatewayReady")
+	}
+	for _, action := range actions {
+		patch, ok := action.(clienttesting.PatchAction)
+		if !ok {
+			t.Fatalf("expected only patch actions, got %v", action)
+		}
+		payload := string(patch.GetPatch())
+		if !strings.Contains(payload, uplinkv1alpha1.UplinkStateConditionHostGatewayReady) {
+			t.Fatalf("expected DPU host to publish HostGatewayReady, got %s", payload)
+		}
+		if strings.Contains(payload, `"`+uplinkv1alpha1.UplinkStateConditionGatewayReady+`"`) {
+			t.Fatalf("expected DPU host not to publish GatewayReady, got %s", payload)
+		}
 	}
 }
 

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -4,6 +4,8 @@
 package vrfmanager
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -11,12 +13,15 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
@@ -248,7 +253,7 @@ func (vrfm *Controller) sync(vrf vrf) error {
 			return fmt.Errorf("failed to check if %s is slave of VRF device %s, err: %v", managedSlave, vrfLink.Attrs().Name, err)
 		}
 		if !alreadyEnslaved {
-			if err = enslaveInterfaceToVRF(vrf.name, managedSlave); err != nil {
+			if err = enslaveInterfaceToVRF(vrf.name, managedSlave, vrf.table); err != nil {
 				return fmt.Errorf("failed to enslave interface %s into VRF device: %s, err: %v", managedSlave, vrf.name, err)
 			}
 		}
@@ -273,8 +278,20 @@ func newVRF(name string, table uint32, slaveInterface string, routes []netlink.R
 		name:          name,
 		table:         table,
 		managedSlaves: managedSlaves,
-		routes:        routes,
+		routes:        markOVNKRoutes(routes),
 	}
+}
+
+// markOVNKRoutes tags the routes with the OVN-Kubernetes protocol, marking
+// their ownership in the kernel: route migration across VRF enslavement
+// relies on the protocol to tell OVN-Kubernetes routes apart from
+// third-party ones, surviving restarts of this process.
+func markOVNKRoutes(routes []netlink.Route) []netlink.Route {
+	routes = slices.Clone(routes)
+	for i := range routes {
+		routes[i].Protocol = netlink.RouteProtocol(types.OVNKProtocol)
+	}
+	return routes
 }
 
 // AddVRF adds a VRF device into the node.
@@ -378,11 +395,13 @@ func (vrfm *Controller) DeleteVRFSlave(name string, slaveInterface string) error
 	if !ok {
 		return fmt.Errorf("failed to find VRF %s", name)
 	}
-	vrfDev.managedSlaves.Delete(slaveInterface)
-	if err = releaseInterfaceFromVRF(slaveInterface, vrfLink.Attrs().Index); err != nil {
+	if err = releaseInterfaceFromVRF(slaveInterface, vrfLink.Attrs().Index, vrfDev.table); err != nil {
 		return fmt.Errorf("failed to release interface %s from VRF %s, err: %v",
 			slaveInterface, name, err)
 	}
+	// Stop managing the slave only once released, so that a failed release
+	// leaves it managed and a later retry still releases it.
+	vrfDev.managedSlaves.Delete(slaveInterface)
 	return vrfm.sync(vrfDev)
 }
 
@@ -401,7 +420,7 @@ func (vrfm *Controller) AddVRFRoutes(name string, routes []netlink.Route) error 
 		return fmt.Errorf("failed to find VRF %s", name)
 	}
 
-	vrfDev.routes = append(vrfDev.routes, routes...)
+	vrfDev.routes = append(vrfDev.routes, markOVNKRoutes(routes)...)
 
 	return vrfm.sync(vrfDev)
 }
@@ -425,9 +444,16 @@ func (vrfm *Controller) DeleteVRFRoutes(name string, routes []netlink.Route) err
 		Dst       string
 		Table     int
 	}
-	deleteRoutesRequested := sets.New[route]()
+	deletedRoutes := sets.New[route]()
 	for _, r := range routes {
-		deleteRoutesRequested.Insert(route{
+		// Delete the explicitly requested kernel route even when it is not
+		// present in the tracked VRF routes, e.g. a route discovered in the
+		// kernel by its protocol after a restart. routeManager.Del also
+		// forgets a tracked route with the same key when one exists.
+		if err = vrfm.routeManager.Del(r); err != nil {
+			break
+		}
+		deletedRoutes.Insert(route{
 			LinkIndex: r.LinkIndex,
 			Dst:       r.Dst.String(),
 			Table:     r.Table,
@@ -435,20 +461,12 @@ func (vrfm *Controller) DeleteVRFRoutes(name string, routes []netlink.Route) err
 	}
 
 	vrf.routes = slices.DeleteFunc(vrf.routes, func(r netlink.Route) bool {
-		if err != nil {
-			return false
+		routeKey := route{
+			LinkIndex: r.LinkIndex,
+			Dst:       r.Dst.String(),
+			Table:     r.Table,
 		}
-		delete := deleteRoutesRequested.Has(
-			route{
-				LinkIndex: r.LinkIndex,
-				Dst:       r.Dst.String(),
-				Table:     r.Table,
-			})
-		if !delete {
-			return false
-		}
-		err = vrfm.routeManager.Del(r)
-		return err == nil
+		return deletedRoutes.Has(routeKey)
 	})
 	vrfm.vrfs[vrfLink.Attrs().Index] = vrf
 	return err
@@ -484,9 +502,10 @@ func (vrfm *Controller) repair(validVRFs sets.Set[string]) error {
 			// vrf not stale
 			continue
 		}
-		err = util.GetNetLinkOps().LinkDelete(link)
+		err = vrfm.deleteVRF(link)
 		if err != nil {
 			klog.Errorf("VRF Manager: error deleting stale VRF device %s, err: %v", name, err)
+			continue
 		}
 		delete(vrfm.vrfs, vrf.Index)
 	}
@@ -530,7 +549,38 @@ func (vrfm *Controller) DeleteVRF(name string) (err error) {
 }
 
 func (vrfm *Controller) deleteVRF(link netlink.Link) error {
-	return util.GetNetLinkOps().LinkDelete(link)
+	vrfLink, isVRF := link.(*netlink.Vrf)
+	if !isVRF {
+		return fmt.Errorf("node has another non VRF device with same name %s, refusing to delete it",
+			link.Attrs().Name)
+	}
+	// Release enslaved interfaces first so that their routes are preserved
+	// into the main table; deleting the VRF device would otherwise purge them
+	// along with the VRF routing table. Slaves and table are derived from
+	// kernel state rather than the cache, so that this also covers VRF
+	// devices the cache does not know about (e.g. a stale VRF repaired after
+	// a restart) or caches with a different, desired table id (recreation on
+	// table conflict).
+	links, err := util.GetNetLinkOps().LinkList()
+	if err != nil {
+		return fmt.Errorf("failed to list links to release slaves of VRF device %s, err: %w", vrfLink.Name, err)
+	}
+	var errs []error
+	for _, l := range links {
+		if l.Attrs().MasterIndex != vrfLink.Index {
+			continue
+		}
+		if err := releaseInterfaceFromVRF(l.Attrs().Name, vrfLink.Index, vrfLink.Table); err != nil {
+			errs = append(errs, fmt.Errorf("failed to release interface %s from VRF %s, err: %w",
+				l.Attrs().Name, vrfLink.Name, err))
+		}
+	}
+	if len(errs) > 0 {
+		// Do not delete the device while interfaces are still enslaved:
+		// deletion would purge their routes. Callers retry the deletion.
+		return utilerrors.Join(errs...)
+	}
+	return util.GetNetLinkOps().LinkDelete(vrfLink)
 }
 
 // isInterfaceSlaveOfVRF checks if a specific interface is enslaved to a VRF
@@ -545,7 +595,7 @@ func isInterfaceSlaveOfVRF(ifName string, vrfIndex int) (bool, error) {
 	return link.Attrs().MasterIndex == vrfIndex, nil
 }
 
-func enslaveInterfaceToVRF(vrfName, ifName string) error {
+func enslaveInterfaceToVRF(vrfName, ifName string, table uint32) error {
 	klog.V(5).Infof("Enslaving interface %s to VRF: %s", ifName, vrfName)
 	iface, err := util.GetNetLinkOps().LinkByName(ifName)
 	if err != nil {
@@ -555,14 +605,42 @@ func enslaveInterfaceToVRF(vrfName, ifName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to retrieve VRF device %s, err: %v", vrfName, err)
 	}
+	// Changing the interface master makes the kernel purge every FIB entry
+	// referencing the interface, regenerating only local and connected routes
+	// in the VRF table. Routes installed by other agents (e.g. a DHCP default
+	// route on an Uplink interface) would be silently destroyed, so capture
+	// them first and restore them into the VRF table after enslavement.
+	routes, err := listRoutesForLink(iface, unix.RT_TABLE_MAIN)
+	if err != nil {
+		return fmt.Errorf("failed to list routes of interface %s before enslaving to VRF %s: %v", ifName, vrfName, err)
+	}
 	err = util.GetNetLinkOps().LinkSetMaster(iface, vrfLink)
 	if err != nil {
 		return fmt.Errorf("failed to enslave interface %s to VRF %s: %v", ifName, vrfName, err)
 	}
+	if restoreErr := restoreRoutesToTable(routes, table); restoreErr != nil {
+		// Without its routes the interface is not functional in the VRF, and
+		// nothing could recover them later: the captured routes are the only
+		// remaining copy once the kernel purged the originals. Undo the
+		// enslavement and put the routes back in the main table, so that the
+		// returned error surfaces the failure and the next reconcile retries
+		// the whole enslavement from a clean state.
+		if err := util.GetNetLinkOps().LinkSetNoMaster(iface); err != nil {
+			return utilerrors.Join(
+				fmt.Errorf("failed to restore routes of interface %s into VRF %s: %w", ifName, vrfName, restoreErr),
+				fmt.Errorf("failed to undo the enslavement of interface %s: %w", ifName, err))
+		}
+		if err := restoreRoutesToTable(routes, unix.RT_TABLE_MAIN); err != nil {
+			klog.Errorf("VRF Manager: failed to restore routes of interface %s back to the main table "+
+				"after undoing its enslavement: %v", ifName, err)
+		}
+		return fmt.Errorf("failed to restore routes of interface %s into VRF %s, undid the enslavement: %w",
+			ifName, vrfName, restoreErr)
+	}
 	return nil
 }
 
-func releaseInterfaceFromVRF(ifName string, vrfIndex int) error {
+func releaseInterfaceFromVRF(ifName string, vrfIndex int, table uint32) error {
 	iface, err := util.GetNetLinkOps().LinkByName(ifName)
 	if err != nil {
 		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
@@ -574,5 +652,139 @@ func releaseInterfaceFromVRF(ifName string, vrfIndex int) error {
 		return nil
 	}
 	klog.V(5).Infof("Releasing interface %s from VRF", ifName)
-	return util.GetNetLinkOps().LinkSetNoMaster(iface)
+	// Releasing the interface from the VRF purges its routes from the VRF
+	// table just like enslaving purged them from the main table. Capture them
+	// and restore them into the main table; the routes that ovn-kubernetes
+	// itself programmed are skipped by their protocol.
+	routes, err := listRoutesForLink(iface, int(table))
+	if err != nil {
+		return fmt.Errorf("failed to list routes of interface %s before releasing from VRF: %v", ifName, err)
+	}
+	if err = util.GetNetLinkOps().LinkSetNoMaster(iface); err != nil {
+		return err
+	}
+	// Log-only: the release already happened, and a returned error could not
+	// be retried meaningfully since the captured routes would be gone.
+	if err = restoreRoutesToTable(routes, unix.RT_TABLE_MAIN); err != nil {
+		klog.Warningf("VRF Manager: failed to restore routes of interface %s released from VRF: %v", ifName, err)
+	}
+	return nil
+}
+
+// listRoutesForLink returns the routes of both IP families that reference the
+// given link in the given routing table.
+func listRoutesForLink(link netlink.Link, table int) ([]netlink.Route, error) {
+	// Filter by interface in code rather than with RT_FILTER_OIF: the kernel
+	// filter only compares the top-level link index, which is 0 for
+	// multipath routes (e.g. static ECMP gateway routes through the
+	// interface), whose interfaces are carried in the nexthops instead.
+	// Multipath routes spanning other interfaces as well are left out: they
+	// cannot follow the interface across routing tables.
+	filter := &netlink.Route{Table: table}
+	routes, err := util.GetNetLinkOps().RouteListFiltered(netlink.FAMILY_ALL, filter, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return nil, err
+	}
+	return util.FilterRoutesByIfIndex(routes, link.Attrs().Index), nil
+}
+
+// shouldSkipRouteMigration returns true for routes whose owner programs them
+// per routing table on its own: OVN-Kubernetes (and OVN) program their routes
+// in the tables they belong to, the kernel regenerates its routes after a
+// master change, and routing daemons (FRR/zebra and friends) install and
+// withdraw their routes in the routing domain they peer in, so a migrated
+// copy would be a stale duplicate that no one manages.
+func shouldSkipRouteMigration(route netlink.Route) bool {
+	switch int(route.Protocol) {
+	case types.OVNKProtocol, unix.RTPROT_OVN,
+		unix.RTPROT_KERNEL, unix.RTPROT_ZEBRA, unix.RTPROT_BGP, unix.RTPROT_OSPF,
+		unix.RTPROT_ISIS, unix.RTPROT_RIP, unix.RTPROT_EIGRP, unix.RTPROT_BABEL:
+		return true
+	}
+	return false
+}
+
+// restoreRoutesToTable re-adds routes into the given routing table, preserving
+// all their attributes. Routes that their owner reprograms per routing table
+// are skipped. Failures are joined and returned so that the caller can decide
+// whether they are fatal for the master change they follow.
+func restoreRoutesToTable(routes []netlink.Route, table uint32) error {
+	// Restore routes without a gateway first: a gateway route is only
+	// accepted once the route covering its gateway is in place. The covering
+	// route is usually a connected route that the kernel regenerates on its
+	// own, but e.g. a DHCP client serving an off-subnet gateway installs a
+	// host route toward it, and that one is migrated like any other.
+	routes = slices.Clone(routes)
+	slices.SortStableFunc(routes, func(a, b netlink.Route) int {
+		gatewayRoutes := func(r netlink.Route) int {
+			if len(r.Gw) > 0 {
+				return 1
+			}
+			for _, nh := range r.MultiPath {
+				if len(nh.Gw) > 0 {
+					return 1
+				}
+			}
+			return 0
+		}
+		return gatewayRoutes(a) - gatewayRoutes(b)
+	})
+	var errs []error
+	for _, route := range routes {
+		if shouldSkipRouteMigration(route) {
+			continue
+		}
+		route.Table = int(table)
+		// Keep only the configuration flags relevant to route installation:
+		// the kernel rejects requests that carry its own state flags, e.g.
+		// RTNH_F_LINKDOWN captured from a carrier-down interface. Multipath
+		// nexthops carry their own flags; copy them before masking, the
+		// captured originals are shared with the caller.
+		route.Flags &= unix.RTNH_F_ONLINK
+		if len(route.MultiPath) > 0 {
+			nexthops := make([]*netlink.NexthopInfo, 0, len(route.MultiPath))
+			for _, nexthop := range route.MultiPath {
+				nexthopCopy := *nexthop
+				nexthopCopy.Flags &= unix.RTNH_F_ONLINK
+				nexthops = append(nexthops, &nexthopCopy)
+			}
+			route.MultiPath = nexthops
+		}
+		if err := addRouteWithRetry(&route); err != nil {
+			if util.GetNetLinkOps().IsAlreadyExistsError(err) {
+				// A route with the same kernel key is already in the table
+				// and wins: nothing was added.
+				klog.V(5).Infof("VRF Manager: route %v already present in table %d, not restored", route, table)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to restore route %v into table %d: %w", route, table, err))
+			continue
+		}
+		klog.V(5).Infof("VRF Manager: restored route %v into table %d", route, table)
+	}
+	return utilerrors.Join(errs...)
+}
+
+const (
+	// routeRestoreTimeout bounds how long a route restore is retried while
+	// the kernel deems the route's gateway unreachable. It has to cover
+	// duplicate address detection (about a second with the default
+	// dad_transmits) plus the addrconf work queue latency, with headroom for
+	// loaded nodes.
+	routeRestoreTimeout      = 4 * time.Second
+	routeRestorePollInterval = 100 * time.Millisecond
+)
+
+// addRouteWithRetry adds the route, retrying briefly while the kernel deems
+// its gateway unreachable: IPv6 connected routes are regenerated
+// asynchronously after a master change, so a gateway route restored right
+// after it can transiently fail the kernel's reachability validation.
+func addRouteWithRetry(route *netlink.Route) error {
+	var err error
+	_ = wait.PollUntilContextTimeout(context.Background(), routeRestorePollInterval, routeRestoreTimeout, true,
+		func(context.Context) (bool, error) {
+			err = util.GetNetLinkOps().RouteAdd(route)
+			return err == nil || !(errors.Is(err, unix.EHOSTUNREACH) || errors.Is(err, unix.ENETUNREACH)), nil
+		})
+	return err
 }

--- a/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
@@ -6,6 +6,8 @@ package vrfmanager
 import (
 	"errors"
 	"fmt"
+	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -22,6 +25,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 )
@@ -127,14 +131,153 @@ var _ = ginkgo.Describe("VRF manager", func() {
 		ginkgo.It("add VRF with a slave interface", func() {
 			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
 			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: 0, Index: getLinkIndex(enslaveLinkName1)}, nil)
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 			nlMock.On("LinkSetMaster", enslaveLinkMock1, buildVRF(vrfLinkName1)).Return(nil)
 			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("migrates the slave interface routes into the VRF table on enslavement", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: 0, Index: slaveLinkIndex}, nil)
+			// The slave interface holds a DHCP default route through an
+			// off-subnet gateway (with the kernel's carrier state flag set),
+			// the DHCP host route covering that gateway, a kernel generated
+			// connected route and a BGP route before the enslavement.
+			dhcpDefaultRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("192.168.2.1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Flags:     unix.RTNH_F_ONLINK | unix.RTNH_F_LINKDOWN,
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			dhcpGatewayHostRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("192.168.2.1/32"),
+				Scope:     netlink.SCOPE_LINK,
+				Protocol:  unix.RTPROT_DHCP,
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			kernelConnectedRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("192.168.1.0/24"),
+				Protocol:  unix.RTPROT_KERNEL,
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			bgpRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("10.10.0.0/16"),
+				Gw:        net.ParseIP("192.168.1.253"),
+				Protocol:  unix.RTPROT_BGP,
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			// A static ECMP route through the slave interface: the kernel
+			// reports it with a zero top-level link index, its interfaces are
+			// in the nexthops.
+			ecmpRoute := netlink.Route{
+				Dst:      ovntest.MustParseIPNet("172.16.0.0/16"),
+				Protocol: unix.RTPROT_STATIC,
+				Table:    unix.RT_TABLE_MAIN,
+				MultiPath: []*netlink.NexthopInfo{
+					{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.1"), Flags: unix.RTNH_F_LINKDOWN},
+					{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.2")},
+				},
+			}
+			// An ECMP route spanning the slave and another interface cannot
+			// follow the slave across routing tables and is not migrated.
+			mixedInterfacesEcmpRoute := netlink.Route{
+				Dst:      ovntest.MustParseIPNet("172.17.0.0/16"),
+				Protocol: unix.RTPROT_STATIC,
+				Table:    unix.RT_TABLE_MAIN,
+				MultiPath: []*netlink.NexthopInfo{
+					{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.1")},
+					{LinkIndex: getLinkIndex(enslaveLinkName2), Gw: net.ParseIP("192.168.3.1")},
+				},
+			}
+			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
+				mock.MatchedBy(func(filter *netlink.Route) bool {
+					return filter.Table == unix.RT_TABLE_MAIN
+				}),
+				uint64(netlink.RT_FILTER_TABLE),
+			).Return([]netlink.Route{dhcpDefaultRoute, kernelConnectedRoute, bgpRoute, dhcpGatewayHostRoute, ecmpRoute, mixedInterfacesEcmpRoute}, nil)
+			nlMock.On("LinkSetMaster", enslaveLinkMock1, buildVRF(vrfLinkName1)).Return(nil)
+			nlMock.On("RouteAdd", mock.Anything).Return(nil)
+
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// The DHCP routes and the ECMP route are restored into the VRF
+			// table with kernel state flags stripped; the kernel generated
+			// route is left for the kernel to regenerate, the BGP route for
+			// its daemon, and the mixed-interfaces ECMP route stays behind.
+			expectedHostRoute := dhcpGatewayHostRoute
+			expectedHostRoute.Table = int(getVRFTable(vrfLinkName1))
+			expectedDefaultRoute := dhcpDefaultRoute
+			expectedDefaultRoute.Table = int(getVRFTable(vrfLinkName1))
+			expectedDefaultRoute.Flags = unix.RTNH_F_ONLINK
+			expectedEcmpRoute := ecmpRoute
+			expectedEcmpRoute.Table = int(getVRFTable(vrfLinkName1))
+			expectedEcmpRoute.MultiPath = []*netlink.NexthopInfo{
+				{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.1")},
+				{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.2")},
+			}
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedHostRoute)
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedDefaultRoute)
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedEcmpRoute)
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 3)
+
+			// The gateway host route must be restored before the gateway
+			// routes that depend on it.
+			var restored []*netlink.Route
+			for _, call := range nlMock.Calls {
+				if call.Method == "RouteAdd" {
+					restored = append(restored, call.Arguments.Get(0).(*netlink.Route))
+				}
+			}
+			gomega.Expect(restored).To(gomega.Equal([]*netlink.Route{&expectedHostRoute, &expectedDefaultRoute, &expectedEcmpRoute}),
+				"expected the gateway host route to be restored before the gateway routes that depend on it")
+		})
+
+		ginkgo.It("undoes the enslavement when the route restore into the VRF fails", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: 0, Index: slaveLinkIndex}, nil)
+			dhcpDefaultRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("192.168.1.1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
+				mock.MatchedBy(func(filter *netlink.Route) bool {
+					return filter.Table == unix.RT_TABLE_MAIN
+				}),
+				uint64(netlink.RT_FILTER_TABLE),
+			).Return([]netlink.Route{dhcpDefaultRoute}, nil)
+			nlMock.On("LinkSetMaster", enslaveLinkMock1, buildVRF(vrfLinkName1)).Return(nil)
+			restoreErr := fmt.Errorf("route restore failed")
+			nlMock.On("IsAlreadyExistsError", restoreErr).Return(false)
+			// The restore into the VRF table fails, the one back into the
+			// main table succeeds.
+			nlMock.On("RouteAdd", mock.Anything).Return(restoreErr).Once()
+			nlMock.On("RouteAdd", mock.Anything).Return(nil)
+			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
+
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
+			gomega.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("undid the enslavement")))
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
+
+			// The captured route went back to the main table.
+			expectedRoute := dhcpDefaultRoute
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRoute)
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 2)
+		})
+
 		ginkgo.It("adds another slave interface to an existing VRF", func() {
 			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: getLinkIndex(enslaveLinkName1)}, nil)
 			enslaveLinkMock2.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName2, MasterIndex: 0, Index: getLinkIndex(enslaveLinkName2)}, nil)
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 			nlMock.On("LinkSetMaster", enslaveLinkMock2, buildVRF(vrfLinkName1)).Return(nil)
 
 			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
@@ -180,6 +323,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 
 		ginkgo.It("removes a slave interface from an existing VRF", func() {
 			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: getLinkIndex(enslaveLinkName1)}, nil)
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
 
 			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
@@ -188,6 +332,194 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			err = c.DeleteVRFSlave(vrfLinkName1, enslaveLinkName1)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
+		})
+
+		ginkgo.It("migrates the slave interface routes back to the main table on release, except OVN managed ones", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			vrfTable := int(getVRFTable(vrfLinkName1))
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: slaveLinkIndex}, nil)
+			// The VRF table holds routes previously migrated on enslavement,
+			// OVN managed routes carrying the OVN-Kubernetes protocol and a
+			// BGP route learned in the VRF, all on the slave interface. Note
+			// that the kernel dumps default routes with a nil destination.
+			migratedDefaultRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("192.168.1.1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Table:     vrfTable,
+			}
+			migratedDefaultRouteV6 := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("2001:db8:1::1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Priority:  1024,
+				Table:     vrfTable,
+			}
+			ovnManagedRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("10.96.0.0/16"),
+				Gw:        net.ParseIP("169.254.169.4"),
+				Protocol:  netlink.RouteProtocol(types.OVNKProtocol),
+				Table:     vrfTable,
+			}
+			ovnManagedRouteV6 := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("fd00:10:96::/112"),
+				Gw:        net.ParseIP("fd69::4"),
+				Protocol:  netlink.RouteProtocol(types.OVNKProtocol),
+				Priority:  1024,
+				Table:     vrfTable,
+			}
+			bgpLearnedRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("10.10.0.0/16"),
+				Gw:        net.ParseIP("192.168.1.253"),
+				Protocol:  unix.RTPROT_BGP,
+				Table:     vrfTable,
+			}
+			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
+				mock.MatchedBy(func(filter *netlink.Route) bool {
+					return filter.Table == vrfTable
+				}),
+				uint64(netlink.RT_FILTER_TABLE),
+			).Return([]netlink.Route{migratedDefaultRoute, migratedDefaultRouteV6, ovnManagedRoute, ovnManagedRouteV6, bgpLearnedRoute}, nil)
+			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
+			nlMock.On("RouteAdd", mock.Anything).Return(nil)
+
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			err = c.DeleteVRFSlave(vrfLinkName1, enslaveLinkName1)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
+
+			// The migrated routes return to the main table; the OVN managed
+			// routes stay with the route manager and the BGP route with its
+			// daemon, recognized by their protocol.
+			expectedRoute := migratedDefaultRoute
+			expectedRoute.Table = unix.RT_TABLE_MAIN
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRoute)
+			expectedRouteV6 := migratedDefaultRouteV6
+			expectedRouteV6.Table = unix.RT_TABLE_MAIN
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRouteV6)
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 2)
+		})
+
+		ginkgo.It("releases enslaved interfaces before deleting a VRF, restoring their routes", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			vrfTable := int(getVRFTable(vrfLinkName1))
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: slaveLinkIndex}, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
+			migratedDefaultRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("192.168.1.1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Table:     vrfTable,
+			}
+			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
+				mock.MatchedBy(func(filter *netlink.Route) bool {
+					return filter.Table == vrfTable
+				}),
+				uint64(netlink.RT_FILTER_TABLE),
+			).Return([]netlink.Route{migratedDefaultRoute}, nil)
+			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
+			nlMock.On("RouteAdd", mock.Anything).Return(nil)
+			nlMock.On("LinkDelete", buildVRF(vrfLinkName1)).Return(nil)
+
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// exercise deleteVRF directly: the mocked IsLinkNotFoundError
+			// catch-all makes DeleteVRF return before reaching it
+			err = c.deleteVRF(buildVRF(vrfLinkName1))
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
+			expectedRoute := migratedDefaultRoute
+			expectedRoute.Table = unix.RT_TABLE_MAIN
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRoute)
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkDelete", buildVRF(vrfLinkName1))
+		})
+
+		ginkgo.It("tags the routes it manages with the OVN-Kubernetes protocol", func() {
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: getLinkIndex(enslaveLinkName1)}, nil)
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			nlMock.On("RouteReplace", mock.Anything).Return(nil)
+			managedRoute := netlink.Route{
+				LinkIndex: getLinkIndex(enslaveLinkName1),
+				Dst:       ovntest.MustParseIPNet("10.96.0.0/16"),
+				Gw:        net.ParseIP("169.254.169.4"),
+				Table:     int(getVRFTable(vrfLinkName1)),
+			}
+
+			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), []netlink.Route{managedRoute})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// The route entered the kernel and the cache carrying the
+			// OVN-Kubernetes protocol, which is what route migration relies
+			// on to tell it apart from third-party routes.
+			taggedRoute := managedRoute
+			taggedRoute.Protocol = netlink.RouteProtocol(types.OVNKProtocol)
+			cached := c.vrfs[getLinkIndex(vrfLinkName1)]
+			gomega.Expect(cached.routes).To(gomega.ConsistOf(taggedRoute))
+			taggedRoute.Priority = 0
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteReplace", &taggedRoute)
+		})
+
+		ginkgo.It("does not delete a VRF whose slave release failed", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: slaveLinkIndex}, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(fmt.Errorf("operation not permitted"))
+
+			// Deleting the VRF device would purge the routes of a still
+			// enslaved interface: a failed release must block the deletion
+			// so that a later retry completes the release first.
+			err := c.deleteVRF(buildVRF(vrfLinkName1))
+			gomega.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("operation not permitted")))
+			nlMock.AssertNotCalled(ginkgo.GinkgoT(), "LinkDelete", mock.Anything)
+		})
+
+		ginkgo.It("restores only third-party routes when deleting a VRF unknown to the cache", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			vrfTable := int(getVRFTable(vrfLinkName1))
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: slaveLinkIndex}, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
+			migratedDefaultRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("192.168.1.1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Table:     vrfTable,
+			}
+			ovnManagedRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("10.96.0.0/16"),
+				Gw:        net.ParseIP("169.254.169.4"),
+				Protocol:  netlink.RouteProtocol(types.OVNKProtocol),
+				Table:     vrfTable,
+			}
+			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
+				mock.MatchedBy(func(filter *netlink.Route) bool {
+					return filter.Table == vrfTable
+				}),
+				uint64(netlink.RT_FILTER_TABLE),
+			).Return([]netlink.Route{migratedDefaultRoute, ovnManagedRoute}, nil)
+			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
+			nlMock.On("RouteAdd", mock.Anything).Return(nil)
+			nlMock.On("LinkDelete", buildVRF(vrfLinkName1)).Return(nil)
+
+			// The VRF was never added to the cache (e.g. a stale device found
+			// by repair after a restart): the OVN-Kubernetes routes are still
+			// recognized by their protocol and are not restored into the main
+			// table, while third-party routes are.
+			err := c.deleteVRF(buildVRF(vrfLinkName1))
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
+			expectedRoute := migratedDefaultRoute
+			expectedRoute.Table = unix.RT_TABLE_MAIN
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRoute)
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 1)
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkDelete", buildVRF(vrfLinkName1))
 		})
 
 		ginkgo.It("fails if we add a VRF with a long name", func() {
@@ -229,6 +561,33 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			err = c.DeleteVRF(vrfLinkName2)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("deletes requested VRF routes that are not tracked in the cache", func() {
+			vrfTable := int(getVRFTable(vrfLinkName1))
+			err := c.AddVRF(vrfLinkName1, "", getVRFTable(vrfLinkName1), nil)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// Default routes discovered in the kernel, e.g. by their
+			// protocol, without a matching entry in the tracked VRF routes,
+			// typically after a restart.
+			untrackedV4Default := netlink.Route{
+				LinkIndex: getLinkIndex(enslaveLinkName1),
+				Dst:       ovntest.MustParseIPNet("0.0.0.0/0"),
+				Gw:        net.ParseIP("192.168.1.1"),
+				Table:     vrfTable,
+			}
+			untrackedV6Default := netlink.Route{
+				LinkIndex: getLinkIndex(enslaveLinkName1),
+				Dst:       ovntest.MustParseIPNet("::/0"),
+				Gw:        net.ParseIP("fd00::1"),
+				Table:     vrfTable,
+			}
+			nlMock.On("RouteDel", mock.Anything).Return(nil)
+
+			err = c.DeleteVRFRoutes(vrfLinkName1, []netlink.Route{untrackedV4Default, untrackedV6Default})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteDel", 2)
 		})
 
 		ginkgo.It("reconcile VRFs", func() {
@@ -321,6 +680,104 @@ var _ = ginkgo.Describe("VRF manager tests with a network namespace", func() {
 		})
 		return err
 	}
+
+	ovntest.OnSupportedPlatformsIt("preserves slave interface routes across VRF enslavement and release", func() {
+		slaveLinkName := "dev100"
+		gatewayIP := net.ParseIP("192.168.1.1")
+		gatewayIPv6 := net.ParseIP("2001:db8:1::1")
+		vrfTable := 1010
+		listDefaultRoutes := func(family, table int) []netlink.Route {
+			routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			var defaultRoutes []netlink.Route
+			for _, route := range routes {
+				if route.Gw != nil && (route.Dst == nil || route.Dst.IP.IsUnspecified()) {
+					defaultRoutes = append(defaultRoutes, route)
+				}
+			}
+			return defaultRoutes
+		}
+		expectDefaultRoutesIn := func(table int, gateways ...net.IP) {
+			for _, gateway := range gateways {
+				family := netlink.FAMILY_V4
+				if gateway.To4() == nil {
+					family = netlink.FAMILY_V6
+				}
+				defaultRoutes := listDefaultRoutes(family, table)
+				gomega.Expect(defaultRoutes).To(gomega.HaveLen(1),
+					"expected exactly one default route via %s in table %d, got %v", gateway, table, defaultRoutes)
+				gomega.Expect(defaultRoutes[0].Gw.String()).To(gomega.Equal(gateway.String()),
+					"expected the default route in table %d to go via %s", table, gateway)
+			}
+		}
+		err := testNS.Do(func(ns.NetNS) error {
+			defer ginkgo.GinkgoRecover()
+			// Set up an interface configured with addresses and default
+			// routes of both families, mimicking an interface handed over to
+			// us that was configured by another agent, e.g. through DHCP.
+			gomega.Expect(netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: slaveLinkName}})).To(gomega.Succeed())
+			slaveLink, err := netlink.LinkByName(slaveLinkName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(netlink.LinkSetUp(slaveLink)).To(gomega.Succeed())
+			// The kernel removes IPv6 addresses on enslavement: mirror the UDN
+			// gateway, which preserves them through keep_addr_on_down before
+			// enslaving the Uplink gateway interface.
+			gomega.Expect(os.WriteFile("/proc/sys/net/ipv6/conf/"+slaveLinkName+"/keep_addr_on_down", []byte("1"), 0644)).To(gomega.Succeed())
+			for _, address := range []string{"192.168.1.10/24", "2001:db8:1::10/64"} {
+				addr, err := netlink.ParseAddr(address)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(netlink.AddrAdd(slaveLink, addr)).To(gomega.Succeed())
+			}
+			for _, gateway := range []net.IP{gatewayIP, gatewayIPv6} {
+				gomega.Expect(netlink.RouteAdd(&netlink.Route{
+					LinkIndex: slaveLink.Attrs().Index,
+					Gw:        gateway,
+				})).To(gomega.Succeed())
+			}
+			// A static ECMP route through two gateways on the interface: the
+			// kernel reports it with a zero top-level link index, so it must
+			// be matched through its nexthops.
+			ecmpDst := ovntest.MustParseIPNet("172.16.0.0/16")
+			ecmpNexthops := []*netlink.NexthopInfo{
+				{LinkIndex: slaveLink.Attrs().Index, Gw: net.ParseIP("192.168.1.1")},
+				{LinkIndex: slaveLink.Attrs().Index, Gw: net.ParseIP("192.168.1.2")},
+			}
+			gomega.Expect(netlink.RouteAdd(&netlink.Route{
+				Dst:       ecmpDst,
+				MultiPath: ecmpNexthops,
+			})).To(gomega.Succeed())
+			listEcmpRoutes := func(table int) []netlink.Route {
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4,
+					&netlink.Route{Table: table, Dst: ecmpDst}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				return routes
+			}
+			expectEcmpRouteIn := func(table int) {
+				routes := listEcmpRoutes(table)
+				gomega.Expect(routes).To(gomega.HaveLen(1),
+					"expected the ECMP route in table %d, got %v", table, routes)
+				gomega.Expect(routes[0].MultiPath).To(gomega.HaveLen(2),
+					"expected the ECMP route in table %d to keep both nexthops, got %v", table, routes[0])
+			}
+
+			// On enslavement, the default routes and the ECMP route are
+			// migrated into the VRF table.
+			gomega.Expect(c.AddVRF(vrfLinkName1, slaveLinkName, uint32(vrfTable), nil)).To(gomega.Succeed())
+			expectEcmpRouteIn(vrfTable)
+			gomega.Expect(listDefaultRoutes(netlink.FAMILY_ALL, unix.RT_TABLE_MAIN)).To(gomega.BeEmpty())
+			expectDefaultRoutesIn(vrfTable, gatewayIP, gatewayIPv6)
+
+			// On release, the default routes and the ECMP route are migrated
+			// back to the main table.
+			gomega.Expect(c.DeleteVRFSlave(vrfLinkName1, slaveLinkName)).To(gomega.Succeed())
+			gomega.Expect(listDefaultRoutes(netlink.FAMILY_ALL, vrfTable)).To(gomega.BeEmpty())
+			expectDefaultRoutesIn(unix.RT_TABLE_MAIN, gatewayIP, gatewayIPv6)
+			gomega.Expect(listEcmpRoutes(vrfTable)).To(gomega.BeEmpty())
+			expectEcmpRouteIn(unix.RT_TABLE_MAIN)
+			return nil
+		})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
 
 	ovntest.OnSupportedPlatformsIt("ensure VRF manager is reconciling configured VRF devices correctly", func() {
 		err := testNS.Do(func(ns.NetNS) error {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -155,12 +155,15 @@ const (
 	// LabelUserDefinedServiceName label key used in mirrored EndpointSlices that contains the service name matching the EndpointSlice
 	LabelUserDefinedServiceName = "k8s.ovn.org/service-name"
 
+	// OVNKProtocol is the protocol value used to mark kernel networking
+	// objects as OVN-Kubernetes-managed. Value 85 is used instead of
+	// RTPROT_OVN (84) so we do not reuse a protocol identifier already
+	// owned by OVN.
+	OVNKProtocol = 85
 	// IFAProtOVNK is the IFA_PROTO value used to mark addresses as
-	// OVN-Kubernetes-managed. Value 85 is used instead of RTPROT_OVN (84)
-	// so we do not reuse a protocol identifier already owned by OVN.
-	// IFA_PROTO requires Linux kernel 5.18+; on older kernels the
-	// attribute is silently ignored.
-	IFAProtOVNK = 85
+	// OVN-Kubernetes-managed. IFA_PROTO requires Linux kernel 5.18+; on
+	// older kernels the attribute is silently ignored.
+	IFAProtOVNK = OVNKProtocol
 
 	// Packet marking
 	EgressIPNodeConnectionMark         = "1008"

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -1091,6 +1092,13 @@ func SetRPFilterLooseModeForInterface(ifName string) error {
 
 // SetIPv6KeepAddrOnDownForInterface preserves global IPv6 addresses when an
 // interface changes state while it is attached to or detached from a VRF.
+// IsIPv6SysctlSupported reports whether the kernel exposes IPv6 sysctls: a
+// kernel with IPv6 disabled (ipv6.disable=1) has no /proc/sys/net/ipv6 tree.
+func IsIPv6SysctlSupported() bool {
+	_, err := os.Stat("/proc/sys/net/ipv6")
+	return err == nil
+}
+
 func SetIPv6KeepAddrOnDownForInterface(ifName string) error {
 	setVal := fmt.Sprintf("net.ipv6.conf.%s.keep_addr_on_down = 1", sysctlIfName(ifName))
 	stdout, stderr, err := RunSysctl("-w", setVal)
@@ -1099,4 +1107,50 @@ func SetIPv6KeepAddrOnDownForInterface(ifName string) error {
 			ifName, stdout, stderr, err)
 	}
 	return nil
+}
+
+// FilterRoutesByIfIndex sieves the provided routes to those that reference
+// the provided interface index. Filtering with netlink.RT_FILTER_OIF instead
+// would miss multipath routes, whose interfaces are carried in the nexthops
+// of Route.MultiPath while the top-level LinkIndex is 0.
+// FilterRoutesByIfIndex will return:
+//
+//	a) if ifIdx <= 0: routesUnfiltered
+//	b) else: a filtered list of routes
+//
+// The filter works as follows:
+//
+//	i)  return routes with LinkIndex == ifIdx
+//	ii) return routes with LinkIndex == 0 and where *all* MultiPaths have LinkIndex == ifIdx
+//
+// That also means: if a MultiPath route points out different interfaces,
+// then skip that route and do not return it.
+func FilterRoutesByIfIndex(routesUnfiltered []netlink.Route, ifIdx int) []netlink.Route {
+	if ifIdx <= 0 {
+		return routesUnfiltered
+	}
+	var routes []netlink.Route
+	for _, r := range routesUnfiltered {
+		if r.LinkIndex == ifIdx ||
+			multipathRouteMatchesIfIndex(r, ifIdx) {
+			routes = append(routes, r)
+		}
+	}
+	return routes
+}
+
+// multipathRouteMatchesIfIndex is a helper for FilterRoutesByIfIndex.
+func multipathRouteMatchesIfIndex(r netlink.Route, ifIdx int) bool {
+	if r.LinkIndex != 0 {
+		return false
+	}
+	if len(r.MultiPath) == 0 {
+		return false
+	}
+	for _, mr := range r.MultiPath {
+		if mr.LinkIndex != ifIdx {
+			return false
+		}
+	}
+	return true
 }

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -4558,7 +4558,7 @@ func checkRouteInFRR(node corev1.Node, podCIDR, routerContainerName string, isIP
 	}, 30*time.Second).Should(gomega.BeTrue(), "route for %s via %s not found on %s", podCIDR, nodeIP[0], routerContainerName)
 }
 
-func hasRouteInCUDNVRF(node corev1.Node, cudnName, cidr, nextHop string) (bool, error) {
+func hasRouteInCUDNVRF(node corev1.Node, cudnName, cidr string, nextHops ...string) (bool, error) {
 	if len(cudnName) > 15 {
 		return false, fmt.Errorf("CUDN name %q is too long to be used as the Linux VRF device name", cudnName)
 	}
@@ -4577,7 +4577,7 @@ func hasRouteInCUDNVRF(node corev1.Node, cudnName, cidr, nextHop string) (bool, 
 		return false, fmt.Errorf("failed to parse routes from CUDN VRF %s on node %s: %w; output: %s", cudnName, node.Name, err, out)
 	}
 	framework.Logf("Routes in CUDN VRF %s on node %s for %s: %s", cudnName, node.Name, cidr, out)
-	return hasBGPRoute(routes, cidr, nextHop), nil
+	return hasBGPRoute(routes, cidr, nextHops...), nil
 }
 
 type kernelRoute struct {
@@ -4591,22 +4591,24 @@ type kernelRouteNexthop struct {
 	Gateway string `json:"gateway"`
 }
 
-func hasBGPRoute(routes []kernelRoute, cidr, nextHop string) bool {
+func hasBGPRoute(routes []kernelRoute, cidr string, nextHops ...string) bool {
 	for _, route := range routes {
-		if route.Dst == cidr && route.Protocol == "bgp" && routeHasGateway(route, nextHop) {
+		if route.Dst == cidr && route.Protocol == "bgp" && routeHasGateway(route, nextHops...) {
 			return true
 		}
 	}
 	return false
 }
 
-func routeHasGateway(route kernelRoute, nextHop string) bool {
-	if route.Gateway == nextHop {
-		return true
-	}
-	for _, nexthop := range route.Nexthops {
-		if nexthop.Gateway == nextHop {
+func routeHasGateway(route kernelRoute, nextHops ...string) bool {
+	for _, nextHop := range nextHops {
+		if route.Gateway == nextHop {
 			return true
+		}
+		for _, nexthop := range route.Nexthops {
+			if nexthop.Gateway == nextHop {
+				return true
+			}
 		}
 	}
 	return false

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -4433,7 +4433,12 @@ func createRouteAdvertisements(
 		return fmt.Errorf("failed to create RouteAdvertisements: %w", err)
 	}
 	ictx.AddCleanUpFn(func() error {
-		return raClient.K8sV1().RouteAdvertisements().Delete(context.Background(), name, metav1.DeleteOptions{})
+		err := raClient.K8sV1().RouteAdvertisements().Delete(context.Background(), name, metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// tolerate tests that delete the RouteAdvertisements themselves
+			return nil
+		}
+		return err
 	})
 	var lastReadyErr error
 	if err := wait.PollUntilContextTimeout(

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -538,7 +538,7 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			gomega.Expect(frrIP).NotTo(gomega.BeEmpty())
 			for _, node := range schedulableNodes.Items {
 				gomega.Eventually(func() (bool, error) {
-					return hasRouteInCUDNVRF(node, networkName, serverCIDR, frrIP)
+					return hasRouteInCUDNVRF(node, networkName, serverCIDR, bgpNextHopsForPeer(family, frrIface)...)
 				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
 					gomega.BeTrue(),
 					"expected node %s to learn %s via %s in CUDN VRF %s",
@@ -1089,7 +1089,7 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			gomega.Expect(frrIP).NotTo(gomega.BeEmpty())
 			for _, node := range schedulableNodes.Items {
 				gomega.Eventually(func() (bool, error) {
-					return hasRouteInDefaultVRF(node, serverCIDR, frrIP)
+					return hasRouteInDefaultVRF(node, serverCIDR, bgpNextHopsForPeer(family, frrIface)...)
 				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
 					gomega.BeTrue(),
 					"expected node %s to learn %s via %s in the default VRF",
@@ -1098,7 +1098,7 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 					frrIP,
 				)
 				gomega.Eventually(func() (bool, error) {
-					return hasRouteInCUDNVRF(node, networkName, serverCIDR, frrIP)
+					return hasRouteInCUDNVRF(node, networkName, serverCIDR, bgpNextHopsForPeer(family, frrIface)...)
 				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
 					gomega.BeTrue(),
 					"expected node %s to leak %s via %s into CUDN VRF %s",
@@ -3031,7 +3031,35 @@ func interfaceMaster(output, interfaceName string) (string, error) {
 	return links[0].Master, nil
 }
 
-func hasRouteInDefaultVRF(node corev1.Node, cidr, nextHop string) (bool, error) {
+// bgpNextHopsForPeer returns the next hops a BGP route learned from the peer
+// may carry in the kernel: the peer's address of the given family and, for
+// IPv6, its EUI-64 link-local, since a directly connected peer may advertise
+// IPv6 routes with its link-local as next hop rather than its global address.
+func bgpNextHopsForPeer(family utilnet.IPFamily, peer infraapi.NetworkInterface) []string {
+	nextHops := []string{getFirstIPStringOfFamily(family, []string{peer.IPv4, peer.IPv6})}
+	if family != utilnet.IPv6 {
+		return nextHops
+	}
+	if ll := ipv6LinkLocalFromMAC(peer.MAC); ll != "" {
+		nextHops = append(nextHops, ll)
+	}
+	return nextHops
+}
+
+// ipv6LinkLocalFromMAC returns the EUI-64 IPv6 link-local address derived
+// from the given MAC, or an empty string if the MAC cannot be parsed.
+func ipv6LinkLocalFromMAC(mac string) string {
+	hw, err := net.ParseMAC(mac)
+	if err != nil || len(hw) != 6 {
+		return ""
+	}
+	return net.IP{
+		0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+		hw[0] ^ 0x02, hw[1], hw[2], 0xff, 0xfe, hw[3], hw[4], hw[5],
+	}.String()
+}
+
+func hasRouteInDefaultVRF(node corev1.Node, cidr string, nextHops ...string) (bool, error) {
 	routeCommand := []string{"ip", "--json", "route", "show", cidr}
 	if utilnet.IsIPv6CIDRString(cidr) {
 		routeCommand = []string{"ip", "-6", "--json", "route", "show", cidr}
@@ -3046,7 +3074,7 @@ func hasRouteInDefaultVRF(node corev1.Node, cidr, nextHop string) (bool, error) 
 		return false, fmt.Errorf("failed to parse routes on node %s: %w; output: %s", node.Name, err, out)
 	}
 	framework.Logf("Routes in default VRF on node %s for %s: %s", node.Name, cidr, out)
-	return hasBGPRoute(routes, cidr, nextHop), nil
+	return hasBGPRoute(routes, cidr, nextHops...), nil
 }
 
 func hasRouteInDPUCUDNVRF(hostNode corev1.Node, cudnName, cidr, nextHop string) (bool, error) {

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	raclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned"
 	uplinkv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
@@ -64,11 +65,25 @@ const (
 	uplinkDefaultDPUResourceName    = "dpusim.io/vf"
 	uplinkDefaultBGPServerIPv4CIDR  = "172.29.0.0/16"
 	uplinkDefaultBGPServerIPv6CIDR  = "fc00:f853:ccd:e797::/64"
+	// uplinkPreservedIPv[4|6]CIDR/IP define a destination that is reachable
+	// only through the default route pre-installed on the Uplink interface
+	// and never advertised over BGP, mimicking a platform where routing state
+	// comes from another agent (e.g. a DHCP client) and the BGP session
+	// toward the node carries no routes.
+	uplinkPreservedIPv4CIDR = "203.0.113.0/24"
+	uplinkPreservedIPv4IP   = "203.0.113.1"
+	uplinkPreservedIPv6CIDR = "2001:db8:cafe::/64"
+	uplinkPreservedIPv6IP   = "2001:db8:cafe::1"
 )
 
 // errUplinkStateNotFound distinguishes "the UplinkState does not exist" from
 // transient API errors in getUplinkState results.
 var errUplinkStateNotFound = errors.New("no matching UplinkState")
+
+// uplinkRouteStableWindow must span at least one VRF manager reconcile period
+// (60s) so that holding an assertion for this long proves periodic
+// reconciliation does not undo the observed routing state.
+const uplinkRouteStableWindow = 90 * time.Second
 
 var uplinkGVR = schema.GroupVersionResource{
 	Group:    "k8s.ovn.org",
@@ -547,6 +562,223 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(podIP).NotTo(gomega.BeEmpty())
 			uplinkPodToClientIPAndExpect(pod, serverIP, podIP)
+		}
+	})
+
+	ginkgo.It("preserves pre-existing Uplink interface routes across VRF enslavement and release", func(ctx ginkgo.SpecContext) {
+		if isDPUUplinkE2E() {
+			e2eskipper.Skipf("preserved-route Uplink e2e uses regular KIND bridge provisioning")
+		}
+		nodes, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		schedulableNodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(schedulableNodes.Items).NotTo(gomega.BeEmpty())
+
+		bgpAlloc, err := allocators.AllocateBGP(f, ictx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		networkName := "uppre" + testSuffix
+		serverName := networkName + "-srv"
+		serverNetworkName := serverName
+		peerCIDRs := []string{bgpAlloc.BGPPeerSubnet, bgpAlloc.BGPPeerSubnet6}
+		serverCIDRs := []string{bgpAlloc.IPVRFSubnet, bgpAlloc.IPVRFSubnet6}
+
+		gomega.Expect(runBGPNetworkAndServer(
+			f,
+			ictx,
+			ipFamilySet,
+			networkName,
+			serverName,
+			serverNetworkName,
+			peerCIDRs,
+			serverCIDRs,
+		)).To(gomega.Succeed())
+
+		peerNetwork, err := infraprovider.Get().GetNetwork(networkName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		nodeIfaces := collectNodeNetworkInterfaces(nodes.Items, peerNetwork)
+
+		bridgeName := uplinkBridgeName("uppre" + testSuffix)
+		gomega.Expect(configureUplinkBridge(f, ictx, bridgeName, nodeIfaces)).To(gomega.Succeed())
+
+		server := infraapi.ExternalContainer{Name: serverName}
+		frr := infraapi.ExternalContainer{Name: networkName + "-frr"}
+		serverNetwork, err := infraprovider.Get().GetNetwork(serverNetworkName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		serverIface, err := infraprovider.Get().GetExternalContainerNetworkInterface(server, serverNetwork)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		frrIface, err := infraprovider.Get().GetExternalContainerNetworkInterface(frr, peerNetwork)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		preservedFor := func(family utilnet.IPFamily) (cidr, ip, frrIP string) {
+			cidr, ip = uplinkPreservedIPv4CIDR, uplinkPreservedIPv4IP
+			if family == utilnet.IPv6 {
+				cidr, ip = uplinkPreservedIPv6CIDR, uplinkPreservedIPv6IP
+			}
+			frrIP = getFirstIPStringOfFamily(family, []string{frrIface.IPv4, frrIface.IPv6})
+			gomega.Expect(frrIP).NotTo(gomega.BeEmpty())
+			return cidr, ip, frrIP
+		}
+
+		defaultCIDRFor := func(family utilnet.IPFamily) string {
+			if family == utilnet.IPv6 {
+				return "::/0"
+			}
+			return "0.0.0.0/0"
+		}
+
+		ginkgo.By("serving a prefix from the BGP server without advertising it and installing default routes on the Uplink bridge")
+		// Serve the preserved prefix from the BGP server without advertising
+		// it over BGP, and install a default route through the FRR peer on
+		// the Uplink bridge before any enslavement. The default route is the
+		// state another agent (e.g. a DHCP client) would have configured on
+		// the interface, and the only path toward the preserved prefix.
+		nodeNames := make([]string, 0, len(nodeIfaces))
+		for nodeName := range nodeIfaces {
+			nodeNames = append(nodeNames, nodeName)
+		}
+		for _, family := range ipFamilySet.UnsortedList() {
+			preservedCIDR, preservedIP, frrIP := preservedFor(family)
+			serverIP := getFirstIPStringOfFamily(family, []string{serverIface.IPv4, serverIface.IPv6})
+			gomega.Expect(serverIP).NotTo(gomega.BeEmpty())
+			hostMask := "/32"
+			ipCmd := "ip"
+			if family == utilnet.IPv6 {
+				hostMask = "/128"
+				ipCmd = "ip -6"
+			}
+			_, err = infraprovider.Get().ExecExternalContainerCommand(server, []string{
+				"sh", "-c", fmt.Sprintf("%s addr add %s%s dev lo", ipCmd, preservedIP, hostMask),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_, err = infraprovider.Get().ExecExternalContainerCommand(frr, []string{
+				"sh", "-c", fmt.Sprintf("%s route add %s via %s", ipCmd, preservedCIDR, serverIP),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(configureUplinkStaticRoute(
+				ictx,
+				bridgeName,
+				nodeNames,
+				defaultCIDRFor(family),
+				frrIP,
+				false,
+			)).To(gomega.Succeed())
+		}
+
+		ginkgo.By("creating the Uplink and waiting for gateway discovery")
+		uplinkName := networkName
+		createUplink(f, ictx, uplinkName, nodes.Items, nodeIfaces, bridgeName)
+		waitForUplinkStatesResolved(f, uplinkName, bridgeName, nodes.Items)
+		// gateway discovery consumed the pre-existing default route
+		waitForUplinkStatesDefaultGateways(f, uplinkName, nodes.Items, ipFamilySet)
+
+		ginkgo.By("creating the advertised CUDN backed by the Uplink")
+		networkLabels := map[string]string{"advertise": networkName}
+		networkSpec := uplinkLayer3NetworkSpec(ipFamilySet, bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6)
+		namespace, err := createUplinkNamespace(f, ictx, "uplink-bgp", networkName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createUplinkCUDN(
+			f,
+			ictx,
+			namespace,
+			networkName,
+			networkSpec,
+			networkLabels,
+			uplinkName,
+		)).To(gomega.Succeed())
+		gomega.Expect(createRouteAdvertisements(
+			f,
+			ictx,
+			networkName,
+			"auto",
+			networkLabels,
+			map[string]string{"network": networkName},
+		)).To(gomega.Succeed())
+
+		ginkgo.By("waiting for the pre-existing default routes to be migrated into the CUDN VRF")
+		// Enslaving the Uplink interface into the CUDN VRF must migrate its
+		// pre-existing default route into the VRF routing table instead of
+		// letting the kernel discard it.
+		for _, family := range ipFamilySet.UnsortedList() {
+			_, _, frrIP := preservedFor(family)
+			for _, node := range schedulableNodes.Items {
+				node := node
+				gomega.Eventually(func() error {
+					return uplinkRouteShownIn(node.Name, "vrf "+networkName, defaultCIDRFor(family), frrIP)
+				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+					gomega.Succeed(),
+					"expected preserved default route via %s in CUDN VRF %s on node %s",
+					frrIP,
+					networkName,
+					node.Name,
+				)
+			}
+		}
+
+		ginkgo.By("verifying VRF connectivity through the preserved default routes")
+		// Host traffic in the CUDN VRF rides the preserved default route:
+		// nothing advertises the preserved prefix over BGP, matching a
+		// platform where the BGP session toward the node carries no routes.
+		for _, family := range ipFamilySet.UnsortedList() {
+			_, preservedIP, _ := preservedFor(family)
+			for _, node := range schedulableNodes.Items {
+				node := node
+				gomega.Eventually(func() error {
+					return uplinkHostVRFTCPProbe(node.Name, networkName, preservedIP, netexecPort)
+				}).WithTimeout(uplinkShortTimeout).WithPolling(uplinkPoll).Should(
+					gomega.Succeed(),
+					"expected node %s to reach %s through the preserved default route in VRF %s",
+					node.Name,
+					preservedIP,
+					networkName,
+				)
+			}
+		}
+
+		ginkgo.By("holding the preserved routes through a full reconcile period")
+		// The migrated route is not owned by any ovnkube manager: make sure
+		// periodic reconciliation does not clean it up. The window spans at
+		// least one full VRF manager reconcile period.
+		gomega.Consistently(func() error {
+			for _, family := range ipFamilySet.UnsortedList() {
+				_, _, frrIP := preservedFor(family)
+				for _, node := range schedulableNodes.Items {
+					if err := uplinkRouteShownIn(node.Name, "vrf "+networkName, defaultCIDRFor(family), frrIP); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}).WithTimeout(uplinkRouteStableWindow).WithPolling(5*time.Second).Should(
+			gomega.Succeed(),
+			"expected preserved default route to remain in CUDN VRF %s",
+			networkName,
+		)
+
+		ginkgo.By("deleting the RouteAdvertisements and waiting for the routes to return to the main table")
+		// Deleting the RouteAdvertisements moves the network back to the
+		// default routing domain: releasing the Uplink interface from the VRF
+		// must migrate its routes back to the main table.
+		raClient, err := raclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(raClient.K8sV1().RouteAdvertisements().Delete(
+			ctx,
+			networkName,
+			metav1.DeleteOptions{},
+		)).To(gomega.Succeed())
+		for _, family := range ipFamilySet.UnsortedList() {
+			_, _, frrIP := preservedFor(family)
+			for _, node := range schedulableNodes.Items {
+				node := node
+				gomega.Eventually(func() error {
+					return uplinkRouteShownIn(node.Name, "", defaultCIDRFor(family), frrIP)
+				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+					gomega.Succeed(),
+					"expected preserved default route via %s back in the main table on node %s",
+					frrIP,
+					node.Name,
+				)
+			}
 		}
 	})
 })
@@ -1409,6 +1641,22 @@ func runDPUUplinkVRFLiteRouteAdvertisements(
 	gomega.Expect(dpuHostNodes).NotTo(gomega.BeEmpty(), "expected at least one ready schedulable DPU host node")
 	nodeIfaces := collectDPUHostUplinkInterfaces(dpuHostNodes)
 
+	// Install a route on each DPU-host Uplink interface before any
+	// enslavement, standing in for routing state another agent (e.g. a DHCP
+	// client) configured there: it must survive the enslavement into the
+	// host-side CUDN VRF.
+	const preservedGateway = "198.51.100.254"
+	for _, node := range dpuHostNodes {
+		gomega.Expect(configureUplinkStaticRoute(
+			ictx,
+			nodeIfaces[node.Name].InfName,
+			[]string{node.Name},
+			uplinkPreservedIPv4CIDR,
+			preservedGateway,
+			true,
+		)).To(gomega.Succeed())
+	}
+
 	createUplink(f, ictx, networkName, dpuHostNodes, nodeIfaces, "")
 	waitForUplinkStatesResolved(f, networkName, os.Getenv(uplinkDPUExpectedBridgeEnv), dpuHostNodes)
 
@@ -1451,6 +1699,25 @@ func runDPUUplinkVRFLiteRouteAdvertisements(
 			node.Name,
 		))
 	}
+
+	// The pre-existing route was migrated into the host-side CUDN VRF on
+	// enslavement. With dynamic network allocation the network is only
+	// rendered on a node once a pod attached to it runs there, so this can
+	// only be asserted after the pods exist.
+	for _, node := range dpuHostNodes {
+		node := node
+		gomega.Eventually(func() error {
+			return uplinkRouteShownIn(node.Name, "vrf "+networkName, uplinkPreservedIPv4CIDR, preservedGateway)
+		}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+			gomega.Succeed(),
+			"expected preserved route %s via %s in host-side CUDN VRF %s on node %s",
+			uplinkPreservedIPv4CIDR,
+			preservedGateway,
+			networkName,
+			node.Name,
+		)
+	}
+
 	pod := pods[0]
 	serverNetwork, err := infraprovider.Get().GetNetwork(bgpExternalNetworkName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1857,6 +2124,100 @@ func configureUplinkBridgeDefaultRoutes(
 	return nil
 }
 
+// configureUplinkStaticRoute installs a static route on the Uplink interface
+// of the given nodes, mimicking routing state installed by another agent
+// (e.g. a DHCP client) on the Uplink interface before OVN-Kubernetes enslaves
+// it into a CUDN VRF. With onlink the route is accepted regardless of the
+// interface's addressing.
+func configureUplinkStaticRoute(
+	ictx infraapi.Context,
+	devName string,
+	nodeNames []string,
+	cidr string,
+	via string,
+	onlink bool,
+) error {
+	ginkgo.GinkgoHelper()
+
+	family := ""
+	if utilnet.IsIPv6CIDRString(cidr) {
+		family = "-6 "
+	}
+	onlinkFlag := ""
+	if onlink {
+		onlinkFlag = "onlink "
+	}
+	for _, nodeName := range nodeNames {
+		// metric 50000 only matters when cidr is a default route: it keeps
+		// the installed route from taking priority over the node's own
+		// default route on its management interface, which would cut the
+		// node off. For more specific prefixes it is inherited harmlessly.
+		if err := execNodeCommand(
+			nodeName,
+			"ip %sroute replace %s via %s dev %s %smetric 50000",
+			family,
+			cidr,
+			via,
+			devName,
+			onlinkFlag,
+		); err != nil {
+			return err
+		}
+	}
+	ictx.AddCleanUpFn(func() error {
+		var errs []error
+		for _, nodeName := range nodeNames {
+			// The route may sit in the main table or may already be gone with
+			// the bridge or the VRF, so deletion is best effort.
+			if err := execNodeCommand(
+				nodeName,
+				"ip %sroute del %s via %s 2>/dev/null || true",
+				family,
+				cidr,
+				via,
+			); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	})
+	return nil
+}
+
+// uplinkRouteShownIn returns nil when the given route is present in the given
+// routing table on the node. tableSelector is an `ip route show` scope
+// selector such as "vrf <name>", or empty for the main table.
+func uplinkRouteShownIn(nodeName, tableSelector, cidr, via string) error {
+	family := ""
+	if utilnet.IsIPv6CIDRString(cidr) {
+		family = "-6 "
+	}
+	return execNodeCommand(
+		nodeName,
+		"ip %sroute show %s %s via %s | grep -q .",
+		family,
+		tableSelector,
+		cidr,
+		via,
+	)
+}
+
+// uplinkHostVRFTCPProbe returns nil when a TCP connection from the node's
+// network context of the given VRF succeeds toward ip:port, proving the VRF
+// routing table holds a working route toward the destination. The host VRF
+// context is the consumer of the kernel VRF routing table; pod egress goes
+// through the OVN gateway router instead, which derives its routes from
+// UplinkState and route import rather than from this table.
+func uplinkHostVRFTCPProbe(nodeName, vrfName, ip string, port int) error {
+	return execNodeCommand(
+		nodeName,
+		"timeout 3 ip vrf exec %s bash -c 'exec 3<>/dev/tcp/%s/%d'",
+		vrfName,
+		ip,
+		port,
+	)
+}
+
 func interfaceGateway(gateway, ip, prefix string) (string, error) {
 	if gateway != "" || ip == "" {
 		return gateway, nil
@@ -1924,6 +2285,13 @@ func runNodeCommand(nodeName, format string, args ...any) error {
 	ginkgo.GinkgoHelper()
 	cmd := fmt.Sprintf(format, args...)
 	_, err := ForContainer(nodeName).Exec("sh", "-c", cmd)
+	return err
+}
+
+// execNodeCommand runs a shell command on the node through the
+// provider-agnostic node exec API.
+func execNodeCommand(nodeName, format string, args ...any) error {
+	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"sh", "-c", fmt.Sprintf(format, args...)})
 	return err
 }
 

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -1700,6 +1700,18 @@ func runDPUUplinkVRFLiteRouteAdvertisements(
 		))
 	}
 
+	// Each side of the split deployment reports its share of the gateway
+	// programming on its own condition, and cluster manager aggregates both
+	// into the CUDN's UplinksReady.
+	for _, node := range dpuHostNodes {
+		waitForUplinkStateGatewayCondition(f, networkName, node.Name,
+			metav1.ConditionTrue, uplinkv1alpha1.UplinkStateReasonGatewayConfigured)
+		waitForUplinkStateConditionOfType(f, networkName, node.Name,
+			uplinkv1alpha1.UplinkStateConditionHostGatewayReady,
+			metav1.ConditionTrue, uplinkv1alpha1.UplinkStateReasonGatewayConfigured)
+	}
+	waitForCUDNUplinksReady(f, networkName)
+
 	// The pre-existing route was migrated into the host-side CUDN VRF on
 	// enslavement. With dynamic network allocation the network is only
 	// rendered on a node once a pod attached to it runs there, so this can
@@ -2596,6 +2608,19 @@ func waitForUplinkStateGatewayCondition(
 	expectedReason string,
 ) {
 	ginkgo.GinkgoHelper()
+	waitForUplinkStateConditionOfType(f, uplinkName, nodeName,
+		uplinkv1alpha1.UplinkStateConditionGatewayReady, expectedStatus, expectedReason)
+}
+
+func waitForUplinkStateConditionOfType(
+	f *framework.Framework,
+	uplinkName string,
+	nodeName string,
+	conditionType string,
+	expectedStatus metav1.ConditionStatus,
+	expectedReason string,
+) {
+	ginkgo.GinkgoHelper()
 
 	gomega.Eventually(func() error {
 		state, err := getUplinkState(f, uplinkName, nodeName)
@@ -2607,16 +2632,16 @@ func waitForUplinkStateGatewayCondition(
 			return err
 		}
 		for _, condition := range conditions {
-			if condition.Type != "GatewayReady" {
+			if condition.Type != conditionType {
 				continue
 			}
 			if condition.Status == expectedStatus && condition.Reason == expectedReason {
 				return nil
 			}
-			return fmt.Errorf("UplinkState %s GatewayReady condition is %s/%s, expected %s/%s",
-				state.GetName(), condition.Status, condition.Reason, expectedStatus, expectedReason)
+			return fmt.Errorf("UplinkState %s %s condition is %s/%s, expected %s/%s",
+				state.GetName(), conditionType, condition.Status, condition.Reason, expectedStatus, expectedReason)
 		}
-		return fmt.Errorf("UplinkState %s has no GatewayReady condition", state.GetName())
+		return fmt.Errorf("UplinkState %s has no %s condition", state.GetName(), conditionType)
 	}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(gomega.Succeed())
 }
 


### PR DESCRIPTION
Changing an interface's master makes the kernel purge every FIB entry referencing it, regenerating only local and connected routes. When the VRF manager enslaves an Uplink gateway interface that another component configured (e.g. a DHCP client), the pre-existing default route is silently destroyed and never re-created: on platforms where the BGP session toward the node intentionally carries no routes, the CUDN VRF is left with no route out, and a manually re-added default route is wiped again on any re-enslavement.

- vrfmanager captures the routes referencing the interface before a master change and restores them into the routing table the interface enters: the VRF table on enslavement, the main table on release. Routes that their owner reprograms per table (kernel, routing daemons) are not migrated, and neither are the routes ovn-kubernetes manages itself in the VRF table. If the restore into the VRF fails, the enslavement is undone and the captured routes go back to the main table, so the next reconcile retries from a clean state.
- VRF device deletion releases the enslaved interfaces the same way first, deriving slaves and table from actual kernel state, so it also covers repair after a restart and recreation on table conflict. A VRF unknown to the cache restores nothing: its ovn-kubernetes routes cannot be told apart from third-party ones and must not leak into the main table.
- The UDN gateway removes its managed default route before enslaving the Uplink interface, so it cannot clobber the preserved one.
- New `HostGatewayReady` UplinkState condition: in split-DPU deployments the host-side share of gateway programming (the VRF attachment above) happens on the DPU-host while the DPU owns `GatewayReady`, so host-side failures had no condition to land on. The DPU-host now publishes its aggregate gateway condition as `HostGatewayReady` under its own field manager, and cluster-manager requires it, where present, for the CUDN's `UplinksReady`.
- New e2e covers the full cycle in full mode (route consumed by discovery, migrated into the CUDN VRF on `targetVRF: auto` enslavement, carrying host traffic toward a prefix never advertised over BGP, surviving a full reconcile period, returning to the main table on RouteAdvertisements deletion) and in split-DPU mode (route migrated into the host-side CUDN VRF, `HostGatewayReady` published and aggregated into `UplinksReady`).
