### PR TITLE
metrics: keep ovnkube-node /metrics scrape under Prometheus' timeout

### DIFF
--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -30,6 +30,12 @@ const (
 	ovsVswitchd   = "ovs-vswitchd"
 
 	metricsUpdateInterval = 5 * time.Minute
+
+	// metricsAppctlTimeout (seconds) bounds every ovs-appctl/ovn-appctl subprocess on
+	// the scrape path via --timeout=N. A saturated daemon (e.g. ovn-controller) would
+	// otherwise block the call and pin the scrape past Prometheus' scrape_timeout,
+	// flapping up to 0. Healthy appctls answer in ms, so a low bound sheds stuck calls.
+	metricsAppctlTimeout = 2
 )
 
 type metricDetails struct {
@@ -119,11 +125,11 @@ func getCoverageShowOutputMap(component string) (map[string]string, error) {
 	}()
 
 	if component == ovnController {
-		stdout, stderr, err = util.RunOVNControllerAppCtl("coverage/show")
+		stdout, stderr, err = util.RunOVNControllerAppCtlWithTimeout(metricsAppctlTimeout, "coverage/show")
 	} else if component == ovnNorthd {
-		stdout, stderr, err = util.RunOVNNorthAppCtl("coverage/show")
+		stdout, stderr, err = util.RunOVNNorthAppCtlWithTimeout(metricsAppctlTimeout, "coverage/show")
 	} else if component == ovsVswitchd {
-		stdout, stderr, err = util.RunOvsVswitchdAppCtl("coverage/show")
+		stdout, stderr, err = util.RunOvsVswitchdAppCtlWithTimeout(metricsAppctlTimeout, "coverage/show")
 	} else {
 		return nil, fmt.Errorf("component is unknown, and it isn't %s, %s, or %s",
 			ovnNorthd, ovnController, ovsVswitchd)
@@ -279,9 +285,9 @@ func getStopwatchShowOutputMap(component string) (map[string]stopwatchStatistics
 
 	switch component {
 	case ovnController:
-		stdout, stderr, err = util.RunOVNControllerAppCtl("stopwatch/show")
+		stdout, stderr, err = util.RunOVNControllerAppCtlWithTimeout(metricsAppctlTimeout, "stopwatch/show")
 	case ovnNorthd:
-		stdout, stderr, err = util.RunOVNNorthAppCtl("stopwatch/show")
+		stdout, stderr, err = util.RunOVNNorthAppCtlWithTimeout(metricsAppctlTimeout, "stopwatch/show")
 	default:
 		return nil, fmt.Errorf("unknown component %s for stopwatch/show", component)
 	}

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -43,7 +43,7 @@ func getOvnNorthdVersionInfo() {
 }
 
 func getOvnNorthdConnectionStatusInfo(command string) float64 {
-	stdout, stderr, err := util.RunOVNNorthAppCtl(command)
+	stdout, stderr, err := util.RunOVNNorthAppCtlWithTimeout(metricsAppctlTimeout, command)
 	if err != nil {
 		klog.Errorf("Failed to get ovn-northd %s stderr(%s): (%v)", command, stderr, err)
 		return -1
@@ -138,7 +138,7 @@ func RegisterOvnNorthdMetrics(ovnRegistry prometheus.Registerer) {
 			Name:      "status",
 			Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
 		}, func() float64 {
-			stdout, stderr, err := util.RunOVNNorthAppCtl("status")
+			stdout, stderr, err := util.RunOVNNorthAppCtlWithTimeout(metricsAppctlTimeout, "status")
 			if err != nil {
 				klog.Errorf("Failed to get ovn-northd status "+
 					"stderr(%s) :(%v)", stderr, err)

--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -363,7 +363,7 @@ func getOvsDatapaths() (datapathsList []string, err error) {
 		}
 	}()
 
-	stdout, stderr, err = util.RunOvsVswitchdAppCtl("dpctl/dump-dps")
+	stdout, stderr, err = util.RunOvsVswitchdAppCtlWithTimeout(metricsAppctlTimeout, "dpctl/dump-dps")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get output of ovs-appctl dpctl/dump-dps "+
 			"stderr(%s) :(%v)", stderr, err)
@@ -399,7 +399,7 @@ func setOvsDatapathMetrics(datapaths []string) (err error) {
 		// the datapath type and 'ovs-system' the datapath name. To uniquely
 		// identify a datapath, both are required when querying OVS. If type is
 		// omitted, OVS will assume 'system'.
-		stdout, stderr, err = util.RunOvsVswitchdAppCtl("dpctl/show", datapath)
+		stdout, stderr, err = util.RunOvsVswitchdAppCtlWithTimeout(metricsAppctlTimeout, "dpctl/show", datapath)
 		if err != nil {
 			return fmt.Errorf("failed to get datapath stats for %s "+
 				"stderr(%s) :(%v)", datapath, stderr, err)

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,6 +26,39 @@ import (
 	ovntls "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/tls"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+const (
+	// metricsScrapeBudgetFallback bounds metric collection when Prometheus does not
+	// advertise its scrape timeout. Kept below the typical 10s scrape_timeout so the
+	// handler still returns in time to serve the last known values (up stays 1).
+	metricsScrapeBudgetFallback = 8 * time.Second
+
+	// metricsScrapeBudgetSlack is subtracted from the advertised scrape timeout to
+	// leave promhttp room to serialize and write the response before Prometheus'
+	// deadline; without it a cached write can lose the race and flap up to 0.
+	metricsScrapeBudgetSlack = 500 * time.Millisecond
+)
+
+// scrapeBudget returns how long metric collection may run before the handler gives
+// up and serves the last known values. It honors Prometheus'
+// X-Prometheus-Scrape-Timeout-Seconds header (minus slack) when present, otherwise
+// falls back to metricsScrapeBudgetFallback.
+func scrapeBudget(r *http.Request) time.Duration {
+	if v := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"); v != "" {
+		if secs, err := strconv.ParseFloat(v, 64); err == nil && secs > 0 {
+			// Honor the advertised deadline minus slack, never the larger fallback.
+			// If that leaves no room, use the full advertised value rather than skip
+			// collection entirely.
+			advertised := time.Duration(secs * float64(time.Second))
+			if budget := advertised - metricsScrapeBudgetSlack; budget > 0 {
+				return budget
+			}
+			return advertised
+		}
+	}
+	// No header, or an unparseable/non-positive one: fall back.
+	return metricsScrapeBudgetFallback
+}
 
 // MetricServerOptions defines the configuration options for the new MetricServer
 type MetricServerOptions struct {
@@ -183,21 +218,48 @@ func (s *MetricServer) updateOvnDBMetrics() {
 	}
 }
 
-// handleMetrics handles the /metrics request
+// handleMetrics refreshes the OVS/OVN metrics before they are emitted. Collection
+// execs ovs-appctl/ovn-appctl subprocesses (each bounded by metricsAppctlTimeout)
+// in a separate goroutine under a scrape budget: if the daemons are slow and it
+// overruns, the handler returns and promhttp serves the last known values, keeping
+// the scrape under Prometheus' scrape_timeout (up stays 1). The goroutine keeps
+// running to refresh the registry for the next scrape.
 func (s *MetricServer) handleMetrics(r *http.Request) {
 	klog.V(5).Infof("MetricServer starts to handle metrics request from %s", r.RemoteAddr)
 
-	if s.opts.EnableOVSMetrics {
-		s.updateOvsMetrics()
-	}
-	if s.opts.EnableOVNDBMetrics {
-		s.updateOvnDBMetrics()
-	}
-	if s.opts.EnableOVNControllerMetrics {
-		s.updateOvnControllerMetrics()
-	}
-	if s.opts.EnableOVNNorthdMetrics {
-		s.updateOvnNorthdMetrics()
+	ctx, cancel := context.WithTimeout(r.Context(), scrapeBudget(r))
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Nothing recovers this detached goroutine, so recover here: a panic in a
+		// metric path must only fail this scrape, not crash ovnkube-node.
+		defer func() {
+			if r := recover(); r != nil {
+				klog.Errorf("MetricServer recovered from panic during metric collection: %v\n%s", r, debug.Stack())
+			}
+		}()
+
+		if s.opts.EnableOVSMetrics {
+			s.updateOvsMetrics()
+		}
+		if s.opts.EnableOVNDBMetrics {
+			s.updateOvnDBMetrics()
+		}
+		if s.opts.EnableOVNControllerMetrics {
+			s.updateOvnControllerMetrics()
+		}
+		if s.opts.EnableOVNNorthdMetrics {
+			s.updateOvnNorthdMetrics()
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		klog.Errorf("MetricServer metric collection exceeded the scrape budget for request from %s; "+
+			"serving last known values (%v)", r.RemoteAddr, ctx.Err())
 	}
 }
 

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -137,7 +137,9 @@ func (s *MetricServer) updateOvsMetrics() {
 	if err := updateOvsInterfaceMetrics(s.opts.OVSDBClient); err != nil {
 		klog.Errorf("Updating ovs interface metrics failed: %s", err.Error())
 	}
-	if err := setOvsMemoryMetrics(util.RunOvsVswitchdAppCtl); err != nil {
+	if err := setOvsMemoryMetrics(func(args ...string) (string, string, error) {
+		return util.RunOvsVswitchdAppCtlWithTimeout(metricsAppctlTimeout, args...)
+	}); err != nil {
 		klog.Errorf("Updating ovs memory metrics failed: %s", err.Error())
 	}
 	if err := setOvsHwOffloadMetrics(s.opts.OVSDBClient); err != nil {
@@ -154,7 +156,9 @@ func (s *MetricServer) updateOvnControllerMetrics() {
 
 	coverageShowMetricsUpdate(ovnController)
 	stopwatchShowMetricsUpdate(ovnController)
-	updateSBDBConnectionMetric(util.RunOVNControllerAppCtl)
+	updateSBDBConnectionMetric(func(args ...string) (string, string, error) {
+		return util.RunOVNControllerAppCtlWithTimeout(metricsAppctlTimeout, args...)
+	})
 
 }
 

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -456,28 +456,28 @@ var (
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dpctl/dump-dps"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "dpctl/dump-dps"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte("system@ovs-system")), bytes.NewBuffer([]byte("")), nil},
 			},
 			// dpctl/show
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dpctl/show", "system@ovs-system"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "dpctl/show", "system@ovs-system"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte(dpctlShowOutput)), bytes.NewBuffer([]byte("")), nil},
 			},
 			// memory/show
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "memory/show"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "memory/show"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovsMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
 			},
 			// coverage/show
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "coverage/show"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "coverage/show"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte(coverageShowOutput)), bytes.NewBuffer([]byte("")), nil},
 			},
 			// ovs-ofctl dump-aggregate br-int
@@ -627,7 +627,7 @@ var (
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "coverage/show"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "coverage/show"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnControllercoverageShowOutput)), bytes.NewBuffer([]byte("")), nil},
 			},
 			// ovs-appctl -t  /var/run/openvswitch/ovn-controller.113.ctl version
@@ -641,7 +641,7 @@ var (
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "connection-status"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "connection-status"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
 			},
 		},
@@ -754,7 +754,7 @@ var (
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "status"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "status"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte("Status: standby")), bytes.NewBuffer([]byte("")), nil},
 				CallTimes:  2,
 			},
@@ -762,7 +762,7 @@ var (
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "sb-connection-status"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "sb-connection-status"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
 				CallTimes:  2,
 			},
@@ -770,7 +770,7 @@ var (
 			{
 				OnCallMethodName: "RunCmd",
 				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
-					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "nb-connection-status"},
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "--timeout=2", "nb-connection-status"},
 				RetArgList: []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
 				CallTimes:  2,
 			},

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"time"
@@ -21,6 +22,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
+
+	kexec "k8s.io/utils/exec"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -263,6 +266,146 @@ var _ = Describe("MetricServer", func() {
 				}
 			})
 		})
+	})
+})
+
+var _ = Describe("scrapeBudget", func() {
+	DescribeTable("derives the collection budget from the scrape-timeout header",
+		func(header string, expected time.Duration) {
+			r, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+			Expect(err).NotTo(HaveOccurred())
+			if header != "" {
+				r.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", header)
+			}
+			Expect(scrapeBudget(r)).To(Equal(expected))
+		},
+		Entry("no header falls back", "", metricsScrapeBudgetFallback),
+		Entry("valid header minus slack", "12", 12*time.Second-metricsScrapeBudgetSlack),
+		Entry("fractional header minus slack", "5.5", time.Duration(5.5*float64(time.Second))-metricsScrapeBudgetSlack),
+		Entry("valid header at slack falls back to advertised", "0.5", time.Duration(0.5*float64(time.Second))),
+		Entry("valid header below slack falls back to advertised", "0.2", time.Duration(0.2*float64(time.Second))),
+		Entry("garbage header falls back", "nope", metricsScrapeBudgetFallback),
+		Entry("zero header falls back", "0", metricsScrapeBudgetFallback),
+	)
+})
+
+// stallingExecRunner is an ExecRunner that blocks the metric collection commands
+// (coverage/show, stopwatch/show) on the release channel to simulate a saturated
+// daemon that cannot answer, while returning immediately for every other command.
+// It lets the overrun test stall only the on-scrape collection path without also
+// blocking promhttp's gather tail.
+//
+// Because the fix runs collection in a detached goroutine, that goroutine outlives
+// the scrape. connectionStatusDone is closed once the goroutine finishes its final
+// runner call (connection-status), which is the last thing it does that reads any
+// process-global; the test waits on it before restoring globals so cleanup does not
+// race the still-running collection.
+type stallingExecRunner struct {
+	release              chan struct{}
+	connectionStatusDone chan struct{}
+}
+
+func (r *stallingExecRunner) RunCmd(_ kexec.Cmd, _ string, _ []string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+	for _, a := range args {
+		switch a {
+		case "coverage/show", "stopwatch/show":
+			<-r.release
+		case "connection-status":
+			defer close(r.connectionStatusDone)
+		}
+	}
+	return bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil
+}
+
+var _ = Describe("scrape budget overrun", func() {
+	It("returns within the budget and serves the registry when collection stalls", func() {
+		savedRunner := util.RunCmdExecRunner
+		DeferCleanup(func() { util.RunCmdExecRunner = savedRunner })
+
+		setupAppFs()
+
+		// Minimal OVS DB so the ovn-controller registration/config metrics resolve.
+		ovsVersion := "2.17.0"
+		br := vswitchd.Bridge{Name: "br-int", UUID: buildUUID()}
+		testDB := []libovsdbtest.TestData{
+			&vswitchd.Bridge{UUID: br.UUID, Name: br.Name},
+			&vswitchd.OpenvSwitch{
+				UUID:       buildUUID(),
+				OVSVersion: &ovsVersion,
+				Bridges:    []string{br.UUID},
+				ExternalIDs: map[string]string{
+					"ovn-remote": "unix:/var/run/ovn/ovnsb_db.sock",
+				},
+			},
+		}
+		ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{OVSData: testDB})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanup.Cleanup)
+
+		// Build a mock kexec interface so the appctl wrappers can construct a Cmd;
+		// the actual exec is intercepted by stallingExecRunner below.
+		mockCmd := new(mock_k8s_io_utils_exec.Cmd)
+		mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
+		for _, n := range []int{3, 4, 5, 6} {
+			anys := make([]interface{}, n)
+			for i := range anys {
+				anys[i] = mock.Anything
+			}
+			mockKexecIface.Mock.On("Command", anys...).Maybe().Return(mockCmd)
+		}
+		_ = util.SetSpecificExec(mockKexecIface)
+		DeferCleanup(util.ResetRunner)
+
+		// The collection path (coverage/show, stopwatch/show) blocks until released,
+		// far past the budget; everything else returns immediately.
+		runner := &stallingExecRunner{
+			release:              make(chan struct{}),
+			connectionStatusDone: make(chan struct{}),
+		}
+		util.RunCmdExecRunner = runner
+
+		opts := MetricServerOptions{
+			EnableOVNControllerMetrics: true,
+			OVSDBClient:                ovsClient,
+			Registerer:                 prometheus.NewRegistry(),
+		}
+		server := NewMetricServer(opts)
+		server.registerMetrics()
+
+		ts := httptest.NewServer(server.mux)
+		DeferCleanup(ts.Close)
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/metrics", nil)
+		Expect(err).NotTo(HaveOccurred())
+		// budget = 2s - 500ms slack = 1.5s; collection stays blocked past it.
+		req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", "2")
+
+		start := time.Now()
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		elapsed := time.Since(start)
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Handler must shed the stalled collection at the budget rather than
+		// blocking on it, and still serve the registry (up stays 1).
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(body).NotTo(BeEmpty())
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+			"scrape blocked on stalled collection instead of returning within the budget")
+		// It should also not return early - the handler is expected to wait out the
+		// ~1.5s budget (2s header minus 500ms slack) because collection never
+		// completes, which proves the budget, not a fast collection, released it.
+		Expect(elapsed).To(BeNumerically(">", time.Second),
+			"scrape returned before the budget elapsed; collection was not actually stalled")
+
+		// Let the detached collection goroutine finish and wait for it before the
+		// DeferCleanups restore the process-global exec runner, otherwise cleanup
+		// races the still-running collection.
+		close(runner.release)
+		Eventually(runner.connectionStatusDone).Within(5 * time.Second).Should(BeClosed())
 	})
 })
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -569,6 +569,15 @@ func RunOVNSBAppCtl(args ...string) (string, string, error) {
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
+// RunOVNNorthAppCtlWithTimeout runs an 'ovs-appctl -t ovn-northd command' with a
+// --timeout so the subprocess self-terminates instead of blocking indefinitely on
+// a busy daemon.
+func RunOVNNorthAppCtlWithTimeout(timeout int, args ...string) (string, string, error) {
+	cmdArgs := []string{fmt.Sprintf("--timeout=%d", timeout)}
+	cmdArgs = append(cmdArgs, args...)
+	return RunOVNNorthAppCtl(cmdArgs...)
+}
+
 // RunOVNNorthAppCtl runs an 'ovs-appctl -t ovn-northd command'.
 // TODO: Currently no module is invoking this function, will need to consider adding an unit test when actively used
 func RunOVNNorthAppCtl(args ...string) (string, string, error) {
@@ -586,6 +595,15 @@ func RunOVNNorthAppCtl(args ...string) (string, string, error) {
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
+// RunOVNControllerAppCtlWithTimeout runs an 'ovs-appctl -t ovn-controller.pid.ctl
+// command' with a --timeout so the subprocess self-terminates instead of blocking
+// indefinitely on a busy daemon.
+func RunOVNControllerAppCtlWithTimeout(timeout int, args ...string) (string, string, error) {
+	cmdArgs := []string{fmt.Sprintf("--timeout=%d", timeout)}
+	cmdArgs = append(cmdArgs, args...)
+	return RunOVNControllerAppCtl(cmdArgs...)
+}
+
 // RunOVNControllerAppCtl runs an 'ovs-appctl -t ovn-controller.pid.ctl command'.
 func RunOVNControllerAppCtl(args ...string) (string, string, error) {
 	getSocketPath := func() ([]string, error) {
@@ -600,6 +618,15 @@ func RunOVNControllerAppCtl(args ...string) (string, string, error) {
 	}
 	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, getSocketPath, args...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
+}
+
+// RunOvsVswitchdAppCtlWithTimeout runs an 'ovs-appctl -t ovs-vswitchd.pid.ctl command'
+// with a --timeout so the subprocess self-terminates instead of blocking indefinitely
+// on a busy daemon.
+func RunOvsVswitchdAppCtlWithTimeout(timeout int, args ...string) (string, string, error) {
+	cmdArgs := []string{fmt.Sprintf("--timeout=%d", timeout)}
+	cmdArgs = append(cmdArgs, args...)
+	return RunOvsVswitchdAppCtl(cmdArgs...)
 }
 
 // RunOvsVswitchdAppCtl runs an 'ovs-appctl -t /var/run/openvsiwthc/ovs-vswitchd.pid.ctl command'


### PR DESCRIPTION
The ovnkube-node `/metrics` handler exec's ~12-15 `ovs-appctl`/`ovn-appctl`   subprocesses synchronously on the scrape path, with no timeout. When a  single-threaded daemon like `ovn-controller` is CPU-saturated, these calls block,   the scrape overruns Prometheus' `scrape_timeout`, and `up` flaps to 0 on a healthy  process (fires alerts). Seen in a UDN scale run.

- Bound each appctl call with `--timeout`.
- Run collection in a goroutine under a total budget from the  `X-Prometheus-Scrape-Timeout-Seconds` header; on overrun, serve the last known values so `up` stays 1.

Trade-off: on a loaded node a scrape may serve slightly stale values instead of blocking. Follow-up: move collection off the scrape path (background collector).

