### PR TITLE
WIP / DNM: OKEP 6815 qos poc

### DIFF
--- a/docs/okeps/okep-6815-network-qos-ipamless.md
+++ b/docs/okeps/okep-6815-network-qos-ipamless.md
@@ -2,13 +2,6 @@
 
 * Issue: [#6815](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6815)
 
-> **Status of this document.** This revision intentionally scopes the problem
-> space only: motivation, use cases, requirements, goals, future goals, and
-> non-goals. The `Proposed Solution`, `Implementation Details`, `Testing
-> Details`, `Risks`, `Version Skew`, `Backwards Compatibility`, and
-> `Alternatives` sections are placeholders to be filled in a subsequent
-> iteration once the community aligns on the problem framing below.
-
 ## Problem Statement
 
 NetworkQoS ([OKEP-4380](okep-4380-network-qos.md)) delivers DSCP marking and
@@ -452,48 +445,460 @@ the upstream enhancement issue
 
 ## Proposed Solution
 
-*To be detailed in a subsequent iteration.*
+The controller gains an **IP-independent source-matching path** that activates
+only on ipamless localnet networks. Instead of resolving source pods to IP
+addresses and matching `ip4.src == {$address_set}`, the controller places each
+selected source pod's **logical switch port (LSP)** into a per-`NetworkQoS`
+**OVN port group** and matches `inport == @<port_group> && (ip4 || ip6)`.
+Everything else about a `NetworkQoS` - destination `ipBlock`, protocol/port
+classifier, DSCP action, bandwidth policing, priority ordering, and the
+`to-lport` QoS row attached to the network's logical switch - is reused
+unchanged from the existing IPAM implementation.
+
+The path is selected at reconcile time by a single predicate,
+`isIPAMlessLocalnet()` = `TopologyType() == LocalnetTopology && !DoesNetworkRequireIPAM(NetInfo)`
+(`go-controller/pkg/ovn/controller/network_qos/utils.go`). When it is false - on
+every IPAM-enabled network and on non-localnet topologies - the controller takes
+the existing address-set path unchanged, which is what makes the no-regression
+guarantee of R12 mechanical rather than aspirational.
+
+Why a port group and not the source MAC: the [Alternatives](#alternatives)
+section gives the full comparison, but in short, `inport` (the logical switch
+port a packet actually ingresses on) is assigned by OVN and cannot be spoofed
+from inside the guest, whereas an `eth.src` MAC match becomes spoofable once the
+localnet disable-MAC-spoofing capability lands. The `(ip4 || ip6)` qualifier is
+mandatory, not cosmetic: on ipamless networks `IPMode()` is `(false, false)`, so
+without the qualifier the match would also catch ARP/ND/DHCP, and a low policing
+`rate` would then throttle address resolution and break connectivity on the
+segment.
+
+On the OVS datapath this produces the two intended actions on egress from the
+selected source: the DSCP field is stamped on the IP header, and the configured
+`rate`/`burst` policer drops excess traffic. See
+[Testing Details](#testing-details) for the behavior the tests assert.
 
 ### API Details
 
-*To be detailed in a subsequent iteration. No NetworkQoS CRD API changes are
-anticipated (R7).*
+**No NetworkQoS CRD API changes (R7).** The feature is entirely
+controller-internal: the same `k8s.ovn.org/v1alpha1` CRD, the same
+`podSelector` / `networkSelectors` / `priority` / `egress` fields, and the same
+`classifier` semantics. There is no OpenAPI/schema diff and no new field, and
+existing manifests are interpreted identically - the only difference is that a
+manifest selecting an ipamless localnet network, which is silently a no-op
+today, becomes functional.
+
+The one behavioral caveat is that on ipamless networks the `classifier.to`
+`podSelector` / `namespaceSelector` destination forms are not honored (see
+[Implementation Details](#implementation-details), R8, and R13); this is a
+behavioral scoping of an existing field on a topology where it cannot be
+resolved, not an API change.
 
 ### Implementation Details
 
-*To be detailed in a subsequent iteration.*
+All changes are confined to
+`go-controller/pkg/ovn/controller/network_qos/` plus one registration in
+`go-controller/pkg/libovsdb/ops/db_object_types.go`; no code outside the
+NetworkQoS controller is modified.
+
+**Branch predicate and match generation.**
+
+- `isIPAMlessLocalnet()` (`utils.go`) gates every new behavior.
+- `generateNetworkQoSMatch(...)` (`utils.go`) takes an `ipamless bool`. When set,
+  the source fragment is `inport == @<SrcPortGroupName> && (ip4 || ip6)`;
+  otherwise it is the unchanged `addressSetToMatchString(...)`
+  (`ip4.src == {$hash}` / `ip6.src == {$hash}`). The destination `ipBlock`/CIDR
+  fragment and the protocol/port classifier are appended identically in both
+  cases.
+
+**Port-group identity and ownership.**
+
+- `db_object_types.go` registers
+  `PortGroupNetworkQoS = newObjectIDsType(portGroup, NetworkQoSOwnerType, [ObjectNameKey])`,
+  so the port group participates in the same ownership/GC machinery as the QoS
+  rows and address sets.
+- `GetNetworkQoSPortGroupDbIDs(ns, name, controller)` (`utils.go`) yields the
+  deterministic external IDs; the OVN port-group name is derived from them via
+  `libovsdbutil.GetPortGroupName` and stored on the in-memory state as
+  `SrcPortGroupName` (`types.go`, set by `initSourcePortGroupName`).
+
+**Port-group lifecycle (pod path).**
+
+- `ipamlessSourceLSPNames(pod)` (`utils.go`) maps a selected source pod to its
+  LSP name(s) via the pod's own network attachment(s) (its
+  `k8s.v1.cni.cncf.io/networks` spec annotation → indexed nadKeys → LSP names).
+  Cross-namespace attachment is handled correctly: a pod in namespace `vms`
+  attaching through a `vms2` NAD lands in the same port group as a pod attaching
+  through the `vms` NAD.
+- `configureSourcePodIPAMless(...)` (`types.go`) resolves each LSP name to a UUID
+  via `GetLogicalSwitchPort` and adds it with `AddPortsToPortGroupOps`. When the
+  LSP is not yet present in NB it returns without error (skip-and-wait) - see the
+  requeue fix below.
+- `ensureSourcePortGroup(...)` (`network_qos_ovnnb.go`) creates the port group if
+  absent and never clobbers existing membership.
+- `removePodLSPFromSource(...)` / `DeletePortsFromPortGroupOps` remove ports when
+  a pod stops matching or is deleted.
+- The `to-lport` QoS row is bound to the source pods' **logical switch**, shared
+  with the IPAM path (`bindQoSToPodSwitch`) - the port group is only the
+  source-match set, not the QoS attachment point (`Port_Group` has no
+  `qos_rules` column).
+
+**Persisted NB DB shape (the contract).** Per egress rule, exactly one
+`nbdb.QoS` row:
+
+- `Direction`: `to-lport`
+- `Priority`: `getQoSRulePriority(qosPriority, ruleIndex) = 10000 + qosPriority*10 + ruleIndex`
+  (`types.go`)
+- `Match`: `inport == @<SrcPortGroupName> && (ip4 || ip6)` [`&& <ipBlock dst>`]
+  [`&& <proto/port>`]; **no `ip4.src == {$…}` fragment**
+- `Action`: `{dscp: <n>}` when DSCP is set
+- `Bandwidth`: `{rate: <kbps>, burst: <kbps>}` when set; empty map when only DSCP
+  is requested
+- `ExternalIDs`: owner keys (`OwnerController`, `OwnerType=NetworkQoS`,
+  `ObjectName=<ns>:<name>`, `RuleIndex`) plus `NetworkExternalID` on UDN
+
+The row is added to `Logical_Switch.qos_rules`; the source port group's `Ports`
+list holds the resolved source-pod LSP UUIDs.
+
+**Deletion ordering.** On `NetworkQoS` delete, `deleteSourcePortGroup(qosName)`
+(`network_qos_ovnnb.go`; owner-ID predicate mirroring `deleteAddressSet`, gated
+on `isIPAMlessLocalnet()`) runs from `deleteByName` **after** the QoS rows have
+been removed from every referencing switch, so no switch ever references a
+deleted QoS row and no QoS row ever references a deleted port group.
+
+**Requeue on late-arriving source pods (correctness fix).** A source pod created
+*after* its selecting `NetworkQoS` - the common KubeVirt case, where VMs are
+created or migrated after the policy exists - must still join the port group
+without waiting for an unrelated event. Two mechanisms currently prevent this on
+ipamless networks:
+
+1. The pod-update requeue filter `onNQOSPodUpdate`
+   (`network_qos_controller.go`) keys "the port is ready now" on a change in the
+   pod's OVN IP count (`util.GetPodIPsOfNetwork`). On ipamless networks there is
+   no OVN IP, so the delta is permanently `0 == 0` and the "LSP is ready"
+   transition is swallowed.
+2. `configureSourcePodIPAMless` skip-and-waits on `ErrNotFound` when the LSP is
+   not yet in NB, and the pod is not re-enqueued afterward.
+
+The recommended fix is **level-based retry (Approach A)**: treat "pod is attached to
+this network per its spec annotation (present from creation) but its source LSP
+is not yet in NB" as a **transient error**, so the existing rate-limited work
+queue retries until the LSP lands; return `nil` (no retry) only when the pod is
+genuinely not attached. The fix is scope-guarded to `isIPAMlessLocalnet()`; the
+IPAM path is unchanged. An annotation-edge requeue (Approach B) is not viable
+because the OVN-written `k8s.ovn.org/pod-networks` annotation is published to the
+apiserver *before* the source LSP is transacted into NB, so there is no reliable
+LSP-readiness pod edge to trigger on. The retry budget is comfortably
+sufficient: the LSP is created by the same ovnkube-controller process
+milliseconds after the annotation, well within the existing `maxRetries`
+backoff. The remaining decisions this fix defers (partial resolution of a
+multi-attachment pod, retry accounting, and zone transitions under Interconnect)
+are tracked in [Deferred / Open Questions](#deferred--open-questions).
+
+### Worked example
+
+The following mirrors Stories 1 and 2 on a single ipamless localnet UDN. The NAD
+is ipamless (no `subnets`) and carries a label the QoS `networkSelectors` match:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: tenant-blue
+  namespace: vms
+  labels:
+    nqos-network: tenant-blue          # matched by networkSelectors below
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "tenant-blue",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
+      "physicalNetworkName": "physnet",
+      "vlanID": 100,
+      "netAttachDefName": "vms/tenant-blue"
+    }                                    # no "subnets" => ipamless
+```
+
+**Story 1 - tier differentiation.** Two objects select each tier by label;
+production is marked EF (46), staging AF11 (10), with `priority` resolving any
+overlap in favour of production:
+
+```yaml
+apiVersion: k8s.ovn.org/v1alpha1
+kind: NetworkQoS
+metadata: { name: tier-production, namespace: vms }
+spec:
+  networkSelectors:
+  - networkSelectionType: NetworkAttachmentDefinitions
+    networkAttachmentDefinitionSelector:
+      namespaceSelector: {}
+      networkSelector: { matchLabels: { nqos-network: tenant-blue } }
+  podSelector: { matchLabels: { tier: production } }
+  priority: 60
+  egress:
+  - dscp: 46                            # EF
+    classifier: { to: [ { ipBlock: { cidr: 0.0.0.0/0 } } ] }
+---
+apiVersion: k8s.ovn.org/v1alpha1
+kind: NetworkQoS
+metadata: { name: tier-staging, namespace: vms }
+spec:
+  networkSelectors:
+  - networkSelectionType: NetworkAttachmentDefinitions
+    networkAttachmentDefinitionSelector:
+      namespaceSelector: {}
+      networkSelector: { matchLabels: { nqos-network: tenant-blue } }
+  podSelector: { matchLabels: { tier: staging } }
+  priority: 40
+  egress:
+  - dscp: 10                            # AF11
+    classifier: { to: [ { ipBlock: { cidr: 0.0.0.0/0 } } ] }
+```
+
+On an ipamless network these produce `to-lport` QoS rows whose **source fragment
+is `inport == @<port_group>`** rather than `ip4.src == {$address_set}`:
+
+```text
+# tier-production rule 0  (spec.priority 60, rule 0) -> OVN priority 10600
+match: inport == @<tier-production pg> && (ip4 || ip6) && ip4.dst == 0.0.0.0/0   action: dscp=46
+# tier-staging rule 0     (spec.priority 40, rule 0) -> OVN priority 10400
+match: inport == @<tier-staging pg>    && (ip4 || ip6) && ip4.dst == 0.0.0.0/0   action: dscp=10
+```
+
+**Story 2 - intra-VM backup deprioritization, and the per-stage priority
+resolution.** A single object with two rules: rule 0 marks all traffic EF; rule 1
+(later in the list, hence higher precedence) demotes backup traffic to CS1 (8)
+and caps it. It is set at `priority: 70`, **deliberately above** `tier-production`
+(60) - see below.
+
+```yaml
+apiVersion: k8s.ovn.org/v1alpha1
+kind: NetworkQoS
+metadata: { name: backup-deprioritization, namespace: vms }
+spec:
+  networkSelectors:
+  - networkSelectionType: NetworkAttachmentDefinitions
+    networkAttachmentDefinitionSelector:
+      namespaceSelector: {}
+      networkSelector: { matchLabels: { nqos-network: tenant-blue } }
+  podSelector: { matchLabels: { app: payments } }
+  priority: 70
+  egress:
+  - dscp: 46                            # rule 0: regular app traffic -> EF
+    classifier: { to: [ { ipBlock: { cidr: 0.0.0.0/0 } } ] }
+  - dscp: 8                             # rule 1: backup traffic -> CS1 + cap
+    bandwidth: { rate: 100000, burst: 5000 }
+    classifier:
+      to: [ { ipBlock: { cidr: 10.20.0.0/16 } } ]
+      ports: [ { protocol: TCP, port: 2049 } ]
+```
+
+A payments VM carrying both `app: payments` and `tier: production` lands in the
+source set of **both** objects, so all three rules install:
+
+| Source rule | dscp | bandwidth | dst match | OVN priority |
+|---|---|---|---|---|
+| `tier-production` r0 | 46 | - | `0.0.0.0/0` | 10600 |
+| `backup-deprioritization` r0 | 46 | - | `0.0.0.0/0` | 10700 |
+| `backup-deprioritization` r1 | 8 | 100 Mbps | `10.20.0.0/16` tcp:2049 | 10701 |
+
+OVN resolves **per packet, per pipeline stage** - marking and metering are
+independent stages, and the highest-priority matching row wins *in each stage
+separately*. This is why `backup-deprioritization` must sit **above**
+`tier-production` in `priority`: if it did not, the tier catch-all (10600,
+dscp 46) would outrank the backup marking rule in the *marking* stage, and backup
+traffic would be throttled yet still marked EF - telling the fabric to prioritize
+exactly the traffic being demoted. With backup at the higher priority, backup
+packets resolve to dscp 8 **and** the rate cap in both stages, while the VM's
+other traffic keeps EF and stays uncapped. This per-stage behavior is a property
+of NetworkQoS priorities generally, but it is easy to get wrong and is called out
+here because these multi-object VM scenarios are the target use cases.
+
+`NetworkQoS.podSelector` matches the **virt-launcher pod**, so QoS labels belong
+on the `VirtualMachine`'s `spec.template.metadata.labels`; guest addressing (a
+static IP or external DHCP) is configured inside the guest and is never seen by
+OVN-Kubernetes.
 
 ### Testing Details
 
-*To be detailed in a subsequent iteration.*
+- **Unit (NB shape).** Assert the complete persisted `nbdb.QoS` row (match,
+  direction, priority, action, bandwidth), port-group membership, and switch
+  binding for: the happy path (DSCP + `ipBlock` + protocol/port + rate/burst);
+  DSCP-only (empty `Bandwidth`); and an IPAM regression proving the address-set
+  path is unchanged (still `ip4.src == {$hash}`, never `inport == @`).
+- **Unit (requeue fix).** attached-but-LSP-absent → transient error → requeue;
+  LSP later present → success and the port joins the group; not-attached →
+  `nil`, no requeue; IPAM path unchanged.
+- **E2E.** Create the `NetworkQoS`, *then* create a source pod, and assert it
+  joins the port group and its egress is DSCP-marked **without** any label toggle
+  or CR edit (this is the acceptance test for the requeue fix); plus
+  delete-on-delete cleanup (QoS rows and port group gone, switch
+  `qos_rules == []`).
+- **Datapath behavior (asserted by E2E).** DSCP: packets from the selected
+  source carry `tos 0xb8` (DSCP 46 / EF) while an unselected pod's packets carry
+  `tos 0x0`. Policing: throughput from the capped source drops sharply below an
+  uncapped baseline and stays under the configured `rate` (for a 100 Mbit `rate`
+  / 5 Mbit `burst`, a reduction of roughly one to two orders of magnitude is
+  representative). Cross-namespace source resolution and delete-on-delete
+  teardown are also covered.
+- **Testing note.** OVN QoS bandwidth is a **policer, not a shaper**: assert
+  "throughput drops sharply when metered," never `throughput == rate`. Note that
+  the common test image `quay.io/openshift/origin-network-tools:latest` has no
+  `iperf3`, so throughput checks should use a tool present in the image (e.g.
+  `socat`/`dd`).
 
 ### Documentation Details
 
-*To be detailed in a subsequent iteration. Must include adding this OKEP to
-`mkdocs.yml` under the OKEPs navigation section.*
+- Add this OKEP to `mkdocs.yml` under the OKEPs navigation section.
+- Document the **permanent `ipBlock`-only destination limitation** prominently -
+  users coming from IPAM NetworkQoS will expect destination `podSelector` /
+  `namespaceSelector` to work.
+- Document the marking-vs-enforcement distinction (R14): DSCP marking is
+  performed by OVN-Kubernetes and verifiable at the source (`tcpdump` on the OVS
+  bridge port); fabric enforcement is a separate, out-of-scope prerequisite.
+- Add user-guide manifests for the target stories (workload-tier
+  differentiation and intra-VM backup deprioritization), including the KubeVirt
+  `VirtualMachine` manifests and guest addressing (static IP / external DHCP). A
+  representative `NetworkQoS` + NAD example, and the per-pipeline-stage priority
+  resolution users must get right, are given in [Worked example](#worked-example).
 
 ## Risks, Known Limitations and Mitigations
 
-*To be detailed in a subsequent iteration.*
+- **No destination `podSelector` / `namespaceSelector`** on ipamless networks
+  (a permanent scope boundary, not a temporary limitation). *Mitigation:* document
+  prominently; R13 requires that this must not degrade silently - the discovery
+  mechanism is still open (see [Deferred / Open Questions](#deferred--open-questions)).
+- **Policing, not shaping.** Bursty traffic sees drops rather than smoothing, and
+  goodput sits below the configured `rate`. *Mitigation:* document; this is
+  inherited OVN QoS behavior, not specific to ipamless.
+- **Late source-pod requeue gap.** Without the level-based retry, QoS silently
+  under-applies to source pods created after the CR. *Mitigation:* Approach A
+  (see [Implementation Details](#implementation-details)) closes it and is part
+  of this deliverable.
+- **Source-MAC spoofing.** Addressed by design: the port-group (`inport`) match
+  cannot be spoofed from the guest, unlike an `eth.src` match.
+- **Stale/orphan port-group GC across controller rename/restart.**
+  *Mitigation:* the implementation must confirm the ownership-keyed GC (the same
+  machinery as address sets) reclaims orphaned port groups; this is called out as
+  an implementation checkpoint.
 
 ## OVN-Kubernetes Version Skew
 
-*To be detailed in a subsequent iteration.*
+This feature is targeted for the next upcoming release, **release-1.4**.
+
+The feature uses only OVN NB constructs that NetworkQoS already depends on - the
+`QoS` table, `Port_Group`, `Logical_Switch.qos_rules`, and the `inport` / `ip4`
+/ `ip6` match primitives. It introduces **no new OVN feature dependency**, so
+there is no `ovn-northd`/OVN version floor beyond what NetworkQoS already
+requires, and no CRD version change. During implementation, confirm that no
+mixed-zone ordering assumption is introduced (moot for single-zone localnet;
+relevant only under OVN Interconnect - see
+[Deferred / Open Questions](#deferred--open-questions)).
 
 ## Backwards Compatibility
 
-*To be detailed in a subsequent iteration. The intended direction is strictly
-additive: NetworkQoS on ipamless networks is non-functional today, so enabling
-it does not change any existing behavior; IPAM-enabled networks are unaffected.*
+Strictly additive. NetworkQoS on ipamless localnet networks is non-functional
+today (source pods are silently skipped for lack of an IP), so enabling it
+changes no existing behavior. IPAM-enabled networks are untouched: the
+`isIPAMlessLocalnet()` predicate isolates every new code path, and the IPAM
+address-set match is emitted exactly as before (R12). There is no migration, no
+data reformat, and no change to any persisted object on existing networks; an
+upgrade simply makes previously-inert manifests take effect on ipamless localnet
+networks.
 
 ## Alternatives
 
-*To be detailed in a subsequent iteration.* The comparison must evaluate the
-candidate IP-independent matching approaches against an IP-in-annotation
-approach, and must call out the **loss of destination `podSelector` /
-`namespaceSelector` matching** as a key drawback of the IP-independent
-approaches (they can express "QoS toward `10.20.0.0/16`" but not "QoS toward
-pods labeled `role: backup-target`" without manual CIDR bookkeeping).
+Source-matching approaches fall into two families: **IP-independent** matching
+(needs no guest IP) and **IP-dependent** matching (obtains the guest IP and
+reuses the existing address-set path). Approach 1 is the preferred alternative,
+offered as a recommendation for the maintainers to weigh.
+
+**IP-independent approaches (no guest IP required).**
+
+1. **Port group / `inport` (preferred).** Match
+   `inport == @<pg> && (ip4 || ip6)`, the port group holding the source LSPs.
+   Spoof-resistant (`inport` is assigned by OVN, not derivable from
+   guest-controlled headers) and requires nothing from the guest. OVN honors the
+   `inport` predicate in a `to-lport` QoS row on a localnet switch, applying both
+   DSCP marking and policing on egress.
+2. **MAC address set / `eth.src`.** Match `eth.src == {$mac_set} && (ip4 || ip6)`.
+   Functionally equivalent for source matching today, but becomes spoofable once
+   the localnet disable-MAC-spoofing capability lands
+   ([OKEP-3926](okep-3926-disable-port-security.md)) - a guest could set its own
+   source MAC to evade or impersonate a QoS class. This spoofing exposure is the
+   reason it is not the preferred option.
+
+**IP-dependent approaches (learn the guest IP, reuse the existing path).** Both
+of the following obtain the guest IP and feed it to the unchanged
+`ip4.src == {$address_set}` machinery. Their shared upside is that they preserve
+the **full** IPAM feature set - including destination `podSelector` /
+`namespaceSelector` - because they produce a real IP. They differ only in *who*
+supplies the IP (the user vs. the controller).
+
+3. **Guest IP recorded in a pod annotation (user/CNI-provided).** Have the
+   user/CNI record the guest IP in an annotation and feed the existing
+   `ip4.src == {$address_set}` machinery. Not preferred: it pushes IPAM
+   responsibility onto the user, is fragile for VMs that change IPs at runtime,
+   and still would not remove the need for a different match on truly static
+   addresses.
+4. **OVN-Kubernetes actively introspects the guest to learn its IP (IP
+   discovery).** Rather than asking the user to supply the IP, the controller
+   *discovers* it and populates the source (and, for VM destinations, the
+   destination) address set, restoring the full IPAM feature set. Candidate
+   discovery mechanisms:
+   - **KubeVirt VMI status watching** - read guest-reported addresses from
+     `VirtualMachineInstance.status.interfaces[].ipAddress` and populate the
+     address set.
+   - **DHCP snooping** - observe DHCP ACKs on the localnet bridge to learn the
+     lease the external server hands the guest.
+   - **ARP/ND learning** - passively learn the source IP from the guest's own
+     ARP/NDP traffic.
+   - **IP-claim CRD** - an `IPAMClaim`-style cluster object recording the guest's
+     address.
+
+   Not preferred, and captured as a [Non-Goal](#non-goals) rather than a live
+   design option, for several reasons:
+   - **It reintroduces the IP-management responsibility this OKEP sets out to
+     avoid.** The target population is precisely VMs whose addresses are managed
+     entirely outside OVN-Kubernetes; making the controller track those addresses
+     re-couples QoS to an IP OVN-K neither owns nor can authoritatively validate.
+   - **Learned IPs are guest-asserted, hence spoofable.** DHCP-snooped and
+     ARP-learned addresses originate from the guest; matching QoS on them reopens
+     the spoofing exposure the `inport` design closes by construction (a guest
+     could source-spoof to change or evade its QoS class), directly conflicting
+     with the localnet disable-MAC-spoofing direction
+     ([OKEP-3926](okep-3926-disable-port-security.md)).
+   - **It is eventually-consistent, so it recreates the silent-skip failure in a
+     new form.** Addresses are learned asynchronously and can change at runtime
+     (renumbering, secondary/floating IPs, failover); between a change and its
+     detection QoS silently under-applies - the very behavior the Problem
+     Statement objects to - and address-set churn adds reconcile load.
+   - **Cost/coupling is disproportionate.** The KubeVirt-status variant adds a
+     hard control-plane dependency on the KubeVirt API for a feature that must
+     also serve non-VM pods and non-KubeVirt deployments; the datapath variants
+     (DHCP snooping, ARP/ND learning) are substantial new datapath features, each
+     larger than the entire rest of this proposal.
+   - **It is not required by the target use cases.** Every source-side use case
+     (Stories 1-4) is satisfied by IP-independent `inport` matching. The only
+     capability introspection would unlock - destination `podSelector` on
+     ipamless networks - is an explicit [Future Goal](#future-goals), and the
+     OKEP prefers to reach it through a clean, authoritative IP path (DHCP IPAM
+     per [OKEP-6224](okep-6224-dhcp-ipam-localnet.md), or static-IP propagation)
+     rather than by inferring IPs the controller does not manage.
+
+**Choosing between the families.** The IP-independent approaches (1, 2) need no
+guest IP and - for approach 1 - are spoof-resistant, but they can express only
+`ipBlock`/CIDR destinations: "QoS toward `10.20.0.0/16`", not "QoS toward pods
+labeled `role: backup-target`" without manual CIDR bookkeeping. The IP-dependent
+approaches (3, 4) preserve the full destination feature set but reintroduce
+IP-management burden, spoofable match criteria, and eventual-consistency gaps.
+This OKEP chooses the IP-independent port group (approach 1) for the committed
+scope and defers destination `podSelector` to a future clean-IP path. This is
+the deliberate scope trade documented in R8 and
+[Scope of destination matching](#scope-of-destination-matching-in-this-proposal):
+source selection stays fully label-driven; destination selection is
+`ipBlock`/CIDR only.
 
 ## Deferred / Open Questions
 
@@ -520,6 +925,27 @@ pods labeled `role: backup-target`" without manual CIDR bookkeeping).
      API change** - an externally observable contract that must be documented and
      maintained, and not "controller-internal behavior alone" as R7 requires.
      So this option is in genuine tension with R7 as currently worded.
+
+### Carried into implementation
+
+These are settled enough to build the feature, but each needs a decision or a
+verification step before GA:
+
+- **Partial resolution of a multi-attachment source pod.** When a source pod has
+  several relevant attachments and only some LSPs exist in NB yet, should the
+  controller add the resolved LSPs immediately and retry the rest, or hold the
+  whole pod until all resolve? Undecided; affects the granularity of the
+  level-based retry.
+- **Retry accounting for the level-based requeue.** Choose the `maxRetries`
+  budget and log level so that a normal transient (source LSP not yet in NB) is
+  not surfaced as an error in logs or metrics.
+- **Zone transitions on ipamless.** The `onNQOSPodUpdate` filter comment also
+  claims to catch zone switches; confirm the level-based retry path covers this,
+  or record it as a separate latent gap. Moot for single-zone localnet; relevant
+  under OVN Interconnect.
+- **Orphan port-group garbage collection** across controller rename/restart;
+  confirm the ownership-keyed GC reclaims orphaned port groups
+  (see [Risks](#risks-known-limitations-and-mitigations)).
 
 ## References
 

--- a/docs/okeps/okep-6815-network-qos-ipamless.md
+++ b/docs/okeps/okep-6815-network-qos-ipamless.md
@@ -1,0 +1,535 @@
+# OKEP-6815: Add NetworkQoS support for ipamless localnet networks
+
+* Issue: [#6815](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6815)
+
+> **Status of this document.** This revision intentionally scopes the problem
+> space only: motivation, use cases, requirements, goals, future goals, and
+> non-goals. The `Proposed Solution`, `Implementation Details`, `Testing
+> Details`, `Risks`, `Version Skew`, `Backwards Compatibility`, and
+> `Alternatives` sections are placeholders to be filled in a subsequent
+> iteration once the community aligns on the problem framing below.
+
+## Problem Statement
+
+NetworkQoS ([OKEP-4380](okep-4380-network-qos.md)) delivers DSCP marking and
+bandwidth policing by building OVN QoS match expressions from pod IP addresses
+read from the `k8s.ovn.org/pod-networks` annotation.
+
+On secondary **localnet** networks with IPAM disabled (**ipamless**) - the topology commonly
+used by KubeVirt / OpenShift Virtualization VMs whose IP addresses are managed
+statically or by an external DHCP server - pods have no OVN-Kubernetes-managed
+IPs, so `getPodAddresses()` returns nothing and the controller silently skips
+them. As a result NetworkQoS is non-functional on these networks, and there is
+today no supported way to apply network QoS (workload-tier prioritization,
+backup-traffic deprioritization, or bandwidth capping) to VMs running on them.
+
+Ipamless **layer2** networks share the same underlying limitation, but this
+proposal is scoped to **localnet**; see [Non-Goals](#non-goals) and
+[Future Goals](#future-goals) for how layer2 is treated.
+
+## Goals
+
+- Make NetworkQoS functional on secondary ipamless **localnet** networks. (The
+  intent to do so without changing the NetworkQoS CRD is captured as R7; the need
+  for network-dependent semantics to be discoverable to users is captured as
+  R13.)
+- Support, on ipamless networks, the QoS capabilities the target use cases
+  require, **without requiring OVN-Kubernetes to discover or manage pod IP
+  addresses**:
+  - source pod/VM selection by label (`podSelector`);
+  - DSCP marking;
+  - bandwidth policing (`rate` / `burst`);
+  - protocol + port classification (TCP/UDP/SCTP + port);
+  - destination matching by IP range (`ipBlock` / CIDR);
+  - priority ordering across and within NetworkQoS objects.
+- Support QoS at **both** levels the use cases demand. OVN-Kubernetes
+  guarantees bandwidth policing in the OVN/OVS datapath (excess dropped within
+  the cluster). For fabric-level QoS, OVN-Kubernetes **marks** DSCP on egress
+  traffic - which on tunnel-free localnet is directly visible to the fabric -
+  but the fabric only enforces (queues/prioritizes) that marking when the
+  physical network is configured to honor and map DSCP to hardware queues; that
+  configuration is outside OVN-Kubernetes' control.
+- Preserve **identical behavior on IPAM-enabled networks**. The existing
+  IP-based address-set path remains the production-proven path for all current
+  NetworkQoS deployments - no regressions, no behavioral change, no performance
+  impact.
+
+## Non-Goals
+
+- **Ipamless layer2 topology, as a committed deliverable.** This proposal
+  targets localnet. The enabling mechanism is expected to apply to ipamless
+  layer2 as well; **if layer2 support comes essentially for free** (little or no
+  additional work beyond the localnet implementation), it will be folded into
+  this effort opportunistically. **If layer2 requires meaningful additional
+  work**, it will be pursued as a **separate enhancement** rather than expanding
+  this one (see [Future Goals](#future-goals)).
+- **Destination selection by `podSelector` / `namespaceSelector` on ipamless
+  networks.** Destination matching on ipamless networks is limited to
+  `ipBlock` (IP / CIDR). The target use cases in this OKEP do not require
+  selecting *destination* pods by label (see Requirements and User-Stories).
+  Supporting labeled-pod destinations on ipamless networks is a
+  [Future Goal](#future-goals): it depends on resolving destination pod
+  identity, which under OVN Interconnect is topology-dependent (and, on
+  localnet specifically, not reliably resolvable across nodes).
+- **NetworkQoS on layer3 ipamless topology.** Layer3 uses per-node logical
+  switches connected by a logical router; layer3 also exists primarily for
+  routed multi-subnet deployments, which implies IPAM.
+- **IP discovery or reporting for ipamless networks** (DHCP snooping, KubeVirt
+  VMI status watching, ARP/NDP learning, IP-claim CRDs, or similar). This OKEP
+  does not add any mechanism for OVN-Kubernetes to learn the guest's IP.
+- **Changes to the NetworkQoS CRD API / schema.** Users create the same
+  `NetworkQoS` resources with the same fields; only controller-internal
+  behavior changes.
+- **Changes to EgressQoS.** EgressQoS is default-network-only and always has
+  IPAM.
+- **MultiNetworkPolicy changes for ipamless networks.** The same restriction
+  (only `ipBlock` peers on ipamless networks) exists for MultiNetworkPolicy and
+  is unblocked by the same underlying enabling work, but the MNP implementation
+  is a separate effort (see [Future Goals](#future-goals)).
+- **Ingress-direction QoS and traffic shaping.** NetworkQoS is egress-only and
+  *polices* (drops excess) rather than *shapes* (queues) - an existing product
+  constraint, not introduced here.
+- **Minimum bandwidth guarantees / reservations.** Not supported by OVN.
+- **Arbitration against other node traffic (host/OCP, CSI, other networks).**
+  NetworkQoS governs only the selected localnet UDN's own egress. It does not
+  prioritize that traffic over - or protect it from - other traffic sharing the
+  node's uplink. The two mechanisms it offers are: **throttling** the UDN's
+  traffic (bandwidth policing, a rate cap on that traffic alone), and **DSCP
+  marking**, which has no local forwarding effect and is only acted upon by the
+  physical fabric. Neither is a cross-class scheduler, and there is no
+  minimum-bandwidth guarantee relative to other traffic.
+
+## Future Goals
+
+- **Ipamless layer2 support**, if it is not delivered opportunistically as part
+  of this proposal. Should enabling layer2 require more than trivial additional
+  work beyond the localnet implementation, it will be tracked and delivered as a
+  separate enhancement that reuses this work.
+- **Destination `podSelector` / `namespaceSelector` on ipamless networks** -
+  "apply QoS to traffic *toward* a labeled set of pods." This is the principal
+  capability deferred by this OKEP. It becomes relevant only if a future
+  requirement needs to select destination pods by label rather than by address
+  range. Because destination matching is built from IP address sets (not port
+  identity), delivering it comes down to getting the pod IP into the
+  `k8s.ovn.org/pod-networks` annotation so the existing IP-based path applies -
+  e.g. KubeVirt static-IP propagation, or the DHCP IPAM path of
+  [OKEP-6224](okep-6224-dhcp-ipam-localnet.md).
+- **MultiNetworkPolicy pod/namespace selectors on ipamless networks.** The same
+  enabling mechanism lifts the current "IPAM-less networks can only have
+  `ipBlock` peers" restriction for MNP. Separate PR.
+- **Convergence with DHCP IPAM ([OKEP-6224](okep-6224-dhcp-ipam-localnet.md)).**
+  DHCP-mode networks have subnets configured (for the DHCP pool), so
+  `DoesNetworkRequireIPAM()` returns true and they already follow the standard
+  IP-based path. A future optimization could unify the ipamless and DHCP paths.
+
+## Introduction
+
+### QoS mechanisms in OVN-Kubernetes today
+
+OVN-Kubernetes offers three QoS mechanisms. The table summarizes their
+capabilities relative to the requirements of this OKEP.
+
+| Capability | NetworkQoS (`v1alpha1`) | EgressQoS (`v1`) | Pod Bandwidth Annotations |
+|---|---|---|---|
+| DSCP marking (0–63) | Yes | Yes | No |
+| Bandwidth policing (rate+burst) | Yes - excess dropped | No | Egress only |
+| Traffic shaping (queuing) | No | No | Ingress only (linux-htb) |
+| Destination CIDR match | Yes | Yes | No |
+| Destination pod/ns selector | Yes (IPAM-enabled only today) | No | No |
+| Protocol + port match | Yes (TCP/UDP/SCTP) | No | No |
+| Source pod selector | Yes (spec-level) | Yes (per-rule) | No |
+| Multi-network / UDN | Yes | No (default only) | Limited |
+| Multiple objects per namespace | Yes | No (one, named `default`) | N/A |
+| Priority | 0–100 (higher wins) | Array position | N/A |
+| Direction | Egress only | Egress only | Both |
+
+**NetworkQoS is the only mechanism with the expressiveness the target use cases
+need** - multi-network/UDN support, DSCP marking, bandwidth policing, and
+traffic classification by protocol/port. EgressQoS is its default-network-only
+predecessor; pod bandwidth annotations are per-interface with no traffic
+classification.
+
+### How NetworkQoS works, and its IP dependency
+
+The NetworkQoS CRD (`k8s.ovn.org/v1alpha1`) is namespace-scoped and defines:
+
+- **`podSelector`** - selects source pods by label (empty = all pods in the
+  namespace).
+- **`networkSelectors`** - restricts the rule to specific networks (default,
+  UDN, NAD).
+- **`priority`** (0–100) - resolves conflicts when multiple NetworkQoS objects
+  match the same packet; higher value wins.
+- **`egress`** (ordered list, up to 20 rules) - each rule specifies `dscp`
+  (0–63), an optional `bandwidth` (`rate` in kbps, `burst` in kilobits;
+  policing, not shaping), and an optional `classifier` matching by destination
+  (`ipBlock`, `podSelector`, `namespaceSelector`) and/or by `ports` (protocol +
+  port). Later rules in the list take higher precedence.
+
+Internally, the controller creates OVN address sets for source (and
+destination) pods, builds match expressions such as
+`ip4.src == {$src_as} && tcp && tcp.dst == 8080`, and attaches OVN QoS entries
+(direction `to-lport`, i.e. egress from the pod's perspective) to the network's
+logical switch. Every step depends on pod IP addresses obtained from the
+`k8s.ovn.org/pod-networks` annotation. On ipamless networks that annotation
+carries a MAC but no IPs, so the controller has nothing to match on and skips
+the pod.
+
+### Why ipamless secondary localnet is the target topology
+
+Enterprises migrating VM workloads to OpenShift Virtualization need the same
+network QoS controls they had on traditional hypervisors (e.g. VMware ESX):
+differentiating priority between workload tiers, between application and
+infrastructure traffic, and capping bandwidth for specific traffic classes.
+
+These VMs commonly attach to **secondary ipamless localnet UDNs** - the guest
+OS or an external DHCP server manages addressing, not OVN-Kubernetes.
+
+A natural question is why these workloads do not simply adopt DHCP IPAM
+([OKEP-6224](okep-6224-dhcp-ipam-localnet.md)), which would place them on the
+standard IP-based path (where destination `podSelector` also works). The target
+population is precisely the set that cannot: VMs with truly static, externally
+managed addresses - for these, no OVN-managed IP ever exists, so an
+IP-independent matching path is the only option. Workloads that *can* use
+DHCP IPAM should prefer it (see [Future Goals](#future-goals) on convergence).
+
+This proposal targets localnet; ipamless layer2 networks share the same
+limitation and may benefit from the same fix, but layer2 is not a committed
+deliverable here (see [Non-Goals](#non-goals) and
+[Future Goals](#future-goals)).
+
+On localnet there is **no Geneve tunnel**: traffic egresses directly onto the
+physical network, so a DSCP value stamped on the IP header is immediately
+visible to the fabric with no inner/outer-header concerns. This is favorable
+for fabric-level prioritization - provided the physical network is configured
+to honor DSCP and map it to hardware queues.
+
+The diagram below shows the egress traffic path for a KubeVirt VM on a secondary
+ipamless localnet UDN, and where each QoS action is enforced. Everything left of
+the enforcement boundary is under OVN-Kubernetes' control on the *sending* node;
+everything right of it is the physical fabric, which OVN-Kubernetes never sees
+again (the basis for the source-only matching argument in the next section).
+
+```text
+           sending node (OVN-Kubernetes control)          │  physical fabric
+                                                          │  (out of OVN-K control)
+ ┌───────────┐   ┌───────────────────────────────────────┐│
+ │ KubeVirt  │   │        secondary localnet UDN         ││
+ │   VM      │   │  (ipamless: MAC only, no OVN-managed  ││
+ │ (source   │ ─>│   pod IP; label-selected source)      ││
+ │  pod,     │   │                                       ││
+ │  label:   │   │   logical switch port ── zone-local   ││
+ │  tier=..) │   │   on the sending node, so the source  ││
+ └───────────┘   │   is always identifiable (no pod IP)  ││
+                 └───────────────┬───────────────────────┘│
+                                 ▼                        │
+                 ┌───────────────────────────────────────┐│
+                 │        OVN/OVS QoS (to-lport)         ││
+                 │  • source matching   (by port/label)  ││
+                 │  • dst matching      (ipBlock/CIDR)   ││
+                 │  • bandwidth policing (rate/burst)    ││
+                 │  • DSCP marking      (stamp IP hdr)   ││
+                 └───────────────┬───────────────────────┘│
+                                 ▼                        │
+                 ┌───────────────────────────────────────┐│      ┌─────────────┐
+                 │   OVS bridge → physical NIC           ││      │ QoS-aware   │
+                 │   (localnet: NO Geneve tunnel;        ││----▶ │ switches    │
+                 │    DSCP on outer IP hdr, fabric-      ││ DSCP │ honor DSCP, │
+                 │    visible immediately)               ││ on   │ map to HW   │
+                 └───────────────────────────────────────┘│ wire │ queues      │
+                                                          │      └─────────────┘
+                 <------- enforcement boundary ---------->│
+```
+
+Because there is no tunnel, the DSCP value stamped by OVN/OVS QoS travels on the
+same IP header the fabric reads - no inner/outer-header translation is needed for
+the marking to reach QoS-aware physical switches.
+
+### Scope of destination matching in this proposal
+
+Destination matching in this OKEP is limited to **IP range (`ipBlock` / CIDR)**.
+Source selection remains fully label-driven; classification by protocol/port is
+unchanged; DSCP, bandwidth, and priority are unchanged. Labeled-pod destination
+selection on ipamless networks is deferred to [Future Goals](#future-goals).
+
+This is a deliberate scoping decision, not merely an implementation shortcut.
+The reasons it is the right initial scope:
+
+1. **On localnet, source is the only thing we can reliably match and enforce
+   on.** OVN-Kubernetes enforces QoS at the sending node's OVN/OVS datapath. On
+   localnet there is no tunnel and no cluster-managed path to the destination:
+   the moment a packet egresses the node onto the physical fabric it leaves
+   OVN-Kubernetes' control and visibility entirely - it can be routed, NAT'd,
+   re-marked, or dropped, and OVN-Kubernetes will never see it again. The source
+   pod, by contrast, is right there on the local switch and always identifiable.
+   Destination pod *identity* is out of reach on ipamless networks for the same
+   root reason the source would be without this proposal's enabling work: there
+   is no OVN-managed IP in the pod annotation. (Destination matching is built
+   from an IP address set - `ip4.dst == $dest_as`, evaluated against the packet
+   header - so wherever pod IPs exist it already works cluster-wide regardless
+   of OVN Interconnect zone; it is not gated on port identity or zone-locality.
+   The blocker on ipamless networks is purely the missing IP, not topology.) On
+   top of that, much QoS-relevant traffic terminates off-cluster (external
+   services, appliances, hosts on the segment) where there is no destination pod
+   to select at all. `ipBlock`, in contrast, is evaluated locally against the packet
+   header before egress - no destination-side cooperation or resolution
+   required - so it is not a lossy substitute for a working feature; it is the
+   honest, complete story for what can be matched correctly today.
+
+2. **The use cases are source-side; the destination refinements are address
+   ranges.** Workload-tier differentiation (production vs. staging), per-class
+   bandwidth capping, and DSCP marking for fabric prioritization are all decided
+   by *who is sending* (selected by label). Destination matching appears only as
+   a secondary refinement (e.g. "deprioritize traffic *to* the backup subnet"),
+   and in every such case the destination is stable, fixed-address
+   infrastructure - backup servers, storage/NFS targets, monitoring collectors.
+   That is the canonical `ipBlock` case ("traffic to `10.20.0.0/16`"), not a
+   churning label-selected pod set. Fabric-level enforcement reinforces this:
+   once a packet is marked, the physical fabric queues it by that marking
+   regardless of destination.
+
+3. **It aligns with an already-accepted platform constraint.** MultiNetworkPolicy
+   already restricts ipamless networks to `ipBlock` peers, and `ipBlock` is a
+   long-established, widely-used selector in Kubernetes NetworkPolicy. Scoping
+   destination matching to IP/CIDR follows an existing platform norm rather than
+   introducing a novel limitation.
+
+4. **There is a clear escape hatch, so the door is not permanently closed.** A
+   user who genuinely needs label-based destination selection can get pod IPs
+   into the `k8s.ovn.org/pod-networks` annotation - via DHCP IPAM
+   ([OKEP-6224](okep-6224-dhcp-ipam-localnet.md)) or static-IP propagation -
+   which moves the network onto the standard IP-based path where destination
+   `podSelector` already works. This capability is deferred
+   ([Future Goals](#future-goals)), not foreclosed.
+
+## User-Stories/Use-Cases
+
+### Definition of personas
+
+- **Cluster admin** - creates and manages secondary networks and cluster-wide
+  policies.
+- **Namespace admin** - deploys workloads and manages per-namespace QoS
+  policies within a namespace.
+- **VM operator** - runs virtual machines via KubeVirt on secondary networks.
+
+### Story 1: Workload-tier differentiation (production over staging)
+
+**As a** cluster admin,
+**I want** production VM workloads to receive higher network priority than
+staging workloads, even when both share the same ipamless localnet subnet,
+**so that** production traffic is forwarded preferentially by the physical
+fabric.
+
+**Example:** Production and staging VMs run on the same secondary localnet UDN,
+labeled `tier: production` and `tier: staging`. The admin creates two
+`NetworkQoS` objects selecting each tier by `podSelector`, marking production
+with a high-priority DSCP class (e.g. EF / 46) and staging with a lower class
+(e.g. AF11 / 10), and uses `priority` to resolve overlaps. This is entirely a
+**source-side** decision. Without ipamless support these objects are silently
+ignored.
+
+### Story 2: Intra-VM backup-traffic deprioritization
+
+**As a** namespace admin,
+**I want** in-guest backup traffic from a VM to be marked at lower priority and
+optionally rate-capped, relative to the VM's regular application traffic,
+**so that** bulk backup transfers do not degrade application performance on the
+shared NIC.
+
+**Example:** VMs run an in-guest backup agent that sends bulk traffic to a
+backup server on a known port and/or a stable address range. Within a single
+`NetworkQoS` object, an earlier egress rule marks general traffic at a high
+DSCP, and a later, higher-precedence rule classifies backup traffic (by
+protocol/port and/or the backup server's `ipBlock`) with a low DSCP and a
+bandwidth cap. Because later rules take higher precedence, the specific backup
+rule overrides the general high-DSCP rule for backup packets. The backup
+destination is stable infrastructure - the canonical `ipBlock` case - not a
+churning set of label-selected pods.
+
+### Story 3: Bandwidth capping per workload class
+
+**As a** namespace admin,
+**I want** to cap egress bandwidth for a specific class of VMs (selected by
+label) on an ipamless localnet network,
+**so that** a batch class cannot exceed a fixed egress rate and monopolize the
+shared NIC, leaving headroom for latency-sensitive workloads - even when IP
+addresses are managed outside Kubernetes.
+
+**Example:** Batch-processing VMs (`workload: batch`) are capped via a
+`NetworkQoS` `bandwidth` rate, leaving the remaining capacity to
+latency-sensitive VMs. This is source- and/or port-scoped, not
+destination-pod-scoped.
+
+### Story 4: DSCP marking for fabric-level prioritization on tunnel-free localnet
+
+**As a** cluster admin,
+**I want** egress traffic from selected VMs on an ipamless localnet network to
+carry a DSCP marking,
+**so that** QoS-aware physical switches place the traffic in the appropriate
+hardware queue - without OVN-Kubernetes needing to know the VMs' IP addresses.
+
+**Example:** VMs labeled `priority: gold` have egress traffic marked DSCP 46.
+Because localnet has no tunnel, the marking is visible on the physical
+interface directly (verifiable with `tcpdump` on the OVS bridge port). This
+`tcpdump` check verifies only that OVN-Kubernetes applied the mark; whether the
+fabric honors it (queues accordingly, or re-marks/clears it at a trust boundary)
+is a separate, out-of-scope prerequisite not validated by this OKEP.
+
+## Requirements
+
+Derived from the user stories above and the driving user requests tracked in
+the upstream enhancement issue
+([#6815](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6815)):
+
+- **R1.** Production workloads must be able to have their egress traffic
+  **marked** with a higher-priority DSCP class than staging workloads, even when
+  both share the same localnet subnet. (Preferential *forwarding* of that traffic
+  depends on the physical fabric being configured to honor the marking - outside
+  OVN-Kubernetes' control; see R5 and [Non-Goals](#non-goals).)
+- **R2.** Within a single VM, in-guest backup traffic must be able to receive
+  lower network priority than the VM's regular application traffic.
+- **R3.** QoS must be selectable by pod/VM **labels** and must support applying
+  a DSCP mark to the selected egress traffic.
+- **R4.** The solution must work on **secondary OVN localnet networks with
+  statically managed IPs (ipamless)**. Ipamless **layer2** is not a committed
+  target: it will be reused opportunistically if the localnet mechanism applies
+  with little or no additional work, otherwise pursued as a separate
+  enhancement.
+- **R5.** QoS must operate at **both** levels: the OVN/OVS datapath, where
+  OVN-Kubernetes guarantees bandwidth policing within the cluster; and the
+  physical network fabric, where OVN-Kubernetes marks DSCP on egress traffic.
+  Fabric-level enforcement of that marking depends on the physical network being
+  configured to honor and map DSCP, which is outside OVN-Kubernetes' control.
+- **R6.** The solution must work with **KubeVirt VMs on OpenShift
+  Virtualization**.
+- **R7.** **No changes to the NetworkQoS CRD API.** Requirements must be met by
+  controller-internal behavior alone. *This requirement is provisional: it may be
+  relaxed or removed depending on how outcomes are surfaced to the user (see
+  R13).*
+- **R8.** Destination matching on ipamless networks must support **IP range
+  (`ipBlock` / CIDR)** classification. Destination selection by `podSelector` /
+  `namespaceSelector` is deliberately out of scope for this proposal (see
+  [Non-Goals](#non-goals) and [Future Goals](#future-goals)), because `ipBlock`
+  is sufficient for the target use cases.
+- **R9.** Bandwidth policing (`rate` in kbps, `burst` in kilobits) must be
+  supported on ipamless networks, to enforce per-source or per-traffic-class
+  egress rate limits (Stories 2 and 3).
+- **R10.** Traffic classification by protocol (TCP/UDP/SCTP) and destination
+  port must be supported on ipamless networks, to differentiate traffic classes
+  within a workload (Story 2).
+- **R11.** Priority ordering - both across NetworkQoS objects (`priority`, 0-100)
+  and within an object's ordered `egress` rule list - must be honored on ipamless
+  networks, to resolve conflicts when multiple policies or rules match the same
+  traffic (Story 1).
+- **R12.** The solution must preserve identical behavior, performance, and OVN
+  datapath constructs for NetworkQoS on **IPAM-enabled** networks; the existing
+  IP-based address-set path must remain unchanged, with no regressions (Goal 4).
+  This guarantee applies to objects whose selected networks are all
+  IPAM-enabled. Because a single `NetworkQoS` object can select multiple networks
+  (the `networkSelectors` list, each entry a label selector), an object may
+  select **both** an IPAM-enabled and an ipamless network; for such
+  mixed-selection objects, any R13 degradation-surfacing may become observable on
+  the object. Reconciling R12's no-change guarantee with R13 for mixed-selection
+  objects is part of the R13 open question (see
+  [Deferred / Open Questions](#deferred--open-questions)).
+- **R13.** When a `NetworkQoS` configuration relies on a capability not
+  supported on the target ipamless network (notably destination `podSelector` /
+  `namespaceSelector`), the outcome must be **discoverable** to the user rather
+  than a silent no-op. This is consistent with the Problem Statement's objection
+  to silently skipped pods: because a single namespace-scoped object can select
+  multiple networks and be honored on an IPAM-enabled network while degrading on
+  an ipamless one, users need to be able to tell which semantics apply where.
+  *How* this is surfaced is an open question (see
+  [Deferred / Open Questions](#deferred--open-questions)) to be settled in the
+  Proposed Solution; this requirement fixes only that the degradation must not be
+  silent.
+- **R14.** The distinction between DSCP *marking* (which OVN-Kubernetes performs)
+  and DSCP *enforcement* (which requires the physical fabric to be configured to
+  honor the marking) must be explicit to users, so that a marked-but-unenforced
+  outcome - the expected result when the fabric is unconfigured - is not mistaken
+  for a broken feature. Marking is verifiable at the source (e.g. `tcpdump` on the
+  OVS bridge port, per Story 4); fabric enforcement is a separate, out-of-scope
+  prerequisite (see R5 and [Non-Goals](#non-goals)).
+
+## Proposed Solution
+
+*To be detailed in a subsequent iteration.*
+
+### API Details
+
+*To be detailed in a subsequent iteration. No NetworkQoS CRD API changes are
+anticipated (R7).*
+
+### Implementation Details
+
+*To be detailed in a subsequent iteration.*
+
+### Testing Details
+
+*To be detailed in a subsequent iteration.*
+
+### Documentation Details
+
+*To be detailed in a subsequent iteration. Must include adding this OKEP to
+`mkdocs.yml` under the OKEPs navigation section.*
+
+## Risks, Known Limitations and Mitigations
+
+*To be detailed in a subsequent iteration.*
+
+## OVN-Kubernetes Version Skew
+
+*To be detailed in a subsequent iteration.*
+
+## Backwards Compatibility
+
+*To be detailed in a subsequent iteration. The intended direction is strictly
+additive: NetworkQoS on ipamless networks is non-functional today, so enabling
+it does not change any existing behavior; IPAM-enabled networks are unaffected.*
+
+## Alternatives
+
+*To be detailed in a subsequent iteration.* The comparison must evaluate the
+candidate IP-independent matching approaches against an IP-in-annotation
+approach, and must call out the **loss of destination `podSelector` /
+`namespaceSelector` matching** as a key drawback of the IP-independent
+approaches (they can express "QoS toward `10.20.0.0/16`" but not "QoS toward
+pods labeled `role: backup-target`" without manual CIDR bookkeeping).
+
+## Deferred / Open Questions
+
+### From 2026-08-19 review
+
+- **R13 discovery mechanism for unsupported/degraded configs on ipamless networks** — Requirements (R13) (P1, product-lens / scope-guardian, confidence 75)
+
+  R13 requires that a `NetworkQoS` config relying on a capability unavailable on
+  an ipamless network (notably destination `podSelector` / `namespaceSelector`)
+  must not degrade silently - but deliberately does not fix *how* the user is
+  told. This is an open design question for the Proposed Solution, with (at
+  least) three candidates:
+
+  1. **Silent no-op** (status quo) - rejected by R13's intent; listed only as the
+     baseline being ruled out.
+  2. **Emit a Kubernetes event per reconcile** - low-effort; events are not part
+     of the `NetworkQoS` API surface, so this is arguably the most R7-clean
+     option (controller-internal behavior). Downsides: events are ephemeral and
+     noisy on a hot reconcile loop, and easy to miss after the fact.
+  3. **Surface a condition on the `NetworkQoS` object's status** - persistent and
+     queryable. Note this is **not** free with respect to R7: although the CRD
+     struct already exposes `Status.Conditions` (no OpenAPI/schema diff needed),
+     introducing a *new condition type* with defined semantics is an **additive
+     API change** - an externally observable contract that must be documented and
+     maintained, and not "controller-internal behavior alone" as R7 requires.
+     So this option is in genuine tension with R7 as currently worded.
+
+## References
+
+- [OKEP-4380: Network QoS Support](okep-4380-network-qos.md) - existing
+  NetworkQoS implementation.
+- [OKEP-6224: DHCP IPAM Support for Localnet Networks](okep-6224-dhcp-ipam-localnet.md)
+  - DHCP-based IP delivery (related, not a dependency).
+- [OVN NB Schema - QoS Table](https://www.ovn.org/support/dist-docs/ovn-nb.5.html)
+  - QoS match expression syntax.
+- Upstream tracking:
+  [ovn-kubernetes#6815](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6815)
+  - enhancement tracking issue for this OKEP, where the driving user requests
+  and discussion are recorded.

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -382,6 +382,14 @@ var PortGroupUDN = newObjectIDsType(portGroup, UDNIsolationOwnerType, []External
 	ObjectNameKey,
 })
 
+// PortGroupNetworkQoS identifies the per-NetworkQoS source port group used to
+// match source pods on ipamless localnet networks (where pods have no
+// OVN-managed IP), via inport == @pg instead of a src-IP address set.
+var PortGroupNetworkQoS = newObjectIDsType(portGroup, NetworkQoSOwnerType, []ExternalIDKey{
+	// NetworkQoS namespace:name
+	ObjectNameKey,
+})
+
 var LogicalRouterPolicyEgressIP = newObjectIDsType(logicalRouterPolicy, EgressIPOwnerType, []ExternalIDKey{
 	// the priority of the LRP
 	PriorityKey,

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos.go
@@ -161,6 +161,16 @@ func (c *Controller) ensureNetworkQos(nqos *networkqosapi.NetworkQoS) error {
 	if err := desiredNQOSState.initAddressSets(c.addressSetFactory, c.controllerName); err != nil {
 		return err
 	}
+	if c.isIPAMlessLocalnet() {
+		// On ipamless localnet networks source pods have no OVN-managed IP, so
+		// they are matched via membership in a per-NetworkQoS source port group
+		// (inport == @pg) instead of a src-IP address set. Ensure the port group
+		// exists before resyncing pods populates it.
+		desiredNQOSState.initSourcePortGroupName(c.controllerName)
+		if err := c.ensureSourcePortGroup(desiredNQOSState); err != nil {
+			return fmt.Errorf("failed to ensure source port group for NetworkQoS %s/%s: %w", nqos.Namespace, nqos.Name, err)
+		}
+	}
 	if err := c.resyncPods(desiredNQOSState); err != nil {
 		return fmt.Errorf("failed to resync pods: %w", err)
 	}

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
@@ -13,10 +13,27 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+// ensureSourcePortGroup creates the per-NetworkQoS source port group used on
+// ipamless localnet networks to match source pods via inport == @pg. Pods are
+// added/removed to it in the pod path; membership is intentionally left
+// untouched here (create-if-absent), so it is safe to call on every reconcile.
+func (c *Controller) ensureSourcePortGroup(qosState *networkQoSState) error {
+	pgIDs := GetNetworkQoSPortGroupDbIDs(qosState.namespace, qosState.name, c.controllerName)
+	pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
+	if c.IsUserDefinedNetwork() {
+		pg.ExternalIDs[types.NetworkExternalID] = c.GetNetworkName()
+	}
+	if err := libovsdbops.CreatePortGroup(c.nbClient, pg); err != nil {
+		return fmt.Errorf("failed to create source port group %s for NetworkQoS %s/%s: %w", pg.Name, qosState.namespace, qosState.name, err)
+	}
+	return nil
+}
 
 func (c *Controller) findLogicalSwitch(switchName string) (*nbdb.LogicalSwitch, error) {
 	if lsws, err := libovsdbops.FindLogicalSwitchesWithPredicate(c.nbClient, func(item *nbdb.LogicalSwitch) bool {

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
@@ -45,7 +45,7 @@ func (c *Controller) addQoSToLogicalSwitch(qosState *networkQoSState, switchName
 			Bandwidth:   map[string]int{},
 			Direction:   nbdb.QoSDirectionToLport,
 			ExternalIDs: dbIDs.GetExternalIDs(),
-			Match:       generateNetworkQoSMatch(qosState, rule, ipv4Enabled, ipv6Enabled),
+			Match:       generateNetworkQoSMatch(qosState, rule, ipv4Enabled, ipv6Enabled, c.isIPAMlessLocalnet()),
 			Priority:    rule.Priority,
 		}
 		if c.IsUserDefinedNetwork() {

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
@@ -210,6 +210,34 @@ func (c *Controller) deleteByName(ovnObjectName string) error {
 	if err = c.deleteAddressSet(ovnObjectName); err != nil {
 		return fmt.Errorf("error cleaning up address sets for %s: %w", ovnObjectName, err)
 	}
+	// On ipamless localnet the source is matched by a per-NetworkQoS port group
+	// instead of a src-IP address set; remove it on delete. Sequenced after the
+	// QoS-row removal above so no QoS row transiently references a deleted port
+	// group. IPAM-enabled networks never create one, so this is skipped for them.
+	if c.isIPAMlessLocalnet() {
+		if err = c.deleteSourcePortGroup(ovnObjectName); err != nil {
+			return fmt.Errorf("error cleaning up source port group for %s: %w", ovnObjectName, err)
+		}
+	}
+	return nil
+}
+
+// deleteSourcePortGroup deletes the per-NetworkQoS source port group owned by this
+// object (matched by owner external IDs, mirroring deleteAddressSet). Used only on
+// ipamless localnet networks. Exhaustive stale/orphan PG GC (rename/restart) is out
+// of scope for the PoC.
+func (c *Controller) deleteSourcePortGroup(qosName string) error {
+	delOps, err := libovsdbops.DeletePortGroupsWithPredicateOps(c.nbClient, nil, func(item *nbdb.PortGroup) bool {
+		return item.ExternalIDs[libovsdbops.OwnerControllerKey.String()] == c.controllerName &&
+			item.ExternalIDs[libovsdbops.OwnerTypeKey.String()] == string(libovsdbops.NetworkQoSOwnerType) &&
+			item.ExternalIDs[libovsdbops.ObjectNameKey.String()] == qosName
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get ops to delete source port group: %w", err)
+	}
+	if _, err := libovsdbops.TransactAndCheck(c.nbClient, delOps); err != nil {
+		return fmt.Errorf("failed to execute ops to delete source port group, err: %w", err)
+	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_pod.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_pod.go
@@ -64,6 +64,9 @@ func (c *Controller) isPodScheduledOnLocalNode(pod *corev1.Pod) bool {
 // - match source: add the ip to source address set, bind qos rule to the switch
 // - match dest: add the ip to the destination address set
 func (c *Controller) setPodForNQOS(pod *corev1.Pod, nqosState *networkQoSState, namespace *corev1.Namespace, addressSetMap map[string]sets.Set[string]) error {
+	if c.isIPAMlessLocalnet() {
+		return c.setPodForNQOSIPAMless(pod, nqosState, namespace, addressSetMap)
+	}
 	addresses, err := getPodAddresses(pod, c.NetInfo, c.podNetworkResolver())
 	if err == nil && len(addresses) == 0 {
 		// pod either is not attached to this network, or hasn't been annotated with addresses yet, return without retry
@@ -95,6 +98,49 @@ func (c *Controller) setPodForNQOS(pod *corev1.Pod, nqosState *networkQoSState, 
 		}
 	}
 	return reconcilePodForDestinations(nqosState, namespace, pod, addresses, addressSetMap)
+}
+
+// setPodForNQOSIPAMless is the ipamless-localnet counterpart of the source half
+// of setPodForNQOS. Source pods on ipamless localnet networks have no
+// OVN-managed IP, so they are matched by logical switch port membership in the
+// per-NetworkQoS source port group (inport == @pg) rather than by a src-IP
+// address set. Attachment is confirmed via the pod's own network-selection
+// annotation (a MAC-only attachment still counts as attached), never by IP.
+func (c *Controller) setPodForNQOSIPAMless(pod *corev1.Pod, nqosState *networkQoSState, namespace *corev1.Namespace, addressSetMap map[string]sets.Set[string]) error {
+	lspNames, err := c.ipamlessSourceLSPNames(pod)
+	if err != nil {
+		return fmt.Errorf("failed to resolve logical switch ports for pod %s/%s, network %s, err: %v", pod.Namespace, pod.Name, c.GetNetworkName(), err)
+	}
+	if len(lspNames) == 0 {
+		// pod is not attached to this network (or hasn't been annotated yet), return without retry
+		klog.V(6).Infof("Pod %s/%s is not attached to network %s, skip NetworkQoS processing", pod.Namespace, pod.Name, c.GetNetworkName())
+		return nil
+	}
+	fullPodName := joinMetaNamespaceAndName(pod.Namespace, pod.Name)
+	// is pod in this zone
+	if c.isPodScheduledOnLocalNode(pod) {
+		if matchSource := nqosState.matchSourceSelector(pod); matchSource {
+			// pod's labels match source selector
+			if err = nqosState.configureSourcePodIPAMless(c, pod, lspNames); err != nil {
+				return err
+			}
+		} else {
+			// pod's labels don't match selector, but it probably matched previously
+			if err = nqosState.removePodLSPFromSource(c, fullPodName); err != nil {
+				return err
+			}
+		}
+	} else {
+		klog.V(4).Infof("Pod %s is not scheduled in local zone, call remove to ensure it's not in source", fullPodName)
+		if err = nqosState.removePodLSPFromSource(c, fullPodName); err != nil {
+			return err
+		}
+	}
+	// Destinations on ipamless localnet are limited to ipBlock/CIDR (no
+	// pod/namespace selectors), so reconcilePodForDestinations naturally no-ops:
+	// its loop only handles selector-based destinations. Called for structural
+	// parity with the IPAM path.
+	return reconcilePodForDestinations(nqosState, namespace, pod, nil, addressSetMap)
 }
 
 func reconcilePodForDestinations(nqosState *networkQoSState, podNs *corev1.Namespace, pod *corev1.Pod, addresses []string, addressSetMap map[string]sets.Set[string]) error {

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
@@ -1413,3 +1413,61 @@ var _ = Describe("NetworkQoS on a DHCP-IPAM localnet network", func() {
 		eventuallyAddressSetHasNo(dhcpAddrsetFactory, nqosNamespace, "dhcp-qos", "src", "0", dhcpControllerName, lease1)
 	})
 })
+
+// U1: pin the source fragment of the generated OVN QoS match string. On ipamless
+// localnet networks the source is matched by port group (inport == @pg) instead
+// of a src-IP address set; the IPAM-enabled path must remain byte-for-byte
+// unchanged (guards R5).
+var _ = Describe("generateNetworkQoSMatch source fragment", func() {
+	const (
+		nqNs   = "qos-ns"
+		nqName = "qos-obj"
+		ctrl   = "netwk1-controller"
+	)
+
+	// ipBlockRule builds an internal GressRule with a single ipBlock destination
+	// (and an optional tcp port), exercising the already IP-independent classifier.
+	ipBlockRule := func(cidr string, tcpPort *int32) *GressRule {
+		classifier := &Classifier{
+			Destinations: []*Destination{{IpBlock: &networkingv1.IPBlock{CIDR: cidr}}},
+		}
+		if tcpPort != nil {
+			classifier.Ports = []*nqostype.Port{{Protocol: "tcp", Port: tcpPort}}
+		}
+		return &GressRule{Priority: 10600, Dscp: 46, Classifier: classifier}
+	}
+
+	It("emits the port-group form on ipamless localnet (happy path)", func() {
+		qosState := &networkQoSState{namespace: nqNs, name: nqName}
+		qosState.initSourcePortGroupName(ctrl)
+		pgName := qosState.SrcPortGroupName
+		Expect(pgName).NotTo(BeEmpty())
+
+		// ipamless IPMode() is (false, false); the (ip4 || ip6) qualifier is hardcoded.
+		match := generateNetworkQoSMatch(qosState, ipBlockRule("0.0.0.0/0", nil), false, false, true)
+		Expect(match).To(Equal(fmt.Sprintf("inport == @%s && (ip4 || ip6) && ip4.dst == 0.0.0.0/0", pgName)))
+	})
+
+	It("keeps the port-group source form with an ipBlock dest + protocol/port (edge case)", func() {
+		qosState := &networkQoSState{namespace: nqNs, name: nqName}
+		qosState.initSourcePortGroupName(ctrl)
+		pgName := qosState.SrcPortGroupName
+
+		port := int32(2049)
+		match := generateNetworkQoSMatch(qosState, ipBlockRule("10.20.0.0/16", &port), false, false, true)
+		Expect(match).To(Equal(fmt.Sprintf("inport == @%s && (ip4 || ip6) && ip4.dst == 10.20.0.0/16 && tcp && tcp.dst == 2049", pgName)))
+	})
+
+	It("keeps the address-set source form on IPAM-enabled networks (regression, guards R5)", func() {
+		factory := addressset.NewFakeAddressSetFactory(ctrl)
+		srcAS, err := factory.EnsureAddressSet(GetNetworkQoSAddrSetDbIDs(nqNs, nqName, "src", "0", ctrl))
+		Expect(err).NotTo(HaveOccurred())
+		v4Hash, _ := srcAS.GetASHashNames()
+
+		qosState := &networkQoSState{namespace: nqNs, name: nqName, SrcAddrSet: srcAS}
+
+		// IPAM-enabled single-stack IPv4: IPMode() -> (true, false); ipamless=false.
+		match := generateNetworkQoSMatch(qosState, ipBlockRule("0.0.0.0/0", nil), true, false, false)
+		Expect(match).To(Equal(fmt.Sprintf("ip4.src == {$%s} && ip4.dst == 0.0.0.0/0", v4Hash)))
+	})
+})

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
@@ -32,6 +32,7 @@ import (
 	crdtypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -1699,5 +1700,69 @@ var _ = Describe("NetworkQoS ipamless localnet source port group", func() {
 		Expect(pgPorts(qosState.SrcPortGroupName)).To(BeEmpty())
 		// Nothing bound yet since no port resolved.
 		Expect(nqosQoSes()).To(BeEmpty())
+	})
+
+	// U3: source port-group cleanup on NetworkQoS object deletion (delete-on-delete).
+	It("removes the source port group and unbinds all QoS rows when the NetworkQoS object is deleted (happy path)", func() {
+		newController("node1")
+		switchName := seedLocalnetSwitch()
+		lspUUID := seedSourceLSP(switchName)
+
+		qosState := newQoSState(nil)
+		pod := sourcePod(map[string]string{"app": "src"})
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+
+		// Populate the source PG and bind a QoS row to the localnet switch.
+		Expect(controller.setPodForNQOS(pod, qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+		Expect(controller.addQoSToLogicalSwitch(qosState, switchName)).To(Succeed())
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(ConsistOf(lspUUID))
+		Expect(nqosQoSes()).To(HaveLen(1))
+
+		// Delete the NetworkQoS object (same OVN object name clearNetworkQos passes).
+		ovnObjectName := joinMetaNamespaceAndName(podNs, nqName, ":")
+		Expect(controller.deleteByName(ovnObjectName)).To(Succeed())
+
+		// The source port group is gone.
+		pgs, err := libovsdbops.FindPortGroupsWithPredicate(testNbClient, func(item *nbdb.PortGroup) bool {
+			return item.Name == qosState.SrcPortGroupName
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pgs).To(BeEmpty())
+
+		// No QoS rows remain, and none are still bound to the switch.
+		Expect(nqosQoSes()).To(BeEmpty())
+		ls, lerr := libovsdbops.GetLogicalSwitch(testNbClient, &nbdb.LogicalSwitch{Name: switchName})
+		Expect(lerr).NotTo(HaveOccurred())
+		Expect(ls.QOSRules).To(BeEmpty())
+	})
+
+	It("does not attempt source port group deletion on IPAM-enabled networks (edge case, ipamless-negative)", func() {
+		// IPAM-enabled localnet (non-empty subnet) => isIPAMlessLocalnet() is false.
+		nad := ovnk8stesting.GenerateNAD(netName, nadK8sName, podNs, types.LocalnetTopology, "10.0.0.0/24", types.NetworkRoleSecondary)
+		immutable, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		netInfo := &secondaryNetInfoWrapper{NetInfo: immutable}
+		ipamController := &Controller{
+			controllerName: ctrlName,
+			NetInfo:        netInfo,
+			networkManager: &networkmanager.FakeNetworkManager{NADNetworks: map[string]util.NetInfo{nadKey: netInfo}},
+			nbClient:       testNbClient,
+			nodeName:       "node1",
+		}
+		Expect(ipamController.isIPAMlessLocalnet()).To(BeFalse())
+
+		// Seed a port group carrying this NetworkQoS's owner external IDs. On an IPAM
+		// network the delete path must leave it untouched (the gate skips PG deletion).
+		pgIDs := GetNetworkQoSPortGroupDbIDs(podNs, nqName, ctrlName)
+		pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
+		Expect(libovsdbops.CreatePortGroup(testNbClient, pg)).To(Succeed())
+
+		ovnObjectName := joinMetaNamespaceAndName(podNs, nqName, ":")
+		Expect(ipamController.deleteByName(ovnObjectName)).To(Succeed())
+
+		// The port group still exists: cleanup did not attempt PG deletion.
+		got, gerr := libovsdbops.GetPortGroup(testNbClient, &nbdb.PortGroup{Name: pg.Name})
+		Expect(gerr).NotTo(HaveOccurred())
+		Expect(got).NotTo(BeNil())
 	})
 })

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
@@ -19,6 +19,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
@@ -1469,5 +1471,233 @@ var _ = Describe("generateNetworkQoSMatch source fragment", func() {
 		// IPAM-enabled single-stack IPv4: IPMode() -> (true, false); ipamless=false.
 		match := generateNetworkQoSMatch(qosState, ipBlockRule("0.0.0.0/0", nil), true, false, false)
 		Expect(match).To(Equal(fmt.Sprintf("ip4.src == {$%s} && ip4.dst == 0.0.0.0/0", v4Hash)))
+	})
+})
+
+// U2: source port-group lifecycle in the pod path on ipamless localnet networks.
+// Source pods there have no OVN-managed IP, so they are matched by logical switch
+// port membership in a per-NetworkQoS source port group (inport == @pg) rather
+// than by a src-IP address set. These specs exercise the NB-facing helpers with a
+// hand-built Controller literal + a dedicated libovsdb NB harness, deliberately
+// avoiding the full watchFactory path (which flakes in the sandbox on NAD-informer
+// cache-sync).
+var _ = Describe("NetworkQoS ipamless localnet source port group", func() {
+	const (
+		podNs      = "qos-ns"
+		nqName     = "qos-obj"
+		ctrlName   = "localnet1-controller"
+		netName    = "localnet1"
+		nadK8sName = "localnad"
+		srcPodName = "src-pod"
+	)
+
+	var (
+		testNbClient libovsdbclient.Client
+		cleanup      *libovsdbtest.Context
+		controller   *Controller
+		nadKey       = util.GetNADName(podNs, nadK8sName)
+	)
+
+	// newController builds a minimal ipamless-localnet controller. controllerNode
+	// is the node this controller manages; a source pod is treated as scheduled
+	// locally when its Spec.NodeName matches (see isPodScheduledOnLocalNode). The
+	// test source pods live on "node1", so pass "node1" for local and any other
+	// value for a remote-node pod.
+	newController := func(controllerNode string) {
+		nad := ovnk8stesting.GenerateNAD(netName, nadK8sName, podNs, types.LocalnetTopology, "", types.NetworkRoleSecondary)
+		immutable, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		netInfo := &secondaryNetInfoWrapper{NetInfo: immutable}
+		fnm := &networkmanager.FakeNetworkManager{
+			NADNetworks: map[string]util.NetInfo{nadKey: netInfo},
+		}
+		controller = &Controller{
+			controllerName: ctrlName,
+			NetInfo:        netInfo,
+			networkManager: fnm,
+			nbClient:       testNbClient,
+			nodeName:       controllerNode,
+		}
+		// sanity: the controller must classify itself as ipamless localnet.
+		Expect(controller.isIPAMlessLocalnet()).To(BeTrue())
+	}
+
+	// sourcePod builds a source pod attached to the ipamless localnet network via
+	// the network-selection annotation only (MAC-only style: no pod-networks IP
+	// annotation). labels drive source-selector matching.
+	sourcePod := func(labels map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: podNs,
+				Name:      srcPodName,
+				Labels:    labels,
+				Annotations: map[string]string{
+					"k8s.v1.cni.cncf.io/networks": nadKey,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "node1"},
+		}
+	}
+
+	// newQoSState builds a networkQoSState with a single ipBlock egress rule and
+	// the source port group name initialised + ensured in the NB DB.
+	newQoSState := func(podSelector labels.Selector) *networkQoSState {
+		qosState := &networkQoSState{
+			namespace:   podNs,
+			name:        nqName,
+			PodSelector: podSelector,
+			EgressRules: []*GressRule{{
+				Priority: 10600,
+				Dscp:     46,
+				Classifier: &Classifier{
+					Destinations: []*Destination{{IpBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}}},
+				},
+			}},
+		}
+		qosState.initSourcePortGroupName(ctrlName)
+		Expect(controller.ensureSourcePortGroup(qosState)).To(Succeed())
+		return qosState
+	}
+
+	// seedLocalnetSwitch creates the localnet switch the QoS binds to.
+	seedLocalnetSwitch := func() string {
+		switchName := controller.getLogicalSwitchName("node1")
+		Expect(switchName).NotTo(BeEmpty())
+		Expect(libovsdbops.CreateOrUpdateLogicalSwitch(testNbClient, &nbdb.LogicalSwitch{Name: switchName})).To(Succeed())
+		return switchName
+	}
+
+	// seedSourceLSP creates the source pod's logical switch port on the localnet
+	// switch and returns its UUID.
+	seedSourceLSP := func(switchName string) string {
+		lspName := util.GetUserDefinedNetworkLogicalPortName(podNs, srcPodName, nadKey)
+		Expect(libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(testNbClient,
+			&nbdb.LogicalSwitch{Name: switchName},
+			&nbdb.LogicalSwitchPort{Name: lspName})).To(Succeed())
+		lsp, err := libovsdbops.GetLogicalSwitchPort(testNbClient, &nbdb.LogicalSwitchPort{Name: lspName})
+		Expect(err).NotTo(HaveOccurred())
+		return lsp.UUID
+	}
+
+	pgPorts := func(pgName string) []string {
+		pg, err := libovsdbops.GetPortGroup(testNbClient, &nbdb.PortGroup{Name: pgName})
+		Expect(err).NotTo(HaveOccurred())
+		return pg.Ports
+	}
+
+	nqosQoSes := func() []*nbdb.QoS {
+		qoses, err := libovsdbops.FindQoSesWithPredicate(testNbClient, func(qos *nbdb.QoS) bool {
+			return qos.ExternalIDs[libovsdbops.OwnerControllerKey.String()] == ctrlName &&
+				qos.ExternalIDs[libovsdbops.OwnerTypeKey.String()] == string(libovsdbops.NetworkQoSOwnerType)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return qoses
+	}
+
+	BeforeEach(func() {
+		var err error
+		testNbClient, cleanup, err = libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if cleanup != nil {
+			cleanup.Cleanup()
+			cleanup = nil
+		}
+	})
+
+	It("adds the source pod's LSP to the port group and binds QoS to the localnet switch (happy path + integration)", func() {
+		newController("node1")
+		switchName := seedLocalnetSwitch()
+		lspUUID := seedSourceLSP(switchName)
+
+		qosState := newQoSState(nil) // nil selector => matches all pods in namespace
+		pod := sourcePod(map[string]string{"app": "src"})
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+
+		Expect(controller.setPodForNQOS(pod, qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+
+		// LSP UUID landed in the source port group.
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(ConsistOf(lspUUID))
+
+		// A QoS row was created, bound to the localnet switch, matching via the PG.
+		qoses := nqosQoSes()
+		Expect(qoses).To(HaveLen(1))
+		Expect(qoses[0].Match).To(ContainSubstring(fmt.Sprintf("inport == @%s", qosState.SrcPortGroupName)))
+
+		ls, err := libovsdbops.GetLogicalSwitch(testNbClient, &nbdb.LogicalSwitch{Name: switchName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ls.QOSRules).To(ConsistOf(qoses[0].UUID))
+	})
+
+	It("does not add the LSP when the pod is not scheduled in the local zone (edge case)", func() {
+		newController("node2") // remote node
+		switchName := seedLocalnetSwitch()
+		_ = seedSourceLSP(switchName)
+
+		qosState := newQoSState(nil)
+		pod := sourcePod(map[string]string{"app": "src"})
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+
+		Expect(controller.setPodForNQOS(pod, qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(BeEmpty())
+	})
+
+	It("removes the LSP when the pod no longer matches the source selector (edge case)", func() {
+		newController("node1")
+		switchName := seedLocalnetSwitch()
+		lspUUID := seedSourceLSP(switchName)
+
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"app": "src"}})
+		Expect(err).NotTo(HaveOccurred())
+		qosState := newQoSState(selector)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+
+		// First: a matching pod gets its LSP added.
+		Expect(controller.setPodForNQOS(sourcePod(map[string]string{"app": "src"}), qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(ConsistOf(lspUUID))
+
+		// Then: the same pod loses the source label -> LSP removed from the PG.
+		Expect(controller.setPodForNQOS(sourcePod(map[string]string{"app": "other"}), qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(BeEmpty())
+	})
+
+	It("treats a MAC-only annotated pod as attached and skips a pod not attached to this network (edge case)", func() {
+		newController("node1")
+
+		// MAC-only style (no pod-networks IP annotation) is still attached.
+		lspNames, err := controller.ipamlessSourceLSPNames(sourcePod(map[string]string{"app": "src"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(lspNames).To(ConsistOf(util.GetUserDefinedNetworkLogicalPortName(podNs, srcPodName, nadKey)))
+
+		// No network-selection annotation for this network -> not attached, skipped.
+		unattached := sourcePod(map[string]string{"app": "src"})
+		unattached.Annotations = nil
+		lspNames, err = controller.ipamlessSourceLSPNames(unattached)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(lspNames).To(BeEmpty())
+
+		// setPodForNQOS on the unattached pod is a no-op (no PG, no QoS) with no error.
+		qosState := newQoSState(nil)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+		Expect(controller.setPodForNQOS(unattached, qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(BeEmpty())
+		Expect(nqosQoSes()).To(BeEmpty())
+	})
+
+	It("skips and waits when the LSP is not yet in the NB DB (ErrNotFound, edge case)", func() {
+		newController("node1")
+		_ = seedLocalnetSwitch() // switch exists, but the LSP does not
+
+		qosState := newQoSState(nil)
+		lspNames := []string{util.GetUserDefinedNetworkLogicalPortName(podNs, srcPodName, nadKey)}
+
+		// ErrNotFound on the LSP lookup must be a soft skip, not a hard failure.
+		Expect(qosState.configureSourcePodIPAMless(controller, sourcePod(map[string]string{"app": "src"}), lspNames)).To(Succeed())
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(BeEmpty())
+		// Nothing bound yet since no port resolved.
+		Expect(nqosQoSes()).To(BeEmpty())
 	})
 })

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
@@ -1765,4 +1765,137 @@ var _ = Describe("NetworkQoS ipamless localnet source port group", func() {
 		Expect(gerr).NotTo(HaveOccurred())
 		Expect(got).NotTo(BeNil())
 	})
+
+	// U4: end-to-end NB DB-shape contract for an ipamless localnet NetworkQoS.
+	// These specs lock the *complete* persisted nbdb.QoS row (match, direction,
+	// DSCP action, bandwidth rate/burst) plus source port group membership and
+	// switch binding - the earlier U2/U3 specs only assert individual facets.
+	It("locks the full NB QoS row shape for a complete ipamless object: PG match, to-lport, DSCP, bandwidth, PG membership (happy path)", func() {
+		newController("node1")
+		switchName := seedLocalnetSwitch()
+		lspUUID := seedSourceLSP(switchName)
+
+		rate := 10000
+		burst := 8000
+		tcpPort := int32(8080)
+		qosState := &networkQoSState{
+			namespace: podNs,
+			name:      nqName,
+			EgressRules: []*GressRule{{
+				Priority: 10600,
+				Dscp:     46,
+				Rate:     &rate,
+				Burst:    &burst,
+				Classifier: &Classifier{
+					Destinations: []*Destination{{IpBlock: &networkingv1.IPBlock{CIDR: "10.20.0.0/16"}}},
+					Ports:        []*nqostype.Port{{Protocol: "tcp", Port: &tcpPort}},
+				},
+			}},
+		}
+		qosState.initSourcePortGroupName(ctrlName)
+		Expect(controller.ensureSourcePortGroup(qosState)).To(Succeed())
+
+		pod := sourcePod(map[string]string{"app": "src"})
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+		// setPodForNQOS adds the LSP to the source PG and (first pod on the switch)
+		// binds the QoS row to the localnet switch.
+		Expect(controller.setPodForNQOS(pod, qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+
+		qoses := nqosQoSes()
+		Expect(qoses).To(HaveLen(1))
+		qos := qoses[0]
+
+		// Full match: PG source form + (ip4 || ip6) qualifier + ipBlock dest + tcp port.
+		Expect(qos.Match).To(Equal(fmt.Sprintf(
+			"inport == @%s && (ip4 || ip6) && ip4.dst == 10.20.0.0/16 && tcp && tcp.dst == 8080",
+			qosState.SrcPortGroupName)))
+		Expect(qos.Direction).To(Equal(nbdb.QoSDirectionToLport))
+		Expect(qos.Priority).To(Equal(10600))
+		Expect(qos.Action).To(HaveKeyWithValue(nbdb.QoSActionDSCP, 46))
+		Expect(qos.Bandwidth).To(HaveKeyWithValue(nbdb.QoSBandwidthRate, rate))
+		Expect(qos.Bandwidth).To(HaveKeyWithValue(nbdb.QoSBandwidthBurst, burst))
+
+		// Source PG holds the pod's LSP; the switch references exactly this QoS row.
+		Expect(pgPorts(qosState.SrcPortGroupName)).To(ConsistOf(lspUUID))
+		ls, err := libovsdbops.GetLogicalSwitch(testNbClient, &nbdb.LogicalSwitch{Name: switchName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ls.QOSRules).To(ConsistOf(qos.UUID))
+	})
+
+	It("persists the PG source form with the (ip4 || ip6) qualifier and no bandwidth when the rule omits it (edge case)", func() {
+		newController("node1")
+		switchName := seedLocalnetSwitch()
+		_ = seedSourceLSP(switchName)
+
+		// No Rate/Burst on the rule => Bandwidth must round-trip empty; DSCP-only.
+		qosState := newQoSState(nil)
+		pod := sourcePod(map[string]string{"app": "src"})
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: podNs}}
+		Expect(controller.setPodForNQOS(pod, qosState, ns, map[string]sets.Set[string]{})).To(Succeed())
+
+		qoses := nqosQoSes()
+		Expect(qoses).To(HaveLen(1))
+		qos := qoses[0]
+
+		// The hardcoded (ip4 || ip6) qualifier survives the round-trip; the source
+		// stays a port group, never an address set (IPMode() is (false,false)).
+		Expect(qos.Match).To(Equal(fmt.Sprintf(
+			"inport == @%s && (ip4 || ip6) && ip4.dst == 0.0.0.0/0", qosState.SrcPortGroupName)))
+		Expect(qos.Match).NotTo(ContainSubstring(".src == {$"))
+		Expect(qos.Direction).To(Equal(nbdb.QoSDirectionToLport))
+		Expect(qos.Action).To(HaveKeyWithValue(nbdb.QoSActionDSCP, 46))
+		Expect(qos.Bandwidth).To(BeEmpty())
+	})
+
+	It("persists the address-set source form on an IPAM-enabled localnet network, not a port group (regression, guards R5)", func() {
+		// IPAM-enabled localnet (non-empty subnet) => isIPAMlessLocalnet() is false,
+		// so the source must still be matched by a src-IP address set.
+		nad := ovnk8stesting.GenerateNAD(netName, nadK8sName, podNs, types.LocalnetTopology, "10.0.0.0/24", types.NetworkRoleSecondary)
+		immutable, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		netInfo := &secondaryNetInfoWrapper{NetInfo: immutable}
+		factory := addressset.NewFakeAddressSetFactory(ctrlName)
+		ipamController := &Controller{
+			controllerName:    ctrlName,
+			NetInfo:           netInfo,
+			networkManager:    &networkmanager.FakeNetworkManager{NADNetworks: map[string]util.NetInfo{nadKey: netInfo}},
+			nbClient:          testNbClient,
+			addressSetFactory: factory,
+			nodeName:          "node1",
+		}
+		Expect(ipamController.isIPAMlessLocalnet()).To(BeFalse())
+
+		srcAS, err := factory.EnsureAddressSet(GetNetworkQoSAddrSetDbIDs(podNs, nqName, "src", "0", ctrlName))
+		Expect(err).NotTo(HaveOccurred())
+		v4Hash, _ := srcAS.GetASHashNames()
+
+		qosState := &networkQoSState{
+			namespace:  podNs,
+			name:       nqName,
+			SrcAddrSet: srcAS,
+			EgressRules: []*GressRule{{
+				Priority: 10600,
+				Dscp:     46,
+				Classifier: &Classifier{
+					Destinations: []*Destination{{IpBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}}},
+				},
+			}},
+		}
+
+		switchName := ipamController.getLogicalSwitchName("node1")
+		Expect(switchName).NotTo(BeEmpty())
+		Expect(libovsdbops.CreateOrUpdateLogicalSwitch(testNbClient, &nbdb.LogicalSwitch{Name: switchName})).To(Succeed())
+
+		Expect(ipamController.addQoSToLogicalSwitch(qosState, switchName)).To(Succeed())
+
+		qoses := nqosQoSes()
+		Expect(qoses).To(HaveLen(1))
+		qos := qoses[0]
+
+		// Single-stack IPv4 IPAM => src address-set match, never a port group form.
+		Expect(qos.Match).To(Equal(fmt.Sprintf("ip4.src == {$%s} && ip4.dst == 0.0.0.0/0", v4Hash)))
+		Expect(qos.Match).NotTo(ContainSubstring("inport == @"))
+		Expect(qos.Direction).To(Equal(nbdb.QoSDirectionToLport))
+		Expect(qos.Action).To(HaveKeyWithValue(nbdb.QoSActionDSCP, 46))
+	})
 })

--- a/go-controller/pkg/ovn/controller/network_qos/types.go
+++ b/go-controller/pkg/ovn/controller/network_qos/types.go
@@ -4,6 +4,7 @@
 package networkqos
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
@@ -22,6 +25,7 @@ import (
 	networkqosv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
@@ -117,6 +121,62 @@ func (nqosState *networkQoSState) configureSourcePod(ctrl *Controller, pod *core
 	}
 	nqosState.Pods.Store(fullPodName, addresses)
 	klog.V(4).Infof("Successfully added address (%s) of pod %s to address set %s", strings.Join(addresses, ","), fullPodName, nqosState.SrcAddrSet.GetName())
+	return nqosState.bindQoSToPodSwitch(ctrl, pod, fullPodName)
+}
+
+// configureSourcePodIPAMless is the ipamless-localnet counterpart of
+// configureSourcePod. Source pods on ipamless localnet networks have no
+// OVN-managed IP, so they are matched by logical switch port membership in the
+// per-NetworkQoS source port group (inport == @pg) rather than by a src-IP
+// address set. It resolves each of the pod's logical switch ports (there is
+// usually one per network attachment) to its UUID, adds the resolved ports to
+// the source port group, and binds the QoS rules to the pod's localnet switch.
+//
+// When a port's LSP is not yet present in the NB DB (the pod is annotated but
+// its LSP has not been created yet), that port is skipped and will be
+// reconciled on a later pod update event, mirroring the AdminNetworkPolicy
+// subject-recompute behaviour. If none of the ports are resolvable yet the call
+// is a no-op (no port group membership, no switch binding) and returns nil so
+// the reconcile is retried later without surfacing an error.
+func (nqosState *networkQoSState) configureSourcePodIPAMless(ctrl *Controller, pod *corev1.Pod, lspNames []string) error {
+	fullPodName := joinMetaNamespaceAndName(pod.Namespace, pod.Name)
+	lspUUIDs := make([]string, 0, len(lspNames))
+	for _, lspName := range lspNames {
+		lsp, err := libovsdbops.GetLogicalSwitchPort(ctrl.nbClient, &nbdb.LogicalSwitchPort{Name: lspName})
+		if err != nil {
+			if errors.Is(err, libovsdbclient.ErrNotFound) {
+				// The pod is annotated but its LSP has not been created yet.
+				// Skip and wait: the later pod update event (once the LSP lands)
+				// will reconcile it.
+				klog.V(5).Infof("NetworkQoS %s/%s: logical switch port %s for source pod %s not found yet, will reconcile on next pod event", nqosState.namespace, nqosState.name, lspName, fullPodName)
+				continue
+			}
+			return fmt.Errorf("failed to look up logical switch port %s for NetworkQoS %s/%s: %w", lspName, nqosState.namespace, nqosState.name, err)
+		}
+		lspUUIDs = append(lspUUIDs, lsp.UUID)
+	}
+	if len(lspUUIDs) == 0 {
+		// Nothing resolvable yet; skip without error so it is retried on the
+		// next pod event.
+		return nil
+	}
+	ops, err := libovsdbops.AddPortsToPortGroupOps(ctrl.nbClient, nil, nqosState.SrcPortGroupName, lspUUIDs...)
+	if err != nil {
+		return fmt.Errorf("failed to build ops to add source pod %s ports to port group %s (NetworkQoS %s/%s): %w", fullPodName, nqosState.SrcPortGroupName, nqosState.namespace, nqosState.name, err)
+	}
+	if _, err := libovsdbops.TransactAndCheck(ctrl.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to add source pod %s ports to port group %s (NetworkQoS %s/%s): %w", fullPodName, nqosState.SrcPortGroupName, nqosState.namespace, nqosState.name, err)
+	}
+	nqosState.Pods.Store(fullPodName, lspUUIDs)
+	klog.V(4).Infof("Successfully added logical switch port(s) %v of pod %s to source port group %s", lspUUIDs, fullPodName, nqosState.SrcPortGroupName)
+	return nqosState.bindQoSToPodSwitch(ctrl, pod, fullPodName)
+}
+
+// bindQoSToPodSwitch resolves the logical switch for the pod and, if the QoS
+// rules are not already bound to it, binds them, tracking the pod under the
+// switch's SwitchRefs entry. Shared by the IPAM (address-set) and ipamless
+// (port-group) source paths.
+func (nqosState *networkQoSState) bindQoSToPodSwitch(ctrl *Controller, pod *corev1.Pod, fullPodName string) error {
 	// get switch name
 	switchName := ctrl.getLogicalSwitchName(pod.Spec.NodeName)
 	if switchName == "" {
@@ -153,6 +213,26 @@ func (nqosState *networkQoSState) removePodFromSource(ctrl *Controller, fullPodN
 	if len(addresses) > 0 {
 		if err := nqosState.SrcAddrSet.DeleteAddresses(addresses); err != nil {
 			return fmt.Errorf("failed to delete addresses (%s) from address set %s: %v", strings.Join(addresses, ","), nqosState.SrcAddrSet.GetName(), err)
+		}
+	}
+	nqosState.Pods.Delete(fullPodName)
+	return nqosState.removeZeroQoSNodes(ctrl, fullPodName)
+}
+
+// removePodLSPFromSource is the ipamless-localnet counterpart of
+// removePodFromSource: it removes the pod's logical switch port(s) from the
+// per-NetworkQoS source port group (rather than deleting src IPs from an address
+// set) and then unbinds the QoS from any switch that no longer has source pods.
+func (nqosState *networkQoSState) removePodLSPFromSource(ctrl *Controller, fullPodName string) error {
+	if val, ok := nqosState.Pods.Load(fullPodName); ok {
+		if lspUUIDs := val.([]string); len(lspUUIDs) > 0 {
+			ops, err := libovsdbops.DeletePortsFromPortGroupOps(ctrl.nbClient, nil, nqosState.SrcPortGroupName, lspUUIDs...)
+			if err != nil {
+				return fmt.Errorf("failed to build ops to remove pod %s ports from port group %s: %w", fullPodName, nqosState.SrcPortGroupName, err)
+			}
+			if _, err := libovsdbops.TransactAndCheck(ctrl.nbClient, ops); err != nil {
+				return fmt.Errorf("failed to remove pod %s ports from port group %s: %w", fullPodName, nqosState.SrcPortGroupName, err)
+			}
 		}
 	}
 	nqosState.Pods.Delete(fullPodName)

--- a/go-controller/pkg/ovn/controller/network_qos/types.go
+++ b/go-controller/pkg/ovn/controller/network_qos/types.go
@@ -21,6 +21,7 @@ import (
 
 	networkqosv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
@@ -33,10 +34,14 @@ type networkQoSState struct {
 	name      string
 	namespace string
 
-	SrcAddrSet  addressset.AddressSet
-	Pods        sync.Map // pods name -> ips in the srcAddrSet
-	SwitchRefs  sync.Map // switch name -> list of source pods
-	PodSelector labels.Selector
+	SrcAddrSet addressset.AddressSet
+	// SrcPortGroupName is the OVN name of the per-NetworkQoS source port group,
+	// used on ipamless localnet networks to match source pods via inport == @pg
+	// instead of the src-IP address set. Empty on IPAM-enabled networks.
+	SrcPortGroupName string
+	Pods             sync.Map // pods name -> ips in the srcAddrSet (IPAM) / LSP UUIDs in the source port group (ipamless)
+	SwitchRefs       sync.Map // switch name -> list of source pods
+	PodSelector      labels.Selector
 
 	// egressRules stores the objects needed to track .Spec.Egress changes
 	EgressRules []*GressRule
@@ -51,6 +56,14 @@ func (nqosState *networkQoSState) getDbObjectIDs(controller string, ruleIndex in
 		libovsdbops.ObjectNameKey: nqosState.getObjectNameKey(),
 		libovsdbops.RuleIndex:     fmt.Sprintf("%d", ruleIndex),
 	})
+}
+
+// initSourcePortGroupName computes and stores the deterministic OVN name of this
+// NetworkQoS's source port group. Used on ipamless localnet networks, where
+// source pods are matched by port-group membership rather than src IP.
+func (nqosState *networkQoSState) initSourcePortGroupName(controllerName string) {
+	nqosState.SrcPortGroupName = libovsdbutil.GetPortGroupName(
+		GetNetworkQoSPortGroupDbIDs(nqosState.namespace, nqosState.name, controllerName))
 }
 
 func (nqosState *networkQoSState) initAddressSets(addressSetFactory addressset.AddressSetFactory, controllerName string) error {

--- a/go-controller/pkg/ovn/controller/network_qos/utils.go
+++ b/go-controller/pkg/ovn/controller/network_qos/utils.go
@@ -55,6 +55,28 @@ func (c *Controller) isIPAMlessLocalnet() bool {
 	return c.TopologyType() == types.LocalnetTopology && !ovnkutil.DoesNetworkRequireIPAM(c.NetInfo)
 }
 
+// ipamlessSourceLSPNames returns the logical switch port names of the pod's
+// attachments to this (ipamless localnet) network, derived from the pod's own
+// network-selection annotation ("k8s.v1.cni.cncf.io/networks") rather than from
+// the controller's NADs. There is normally a single attachment per network, but
+// the pod may attach to the same network multiple times, so all matching ports
+// are returned. An empty result means the pod is not attached to this network
+// (or is not yet annotated) and the caller should skip it without retrying.
+func (c *Controller) ipamlessSourceLSPNames(pod *corev1.Pod) ([]string, error) {
+	on, networkMap, err := ovnkutil.GetUDNPodNADToNetworkMapping(pod, c.NetInfo, c.podNetworkResolver())
+	if err != nil {
+		return nil, err
+	}
+	if !on {
+		return nil, nil
+	}
+	lspNames := make([]string, 0, len(networkMap))
+	for nadKey := range networkMap {
+		lspNames = append(lspNames, ovnkutil.GetUserDefinedNetworkLogicalPortName(pod.Namespace, pod.Name, nadKey))
+	}
+	return lspNames, nil
+}
+
 func getPodAddresses(pod *corev1.Pod, networkInfo ovnkutil.NetInfo, resolver func(nadKey string) string) ([]string, error) {
 	// check annotation "k8s.ovn.org/pod-networks" before calling GetPodIPsOfNetwork,
 	// as it's no easy to check if the error is caused by missing annotation, while

--- a/go-controller/pkg/ovn/controller/network_qos/utils.go
+++ b/go-controller/pkg/ovn/controller/network_qos/utils.go
@@ -35,6 +35,26 @@ func GetNetworkQoSAddrSetDbIDs(nqosNamespace, nqosName, ruleIndex, ipBlockIndex,
 		})
 }
 
+// GetNetworkQoSPortGroupDbIDs returns the DbObjectIDs of the per-NetworkQoS
+// source port group. On ipamless localnet networks the source pods have no
+// OVN-managed IP, so they are matched via inport == @pg instead of a src-IP
+// address set. There is a single source port group per NetworkQoS object,
+// keyed by namespace:name (mirroring GetNetworkQoSAddrSetDbIDs' ObjectNameKey).
+func GetNetworkQoSPortGroupDbIDs(nqosNamespace, nqosName, controller string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.PortGroupNetworkQoS, controller,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: joinMetaNamespaceAndName(nqosNamespace, nqosName, ":"),
+		})
+}
+
+// isIPAMlessLocalnet reports whether this controller manages an ipamless
+// (no OVN-managed pod IPs) secondary localnet network. On such networks source
+// pods carry MAC-only logical switch ports, so NetworkQoS must match source pods
+// via a port group (inport == @pg) rather than a src-IP address set.
+func (c *Controller) isIPAMlessLocalnet() bool {
+	return c.TopologyType() == types.LocalnetTopology && !ovnkutil.DoesNetworkRequireIPAM(c.NetInfo)
+}
+
 func getPodAddresses(pod *corev1.Pod, networkInfo ovnkutil.NetInfo, resolver func(nadKey string) string) ([]string, error) {
 	// check annotation "k8s.ovn.org/pod-networks" before calling GetPodIPsOfNetwork,
 	// as it's no easy to check if the error is caused by missing annotation, while
@@ -55,8 +75,18 @@ func getPodAddresses(pod *corev1.Pod, networkInfo ovnkutil.NetInfo, resolver fun
 	return addresses, nil
 }
 
-func generateNetworkQoSMatch(qosState *networkQoSState, rule *GressRule, ipv4Enabled, ipv6Enabled bool) string {
-	match := addressSetToMatchString(qosState.SrcAddrSet, trafficDirSource, ipv4Enabled, ipv6Enabled)
+func generateNetworkQoSMatch(qosState *networkQoSState, rule *GressRule, ipv4Enabled, ipv6Enabled, ipamless bool) string {
+	var match string
+	if ipamless {
+		// Ipamless localnet source pods have no OVN-managed IP, so scope to the
+		// selected source pods by their logical switch port membership in the
+		// per-NetworkQoS source port group. IPMode() is (false,false) on ipamless
+		// networks, so an explicit (ip4 || ip6) qualifier is required to avoid
+		// matching ARP/ND/DHCP and breaking address acquisition.
+		match = fmt.Sprintf("inport == @%s && (ip4 || ip6)", qosState.SrcPortGroupName)
+	} else {
+		match = addressSetToMatchString(qosState.SrcAddrSet, trafficDirSource, ipv4Enabled, ipv6Enabled)
+	}
 
 	classiferMatchString := rule.Classifier.ToQosMatchString(ipv4Enabled, ipv6Enabled)
 	if classiferMatchString != "" {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ nav:
     - VRF-Lite Shared Gateway Mode with Uplinks: okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
     - Disable Port Security: okeps/okep-3926-disable-port-security.md
     - OVN Observability API: okeps/okep-5212-ovnobserv-api.md
+    - NetworkQoS for Ipamless Localnet Networks: okeps/okep-6815-network-qos-ipamless.md
   - Blog:
     - blog/index.md
     - Accelerating and Securing Kubernetes Networking with DPUs: blog/dpu-acceleration.md


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
