### PR TITLE
release-note: add a section to PR description and a coderabbit rule

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -78,7 +78,7 @@ reviews:
           update). Flag PRs that mix unrelated changes in a single
           commit.
         - PR description template: "Description", "Additional Information",
-          and "How to verify it" sections must be filled — flag if empty.
+          "Release Notes", and "How to verify it" sections must be filled — flag if empty.
           "Description" must lead with the Why (the problem being solved)
           before explaining What the PR does — flag if it jumps straight
           into implementation details without motivation.
@@ -642,5 +642,24 @@ reviews:
 
           Pass only if none of those files are modified, or the PR
           author is listed in MAINTAINERS.md as a current maintainer.
+      - name: "Release Notes Section"
+        mode: "error"
+        instructions: >-
+          Every PR must include a "Release Notes" section whose
+          `release-note` fenced code block contains either a user-facing
+          release note or the single word `NONE` (both are valid entries).
+
+          Fail if the "Release Notes" section is missing, the
+          `release-note` block is absent or empty, or it still contains
+          only the template comment.
+
+          Also fail if the PR adds, changes, or removes a flag, API, or
+          user-facing behavior, or deprecates something, but the block is
+          left as `NONE` — ask the author to write a short user-facing
+          note instead.
+
+          Pass if the block contains a meaningful user-facing note, or if
+          it contains `NONE` and the PR genuinely has no user-facing
+          impact (tests, refactors, CI, internal-only changes).
 chat:
   auto_reply: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,18 @@ _If PR is about `failing-tests or flakes`, please post the related issues/tests 
 -->
 Fixes #
 
+## Release Notes
+<!--
+REQUIRED. Add a short, user-facing release note in the block below describing any
+user-visible change (new/changed/removed flags or APIs, behavior changes,
+deprecations, etc.).
+Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
+internal-only changes) — `NONE` is a valid entry.
+-->
+```release-note
+NONE
+```
+
 ## Additional Information for reviewers
 <!--
 What exactly did you change - you may also defer to information


### PR DESCRIPTION
Ask rabbit to make sure user-facing changes are listed in the release note section

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [X] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [X] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
