### PR TITLE
routeadvertisements: identify DPU hosts by annotation

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -1455,8 +1455,12 @@ func (c *Controller) getDPUHostGatewayNextHops(
 	if config.Gateway.Mode != config.GatewayModeShared {
 		return nil, nil
 	}
-	if _, ok := node.Labels[types.OvnDPUHostNodeLabel]; !ok {
-		return nil, nil
+	if _, err := util.GetNodePrimaryDPUHostAddrAnnotation(node); err != nil {
+		if util.IsAnnotationNotSetError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: failed to parse primary DPU host address annotation for node %q: %w",
+			errConfig, node.Name, err)
 	}
 
 	uplinkName := selectedNetworks.networkUplinks[networkName]
@@ -1911,6 +1915,7 @@ func nodeNeedsUpdate(oldObj, newObj *corev1.Node) bool {
 		// ID allocation determines which nodes advertise the network.
 		oldObj.Annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] != newObj.Annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] ||
 		oldObj.Annotations[util.OvnNodeIfAddr] != newObj.Annotations[util.OvnNodeIfAddr] ||
+		util.NodePrimaryDPUHostAddrAnnotationChanged(oldObj, newObj) ||
 		util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||
 		util.NodeChassisIDAnnotationChanged(oldObj, newObj) ||
 		util.NodeVTEPsAnnotationChanged(oldObj, newObj)

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -6,6 +6,7 @@ package routeadvertisements
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -143,6 +144,7 @@ type testNode struct {
 	Generation                int
 	Labels                    map[string]string
 	PrimaryAddressAnnotation  string
+	DPUHostAddressAnnotation  string
 	SubnetsAnnotation         string
 	TunnelIDsAnnotation       string
 	L3GatewayConfigAnnotation string
@@ -162,6 +164,9 @@ func (tn testNode) Node() *corev1.Node {
 	}
 	if tn.TunnelIDsAnnotation != "" {
 		annotations[types.UDNLayer2NodeGRLRPTunnelIDAnnotation] = tn.TunnelIDsAnnotation
+	}
+	if tn.DPUHostAddressAnnotation != "" {
+		annotations[util.OVNNodePrimaryDPUHostAddr] = tn.DPUHostAddressAnnotation
 	}
 	if tn.L3GatewayConfigAnnotation != "" {
 		annotations[util.OvnNodeL3GatewayConfig] = tn.L3GatewayConfigAnnotation
@@ -188,6 +193,45 @@ func (tn testNode) Node() *corev1.Node {
 			Annotations: annotations,
 		},
 	}
+}
+
+func TestGetDPUHostGatewayNextHopsUsesDPUHostAddressAnnotation(t *testing.T) {
+	g := gomega.NewWithT(t)
+	previousGatewayMode := config.Gateway.Mode
+	t.Cleanup(func() { config.Gateway.Mode = previousGatewayMode })
+	config.Gateway.Mode = config.GatewayModeShared
+
+	c := &Controller{}
+	selected := &selectedNetworks{networkUplinks: map[string]string{}}
+
+	nextHops, err := c.getDPUHostGatewayNextHops(&corev1.Node{}, selected, types.DefaultNetworkName)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(nextHops).To(gomega.BeNil(), "a node without the annotation is not a DPU host")
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Annotations: map[string]string{util.OVNNodePrimaryDPUHostAddr: "invalid"},
+	}}
+	_, err = c.getDPUHostGatewayNextHops(node, selected, types.DefaultNetworkName)
+	g.Expect(errors.Is(err, errConfig)).To(gomega.BeTrue(), "a malformed DPU-host annotation is a configuration error")
+
+	node.Annotations[util.OVNNodePrimaryDPUHostAddr] = `{"ipv4":"not-a-cidr"}`
+	_, err = c.getDPUHostGatewayNextHops(node, selected, types.DefaultNetworkName)
+	g.Expect(errors.Is(err, errConfig)).To(gomega.BeTrue(), "an invalid DPU-host CIDR is a configuration error")
+
+	for _, annotation := range []string{
+		`{"ipv4":"fd00::1/64"}`,
+		`{"ipv6":"192.0.2.1/24"}`,
+	} {
+		node.Annotations[util.OVNNodePrimaryDPUHostAddr] = annotation
+		_, err = c.getDPUHostGatewayNextHops(node, selected, types.DefaultNetworkName)
+		g.Expect(errors.Is(err, errConfig)).To(gomega.BeTrue(),
+			"a CIDR in the wrong address-family field is a configuration error: %s", annotation)
+	}
+
+	node.Annotations[util.OVNNodePrimaryDPUHostAddr] = `{"ipv4":"172.18.255.254/16"}`
+	_, err = c.getDPUHostGatewayNextHops(node, selected, types.DefaultNetworkName)
+	g.Expect(errors.Is(err, errPending)).To(gomega.BeTrue(), "a DPU host waits for its gateway state")
 }
 
 type testPod struct {
@@ -1148,7 +1192,7 @@ func TestController_reconcile(t *testing.T) {
 			nodes: []*testNode{
 				{
 					Name:                      "node",
-					Labels:                    map[string]string{types.OvnDPUHostNodeLabel: ""},
+					DPUHostAddressAnnotation:  `{"ipv4":"172.18.255.254/16"}`,
 					SubnetsAnnotation:         "{\"default\":\"1.1.0.0/24\"}",
 					L3GatewayConfigAnnotation: `{"default":{"mode":"shared","mac-address":"52:54:00:4c:e6:00","ip-addresses":["172.18.255.254/16"],"next-hops":["172.18.0.1"]}}`,
 				},
@@ -1186,7 +1230,7 @@ func TestController_reconcile(t *testing.T) {
 			nodes: []*testNode{
 				{
 					Name:                      "node",
-					Labels:                    map[string]string{types.OvnDPUHostNodeLabel: ""},
+					DPUHostAddressAnnotation:  `{"ipv4":"172.18.255.254/16","ipv6":"fc00:f853:ccd:e793::4/64"}`,
 					SubnetsAnnotation:         "{\"default\":[\"1.1.0.0/24\",\"fd01::/64\"]}",
 					L3GatewayConfigAnnotation: `{"default":{"mode":"shared","mac-address":"52:54:00:4c:e6:00","ip-addresses":["172.18.255.254/16","fc00:f853:ccd:e793::4/64"],"next-hops":["172.18.0.1","fc00:f853:ccd:e793::1"]}}`,
 				},
@@ -3412,6 +3456,18 @@ func TestUpdates(t *testing.T) {
 			name:              "reconciles all RAs on updated Node primary address annotation",
 			oldObject:         &testNode{Name: "eip", PrimaryAddressAnnotation: "old"},
 			newObject:         &testNode{Name: "eip", PrimaryAddressAnnotation: "new"},
+			expectedReconcile: []string{"ra1", "ra2", "ra3"},
+		},
+		{
+			name:              "reconciles all RAs when the Node becomes a DPU host",
+			oldObject:         &testNode{Name: "eip"},
+			newObject:         &testNode{Name: "eip", DPUHostAddressAnnotation: `{"ipv4":"172.18.255.254/16"}`},
+			expectedReconcile: []string{"ra1", "ra2", "ra3"},
+		},
+		{
+			name:              "reconciles all RAs when the Node stops being a DPU host",
+			oldObject:         &testNode{Name: "eip", DPUHostAddressAnnotation: `{"ipv4":"172.18.255.254/16"}`},
+			newObject:         &testNode{Name: "eip"},
 			expectedReconcile: []string{"ra1", "ra2", "ra3"},
 		},
 		{

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -725,6 +725,22 @@ func createNodeManagementPortController(
 	return managementport.NewManagementPortController(ovsClient, node, subnets, netdevName, rep, routeManager, netInfo)
 }
 
+// removeStaleDPUHostAddressAnnotation clears state owned by DPU-host mode before
+// full-mode initialization continues, so consumers do not classify this node as a DPU host.
+func (nc *DefaultNodeNetworkController) removeStaleDPUHostAddressAnnotation() error {
+	if !config.IsModeFull() {
+		return nil
+	}
+
+	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, nc.name)
+	nodeAnnotator.Delete(util.OVNNodePrimaryDPUHostAddr)
+	if err := nodeAnnotator.Run(); err != nil {
+		return fmt.Errorf("failed to remove stale %s annotation from node %s: %w",
+			util.OVNNodePrimaryDPUHostAddr, nc.name, err)
+	}
+	return nil
+}
+
 // Init executes the first steps to start the DefaultNodeNetworkController.
 // It is split from Start() and executed before UserDefinedNodeNetworkController (UDNNC)
 // to allow UDNNC to reference the openflow manager created in Init.
@@ -733,6 +749,9 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 
 	if nc.name == "" {
 		return fmt.Errorf("ovnkube-node name is required")
+	}
+	if err := nc.removeStaleDPUHostAddressAnnotation(); err != nil {
+		return err
 	}
 
 	var err error

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
@@ -60,6 +61,79 @@ add set inet ovn-kubernetes remote-node-ips-v6 { type ipv6_addr ; comment "Block
 `
 
 var _ = Describe("Node", func() {
+	Describe("removing stale DPU-host address annotations", func() {
+		const nodeName = "my-node"
+
+		newController := func(kubeInterface kube.Interface) *DefaultNodeNetworkController {
+			return &DefaultNodeNetworkController{
+				BaseNodeNetworkController: BaseNodeNetworkController{
+					CommonNodeNetworkControllerInfo: CommonNodeNetworkControllerInfo{
+						name: nodeName,
+						Kube: kubeInterface,
+					},
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			Expect(config.PrepareTestConfig()).To(Succeed())
+		})
+
+		It("removes the annotation during full-mode startup", func() {
+			config.OvnKubeNode.Mode = types.NodeModeFull
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					util.OVNNodePrimaryDPUHostAddr: `{"ipv4":"10.1.1.10/24"}`,
+				},
+			}}
+			client := fake.NewSimpleClientset(node)
+			nc := newController(&kube.Kube{KClient: client})
+
+			Expect(nc.removeStaleDPUHostAddressAnnotation()).To(Succeed())
+
+			updatedNode, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedNode.Annotations).NotTo(HaveKey(util.OVNNodePrimaryDPUHostAddr))
+		})
+
+		DescribeTable("preserves the annotation outside full mode", func(mode string) {
+			config.OvnKubeNode.Mode = mode
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					util.OVNNodePrimaryDPUHostAddr: `{"ipv4":"10.1.1.10/24"}`,
+				},
+			}}
+			client := fake.NewSimpleClientset(node)
+			nc := newController(&kube.Kube{KClient: client})
+
+			Expect(nc.removeStaleDPUHostAddressAnnotation()).To(Succeed())
+
+			updatedNode, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedNode.Annotations).To(HaveKey(util.OVNNodePrimaryDPUHostAddr))
+		},
+			Entry("in DPU mode", types.NodeModeDPU),
+			Entry("in DPU-host mode", types.NodeModeDPUHost),
+		)
+
+		It("returns an error when the annotation cannot be removed", func() {
+			config.OvnKubeNode.Mode = types.NodeModeFull
+			kubeMock := new(mocks.Interface)
+			kubeMock.On("SetAnnotationsOnNode", nodeName, map[string]interface{}{
+				util.OVNNodePrimaryDPUHostAddr: nil,
+			}).Return(fmt.Errorf("patch failed"))
+			nc := newController(kubeMock)
+
+			err := nc.removeStaleDPUHostAddressAnnotation()
+			Expect(err).To(MatchError(And(
+				ContainSubstring("failed to remove stale"),
+				ContainSubstring("patch failed"),
+			)))
+			kubeMock.AssertExpectations(GinkgoT())
+		})
+	})
 
 	Describe("validateMTU", func() {
 		var (

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -224,7 +224,6 @@ const (
 	OvnK8sTopoAnno            = OvnK8sPrefix + "/" + "topology-version"
 	OvnK8sSmallMTUTaintKey    = OvnK8sPrefix + "/" + "mtu-too-small"
 	OvnRouteAdvertisementsKey = OvnK8sPrefix + "/route-advertisements"
-	OvnDPUHostNodeLabel       = OvnK8sPrefix + "/dpu-host"
 
 	// name of the configmap used to synchronize status (e.g. watch for topology changes)
 	OvnK8sStatusCMName         = "control-plane-status"

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -105,7 +105,8 @@ const (
 	// OVNNodeHostCIDRs is used to track the different host IP addresses and subnet masks on the node
 	OVNNodeHostCIDRs = "k8s.ovn.org/host-cidrs"
 
-	// OVNNodePrimaryDPUHostAddr is used to track the primary DPU host address on the node
+	// OVNNodePrimaryDPUHostAddr tracks the primary DPU host address on the node.
+	// Its presence identifies a node whose host-side ovnkube-node runs in DPU-host mode.
 	OVNNodePrimaryDPUHostAddr = "k8s.ovn.org/primary-dpu-host-addr"
 
 	// OVNNodeSecondaryHostEgressIPs contains EgressIP addresses that aren't managed by OVN. The EIP addresses are assigned to
@@ -733,6 +734,9 @@ func convertPrimaryIfAddrAnnotationToIPNet(ifAddr PrimaryIfAddrAnnotation) ([]*n
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse IPv4 address %s, err: %w", ifAddr.IPv4, err)
 		}
+		if ip.To4() == nil {
+			return nil, fmt.Errorf("IPv4 address field contains non-IPv4 CIDR %s", ifAddr.IPv4)
+		}
 		ipAddrs = append(ipAddrs, &net.IPNet{IP: ip, Mask: ipNet.Mask})
 	}
 
@@ -740,6 +744,9 @@ func convertPrimaryIfAddrAnnotationToIPNet(ifAddr PrimaryIfAddrAnnotation) ([]*n
 		ip, ipNet, err := net.ParseCIDR(ifAddr.IPv6)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse IPv6 address %s, err: %w", ifAddr.IPv6, err)
+		}
+		if ip.To4() != nil {
+			return nil, fmt.Errorf("IPv6 address field contains non-IPv6 CIDR %s", ifAddr.IPv6)
 		}
 		ipAddrs = append(ipAddrs, &net.IPNet{IP: ip, Mask: ipNet.Mask})
 	}
@@ -1357,6 +1364,12 @@ func GetNodePrimaryDPUHostAddrAnnotation(node *corev1.Node) (*ifAddr, error) {
 	}
 	if nodeIfAddr.IPv4 == "" && nodeIfAddr.IPv6 == "" {
 		return nil, fmt.Errorf("node: %q does not have any IP information set", node.Name)
+	}
+	if _, err := convertPrimaryIfAddrAnnotationToIPNet(PrimaryIfAddrAnnotation{
+		IPv4: nodeIfAddr.IPv4,
+		IPv6: nodeIfAddr.IPv6,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to parse annotation: %s for node %q, err: %w", OVNNodePrimaryDPUHostAddr, node.Name, err)
 	}
 	return nodeIfAddr, nil
 }


### PR DESCRIPTION
Use the automatically managed primary-dpu-host-addr annotation instead of the legacy dpu-host label when selecting DPU-specific BGP next hops. Reconcile annotation changes and reject malformed values so incomplete DPU state does not silently look like a regular node.

Clear stale annotation state when a node is reconfigured in full mode, and cover identification, update, and cleanup behavior in tests.

Assisted-by: OpenAI Codex

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
