### PR TITLE
docs: fix versioned-site deep links and install root 404 redirects

### DIFF
--- a/.github/workflows/docs-versioning.yml
+++ b/.github/workflows/docs-versioning.yml
@@ -12,6 +12,7 @@ on:
       - 'mkdocs.yml'
       - '.github/workflows/docs-versioning.yml'
       - 'hack/build-docs.sh'
+      - 'hack/docs-site-404.html'
       - 'requirements.txt'
   # Creating a new release-* ref (e.g. git push origin master:release-1.4) often
   # has no path diff, so the paths filter above would skip it. The create event

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,8 @@ jobs:
           pip install mkdocs-awesome-pages-plugin
           pip install $(mkdocs-get-deps)
       - run: mkdocs build --strict
+      - name: Test root 404 install helper
+        run: ./hack/test-install-gh-pages-404.sh
       - name: Upload Artifact (Test)
         uses: actions/upload-artifact@v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ In some cases, other changes may conflict with your PR. If this happens, you wil
 
 ## Development Environment Setup
 
-You can easily setup a developer environment by following the instructions [here](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-on-kind/).
+You can easily setup a developer environment by following the instructions [here](https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-on-kind/).
 
 ## Sign Your Commits
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ CNI (Container Network Interface) specifications.
 Here are some links to help in your ovn-kubernetes journey:
 
 - [Welcome to ovn-kubernetes](https://ovn-kubernetes.io/) for overview of ovn-kubernetes.
-- [Architecture of ovn-kubernetes](https://ovn-kubernetes.io/design/architecture/)
-- [Deploying OVN-Kubernetes cluster using KIND](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-on-kind/)
-- [Deploying OVN-Kubernetes CNI using Helm](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-with-helm/)
-- [Contributing to OVN-Kubernetes](https://ovn-kubernetes.io/governance/CONTRIBUTING/) for how to get involved
+- [Architecture of ovn-kubernetes](https://ovn-kubernetes.io/master/design/architecture/)
+- [Deploying OVN-Kubernetes cluster using KIND](https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-on-kind/)
+- [Deploying OVN-Kubernetes CNI using Helm](https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-with-helm/)
+- [Contributing to OVN-Kubernetes](https://ovn-kubernetes.io/master/governance/CONTRIBUTING/) for how to get involved
   in our project
-- [Meet the Community](https://ovn-kubernetes.io/governance/MEETINGS/) for details on community
+- [Meet the Community](https://ovn-kubernetes.io/master/governance/MEETINGS/) for details on community
   meeting details.
 
 ## License

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,6 +15,9 @@
 RELEASES ?= all
 PUSH ?= 0
 
-.PHONY: build-docs
+.PHONY: build-docs test-install-gh-pages-404
 build-docs:
 	../hack/build-docs.sh $(if $(filter 1 true YES yes,$(PUSH)),--push) --releases "$(RELEASES)"
+
+test-install-gh-pages-404:
+	../hack/test-install-gh-pages-404.sh

--- a/docs/api-reference/introduction.md
+++ b/docs/api-reference/introduction.md
@@ -32,12 +32,12 @@ Kubernetes ecosystem APIs that is watched and implemented by OVN-Kubernetes
 This section contains the API Reference guide for features
 designed and implemented by OVN-Kubernetes
 
-* [EgressIP](https://ovn-kubernetes.io/api-reference/egress-ip-api-spec/)
-* [EgressService](https://ovn-kubernetes.io/api-reference/egress-service-api-spec/)
-* [EgressQoS](https://ovn-kubernetes.io/api-reference/egress-qos-api-spec/)
-* [EgressFirewall](https://ovn-kubernetes.io/api-reference/egress-firewall-api-spec/)
-* [AdminPolicyBasedExternalRoutes](https://ovn-kubernetes.io/api-reference/admin-epbr-api-spec/)
-* [UserDefinedNetwork](https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/)
+* [EgressIP](egress-ip-api-spec.md)
+* [EgressService](egress-service-api-spec.md)
+* [EgressQoS](egress-qos-api-spec.md)
+* [EgressFirewall](egress-firewall-api-spec.md)
+* [AdminPolicyBasedExternalRoutes](admin-epbr-api-spec.md)
+* [UserDefinedNetwork](userdefinednetwork-api-spec.md)
 * [RouteAdvertisements](routeadvertisements-api-spec.md)
 * [VTEP](vtep-api-spec.md)
 * [ClusterNetworkConnect](clusternetworkconnect-api-spec.md)

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -17,7 +17,7 @@ where we mandate docs include:
 
 * **Enhancement Proposals**: If you are planning to do a new feature, then start
 with an enhancement proposal a.k.a OKEP so that maintainers and other reviewers
-can get an understanding of what your goals are. See [here](https://ovn-kubernetes.io/okeps/okep-4368-template/)
+can get an understanding of what your goals are. See [here](../okeps/okep-4368-template.md)
 for more details and open a commit adding it to our `docs/okeps` folder.
 
 * **Architecture and Topology docs**: Did you change the architecture or topology?
@@ -40,7 +40,7 @@ feel free to write it. If you are unsure where this should be placed; reach out 
 
 * **Blog Posts**: Are you an end-user of OVN-Kubernetes? Is there something you wish to share with
 the community about your awesome use cases and how you used our CNI to solve your problems? We
-welcome blog post contributions from all! See [here](https://ovn-kubernetes.io/blog/) for details.
+welcome blog post contributions from all! See [here](../blog/index.md) for details.
 Open a commit adding it to our `docs/blog` folder.
 
 * **Performance Enhancements**: We love performance enhancements! Did you write a cool patch
@@ -48,7 +48,7 @@ to reduce the time it takes for iptables to sync up on startup? Think about writ
 around this! Open a commit adding it to our `docs/blog` folder.
 
 * **API Reference**: Did you introduce a new CRD? OR Did you add a watcher a new CRD? Include API
-Reference documentation changes to `docs/api-reference` folder. See [here](https://ovn-kubernetes.io/api-reference/introduction/)
+Reference documentation changes to `docs/api-reference` folder. See [here](../api-reference/introduction.md)
 for more details.
 
 ## Website Guide
@@ -80,8 +80,9 @@ workflow so the two do not overwrite each other.
 
 The versioning workflow runs on pushes to `master` or any `release-*` branch when
 docs-related paths change (`docs/**`, `mkdocs.yml`, the workflow file,
-`hack/build-docs.sh`, or `requirements.txt`). By default each run rebuilds **all**
-versions so Latest/Stable/Legacy labels and the version dropdown stay consistent.
+`hack/build-docs.sh`, `hack/docs-site-404.html`, or `requirements.txt`). By default
+each run rebuilds **all** versions so Latest/Stable/Legacy labels and the version
+dropdown stay consistent.
 
 - The nav structure (`nav:` in `mkdocs.yml`) is **per-branch**. A new page added
   on `master` does not appear in older release versions (and will not break them).
@@ -107,6 +108,80 @@ versions so Latest/Stable/Legacy labels and the version dropdown stay consistent
 - Prefer `make -C docs build-docs` over ad-hoc `mike` commands so the same
   validations run locally and in CI.
 
+### Linking between docs pages (use relative paths)
+
+Mike publishes each docs version under its own URL prefix — for example
+`/master/...`, `/1.3/...`, or the `latest` alias. A page that used to live at
+`https://ovn-kubernetes.io/design/architecture/` is now served at
+`https://ovn-kubernetes.io/master/design/architecture/` (or under the release
+you selected in the version dropdown).
+
+**Do not** link to docs pages with unversioned absolute site URLs such as
+`https://ovn-kubernetes.io/design/architecture/` or
+`https://ovn-kubernetes.io/installation/...`. Those paths no longer exist at
+the site root after versioning, so they 404. The same problem affects any
+hard-coded `https://ovn-kubernetes.io/<page>/` link that omits the version
+segment.
+
+**Going forward, link with relative Markdown paths** so MkDocs resolves the
+target within the version currently being viewed:
+
+```markdown
+<!-- Good: stays inside the current mike version -->
+See the [Architecture](../design/architecture.md) page.
+
+<!-- Bad: 404s on the versioned site -->
+See the [Architecture](https://ovn-kubernetes.io/design/architecture/) page.
+```
+
+Relative links also keep working when someone switches the version dropdown
+(for example from Master to a `release-*` docs tree), because the browser stays
+under that version’s prefix.
+
+A bare homepage link to `https://ovn-kubernetes.io/` is fine (the root still
+redirects into the default version). External sites, GitHub URLs, and other
+non-docs destinations should keep using absolute URLs as usual.
+
+**Exception: root files symlinked into `docs/governance/`.** Files such as
+`CONTRIBUTING.md`, `GOVERNANCE.md`, and `MEETINGS.md` live at the repository
+root and are symlinked under `docs/governance/` for the website. A relative
+path that is correct from `docs/governance/` (for example
+`../installation/launching-ovn-kubernetes-on-kind.md`) breaks when the same
+file is viewed on GitHub at the repo root. For those shared files, use a
+versioned absolute docs URL instead, for example
+`https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-on-kind/`,
+so the link works both on GitHub and on the published site.
+
+When you touch docs links in a PR, prefer relative paths under `docs/` and
+avoid introducing new unversioned `ovn-kubernetes.io/<page>/` URLs.
+
+Repo files outside `docs/` that must deep-link into the published site (for
+example `README.md`) should use a versioned absolute URL under `/master/…`,
+not an unversioned path.
+
+### Root `404.html` (pre-versioning deep links)
+
+GitHub Pages serves a site-root `404.html` when a URL is missing. Mike only
+publishes version directories (`master/`, `1.3/`, …) and does not install a root
+404, so old bookmarks such as `https://ovn-kubernetes.io/design/architecture/`
+would otherwise hit GitHub’s generic 404.
+
+`hack/build-docs.sh` copies `hack/docs-site-404.html` to `404.html` on the
+`gh-pages` branch after each deploy. That page redirects unversioned paths to
+the same path under `/master/…`. Paths that already include a version or alias
+(`master`, `latest`, or `N.N`) and are still missing go to that version’s home.
+If the request is already at a version root that does not exist (so a second
+redirect would loop on itself), the page falls back to `/master/` (or `/` when
+the prefix is already `master`).
+
+Do not hand-edit `404.html` on `gh-pages`; change `hack/docs-site-404.html` on
+`master` and let the versioning workflow republish it.
+
+Shell coverage for the install helper (local/remote `gh-pages`, unchanged vs
+changed template, `PUSH=false`/`true`, push failure) and for the clean-worktree
+preflight lives in `hack/test-install-gh-pages-404.sh`
+(`make -C docs test-install-gh-pages-404`).
+
 ### Manual rebuild (workflow_dispatch)
 
 Anyone with write access can trigger a rebuild from the **Actions** tab
@@ -118,7 +193,7 @@ comma-separated list of existing branches (for example `release-1.1` or
 
 | Event | Rebuilds docs site? |
 |-------|---------------------|
-| Push to `master` / `release-*` changing `docs/**`, `mkdocs.yml`, the versioning workflow, `hack/build-docs.sh`, or `requirements.txt` | Yes (all versions) |
+| Push to `master` / `release-*` changing `docs/**`, `mkdocs.yml`, the versioning workflow, `hack/build-docs.sh`, `hack/docs-site-404.html`, or `requirements.txt` | Yes (all versions) |
 | Creating a new `release-*` branch | Yes (`create` event; labels recompute) |
 | Manual **workflow_dispatch** | Yes (`all` or the branches you list) |
 | Go-only / non-docs commits on `master` or `release-*` | No (by design) |
@@ -251,6 +326,8 @@ Push the local `gh-pages` branch only if you intend to update the remote
 make -C docs build-docs PUSH=1
 ```
 
-`hack/build-docs.sh` refuses to run while checked out on `gh-pages`, and
-refuses to continue if `extra.css` is dirty on a `release-*` branch. There
+`hack/build-docs.sh` refuses to run while checked out on `gh-pages`, refuses
+to continue if `extra.css` is dirty on a `release-*` branch, and refuses to
+run at all when any tracked file has local modifications (mike and the root
+404 install use `git checkout -f`, which would discard those changes). There
 is no interactive override.

--- a/docs/developer-guide/local_testing_guide.md
+++ b/docs/developer-guide/local_testing_guide.md
@@ -104,7 +104,7 @@ container is created per Kubernetes node. The CI tests run on this Kubernetes
 deployment. Therefore, KIND will need to be installed locally.
 
 Generic instructions for installing and running OVN-Kubernetes with KIND can be found at:
-[OVN-Kubernetes KIND Setup](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-on-kind/)
+[OVN-Kubernetes KIND Setup](../installation/launching-ovn-kubernetes-on-kind.md)
 
 Make sure to set the required environment variables first (see section above). Then, deploy kind:
 ```

--- a/docs/features/hardware-offload/ovs-doca.md
+++ b/docs/features/hardware-offload/ovs-doca.md
@@ -6,7 +6,7 @@ OVS supports [Hardware Acceleration features](https://docs.openvswitch.org/en/la
 
 DOCA (Data Center Infrastructure-on-a-Chip Architecture) is a software stack for NVIDIA Smart NIC (ConnectX) and Data Processing Unit (BlueField) product lines. It contains a runtime and development environment, including libraries and drivers for device management and programmability, for the host (Smart NIC) or as part of the Data Processing Unit (DPU).
 
-OVS-DOCA extends traditional OVS-DPDK and OVS-Kernel data-path offload interfaces (DPIF), adds  OVS-DOCA as an additional DPIF implementation. It preserves the same interfaces as OVS-DPDK and OVS-Kernel while utilizing the DOCA Flow library. OVS-DOCA uses unique hardware offload mechanisms and application techniques to maximize performance and adds other features. OVS Acceleration with kernel datapath is documented [here](https://ovn-kubernetes.io/features/hardware-offload/ovs_acceleration/)
+OVS-DOCA extends traditional OVS-DPDK and OVS-Kernel data-path offload interfaces (DPIF), adds  OVS-DOCA as an additional DPIF implementation. It preserves the same interfaces as OVS-DPDK and OVS-Kernel while utilizing the DOCA Flow library. OVS-DOCA uses unique hardware offload mechanisms and application techniques to maximize performance and adds other features. OVS Acceleration with kernel datapath is documented [here](ovs-kernel.md)
 
 ![ovs-datapath-offload-interfaces](../../images/ovs-datapath-offload-interfaces.png)
 

--- a/docs/features/network-security-controls/admin-network-policy.md
+++ b/docs/features/network-security-controls/admin-network-policy.md
@@ -1124,7 +1124,7 @@ packet which is the `action` on the ACL.
 Using this method each policy rule can be debugged to
 see if constructs at OVN level are created correctly.
 An easier way is to simply run an
-[ovnkube-trace](https://ovn-kubernetes.io/troubleshooting/ovnkube-trace/).
+[ovnkube-trace](../../troubleshooting/ovnkube-trace.md).
 
 ### OVN Tracing
 

--- a/docs/features/user-defined-networks/dynamic-udn.md
+++ b/docs/features/user-defined-networks/dynamic-udn.md
@@ -116,4 +116,4 @@ to do that is to schedule the speaker on the designated UDN nodes.
 ## References
 
 * User Defined Networks [feature page](user-defined-networks.md)
-* Dynamic UDN Node Allocation [enhancement](https://ovn-kubernetes.io/okeps/okep-5552-dynamic-udn-node-allocation/)
+* Dynamic UDN Node Allocation [enhancement](../../okeps/okep-5552-dynamic-udn-node-allocation.md)

--- a/docs/features/user-defined-networks/user-defined-networks.md
+++ b/docs/features/user-defined-networks/user-defined-networks.md
@@ -23,13 +23,13 @@ can use the same IP address ranges for pods, expanding deployment scenarios.
 
 See the [enhancement] for more details.
 
-[enhancement]: https://ovn-kubernetes.io/okeps/okep-5193-user-defined-networks/
+[enhancement]: ../../okeps/okep-5193-user-defined-networks.md
 
 ### User-Stories/Use-Cases
 
 See the [user-stories] defined in the enhancement.
 
-[user-stories]: https://ovn-kubernetes.io/okeps/okep-5193-user-defined-networks/#user-storiesuse-cases
+[user-stories]: ../../okeps/okep-5193-user-defined-networks.md#user-storiesuse-cases
 
 The two main user stories are:
 
@@ -115,7 +115,7 @@ will not be considered for UDN creation.
 
 See the [api-specification-docs] for information on each of the fields
 
-[api-specification-docs]: https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/
+[api-specification-docs]: ../../api-reference/userdefinednetwork-api-spec.md
 
 ### OVN-Kubernetes Implementation Details
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ to be a highly scalable and performant Networking Platform.
 
 For more details, please see the following:
 
-- [OVN-Kubernetes Architecture](https://ovn-kubernetes.io/design/architecture/)
+- [OVN-Kubernetes Architecture](design/architecture.md)
 - [Deploying OVN-Kubernetes cluster using KIND](installation/launching-ovn-kubernetes-on-kind.md)
 - [Deploying OVN-Kubernetes CNI using Helm](installation/launching-ovn-kubernetes-with-helm.md)
 - [Setup and Building OVN-Kubernetes](developer-guide/documentation.md) for instructions

--- a/docs/okeps/okep-5193-user-defined-networks.md
+++ b/docs/okeps/okep-5193-user-defined-networks.md
@@ -439,7 +439,7 @@ an error status can be reported to the CR, rather than relying on the user to ch
 
 #### API Overview
 
-Two CRDs shall be introduced. Note for the final implementation, see the [official api](https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/).
+Two CRDs shall be introduced. Note for the final implementation, see the [official api](../api-reference/userdefinednetwork-api-spec.md).
 - Namespace scoped CRD - represent user request for creating namespace scoped OVN network.
   - Shall be defined with `namespace` scope.
   - Targeted for cluster admin and non-admin users, enable creating OVN network in a specific namespace.

--- a/docs/okeps/okep-5224-connecting-udns/okep-5224-connecting-udns.md
+++ b/docs/okeps/okep-5224-connecting-udns/okep-5224-connecting-udns.md
@@ -9,8 +9,8 @@ together, better known as "Connecting (C)UDNs". This solution will ensure
 that (C)UDNs remain isolated unless an explicit request to connect them
 together has been made.
 
-[UserDefinedNetworks]: https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#userdefinednetwork
-[ClusterUserDefinedNetworks]: https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#clusteruserdefinednetwork
+[UserDefinedNetworks]: ../../api-reference/userdefinednetwork-api-spec.md#userdefinednetwork
+[ClusterUserDefinedNetworks]: ../../api-reference/userdefinednetwork-api-spec.md#clusteruserdefinednetwork
 
 ### User Personas:
 
@@ -1589,7 +1589,7 @@ connect UDNs when overlay is turned off.
 
 ![blue-green-yellow-l3-connect-scale](images/l3-connecting-udns-scale.png)
 
-[Dynamic UDN Node Allocation]: https://ovn-kubernetes.io/okeps/okep-5552-dynamic-udn-node-allocation/
+[Dynamic UDN Node Allocation]: ../okep-5552-dynamic-udn-node-allocation.md
 
 ## OVN Kubernetes Version Skew
 
@@ -1721,4 +1721,4 @@ cannot be load balanced.
 
 * This enhancement depends on the [new Layer2 topology] changes.
 
-[new Layer2 topology]: https://ovn-kubernetes.io/okeps/okep-5094-layer2-transit-router/
+[new Layer2 topology]: ../okep-5094-layer2-transit-router.md

--- a/docs/okeps/okep-5259-no-overlay.md
+++ b/docs/okeps/okep-5259-no-overlay.md
@@ -24,7 +24,7 @@ benefits:
 
 ## Terminology
 
-See [terminology](https://ovn-kubernetes.io/okeps/okep-5193-user-defined-networks/#terminology) details.
+See [terminology](okep-5193-user-defined-networks.md#terminology) details.
 
 ## Goals
 

--- a/hack/build-docs.sh
+++ b/hack/build-docs.sh
@@ -73,6 +73,12 @@ die() {
 # Temporary / manual edits of gh-pages or of extra.css on release branches are
 # not allowed. The automated versioning process owns gh-pages, and release
 # branches always receive master's extra.css at build time.
+# Force-checkouts (mike deploy, root 404 install) also require a clean worktree
+# so local tracked edits are never discarded.
+
+# shellcheck source=hack/lib/require-clean-worktree.sh
+source "${ROOT_DIR}/hack/lib/require-clean-worktree.sh"
+require_clean_worktree
 
 current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
 if [[ "${current_branch}" == "gh-pages" ]]; then
@@ -97,17 +103,24 @@ fi
 command -v mike >/dev/null 2>&1 || die "mike is not installed. Run: pip install -r requirements.txt"
 command -v mkdocs >/dev/null 2>&1 || die "mkdocs is not installed. Run: pip install -r requirements.txt"
 
+SITE_404_SRC="${ROOT_DIR}/hack/docs-site-404.html"
+[[ -f "${SITE_404_SRC}" ]] || die "missing root 404 template: ${SITE_404_SRC}"
+# Cache before mike checks out other branches that may not have this file yet.
+SITE_404_CACHE="$(mktemp)"
+cp "${SITE_404_SRC}" "${SITE_404_CACHE}"
+
 # mike deploy checks out origin/* refs and would otherwise leave the repo in
 # detached HEAD. Restore the caller's starting branch/commit on exit.
 START_REF="$(git symbolic-ref -q --short HEAD 2>/dev/null || git rev-parse HEAD)"
-restore_start_ref() {
+cleanup_on_exit() {
   local ec=$?
+  rm -f "${SITE_404_CACHE}"
   if [[ -n "${START_REF}" ]] && ! git checkout -f "${START_REF}" >/dev/null 2>&1; then
     echo "WARNING: could not restore git checkout to '${START_REF}'" >&2
   fi
   exit "${ec}"
 }
-trap restore_start_ref EXIT
+trap cleanup_on_exit EXIT
 
 git fetch origin gh-pages --depth=1 2>/dev/null || true
 
@@ -125,6 +138,13 @@ elif git show master:docs/stylesheets/extra.css > /tmp/master-stylesheets/extra.
 else
   die "could not read docs/stylesheets/extra.css from origin/master (or master)"
 fi
+
+# Install GitHub Pages root 404.html after mike deploy. Mike only manages
+# version directories and versions.json; a root 404 is required so pre-versioning
+# deep links (e.g. /design/architecture/) redirect under /master/... instead
+# of showing GitHub's generic 404.
+# shellcheck source=hack/lib/install-gh-pages-404.sh
+source "${ROOT_DIR}/hack/lib/install-gh-pages-404.sh"
 
 # Collect all release-* branches, sorted by version (ascending)
 mapfile -t ALL_RELEASES < <(
@@ -260,5 +280,7 @@ if [[ "${deploy_master}" == "true" ]]; then
   # Master is the default landing page (only when deploying master / all)
   mike set-default ${MIKE_PUSH[@]+"${MIKE_PUSH[@]}"} master
 fi
+
+install_gh_pages_404
 
 echo "Docs versioning deploy complete (releases=${RELEASES}, push=${PUSH})."

--- a/hack/docs-site-404.html
+++ b/hack/docs-site-404.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <script>
+    (function () {
+      var path = location.pathname;
+      var suffix = location.search + location.hash;
+      // Already under a mike version or alias? Prefer that version's home for
+      // true missing pages. If we're already at the version root (e.g. an
+      // unpublished /999/), do not self-redirect — fall back to a known page.
+      var versioned = path.match(/^\/(master|latest|\d+(?:\.\d+)*)(?:\/|$)/);
+      if (versioned) {
+        var ver = versioned[1];
+        var atVersionRoot = path === "/" + ver || path === "/" + ver + "/";
+        if (atVersionRoot) {
+          location.replace((ver === "master" ? "/" : "/master/") + suffix);
+          return;
+        }
+        location.replace("/" + ver + "/" + suffix);
+        return;
+      }
+      // Pre-versioning deep link (e.g. /design/architecture/) → same path
+      // under the default docs version (master).
+      location.replace("/master" + path + suffix);
+    })();
+  </script>
+</head>
+<body>
+  <noscript>
+    <p>
+      This page was not found. Try the
+      <a href="/master/">current documentation</a>.
+    </p>
+  </noscript>
+  <p>Redirecting…</p>
+</body>
+</html>

--- a/hack/lib/install-gh-pages-404.sh
+++ b/hack/lib/install-gh-pages-404.sh
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install GitHub Pages root 404.html after mike deploy. Sourced by
+# hack/build-docs.sh and hack/test-install-gh-pages-404.sh.
+#
+# Required environment:
+#   SITE_404_CACHE  path to the cached template file to install
+#   PUSH            "true" to push gh-pages after commit; otherwise local only
+
+install_gh_pages_404() {
+  echo "==> Installing root 404.html on gh-pages"
+  if ! git show-ref --verify --quiet refs/heads/gh-pages; then
+    if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+      git branch gh-pages origin/gh-pages
+    else
+      echo "WARNING: no local or remote gh-pages branch; skipping root 404.html"
+      return 0
+    fi
+  fi
+
+  git checkout -f gh-pages
+  cp "${SITE_404_CACHE}" 404.html
+  git add 404.html
+  if git diff --cached --quiet; then
+    echo "    404.html already up to date"
+    return 0
+  fi
+
+  git commit -m "docs: preserve pre-versioning deep links by refreshing root 404"
+  if [[ "${PUSH}" == "true" ]]; then
+    git push origin gh-pages
+  fi
+}

--- a/hack/lib/require-clean-worktree.sh
+++ b/hack/lib/require-clean-worktree.sh
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Refuse to run when tracked files are modified. Force-checkouts in the docs
+# publish path (mike deploy, install_gh_pages_404) would discard those changes.
+# Sourced by hack/build-docs.sh and hack/test-install-gh-pages-404.sh.
+#
+# Optional: die() may already be defined by the caller. If not, a minimal one
+# is provided.
+
+if ! declare -F die >/dev/null 2>&1; then
+  die() {
+    echo "ERROR: $*" >&2
+    exit 1
+  }
+fi
+
+require_clean_worktree() {
+  # Only tracked changes matter: git checkout -f discards them. Untracked files
+  # are left alone and are not a reason to block the build.
+  if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+    die "refusing to run with a dirty worktree (tracked files have local changes).
+
+git checkout -f during versioned docs builds would discard those changes.
+Commit, stash, or discard local modifications, then retry.
+See docs/developer-guide/documentation.md for details.
+
+$(git status --porcelain --untracked-files=no)"
+  fi
+}

--- a/hack/test-install-gh-pages-404.sh
+++ b/hack/test-install-gh-pages-404.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shell-level coverage for install_gh_pages_404 (hack/lib/install-gh-pages-404.sh).
+# Uses disposable git repos — no network, no mike.
+#
+# Usage (from repo root):
+#   ./hack/test-install-gh-pages-404.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=hack/lib/install-gh-pages-404.sh
+source "${ROOT_DIR}/hack/lib/install-gh-pages-404.sh"
+# shellcheck source=hack/lib/require-clean-worktree.sh
+source "${ROOT_DIR}/hack/lib/require-clean-worktree.sh"
+
+PASS=0
+FAIL=0
+TMP=""
+
+cleanup() {
+  if [[ -n "${TMP}" && -d "${TMP}" ]]; then
+    rm -rf "${TMP}"
+  fi
+}
+trap cleanup EXIT
+
+assert_eq() {
+  local name="$1" got="$2" want="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    echo "  PASS: ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${name} (got='${got}' want='${want}')" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_true() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "  PASS: ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${name}" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_false() {
+  local name="$1"
+  shift
+  if ! "$@"; then
+    echo "  PASS: ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${name} (expected failure)" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+git_init_identity() {
+  git config user.email "docs-404-test@example.com"
+  git config user.name "docs-404-test"
+}
+
+make_bare_remote() {
+  local bare="$1"
+  local branch="${2:-master}"
+  local seed
+  seed="$(mktemp -d)"
+  git init -q -b "${branch}" "${seed}"
+  (
+    cd "${seed}"
+    git_init_identity
+    echo seed > README
+    git add README
+    git commit -q -m "seed"
+  )
+  git clone -q --bare "${seed}" "${bare}"
+  rm -rf "${seed}"
+}
+
+clone_worktree() {
+  local bare="$1"
+  local work="$2"
+  git clone -q "${bare}" "${work}"
+  (
+    cd "${work}"
+    git_init_identity
+  )
+}
+
+ensure_local_gh_pages() {
+  git checkout -q -b gh-pages
+  echo pages > index.html
+  git add index.html
+  git commit -q -m "gh-pages seed"
+  git checkout -q master
+}
+
+begin_fixture() {
+  cleanup
+  TMP="$(mktemp -d)"
+  make_bare_remote "${TMP}/remote.git"
+  clone_worktree "${TMP}/remote.git" "${TMP}/work"
+  cd "${TMP}/work"
+}
+
+echo "==> test: skip when no local or remote gh-pages"
+begin_fixture
+SITE_404_CACHE="$(mktemp)"
+echo 'TEMPLATE-A' > "${SITE_404_CACHE}"
+PUSH=false
+out="$(install_gh_pages_404 2>&1 || true)"
+assert_true "warns and skips" grep -q "skipping root 404.html" <<<"${out}"
+assert_false "did not create gh-pages" git show-ref --verify --quiet refs/heads/gh-pages
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo "==> test: existing local gh-pages, changed template, PUSH=false"
+begin_fixture
+ensure_local_gh_pages
+SITE_404_CACHE="$(mktemp)"
+echo 'TEMPLATE-NEW' > "${SITE_404_CACHE}"
+PUSH=false
+install_gh_pages_404 >/dev/null
+assert_eq "404 contents" "$(cat 404.html)" "TEMPLATE-NEW"
+msg="$(git log -1 --pretty=%s)"
+assert_eq "commit message" "${msg}" "docs: preserve pre-versioning deep links by refreshing root 404"
+assert_false "origin has no gh-pages" git -C "${TMP}/remote.git" show-ref --verify --quiet refs/heads/gh-pages
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo "==> test: unchanged template is a no-op"
+begin_fixture
+ensure_local_gh_pages
+SITE_404_CACHE="$(mktemp)"
+echo 'SAME' > "${SITE_404_CACHE}"
+PUSH=false
+install_gh_pages_404 >/dev/null
+commits_after_first="$(git rev-list --count gh-pages)"
+out="$(install_gh_pages_404 2>&1)"
+assert_true "reports up to date" grep -q "already up to date" <<<"${out}"
+assert_eq "no extra commit" "$(git rev-list --count gh-pages)" "${commits_after_first}"
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo "==> test: remote-only gh-pages (create local tracking branch)"
+begin_fixture
+ensure_local_gh_pages
+git push -q origin gh-pages
+cd "${ROOT_DIR}"
+# Fresh clone: origin/gh-pages exists, local gh-pages does not.
+rm -rf "${TMP}/work"
+clone_worktree "${TMP}/remote.git" "${TMP}/work"
+cd "${TMP}/work"
+assert_false "no local gh-pages before install" git show-ref --verify --quiet refs/heads/gh-pages
+assert_true "remote gh-pages present" git show-ref --verify --quiet refs/remotes/origin/gh-pages
+SITE_404_CACHE="$(mktemp)"
+echo 'FROM-REMOTE-ONLY' > "${SITE_404_CACHE}"
+PUSH=false
+install_gh_pages_404 >/dev/null
+assert_true "local gh-pages created" git show-ref --verify --quiet refs/heads/gh-pages
+assert_eq "404 installed" "$(git show gh-pages:404.html)" "FROM-REMOTE-ONLY"
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo "==> test: PUSH=true pushes commit to origin"
+begin_fixture
+ensure_local_gh_pages
+git push -q origin gh-pages
+SITE_404_CACHE="$(mktemp)"
+echo 'PUSHED-TEMPLATE' > "${SITE_404_CACHE}"
+PUSH=true
+install_gh_pages_404 >/dev/null
+assert_eq "remote 404" "$(git --git-dir="${TMP}/remote.git" show gh-pages:404.html)" "PUSHED-TEMPLATE"
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo "==> test: PUSH=true surfaces push failure"
+begin_fixture
+ensure_local_gh_pages
+git push -q origin gh-pages
+cat > "${TMP}/remote.git/hooks/pre-receive" <<'EOF'
+#!/bin/sh
+echo "push rejected by test hook" >&2
+exit 1
+EOF
+chmod +x "${TMP}/remote.git/hooks/pre-receive"
+SITE_404_CACHE="$(mktemp)"
+echo 'WILL-FAIL-PUSH' > "${SITE_404_CACHE}"
+PUSH=true
+set +e
+install_gh_pages_404 >/dev/null 2>"${TMP}/err"
+ec=$?
+set -e
+assert_false "install fails when push fails" test "${ec}" -eq 0
+assert_true "error mentions rejection" grep -Eqi 'rejected|hook|denied|error' "${TMP}/err"
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo "==> test: require_clean_worktree allows a clean repo"
+begin_fixture
+set +e
+( require_clean_worktree ) >/dev/null 2>"${TMP}/err"
+ec=$?
+set -e
+assert_eq "clean worktree exit code" "${ec}" "0"
+cd "${ROOT_DIR}"
+
+echo "==> test: require_clean_worktree rejects dirty tracked files"
+begin_fixture
+echo "local-edit" >> README
+set +e
+( require_clean_worktree ) >/dev/null 2>"${TMP}/err"
+ec=$?
+set -e
+assert_false "dirty worktree is rejected" test "${ec}" -eq 0
+assert_true "error mentions dirty worktree" grep -q "dirty worktree" "${TMP}/err"
+# Confirm the local edit was not discarded by the preflight itself.
+assert_true "local edit still present" grep -q "local-edit" README
+cd "${ROOT_DIR}"
+
+echo "==> test: dirty worktree survives install_gh_pages_404 only if caller gates first"
+# Regression: without require_clean_worktree, checkout -f would drop tracked edits.
+# With the gate, we refuse before switching branches so the edit remains.
+begin_fixture
+ensure_local_gh_pages
+echo "keep-me" >> README
+SITE_404_CACHE="$(mktemp)"
+echo 'TEMPLATE' > "${SITE_404_CACHE}"
+PUSH=false
+set +e
+( require_clean_worktree ) >/dev/null 2>"${TMP}/err"
+gate_ec=$?
+set -e
+assert_false "gate blocks before install" test "${gate_ec}" -eq 0
+assert_true "README edit preserved" grep -q "keep-me" README
+assert_eq "still on master" "$(git symbolic-ref --short HEAD)" "master"
+rm -f "${SITE_404_CACHE}"
+cd "${ROOT_DIR}"
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "${FAIL}" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes broken documentation links after mike multi-version publishing on ovn-kubernetes.io. Unversioned deep links 404 because pages now live under `/master/`, `/1.x/`, etc. This PR updates in-repo linking conventions, installs a root GitHub Pages `404.html` redirect during docs publish, hardens
that install path, and documents/tests the behavior.

| Problem | Solution | Reason |
|--------|----------|-----|
| Absolute unversioned docs URLs (e.g. `https://ovn-kubernetes.io/design/architecture/`) 404 after mike versioning | Convert in-`docs/` links to **relative Markdown paths** (e.g. `../design/architecture.md`) | MkDocs resolves them inside the current version prefix, so links keep working across `/master/`, `/1.x/`, and the version dropdown |
| Root files symlinked into `docs/governance/` (e.g. `CONTRIBUTING.md`) break if relative paths assume the docs tree | Use **versioned absolute** URLs under `/master/...` for those shared files | Same file is viewed on GitHub (repo root) and on the site (`docs/governance/`); `/master/...` works in both places |
| README / other non-`docs/` deep links to the live site used unversioned paths | Point them at **`https://ovn-kubernetes.io/master/...`** | Repo-root Markdown is not version-aware; `/master/` is the stable published tree for current docs |
| Old bookmarks and external links still hit unversioned paths and get GitHub’s generic 404 | Install root **`404.html`** from `hack/docs-site-404.html` on `gh-pages` after each mike deploy | GitHub Pages serves site-root `404.html` for missing URLs; redirect unversioned paths to `/master` + same path |
| Missing pages already under a version (e.g. `/master/missing`) or unpublished version roots (e.g. `/999/`) could redirect badly or loop | Versioned misses → that version’s home; version **root** that doesn’t exist → `/master/` (or `/` if already `master`) — **no self-redirect** | Avoid redirect loops while still recovering from bad bookmarks |
| Hand-editing `404.html` on `gh-pages` drifts from source and is easy to overwrite | Treat `hack/docs-site-404.html` as source of truth; workflow installs it via `hack/build-docs.sh` | Publish owns `gh-pages`; maintainers change the template on `master` only |
| Force-checkouts during 404 install can wipe local tracked edits if the worktree is dirty | **`require_clean_worktree`** gate before publish/install | Fail fast instead of silently losing local work |
| 404 install / clean-worktree logic had no automated coverage | Sourcable helpers + **`hack/test-install-gh-pages-404.sh`** (wired into Test Docs Build / docs Makefile) | Catch skip/no-op/push/push-failure and dirty-worktree cases in CI without touching real `gh-pages` |
| Contributors didn’t know the new linking / 404 rules | Document relative vs `/master/` rules and root-404 behavior in **developer-guide/documentation.md** | Prevent regressions and make post-merge verification clear |

## Backports (older published versions)

Mike builds each docs version from its own `release-*` branch, so fixing links only on `master` does **not** update in-page links under `/1.0/`, `/1.1/`, `/1.2/`, or `/1.3/`. I opened content-only backport PRs so those versions get the same deep-link fixes.

### What the backports do
- Convert unversioned `https://ovn-kubernetes.io/<page>/` docs links to **relative Markdown** (so clicks stay inside that version’s prefix, e.g. `/1.3/...`).
- Point `README.md` / `CONTRIBUTING.md` site links at **`/master/...`** where needed (shared root files).
- Do **not** include the master-only mike / root-`404.html` / CI harness — that stays on this PR; older branches never had those files.

### Backport PRs
| Target branch | Backport PR |
|---------------|-------------|
| `release-1.0` | #6853  |
| `release-1.1` | #6852  |
| `release-1.2` | #6854  |
| `release-1.3` | #6855  |

### After merge
1. Merge this PR to `master` (publishes master + installs root `404.html` for old unversioned bookmarks).
2. Merge the four backport PRs.
3. Run **Actions → Publish Versioned Docs** with `releases=all` so every version is rebuilt from the updated branches.
