### PR TITLE
e2e: allow a separate agnhost image for external containers

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -214,7 +214,7 @@ func containsIPInLastEntry(data, ip string) bool {
 
 // support for agnhost image is limited to netexec command
 func isSupportedAgnhostForEIP(externalContainer infraapi.ExternalContainer) bool {
-	if externalContainer.Image != images.AgnHost() {
+	if externalContainer.Image != images.ExternalAgnHost() {
 		return false
 	}
 	if !util.SliceHasStringItem(externalContainer.CmdArgs, "netexec") {
@@ -370,7 +370,7 @@ func targetExternalContainerAndTest(externalContainer infraapi.ExternalContainer
 		// we determine the src IP based on the target image
 		// agnhost netexec will return the source IP as payload
 		switch externalContainer.Image {
-		case images.AgnHost():
+		case images.ExternalAgnHost():
 			for _, expectedIP := range verifyIPs {
 				if containsIPInLastEntry(clientStdOut, expectedIP) {
 					verifyIPs = util.RemoveItemFromSliceUnstable(verifyIPs, expectedIP)

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -61,6 +61,19 @@ func AgnHost() string {
 	return deploymentconfig.Get().GetAgnHostContainerImage()
 }
 
+// ExternalAgnHost returns the default image used for external
+// (host-side) containers. Such containers may run on a host that cannot reach
+// the same registry as in-cluster pods, so USER_PROVIDED_AGNHOST_IMAGE can point
+// them at a reachable image. When it is unset the value falls back to AgnHost()
+// (which itself honors the cluster-wide AGNHOST_IMAGE override), so the default
+// image is unchanged.
+func ExternalAgnHost() string {
+	if v := os.Getenv("USER_PROVIDED_AGNHOST_IMAGE"); v != "" {
+		return v
+	}
+	return AgnHost()
+}
+
 func IPerf3() string {
 	return iperf3
 }

--- a/test/e2e/infraprovider/engine/container/ops/ops.go
+++ b/test/e2e/infraprovider/engine/container/ops/ops.go
@@ -410,6 +410,12 @@ func (o *ContainerOps) DeleteNetwork(network api.Network) error {
 }
 
 func (o *ContainerOps) CreateExternalContainer(container api.ExternalContainer) (api.ExternalContainer, error) {
+	// External containers default to agnhost but may need an image from a
+	// registry the host can reach; normalize the default here so individual
+	// callers keep requesting images.AgnHost().
+	if container.Image == images.AgnHost() {
+		container.Image = images.ExternalAgnHost()
+	}
 	if valid, err := container.IsValidPreCreateContainer(); !valid {
 		return container, err
 	}
@@ -435,7 +441,7 @@ func (o *ContainerOps) CreateExternalContainer(container api.ExternalContainer) 
 	if len(container.CmdArgs) > 0 {
 		cmd = append(cmd, container.CmdArgs...)
 	} else {
-		if images.AgnHost() == container.Image {
+		if images.ExternalAgnHost() == container.Image {
 			cmd = append(cmd, "pause")
 		}
 	}


### PR DESCRIPTION
External (host-side) containers may not reach the same registry as in-cluster pods. Add images.ExternalAgnHost(), which honors EXTERNAL_AGNHOST_IMAGE and otherwise falls back to AgnHost() (no default change). CreateExternalContainer normalizes AgnHost to ExternalAgnHost.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
