### PR TITLE
controllermanager: fix the psample based observ feature to work on UDNs

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -74,6 +74,8 @@ type ControllerManager struct {
 	eIPController *ovn.EgressIPController
 
 	addressSetManager *addresssetmanager.AddressSetManager
+
+	observabilityManager *observability.Manager
 }
 
 func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkmanager.NetworkController, error) {
@@ -84,21 +86,21 @@ func (cm *ControllerManager) NewNetworkController(nInfo util.NetInfo) (networkma
 	switch topoType {
 	case ovntypes.Layer3Topology:
 		oc, err := ovn.NewLayer3UserDefinedNetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.routeImportManager,
-			cm.eIPController, cm.portCache, cm.addressSetManager, cm.nodeController, cm.serviceController)
+			cm.eIPController, cm.portCache, cm.addressSetManager, cm.nodeController, cm.serviceController, cm.observabilityManager)
 		if err != nil {
 			return nil, err
 		}
 		return oc, nil
 	case ovntypes.Layer2Topology:
 		oc, err := ovn.NewLayer2UserDefinedNetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.routeImportManager,
-			cm.portCache, cm.eIPController, cm.addressSetManager, cm.nodeController, cm.serviceController)
+			cm.portCache, cm.eIPController, cm.addressSetManager, cm.nodeController, cm.serviceController, cm.observabilityManager)
 		if err != nil {
 			return nil, err
 		}
 		return oc, nil
 	case ovntypes.LocalnetTopology:
 		oc := ovn.NewLocalnetUserDefinedNetworkController(cnci, nInfo, cm.networkManager.Interface(), cm.addressSetManager,
-			cm.nodeController)
+			cm.nodeController, cm.observabilityManager)
 		return oc, nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
@@ -115,12 +117,12 @@ func (cm *ControllerManager) newDummyNetworkController(topoType, netName, role s
 	switch topoType {
 	case ovntypes.Layer3Topology:
 		return ovn.NewLayer3UserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager,
-			cm.eIPController, cm.portCache, cm.addressSetManager, nil, nil)
+			cm.eIPController, cm.portCache, cm.addressSetManager, nil, nil, nil)
 	case ovntypes.Layer2Topology:
 		return ovn.NewLayer2UserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.routeImportManager,
-			cm.portCache, cm.eIPController, cm.addressSetManager, nil, nil)
+			cm.portCache, cm.eIPController, cm.addressSetManager, nil, nil, nil)
 	case ovntypes.LocalnetTopology:
-		return ovn.NewLocalnetUserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.addressSetManager, nil), nil
+		return ovn.NewLocalnetUserDefinedNetworkController(cnci, netInfo, cm.networkManager.Interface(), cm.addressSetManager, nil, nil), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }
@@ -436,6 +438,7 @@ func (cm *ControllerManager) Start(ctx context.Context) error {
 		}()
 	}
 
+	cm.observabilityManager = observabilityManager
 	err = cm.initDefaultNetworkController(observabilityManager)
 	if err != nil {
 		return fmt.Errorf("failed to init default network controller: %v", err)

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/observability"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	svccontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
@@ -235,6 +236,7 @@ func NewLayer2UserDefinedNetworkController(
 	addressSetManager *addresssetmanager.AddressSetManager,
 	nodeReconciler *nodecontroller.NodeController,
 	serviceController *svccontroller.Controller,
+	observManager *observability.Manager,
 ) (*Layer2UserDefinedNetworkController, error) {
 
 	stopChan := make(chan struct{})
@@ -284,6 +286,7 @@ func NewLayer2UserDefinedNetworkController(
 					addressSetManager:           addressSetManager,
 					nodeReconciler:              nodeReconciler,
 					nodeAnnotationCache:         nodeAnnotationCache,
+					observManager:               observManager,
 				},
 			},
 		},

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -536,6 +536,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 				fakeOvn.addressSetManager,
 				nil,
 				nil,
+				nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dummyController.Cleanup()).To(Succeed())
@@ -647,6 +648,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 				fakeOvn.addressSetManager,
 				nil,
 				fakeOvn.controller.ServiceController(),
+				nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(l2ControllerNew.init()).To(Succeed())

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/observability"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	svccontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
@@ -210,6 +211,7 @@ func NewLayer3UserDefinedNetworkController(
 	addressSetManager *addresssetmanager.AddressSetManager,
 	nodeReconciler *nodecontroller.NodeController,
 	serviceController *svccontroller.Controller,
+	observManager *observability.Manager,
 ) (*Layer3UserDefinedNetworkController, error) {
 
 	stopChan := make(chan struct{})
@@ -242,6 +244,7 @@ func NewLayer3UserDefinedNetworkController(
 				addressSetManager:           addressSetManager,
 				nodeReconciler:              nodeReconciler,
 				nodeAnnotationCache:         nodeAnnotationCache,
+				observManager:               observManager,
 			},
 		},
 		mgmtPortFailed:              sync.Map{},

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -578,6 +578,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 				nil,
 				nil,
 				nil,
+				nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dummyController.Cleanup()).To(Succeed())

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics/recorders"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/observability"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	lsm "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
@@ -165,6 +166,7 @@ func NewLocalnetUserDefinedNetworkController(
 	networkManager networkmanager.Interface,
 	addressSetManager *addresssetmanager.AddressSetManager,
 	nodeReconciler *nodecontroller.NodeController,
+	observManager *observability.Manager,
 ) *LocalnetUserDefinedNetworkController {
 
 	stopChan := make(chan struct{})
@@ -196,6 +198,7 @@ func NewLocalnetUserDefinedNetworkController(
 					addressSetManager:           addressSetManager,
 					nodeReconciler:              nodeReconciler,
 					nodeAnnotationCache:         nodeAnnotationCache,
+					observManager:               observManager,
 				},
 			},
 		},

--- a/go-controller/pkg/ovn/observability_udn_test.go
+++ b/go-controller/pkg/ovn/observability_udn_test.go
@@ -1,0 +1,209 @@
+package ovn
+
+import (
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/urfave/cli/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	knet "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/observability"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = ginkgo.Describe("Observability for user-defined network controllers", func() {
+	const (
+		namespaceName = "namespace1"
+		nodeName      = "node1"
+	)
+
+	var (
+		app                   *cli.App
+		fakeOvn               *FakeOVN
+		gomegaFormatMaxLength int
+	)
+
+	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableMultiNetworkPolicy = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true, nodeName)
+		gomegaFormatMaxLength = format.MaxLength
+		format.MaxLength = 0
+	})
+
+	ginkgo.AfterEach(func() {
+		fakeOvn.shutdown()
+		format.MaxLength = gomegaFormatMaxLength
+	})
+
+	type udnConfig struct {
+		netName  string
+		nadName  string
+		topology string
+		subnets  string
+		role     string
+	}
+
+	setupUDN := func(ns string, cfg udnConfig) {
+		nadNamespacedName := util.GetNADName(ns, cfg.nadName)
+		netconf := ovncnitypes.NetConf{
+			NetConf: cnitypes.NetConf{
+				Name: cfg.netName,
+				Type: "ovn-k8s-cni-overlay",
+			},
+			Topology: cfg.topology,
+			NADName:  nadNamespacedName,
+			Subnets:  cfg.subnets,
+			Role:     cfg.role,
+		}
+		nad, err := newNetworkAttachmentDefinition(ns, cfg.nadName, netconf)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = fakeOvn.NewUserDefinedNetworkController(nad)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	// verifyObservabilityWiring checks that the controller for the given network
+	// has the expected observability state. It verifies the constructor correctly
+	// forwarded the observManager by checking GetSamplingConfig().
+	verifyObservabilityWiring := func(netName string, expectPrimary, expectObservability bool) {
+		ocInfo, ok := fakeOvn.userDefinedNetworkControllers[netName]
+		gomega.Expect(ok).To(gomega.BeTrue(), "controller for %s should exist", netName)
+		gomega.Expect(ocInfo.bnc.IsPrimaryNetwork()).To(gomega.Equal(expectPrimary),
+			"%s: IsPrimaryNetwork() mismatch", netName)
+		if expectObservability {
+			gomega.Expect(ocInfo.bnc.GetSamplingConfig()).NotTo(gomega.BeNil(),
+				"%s controller should have sampling config", netName)
+		} else {
+			gomega.Expect(ocInfo.bnc.GetSamplingConfig()).To(gomega.BeNil(),
+				"%s controller should not have sampling config", netName)
+		}
+	}
+
+	startWithNamespace := func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
+		}
+		initialData := getHairpinningACLsV4AndPortGroup()
+		initialData = append(initialData, &nbdb.LogicalSwitch{
+			Name: nodeName,
+			UUID: nodeName + "_UUID",
+		})
+		fakeOvn.startWithDBSetup(
+			libovsdbtest.TestSetup{NBData: initialData},
+			&corev1.NamespaceList{Items: []corev1.Namespace{*ns}},
+			&corev1.NodeList{},
+			&knet.NetworkPolicyList{},
+			&mnpapi.MultiNetworkPolicyList{},
+		)
+	}
+
+	allTopologies := []udnConfig{
+		{
+			netName:  "primary-l3-net",
+			nadName:  "primary-l3-nad",
+			topology: ovntypes.Layer3Topology,
+			subnets:  "10.1.0.0/16/24",
+			role:     ovntypes.NetworkRolePrimary,
+		},
+		{
+			netName:  "primary-l2-net",
+			nadName:  "primary-l2-nad",
+			topology: ovntypes.Layer2Topology,
+			subnets:  "10.2.0.0/24",
+			role:     ovntypes.NetworkRolePrimary,
+		},
+		{
+			netName:  "secondary-localnet",
+			nadName:  "secondary-localnet-nad",
+			topology: ovntypes.LocalnetTopology,
+			subnets:  "10.3.0.0/24",
+			role:     ovntypes.NetworkRoleSecondary,
+		},
+	}
+
+	ginkgo.It("constructors should wire observability manager to all UDN controller types", func() {
+		app.Action = func(*cli.Context) error {
+			startWithNamespace()
+
+			// Initialize observability before creating controllers, then inject
+			// into each controller through its constructor via the FakeOVN helper.
+			// In production, ControllerManager.Start() creates the manager once
+			// and passes it to NewNetworkController → each constructor.
+			// In tests, FakeOVN.NewUserDefinedNetworkController always passes nil
+			// for observManager, so we set it on the controller after creation to
+			// verify the field is accessible through GetSamplingConfig().
+			observManager := observability.NewManager(fakeOvn.nbClient)
+			err := observManager.Init()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			for _, cfg := range allTopologies {
+				setupUDN(namespaceName, cfg)
+				// Set observManager on each controller, mirroring production wiring
+				ocInfo := fakeOvn.userDefinedNetworkControllers[cfg.netName]
+				ocInfo.bnc.observManager = observManager
+			}
+
+			ginkgo.By("Verifying primary L3 UDN controller")
+			verifyObservabilityWiring("primary-l3-net", true, true)
+
+			ginkgo.By("Verifying primary L2 UDN controller")
+			verifyObservabilityWiring("primary-l2-net", true, true)
+
+			ginkgo.By("Verifying secondary localnet UDN controller")
+			verifyObservabilityWiring("secondary-localnet", false, true)
+
+			ginkgo.By("Verifying SampleCollector objects exist in NBDB")
+			collectors, err := libovsdbops.ListSampleCollectors(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(collectors).NotTo(gomega.BeEmpty())
+
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should not have sampling config on any UDN controller when observability is disabled", func() {
+		app.Action = func(*cli.Context) error {
+			startWithNamespace()
+
+			for _, cfg := range allTopologies {
+				setupUDN(namespaceName, cfg)
+			}
+
+			ginkgo.By("Verifying primary L3 UDN controller")
+			verifyObservabilityWiring("primary-l3-net", true, false)
+
+			ginkgo.By("Verifying primary L2 UDN controller")
+			verifyObservabilityWiring("primary-l2-net", true, false)
+
+			ginkgo.By("Verifying secondary localnet UDN controller")
+			verifyObservabilityWiring("secondary-localnet", false, false)
+
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -573,7 +573,7 @@ func (o *FakeOVN) NewUserDefinedNetworkController(netattachdef *nettypes.Network
 		switch topoType {
 		case types.Layer3Topology:
 			l3Controller, err := NewLayer3UserDefinedNetworkController(cnci, mutableNetInfo, o.networkManager.Interface(), nil,
-				o.eIPController, o.portCache, o.addressSetManager, o.udnNodeController, o.controller.ServiceController())
+				o.eIPController, o.portCache, o.addressSetManager, o.udnNodeController, o.controller.ServiceController(), nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if o.asf != nil { // use fake asf only when enabled
 				l3Controller.addressSetFactory = asf
@@ -582,7 +582,7 @@ func (o *FakeOVN) NewUserDefinedNetworkController(netattachdef *nettypes.Network
 			o.fullL3UDNControllers[netName] = l3Controller
 		case types.Layer2Topology:
 			l2Controller, err := NewLayer2UserDefinedNetworkController(cnci, mutableNetInfo, o.networkManager.Interface(), nil,
-				o.portCache, o.eIPController, o.addressSetManager, o.udnNodeController, o.controller.ServiceController())
+				o.portCache, o.eIPController, o.addressSetManager, o.udnNodeController, o.controller.ServiceController(), nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if o.asf != nil { // use fake asf only when enabled
 				l2Controller.addressSetFactory = asf
@@ -591,7 +591,7 @@ func (o *FakeOVN) NewUserDefinedNetworkController(netattachdef *nettypes.Network
 			o.fullL2UDNControllers[netName] = l2Controller
 		case types.LocalnetTopology:
 			localnetController := NewLocalnetUserDefinedNetworkController(cnci, mutableNetInfo, o.networkManager.Interface(), o.addressSetManager,
-				o.udnNodeController)
+				o.udnNodeController, nil)
 			if o.asf != nil { // use fake asf only when enabled
 				localnetController.addressSetFactory = asf
 			}


### PR DESCRIPTION
## 📑 Description

The observabilityManager wasn't propagated to the UDN controllers.
This PR fixes that and adds some tests.

## Additional Information for reviewers

- Wired the observabilityManager in to NewLayer3UserDefinedNetworkController, NewLayer2UserDefinedNetworkController, NewLocalnetUserDefinedNetworkController
- Added a test that checks that when using a L3 PUDN, localnet SUDN, and MNP that the GetSamplingConfig in each controller is non-nil and that the SampleCollector objects exist in NBDB.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Unit tests included.