### PR TITLE
e2e: fix Uplink route checks for Dynamic UDNs

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -231,13 +231,10 @@ jobs:
           export ENABLE_MULTI_NET=true
           export ENABLE_NETWORK_SEGMENTATION=true
           export ENABLE_ROUTE_ADVERTISEMENTS=true
+          export ENABLE_UPLINK=true
           export ENABLE_NO_OVERLAY=true
           export DYNAMIC_UDN_ALLOCATION=true
-          make -C test control-plane WHAT="Network Segmentation Uplink route advertisements uses the Uplink interface as the targetVRF auto BGP peering path"
-          make -C test control-plane WHAT="Uplink route advertisements with Dynamic UDN allocation allows node-disjoint Dynamic CUDNs to share a targetVRF auto Uplink and rejects overlap"
-          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions keeps one writer per condition and recovers a missing host interface"
-          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions recreates an UplinkState deleted out of band"
-          make -C test control-plane WHAT="Network Segmentation Uplink split DPU status conditions resolves the bridge by host function and falls back to host MAC"
+          make -C test control-plane WHAT="Uplink"
 
       - name: Export kind logs on failure
         if: failure()

--- a/test/e2e/feature/features.go
+++ b/test/e2e/feature/features.go
@@ -36,6 +36,7 @@ var (
 	// is specific to dynamic UDN allocation; these tests require clusters
 	// with both route advertisements and dynamic UDN allocation enabled.
 	RouteAdvertisementsDynamicUDN = New("RouteAdvertisementsDynamicUDN")
+	Uplink                        = New("Uplink")
 	Unidle                        = New("Unidle")
 	NetworkQos                    = New("NetworkQos")
 	NetworkConnect                = New("NetworkConnect")

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -2899,6 +2899,8 @@ func createUplinkNodePortService(f *framework.Framework, namespace string, selec
 
 	service := e2eservice.CreateServiceSpec("server", "", false, selector)
 	service.Spec.Type = corev1.ServiceTypeNodePort
+	preferDualStack := corev1.IPFamilyPolicyPreferDualStack
+	service.Spec.IPFamilyPolicy = &preferDualStack
 	service.Spec.Ports[0].Port = netexecPort
 	service.Spec.Ports[0].TargetPort = intstr.FromInt32(netexecPort)
 	service, err := f.ClientSet.CoreV1().Services(namespace).Create(

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -686,6 +686,17 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			networkLabels,
 			uplinkName,
 		)).To(gomega.Succeed())
+		if isDynamicUDNEnabled() {
+			ginkgo.By("activating the dynamic CUDN on the nodes under test")
+			for i, node := range schedulableNodes.Items {
+				createUplinkNetexecPod(
+					f,
+					namespace.Name,
+					fmt.Sprintf("activate-%s-%d", networkName, i),
+					node.Name,
+				)
+			}
+		}
 		gomega.Expect(createRouteAdvertisements(
 			f,
 			ictx,

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -108,7 +108,7 @@ type dpuHostAddrAnnotation struct {
 	IPv6 string `json:"ipv6"`
 }
 
-var _ = ginkgo.Describe("Network Segmentation Uplink default-VRF egress", feature.NetworkSegmentation, func() {
+var _ = ginkgo.Describe("Network Segmentation Uplink default-VRF egress", feature.NetworkSegmentation, feature.Uplink, func() {
 	f := wrappedTestFramework("uplink-default")
 	f.SkipNamespaceCreation = true
 
@@ -429,7 +429,7 @@ func provisionUplinkWithActiveCUDN(
 	}
 }
 
-var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feature.NetworkSegmentation, feature.RouteAdvertisements, func() {
+var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feature.NetworkSegmentation, feature.RouteAdvertisements, feature.Uplink, func() {
 	f := wrappedTestFramework("uplink-bgp")
 	f.SkipNamespaceCreation = true
 
@@ -783,7 +783,7 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 	})
 })
 
-var _ = ginkgo.Describe("Uplink route advertisements with Dynamic UDN allocation", feature.RouteAdvertisementsDynamicUDN, func() {
+var _ = ginkgo.Describe("Uplink route advertisements with Dynamic UDN allocation", feature.RouteAdvertisementsDynamicUDN, feature.Uplink, func() {
 	f := wrappedTestFramework("uplink-dynamic-bgp")
 	f.SkipNamespaceCreation = true
 
@@ -983,7 +983,7 @@ var _ = ginkgo.Describe("Uplink route advertisements with Dynamic UDN allocation
 	})
 })
 
-var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feature.NetworkSegmentation, feature.RouteAdvertisements, func() {
+var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feature.NetworkSegmentation, feature.RouteAdvertisements, feature.Uplink, func() {
 	f := wrappedTestFramework("uplink-bgp")
 	f.SkipNamespaceCreation = true
 
@@ -1058,6 +1058,12 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			"client-"+networkName,
 			schedulableNodes.Items[0].Name,
 		)
+		cudnNodes := schedulableNodes.Items
+		if isDynamicUDNEnabled() {
+			// With dynamic UDN allocation, the CUDN and its VRF only exist on
+			// nodes running workloads attached to the network.
+			cudnNodes = []corev1.Node{schedulableNodes.Items[0]}
+		}
 
 		serverNetwork, err := infraprovider.Get().GetNetwork(serverNetworkName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1097,6 +1103,8 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 					serverCIDR,
 					frrIP,
 				)
+			}
+			for _, node := range cudnNodes {
 				gomega.Eventually(func() (bool, error) {
 					return hasRouteInCUDNVRF(node, networkName, serverCIDR, bgpNextHopsForPeer(family, frrIface)...)
 				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
@@ -1213,7 +1221,7 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 	})
 })
 
-var _ = ginkgo.Describe("Network Segmentation Uplink split DPU status conditions", feature.NetworkSegmentation, func() {
+var _ = ginkgo.Describe("Network Segmentation Uplink split DPU status conditions", feature.NetworkSegmentation, feature.Uplink, func() {
 	f := wrappedTestFramework("uplink-conditions")
 	f.SkipNamespaceCreation = true
 

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -139,13 +139,19 @@ if [[ "${WHAT}" != *"${DHCP_IPAM_TESTS}"* ]]; then
   skip_label "Feature:DHCPIPAM"
 fi
 
-# Only run network segmentation tests if they are explicitly requested
+# Only run network segmentation tests if they are explicitly requested. Route
+# advertisement lanes are the exception: allow tests in the intersection of
+# network segmentation and route advertisements when both features are enabled.
 NETWORK_SEGMENTATION_TESTS="Network Segmentation"
 if [[ "${WHAT}" = "${NETWORK_SEGMENTATION_TESTS}"* ]]; then
   require_label "Feature:NetworkSegmentation"
   shift # don't "focus" on Network Segmentation since we filter by label
 elif [[ "${WHAT}" != "${NETWORK_SEGMENTATION_TESTS}"* ]]; then
-  skip_label "Feature:NetworkSegmentation"
+  if [ "$ENABLE_NETWORK_SEGMENTATION" == true ] && [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
+    skip_label "Feature:NetworkSegmentation && !(Feature:RouteAdvertisements)"
+  else
+    skip_label "Feature:NetworkSegmentation"
+  fi
 fi
 
 # Network Segmentation suite selection uses a feature label and removes the
@@ -166,6 +172,10 @@ SERIAL_LABEL="Serial"
 if [[ "${WHAT}" = "$SERIAL_LABEL" ]]; then
   require_label "$SERIAL_LABEL"
   shift # don't "focus" on Serial since we filter by label
+fi
+
+if [ "$ENABLE_UPLINK" != true ]; then
+  skip_label "Feature:Uplink"
 fi
 
 if [ "$ENABLE_EVPN" != true ]; then

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -139,11 +139,18 @@ if [[ "${WHAT}" != *"${DHCP_IPAM_TESTS}"* ]]; then
   skip_label "Feature:DHCPIPAM"
 fi
 
+# Select all Uplink tests by feature label. These tests span network
+# segmentation and route advertisement suites, with individual specs deciding
+# whether to use or skip DPU-specific behavior.
 # Only run network segmentation tests if they are explicitly requested. Route
 # advertisement lanes are the exception: allow tests in the intersection of
 # network segmentation and route advertisements when both features are enabled.
+UPLINK_TESTS="Uplink"
 NETWORK_SEGMENTATION_TESTS="Network Segmentation"
-if [[ "${WHAT}" = "${NETWORK_SEGMENTATION_TESTS}"* ]]; then
+if [[ "${WHAT}" = "${UPLINK_TESTS}" ]]; then
+  require_label "Feature:Uplink"
+  shift # don't "focus" on Uplink since we filter by label
+elif [[ "${WHAT}" = "${NETWORK_SEGMENTATION_TESTS}"* ]]; then
   require_label "Feature:NetworkSegmentation"
   shift # don't "focus" on Network Segmentation since we filter by label
 elif [[ "${WHAT}" != "${NETWORK_SEGMENTATION_TESTS}"* ]]; then


### PR DESCRIPTION
Dynamic UDN allocation only creates a CUDN VRF on nodes where the network is active. The default-VRF Uplink test placed its client on one node but expected CUDN routes on every schedulable node, so inactive nodes failed route inspection with "Invalid VRF". Continue checking BGP routes in the default VRF on every node, but limit CUDN VRF checks to active nodes when dynamic allocation is enabled.

Permit tests labeledfor both NetworkSegmentation and RouteAdvertisements in route-advertisement lanes. The test was not being executed in our CI due to this issue.


