### PR TITLE
kind: preload multus image instead of pulling it on every node

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1422,7 +1422,19 @@ install_image() {
       podman save -o /tmp/image.tar "${1}"
       kind load image-archive /tmp/image.tar --name "${KIND_CLUSTER_NAME}"
     else
-      kind load docker-image "${1}" --name "${KIND_CLUSTER_NAME}"
+      # docker: with the containerd image store (default since Docker 27), an
+      # archive of a pulled multi-arch image references every platform but only
+      # contains the host platform's blobs, and the "ctr images import
+      # --all-platforms" that kind runs fails on the missing digests. Save the
+      # host platform only (docker save --platform, Docker 28+) and load the
+      # archive; older docker lacks the flag and its classic image store
+      # produces single-platform archives anyway, so fall back to kind load.
+      rm -f /tmp/image.tar
+      if docker save --platform "linux/$(docker version -f '{{.Server.Arch}}')" -o /tmp/image.tar "${1}" 2>/dev/null; then
+        kind load image-archive /tmp/image.tar --name "${KIND_CLUSTER_NAME}"
+      else
+        kind load docker-image "${1}" --name "${KIND_CLUSTER_NAME}"
+      fi
     fi
   fi
 }

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1416,26 +1416,33 @@ install_image() {
   if [ "$KIND_LOCAL_REGISTRY" == true ]; then
     echo "${1} should already be avaliable in local registry, not loading"
   else
-    if [ "$OCI_BIN" == "podman" ]; then
-      # podman: cf https://github.com/kubernetes-sigs/kind/issues/2027
-      rm -f /tmp/image.tar
-      podman save -o /tmp/image.tar "${1}"
-      kind load image-archive /tmp/image.tar --name "${KIND_CLUSTER_NAME}"
-    else
-      # docker: with the containerd image store (default since Docker 27), an
-      # archive of a pulled multi-arch image references every platform but only
-      # contains the host platform's blobs, and the "ctr images import
-      # --all-platforms" that kind runs fails on the missing digests. Save the
-      # host platform only (docker save --platform, Docker 28+) and load the
-      # archive; older docker lacks the flag and its classic image store
-      # produces single-platform archives anyway, so fall back to kind load.
-      rm -f /tmp/image.tar
-      if docker save --platform "linux/$(docker version -f '{{.Server.Arch}}')" -o /tmp/image.tar "${1}" 2>/dev/null; then
-        kind load image-archive /tmp/image.tar --name "${KIND_CLUSTER_NAME}"
+    # Write the archive under a unique temporary directory per invocation:
+    # podman save refuses to write to an existing file, and concurrent or
+    # aborted runs must not clash on a shared archive path. The subshell
+    # scopes the cleanup trap to this function call.
+    (
+      archive_dir=$(mktemp -d)
+      trap 'rm -rf "${archive_dir}"' EXIT
+      archive="${archive_dir}/image.tar"
+      if [ "$OCI_BIN" == "podman" ]; then
+        # podman: cf https://github.com/kubernetes-sigs/kind/issues/2027
+        podman save -o "${archive}" "${1}"
+        kind load image-archive "${archive}" --name "${KIND_CLUSTER_NAME}"
       else
-        kind load docker-image "${1}" --name "${KIND_CLUSTER_NAME}"
+        # docker: with the containerd image store (default since Docker 27), an
+        # archive of a pulled multi-arch image references every platform but only
+        # contains the host platform's blobs, and the "ctr images import
+        # --all-platforms" that kind runs fails on the missing digests. Save the
+        # host platform only (docker save --platform, Docker 28+) and load the
+        # archive; older docker lacks the flag and its classic image store
+        # produces single-platform archives anyway, so fall back to kind load.
+        if docker save --platform "linux/$(docker version -f '{{.Server.Arch}}')" -o "${archive}" "${1}" 2>/dev/null; then
+          kind load image-archive "${archive}" --name "${KIND_CLUSTER_NAME}"
+        else
+          kind load docker-image "${1}" --name "${KIND_CLUSTER_NAME}"
+        fi
       fi
-    fi
+    )
   fi
 }
 

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1232,7 +1232,16 @@ install_kubevirt_ipam_controller() {
 
 install_multus() {
   local version="v4.1.3"
+  local image="ghcr.io/k8snetworkplumbingwg/multus-cni:${version}"
   echo "Installing multus-cni $version daemonset ..."
+  # Pull the image once on the host and load it into every kind node, instead
+  # of having each node pull ~180MB from ghcr.io independently. The daemonset
+  # pins the image tag and has no imagePullPolicy, so the kubelet default
+  # (IfNotPresent) uses the preloaded image.
+  if [ "$KIND_LOCAL_REGISTRY" != true ]; then
+    "$OCI_BIN" pull "$image"
+    install_image "$image"
+  fi
   wget -qO- "https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/${version}/deployments/multus-daemonset.yml" |\
     sed -e "s|multus-cni:snapshot|multus-cni:${version}|g" |\
     run_kubectl apply -f -


### PR DESCRIPTION
Every kind node was pulling the multus image (~180MB compressed) from ghcr.io, that is ~550MB per bring-up on a default 3-node cluster. We now pull it once on the host and `kind load` it into all nodes; the kubelet then uses the preloaded image (pinned tag, no explicit `imagePullPolicy`, so `IfNotPresent`). Since the host image store survives cluster deletion, only the very first bring-up downloads the image; later ones just verify the digest, same as for the locally built OVN image. One single pull also means fewer chances of hitting ghcr.io rate limits or transient pull failures.

The second commit fixes `install_image` for docker with the containerd image store (default since docker 27): `docker save` of a pulled multi-arch image produces an archive that references all platforms but only contains the host one, and the `ctr images import --all-platforms` that `kind load` runs on each node fails with `ctr: content digest ... not found`. We now save the host platform only (`docker save --platform`, docker 28+), falling back to the old path on older docker. Locally built images are single-platform, which is why this never surfaced before. Upstream this is tracked in https://github.com/kubernetes-sigs/kind/issues/3795; our workaround works with any kind version and becomes a no-op once kind's fix ships.

The third commit writes the archives under a unique temporary directory, so that concurrent or aborted runs don't clash on a fixed path.

Bringing up a default cluster with `kind.sh` on my machine: **10m10s** without this change, **8m17s** with it (and the multus step costs no network at all on subsequent runs).
