### PR TITLE
uplink: resolve the DPU gateway representor by host function

### DIFF
--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -163,6 +163,39 @@ func GetPortBridge(ovsClient libovsdbclient.Client, portName string) (*vswitchd.
 	return nil, fmt.Errorf("no bridge contains port %q: %w", portName, libovsdbclient.ErrNotFound)
 }
 
+// FindPortsForPortOrInterface returns the Ports that carry name: the Port
+// named name, and any Port holding an Interface of that name under another
+// Port name (e.g. a bond member). Unlike GetPortBridge, it makes no
+// port-to-br judgment: callers decide what bridge membership of the returned
+// ports means.
+func FindPortsForPortOrInterface(ovsClient libovsdbclient.Client, name string) ([]*vswitchd.Port, error) {
+	interfaces, err := FindInterfacesWithPredicate(ovsClient, func(iface *vswitchd.Interface) bool {
+		return iface.Name == name
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up OVS interface %s: %w", name, err)
+	}
+	interfaceIDs := make(map[string]struct{}, len(interfaces))
+	for _, iface := range interfaces {
+		interfaceIDs[iface.UUID] = struct{}{}
+	}
+	ports, err := FindOVSPortsWithPredicate(ovsClient, func(port *vswitchd.Port) bool {
+		if port.Name == name {
+			return true
+		}
+		for _, interfaceID := range port.Interfaces {
+			if _, ok := interfaceIDs[interfaceID]; ok {
+				return true
+			}
+		}
+		return false
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up OVS port for %s: %w", name, err)
+	}
+	return ports, nil
+}
+
 // CreateOrUpdateNicBridge creates (or reconfigures) an OVS bridge for an
 // uplink NIC. It sets fail-mode=standalone, the supplied hardware address,
 // and external_ids bridge-id/bridge-uplink on the bridge; attaches the

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
@@ -108,6 +110,85 @@ func TestGetPortBridge(t *testing.T) {
 			}
 			if got.Name != tt.expectName {
 				t.Fatalf("expected bridge %q, got %q", tt.expectName, got.Name)
+			}
+		})
+	}
+}
+
+func TestFindPortsForPortOrInterface(t *testing.T) {
+	bridgeUUID := buildNamedUUID()
+	ownPortUUID := buildNamedUUID()
+	ownInterfaceUUID := buildNamedUUID()
+	bondPortUUID := buildNamedUUID()
+	bondMemberInterfaceUUID := buildNamedUUID()
+	otherInterfaceUUID := buildNamedUUID()
+
+	ovs := &vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}}
+	ownPort := &vswitchd.Port{UUID: ownPortUUID, Name: "pf0vf0", Interfaces: []string{ownInterfaceUUID}}
+	ownInterface := &vswitchd.Interface{UUID: ownInterfaceUUID, Name: "pf0vf0"}
+	// pf0vf0 enslaved in a bond: the Interface keeps its name under a Port
+	// named differently.
+	bondPort := &vswitchd.Port{UUID: bondPortUUID, Name: "bond0",
+		Interfaces: []string{bondMemberInterfaceUUID, otherInterfaceUUID}}
+	bondMemberInterface := &vswitchd.Interface{UUID: bondMemberInterfaceUUID, Name: "pf0vf0"}
+	otherInterface := &vswitchd.Interface{UUID: otherInterfaceUUID, Name: "eth7"}
+
+	tests := []struct {
+		desc            string
+		name            string
+		expectPortNames []string
+		initialOvs      libovsdbtest.TestSetup
+	}{
+		{
+			desc:            "finds the port named after the interface",
+			name:            "pf0vf0",
+			expectPortNames: []string{"pf0vf0"},
+			initialOvs: libovsdbtest.TestSetup{OVSData: []libovsdbtest.TestData{
+				ovs.DeepCopy(),
+				&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-x", Ports: []string{ownPortUUID}},
+				ownPort.DeepCopy(), ownInterface.DeepCopy(),
+			}},
+		},
+		{
+			desc:            "finds the port holding the interface as a member",
+			name:            "pf0vf0",
+			expectPortNames: []string{"bond0"},
+			initialOvs: libovsdbtest.TestSetup{OVSData: []libovsdbtest.TestData{
+				ovs.DeepCopy(),
+				&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-x", Ports: []string{bondPortUUID}},
+				bondPort.DeepCopy(), bondMemberInterface.DeepCopy(), otherInterface.DeepCopy(),
+			}},
+		},
+		{
+			desc:            "returns no ports for an unknown name",
+			name:            "no-such-netdev",
+			expectPortNames: []string{},
+			initialOvs: libovsdbtest.TestSetup{OVSData: []libovsdbtest.TestData{
+				ovs.DeepCopy(),
+				&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-x", Ports: []string{ownPortUUID}},
+				ownPort.DeepCopy(), ownInterface.DeepCopy(),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(tt.initialOvs)
+			if err != nil {
+				t.Fatalf("test: %q failed to set up harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			ports, err := FindPortsForPortOrInterface(ovsClient, tt.name)
+			if err != nil {
+				t.Fatalf("FindPortsForPortOrInterface() error = %v", err)
+			}
+			portNames := make([]string, 0, len(ports))
+			for _, port := range ports {
+				portNames = append(portNames, port.Name)
+			}
+			sort.Strings(portNames)
+			if !reflect.DeepEqual(portNames, tt.expectPortNames) {
+				t.Fatalf("expected ports %v, got %v", tt.expectPortNames, portNames)
 			}
 		})
 	}

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,7 @@ import (
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	uplinkv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/egressip"
@@ -24,6 +26,7 @@ import (
 	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
 // BridgeUDNConfiguration holds the patchport and ctMark
@@ -303,9 +306,12 @@ func (b *BridgeConfiguration) setDPUHostGatewayConfiguration(nodeName string) er
 
 // NewUnmanagedBridgeConfiguration creates a bridge configuration for an
 // existing OVS bridge. The caller is responsible for provisioning the bridge
-// and moving gateway IPs/MACs onto the selected host interface.
+// and moving gateway IPs/MACs onto the selected host interface. hostFunction,
+// when known, identifies the host PCI function that macAddress belongs to and
+// is what a DPU resolves its gateway representor from.
 func NewUnmanagedBridgeConfiguration(ovsClient libovsdbclient.Client, bridgeName, hostInterfaceName, nodeName,
-	physicalNetworkName string, gwIPs []*net.IPNet, macAddress net.HardwareAddr) (*BridgeConfiguration, error) {
+	physicalNetworkName string, gwIPs []*net.IPNet, macAddress net.HardwareAddr,
+	hostFunction *uplinkv1alpha1.HostFunction) (*BridgeConfiguration, error) {
 	bridge, err := ovsops.GetBridge(ovsClient, bridgeName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find OVS bridge %s: %w", bridgeName, err)
@@ -330,10 +336,7 @@ func NewUnmanagedBridgeConfiguration(ovsClient libovsdbclient.Client, bridgeName
 	if gwIface == "" || config.IsModeDPU() {
 		gwIface = bridgeName
 		if config.IsModeDPU() {
-			// Uplink host interfaces may be backed by a VF or SF, not just a
-			// PF, so select the representor by its host peer MAC rather than
-			// assuming the bridge holds a single PF representor.
-			gwIfaceRep, err = util.GetDPUOps().FindHostRepresentorByPeerMAC(ovsClient, bridge, macAddress, nodeName)
+			gwIfaceRep, err = dpuGatewayRepresentor(ovsClient, bridge, hostFunction, macAddress, nodeName)
 			if err != nil {
 				return nil, err
 			}
@@ -781,6 +784,59 @@ func bridgedGatewayNodeSetup(ovsClient libovsdbclient.Client, nodeName, bridgeNa
 
 func getRepresentor(intfName string) (string, error) {
 	return util.GetNetdeviceRepresentorName(intfName)
+}
+
+// dpuGatewayRepresentor selects the DPU-side representor that carries the
+// gateway MAC on bridge. Uplink host interfaces may be backed by a VF or SF,
+// not just a PF, so the bridge cannot be assumed to hold a single PF
+// representor. The host function published by the DPU-host is the primary key:
+// the host owns the MAC of its VFs and SFs, so the DPU eswitch usually reports
+// no function MAC for the matching representor and a scan by host MAC cannot
+// find it. That scan stays as the fallback for uplinks whose host function
+// could not be published.
+func dpuGatewayRepresentor(ovsClient libovsdbclient.Client, bridge *vswitchd.Bridge,
+	hostFunction *uplinkv1alpha1.HostFunction, macAddress net.HardwareAddr,
+	nodeName string) (string, error) {
+	var functionErr error
+	if hostFunction != nil {
+		rep, err := util.FindHostRepresentorByFunction(hostFunction.PFID, hostFunction.VFID, macAddress, nodeName)
+		if err == nil {
+			err = representorOnBridge(ovsClient, bridge, rep)
+		}
+		if err == nil {
+			klog.Infof("Bridge %s: host function %s resolved gateway representor %s", bridge.Name,
+				util.HostFunctionName(hostFunction.PFID, hostFunction.VFID), rep)
+			return rep, nil
+		}
+		functionErr = err
+		klog.Warningf("Bridge %s: host function %s did not resolve a gateway representor, "+
+			"falling back to the host MAC scan: %v",
+			bridge.Name, util.HostFunctionName(hostFunction.PFID, hostFunction.VFID), err)
+	}
+
+	rep, err := util.GetDPUOps().FindHostRepresentorByPeerMAC(ovsClient, bridge, macAddress, nodeName)
+	if err != nil && functionErr != nil {
+		return "", fmt.Errorf("%w; host function %s did not resolve one either: %w", err,
+			util.HostFunctionName(hostFunction.PFID, hostFunction.VFID), functionErr)
+	}
+	return rep, err
+}
+
+// representorOnBridge errors unless rep is attached to bridge, either as a
+// port of its own or as an interface of another port (e.g. a bond member),
+// the same membership the uplink discovery accepts when it resolves the
+// bridge from the representor.
+func representorOnBridge(ovsClient libovsdbclient.Client, bridge *vswitchd.Bridge, rep string) error {
+	ports, err := ovsops.FindPortsForPortOrInterface(ovsClient, rep)
+	if err != nil {
+		return fmt.Errorf("failed to look up representor %s: %w", rep, err)
+	}
+	for _, port := range ports {
+		if slices.Contains(bridge.Ports, port.UUID) {
+			return nil
+		}
+	}
+	return fmt.Errorf("representor %s is not attached to OVS bridge %s", rep, bridge.Name)
 }
 
 func gatewayHostOVSInterface(bridgeName, gwIface string) (string, error) {

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/onsi/gomega"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -91,7 +93,14 @@ func TestGatewayHostOVSInterfaceResolvesSmartNICRepresentor(t *testing.T) {
 	g.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc())
 }
 
-func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T) {
+// newDPUUnmanagedBridgeHarness prepares the scaffolding shared by the
+// unmanaged bridge configuration tests: a DPU-mode node config restored on
+// cleanup, an OVSDB with one bridge holding the eth1 uplink and one
+// (Port, Interface) pair per representor name, a fake exec that answers the
+// eth1 ofport probe, and a fresh sriovnet mock installed for the test.
+func newDPUUnmanagedBridgeHarness(t *testing.T, bridgeName string, bridgeExternalIDs map[string]string,
+	repNames ...string) (libovsdbclient.Client, *ovntest.FakeExec, *utilmocks.SriovnetOps) {
+	t.Helper()
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 	t.Cleanup(func() {
@@ -101,26 +110,31 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 	config.IPv4Mode = false
 	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
 
-	bridgeUUID := "ovsbr1-uuid"
-	uplinkPortUUID := "eth1-port-uuid"
-	uplinkInterfaceUUID := "eth1-interface-uuid"
-	hostRepPortUUID := "pfhpf0-port-uuid"
-	hostRepInterfaceUUID := "pfhpf0-interface-uuid"
-	ovsClient, ovsCleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
-		OVSData: []libovsdbtest.TestData{
-			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
-			&vswitchd.Bridge{
-				UUID:        bridgeUUID,
-				Name:        "ovsbr1",
-				Ports:       []string{uplinkPortUUID, hostRepPortUUID},
-				ExternalIDs: map[string]string{"bridge-uplink": "eth1"},
-			},
-			&vswitchd.Port{UUID: uplinkPortUUID, Name: "eth1", Interfaces: []string{uplinkInterfaceUUID}},
-			&vswitchd.Interface{UUID: uplinkInterfaceUUID, Name: "eth1", Type: "system"},
-			&vswitchd.Port{UUID: hostRepPortUUID, Name: "pfhpf0", Interfaces: []string{hostRepInterfaceUUID}},
-			&vswitchd.Interface{UUID: hostRepInterfaceUUID, Name: "pfhpf0", Type: "system"},
+	bridgeUUID := bridgeName + "-uuid"
+	portUUIDs := []string{"eth1-port-uuid"}
+	ovsData := []libovsdbtest.TestData{
+		&vswitchd.Port{UUID: "eth1-port-uuid", Name: "eth1", Interfaces: []string{"eth1-interface-uuid"}},
+		&vswitchd.Interface{UUID: "eth1-interface-uuid", Name: "eth1", Type: "system"},
+	}
+	for _, repName := range repNames {
+		portUUID := repName + "-port-uuid"
+		interfaceUUID := repName + "-interface-uuid"
+		portUUIDs = append(portUUIDs, portUUID)
+		ovsData = append(ovsData,
+			&vswitchd.Port{UUID: portUUID, Name: repName, Interfaces: []string{interfaceUUID}},
+			&vswitchd.Interface{UUID: interfaceUUID, Name: repName, Type: "system"},
+		)
+	}
+	ovsData = append(ovsData,
+		&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+		&vswitchd.Bridge{
+			UUID:        bridgeUUID,
+			Name:        bridgeName,
+			Ports:       portUUIDs,
+			ExternalIDs: bridgeExternalIDs,
 		},
-	})
+	)
+	ovsClient, ovsCleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{OVSData: ovsData})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	t.Cleanup(ovsCleanup.Cleanup)
 
@@ -137,6 +151,13 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 	t.Cleanup(func() {
 		util.SetSriovnetOpsInst(origSriovOps)
 	})
+	return ovsClient, fexec, sriovOps
+}
+
+func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient, fexec, sriovOps := newDPUUnmanagedBridgeHarness(t, "ovsbr1",
+		map[string]string{"bridge-uplink": "eth1"}, "pfhpf0")
 	// FindHostRepresentorByPeerMAC walks the bridge ports in map order and
 	// returns on the first match, so expectations for the other ports may
 	// legitimately go unused.
@@ -167,55 +188,9 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 
 func TestNewUnmanagedBridgeConfigurationResolvesDPUHostVFRepresentor(t *testing.T) {
 	g := gomega.NewWithT(t)
-	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
-	t.Cleanup(func() {
-		_ = config.PrepareTestConfig()
-		util.ResetRunner()
-	})
-	config.IPv4Mode = false
-	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
-
-	bridgeUUID := "br-hostvf0-uuid"
-	uplinkPortUUID := "eth1-port-uuid"
-	uplinkInterfaceUUID := "eth1-interface-uuid"
-	vf0PortUUID := "pf0vf0-port-uuid"
-	vf0InterfaceUUID := "pf0vf0-interface-uuid"
-	vf7PortUUID := "pf0vf7-port-uuid"
-	vf7InterfaceUUID := "pf0vf7-interface-uuid"
-	ovsClient, ovsCleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
-		OVSData: []libovsdbtest.TestData{
-			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
-			// No bridge-uplink external-id: the physical uplink must be derived
-			// by skipping the VF representors.
-			&vswitchd.Bridge{
-				UUID:  bridgeUUID,
-				Name:  "br-hostvf0",
-				Ports: []string{uplinkPortUUID, vf0PortUUID, vf7PortUUID},
-			},
-			&vswitchd.Port{UUID: uplinkPortUUID, Name: "eth1", Interfaces: []string{uplinkInterfaceUUID}},
-			&vswitchd.Interface{UUID: uplinkInterfaceUUID, Name: "eth1", Type: "system"},
-			&vswitchd.Port{UUID: vf0PortUUID, Name: "pf0vf0", Interfaces: []string{vf0InterfaceUUID}},
-			&vswitchd.Interface{UUID: vf0InterfaceUUID, Name: "pf0vf0", Type: "system"},
-			&vswitchd.Port{UUID: vf7PortUUID, Name: "pf0vf7", Interfaces: []string{vf7InterfaceUUID}},
-			&vswitchd.Interface{UUID: vf7InterfaceUUID, Name: "pf0vf7", Type: "system"},
-		},
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	t.Cleanup(ovsCleanup.Cleanup)
-
-	fexec := ovntest.NewLooseCompareFakeExec()
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 get interface eth1 ofport",
-		Output: "7",
-	})
-	g.Expect(util.SetExec(fexec)).To(gomega.Succeed())
-
-	sriovOps := utilmocks.NewSriovnetOps(t)
-	origSriovOps := util.GetSriovnetOps()
-	util.SetSriovnetOpsInst(sriovOps)
-	t.Cleanup(func() {
-		util.SetSriovnetOpsInst(origSriovOps)
-	})
+	// No bridge-uplink external-id: the physical uplink must be derived by
+	// skipping the VF representors.
+	ovsClient, fexec, sriovOps := newDPUUnmanagedBridgeHarness(t, "br-hostvf0", nil, "pf0vf0", "pf0vf7")
 	// The walk returns on the first match (pf0vf7), so the probes of the
 	// other ports may legitimately go unused depending on map order.
 	sriovOps.On("GetRepresentorPortFlavour", "eth1").

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
@@ -10,9 +10,13 @@ import (
 	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/onsi/gomega"
 
+	"k8s.io/utils/ptr"
+
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	uplinkv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -177,6 +181,7 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 		"physnet-blue",
 		ovntest.MustParseIPNets("172.28.0.2/24"),
 		ovntest.MustParseMAC("00:11:22:33:44:55"),
+		nil,
 	)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "the PF-backed unmanaged bridge configuration must succeed")
 	g.Expect(bridge.GetGatewayIfaceRep()).To(gomega.Equal("pfhpf0"),
@@ -184,6 +189,123 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 	g.Expect(bridge.GetStaticFDBPort()).To(gomega.Equal("pfhpf0"),
 		"the static FDB entry must be pinned to the PF representor")
 	g.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc())
+}
+
+// TestNewUnmanagedBridgeConfigurationResolvesDPUHostFunctionRepresentor covers
+// the common host VF layout: the host assigns its own VF MAC, so the DPU
+// eswitch reports no function MAC for the VF representor and only the published
+// host function indices can identify it.
+func TestNewUnmanagedBridgeConfigurationResolvesDPUHostFunctionRepresentor(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient, fexec, sriovOps := newDPUUnmanagedBridgeHarness(t, "br-hostvf0", nil, "pf0vf0")
+	sriovOps.On("GetVfRepresentorDPU", "0", "0").Return("pf0vf0", nil)
+	sriovOps.On("GetRepresentorPortFlavour", "eth1").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a representor"))
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+	// The eswitch holds no function MAC for a host assigned VF MAC, so the
+	// representor offers no identity to verify against.
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(nil, fmt.Errorf("devlink port function for netdev pf0vf0 does not report a usable hardware address"))
+
+	bridge, err := NewUnmanagedBridgeConfiguration(
+		ovsClient,
+		"br-hostvf0",
+		"enp4s0f0v0",
+		"node-a",
+		"physnet-blue",
+		ovntest.MustParseIPNets("172.28.0.2/24"),
+		ovntest.MustParseMAC("4e:68:cd:ae:2b:f5"),
+		&uplinkv1alpha1.HostFunction{PFID: 0, VFID: ptr.To(int32(0))},
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"an unreadable eswitch function MAC must not block gateway representor resolution")
+	g.Expect(bridge.GetGatewayIfaceRep()).To(gomega.Equal("pf0vf0"),
+		"the representor of the published host function must be selected as the gateway representor")
+	g.Expect(bridge.GetStaticFDBPort()).To(gomega.Equal("pf0vf0"),
+		"the static FDB entry must be pinned to the host function representor")
+	g.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc())
+}
+
+// TestDPUGatewayRepresentorFallback covers the non-happy branches of
+// dpuGatewayRepresentor: the MAC scan fallback when the host function lookup
+// fails or resolves a representor that is not on the bridge, and the combined
+// error when both resolution paths fail.
+func TestDPUGatewayRepresentorFallback(t *testing.T) {
+	hostMAC := ovntest.MustParseMAC("4e:68:cd:ae:2b:f5")
+	hostFunction := &uplinkv1alpha1.HostFunction{PFID: 0, VFID: ptr.To(int32(0))}
+
+	// The MAC scan walks the bridge ports in map order, so the eth1 probe may
+	// legitimately go unused when pf0vf0 matches first.
+	mockUplinkNotARepresentor := func(sriovOps *utilmocks.SriovnetOps) {
+		sriovOps.On("GetRepresentorPortFlavour", "eth1").
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a representor")).
+			Maybe()
+	}
+
+	t.Run("falls back to the MAC scan when the host function lookup fails", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		ovsClient, _, sriovOps := newDPUUnmanagedBridgeHarness(t, "br-hostvf0", nil, "pf0vf0")
+		sriovOps.On("GetVfRepresentorDPU", "0", "0").
+			Return("", fmt.Errorf("failed to get VF representor"))
+		mockUplinkNotARepresentor(sriovOps)
+		sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+		sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+			Return(hostMAC, nil)
+
+		bridge, err := ovsops.GetBridge(ovsClient, "br-hostvf0")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		rep, err := dpuGatewayRepresentor(ovsClient, bridge, hostFunction, hostMAC, "node-a")
+		g.Expect(err).NotTo(gomega.HaveOccurred(),
+			"a failed host function lookup must fall back to the MAC scan")
+		g.Expect(rep).To(gomega.Equal("pf0vf0"))
+	})
+
+	t.Run("falls back to the MAC scan when the resolved representor is not on the bridge", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		ovsClient, _, sriovOps := newDPUUnmanagedBridgeHarness(t, "br-hostvf0", nil, "pf0vf0")
+		// The indices resolve a representor that is not attached to the
+		// uplink bridge, with no eswitch function MAC to veto it early.
+		sriovOps.On("GetVfRepresentorDPU", "0", "0").Return("pf9vf9", nil)
+		sriovOps.On("GetRepresentorPortFlavour", "pf9vf9").
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+		sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf9vf9").
+			Return(nil, fmt.Errorf("no usable hardware address"))
+		mockUplinkNotARepresentor(sriovOps)
+		sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+		sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+			Return(hostMAC, nil)
+
+		bridge, err := ovsops.GetBridge(ovsClient, "br-hostvf0")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		rep, err := dpuGatewayRepresentor(ovsClient, bridge, hostFunction, hostMAC, "node-a")
+		g.Expect(err).NotTo(gomega.HaveOccurred(),
+			"a representor on another bridge must be rejected and fall back to the MAC scan")
+		g.Expect(rep).To(gomega.Equal("pf0vf0"))
+	})
+
+	t.Run("combines the errors when both resolution paths fail", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		ovsClient, _, sriovOps := newDPUUnmanagedBridgeHarness(t, "br-hostvf0", nil, "pf0vf0")
+		sriovOps.On("GetVfRepresentorDPU", "0", "0").
+			Return("", fmt.Errorf("failed to get VF representor"))
+		mockUplinkNotARepresentor(sriovOps)
+		// The only representor on the bridge peers with some other host MAC.
+		sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+		sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+			Return(ovntest.MustParseMAC("00:11:22:33:44:66"), nil)
+
+		bridge, err := ovsops.GetBridge(ovsClient, "br-hostvf0")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = dpuGatewayRepresentor(ovsClient, bridge, hostFunction, hostMAC, "node-a")
+		g.Expect(err).To(gomega.MatchError(util.ErrHostRepresentorNotFound),
+			"the MAC scan miss must stay inspectable in the combined error")
+		g.Expect(err.Error()).To(gomega.ContainSubstring("host function pf0vf0 did not resolve one either"),
+			"the combined error must carry the host function failure as well")
+	})
 }
 
 func TestNewUnmanagedBridgeConfigurationResolvesDPUHostVFRepresentor(t *testing.T) {
@@ -215,6 +337,7 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostVFRepresentor(t *testing.
 		"physnet-blue",
 		ovntest.MustParseIPNets("172.28.0.2/24"),
 		ovntest.MustParseMAC("00:11:22:33:44:55"),
+		nil,
 	)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "the VF-backed unmanaged bridge configuration must succeed")
 	g.Expect(bridge.GetGatewayIfaceRep()).To(gomega.Equal("pf0vf7"),

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -204,6 +204,9 @@ type resolvedUplinkGateway struct {
 	macAddress        net.HardwareAddr
 	ipAddresses       []*net.IPNet
 	defaultGateways   []net.IP
+	// hostFunction identifies the host PCI function backing the host
+	// interface; nil when the DPU-host could not resolve it.
+	hostFunction *uplinkv1alpha1.HostFunction
 }
 
 func (udng *UserDefinedNetworkGateway) ensureUplinkGateway() (*bridgeconfig.BridgeConfiguration, error) {
@@ -253,6 +256,7 @@ func (udng *UserDefinedNetworkGateway) ensureUplinkGateway() (*bridgeconfig.Brid
 		physicalNetworkName(udng.NetInfo),
 		resolved.ipAddresses,
 		resolved.macAddress,
+		resolved.hostFunction,
 	)
 	if err != nil {
 		return nil, newUplinkGatewayError(
@@ -382,6 +386,7 @@ func parseResolvedUplinkGateway(state *uplinkv1alpha1.UplinkState) (*resolvedUpl
 		macAddress:        macAddress,
 		ipAddresses:       ipAddresses,
 		defaultGateways:   defaultGateways,
+		hostFunction:      state.Status.HostFunction.DeepCopy(),
 	}, nil
 }
 

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -4,7 +4,6 @@
 package uplink
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -413,7 +412,7 @@ func (c *Controller) reconcileUplinkState(key string) error {
 			if err != nil {
 				klog.Warningf("UplinkState %s: host function %s did not resolve an OVS bridge, "+
 					"falling back to the host MAC scan: %v",
-					state.Name, hostFunctionName(hostState.hostFunction), err)
+					state.Name, util.HostFunctionName(hostState.hostFunction.PFID, hostState.hostFunction.VFID), err)
 				bridgeName, err = c.bridgeResolver.ResolveByHostMAC(hostState.macAddress, c.nodeName)
 			} else {
 				resolvedVia = "host function"
@@ -1283,59 +1282,10 @@ func (r defaultOVSBridgeResolver) ResolveByHostFunction(
 	hostMAC net.HardwareAddr,
 	nodeName string,
 ) (string, error) {
-	function := hostFunctionName(details)
-	// TODO: this lookup relies on sriovnet's deprecated
-	// GetVfRepresentorDPU/GetPfRepresentorDPU, which only accept PF
-	// indices 0 and 1 and only match c1/legacy phys_port_name patterns:
-	// multi-host DPUs (controllers other than c1) and cards with more
-	// than two PFs cannot be resolved this way, and (pfID, vfID) alone
-	// is ambiguous across DPUs and controllers in any case; such layouts
-	// take the MAC scan on every reconcile. The way out is publishing an
-	// unambiguous anchor, the MAC of the backing PF, and resolving
-	// through sriovnet's port params API
-	// (GetPFRepresentorPortParamsFromMAC and the
-	// Get*RepresentorFromPortParams lookups), which works on any
-	// controller and PF count.
-	var rep string
-	var err error
-	if details.VFID != nil {
-		rep, err = util.GetDPUOps().GetPortRepresentor(
-			fmt.Sprintf("%d", details.PFID),
-			fmt.Sprintf("%d", *details.VFID),
-		)
-	} else {
-		rep, err = util.GetDPUOps().GetPFRepresentor(fmt.Sprintf("%d", details.PFID))
-	}
+	function := util.HostFunctionName(details.PFID, details.VFID)
+	rep, err := util.FindHostRepresentorByFunction(details.PFID, details.VFID, hostMAC, nodeName)
 	if err != nil {
-		return "", newDiscoveryError(
-			uplinkv1alpha1.UplinkStateReasonBridgeNotFound,
-			fmt.Errorf("failed to find representor for host function %s: %w", function, err),
-		)
-	}
-	// The published MAC is the uplink's identity: indices of a host function
-	// on some other SR-IOV device could still resolve a representor here.
-	// The representor's host-side peer MAC — the eswitch's record of the
-	// host function MAC, read via devlink, not the representor netdev's own
-	// address — must therefore equal the published MAC when it is readable,
-	// or the representor is not a match. A representor with no readable
-	// peer MAC (hardware that leaves representor function MACs unset
-	// reports errors or all zeroes) offers no identity to compare, and no
-	// way to resolve by MAC at all, so the published indices stand on their
-	// own there.
-	peerMAC, err := util.GetDPUOps().GetHostPeerMACAddress(rep, nodeName)
-	switch {
-	case err != nil:
-		klog.V(2).Infof("Uplink host function %s representor %s has no readable host peer MAC, "+
-			"skipping identity verification: %v", function, rep, err)
-	case !util.IsUsableEthernetMAC(peerMAC):
-		klog.V(2).Infof("Uplink host function %s representor %s host peer MAC %s is unusable, "+
-			"skipping identity verification", function, rep, peerMAC)
-	case !bytes.Equal(peerMAC, hostMAC):
-		return "", newDiscoveryError(
-			uplinkv1alpha1.UplinkStateReasonBridgeNotFound,
-			fmt.Errorf("representor %s for host function %s peers with MAC %s, not the published host MAC %s",
-				rep, function, peerMAC, hostMAC),
-		)
+		return "", newDiscoveryError(uplinkv1alpha1.UplinkStateReasonBridgeNotFound, err)
 	}
 	bridgeName, err := r.bridgeForPortOrInterface(rep)
 	if err != nil {
@@ -1348,15 +1298,6 @@ func (r defaultOVSBridgeResolver) ResolveByHostFunction(
 	klog.Infof("Resolved Uplink host function %s to OVS bridge %s via DPU representor %s",
 		function, bridgeName, rep)
 	return bridgeName, nil
-}
-
-// hostFunctionName renders host function as pf<N> or pf<N>vf<M> for logs
-// and error messages.
-func hostFunctionName(details *uplinkv1alpha1.HostFunction) string {
-	if details.VFID != nil {
-		return fmt.Sprintf("pf%dvf%d", details.PFID, *details.VFID)
-	}
-	return fmt.Sprintf("pf%d", details.PFID)
 }
 
 func (r defaultOVSBridgeResolver) ResolveByHostMAC(hostMAC net.HardwareAddr, nodeName string) (string, error) {
@@ -1398,30 +1339,9 @@ func (r defaultOVSBridgeResolver) ResolveByHostMAC(hostMAC net.HardwareAddr, nod
 }
 
 func (r defaultOVSBridgeResolver) bridgeForPortOrInterface(name string) (string, error) {
-	interfaces, err := ovsops.FindInterfacesWithPredicate(r.ovsClient, func(iface *vswitchd.Interface) bool {
-		return iface.Name == name
-	})
+	ports, err := libovsdbops.FindPortsForPortOrInterface(r.ovsClient, name)
 	if err != nil {
-		return "", fmt.Errorf("failed to look up OVS interface %s: %w", name, err)
-	}
-	interfaceIDs := make(map[string]struct{}, len(interfaces))
-	for _, iface := range interfaces {
-		interfaceIDs[iface.UUID] = struct{}{}
-	}
-
-	ports, err := libovsdbops.FindOVSPortsWithPredicate(r.ovsClient, func(port *vswitchd.Port) bool {
-		if port.Name == name {
-			return true
-		}
-		for _, interfaceID := range port.Interfaces {
-			if _, ok := interfaceIDs[interfaceID]; ok {
-				return true
-			}
-		}
-		return false
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to look up OVS port for %s: %w", name, err)
+		return "", err
 	}
 	if len(ports) == 0 {
 		return "", fmt.Errorf("OVS port or interface %s not found: %w", name, libovsdbclient.ErrNotFound)

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -143,6 +143,65 @@ func IsSimulatedDPU() bool {
 	return false
 }
 
+// FindHostRepresentorByFunction returns the DPU-side representor of the host
+// function identified by pfID, and by vfID when that function is a VF. hostMAC
+// is the function's published identity and only rejects a wrong match: the host
+// owns the MAC of its VFs and SFs, so the DPU eswitch commonly has no function
+// MAC to compare a representor against, and the indices then stand on their
+// own. nodeName is the K8s node name of the host this DPU operates on behalf
+// of.
+//
+// TODO: this lookup relies on sriovnet's deprecated
+// GetVfRepresentorDPU/GetPfRepresentorDPU, which only accept PF indices 0 and 1
+// and only match c1/legacy phys_port_name patterns: multi-host DPUs
+// (controllers other than c1) and cards with more than two PFs cannot be
+// resolved this way, and (pfID, vfID) alone is ambiguous across DPUs and
+// controllers in any case. The way out is publishing an unambiguous anchor, the
+// MAC of the backing PF, and resolving through sriovnet's port params API
+// (GetPFRepresentorPortParamsFromMAC and the Get*RepresentorFromPortParams
+// lookups), which works on any controller and PF count.
+func FindHostRepresentorByFunction(pfID int32, vfID *int32, hostMAC net.HardwareAddr,
+	nodeName string) (string, error) {
+	function := HostFunctionName(pfID, vfID)
+	var rep string
+	var err error
+	if vfID != nil {
+		rep, err = GetDPUOps().GetPortRepresentor(strconv.Itoa(int(pfID)), strconv.Itoa(int(*vfID)))
+	} else {
+		rep, err = GetDPUOps().GetPFRepresentor(strconv.Itoa(int(pfID)))
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to find representor for host function %s: %w", function, err)
+	}
+	// The representor's host-side peer MAC — the eswitch's record of the host
+	// function MAC, not the representor netdev's own address — must equal
+	// hostMAC when it is readable, or the indices resolved a function on some
+	// other SR-IOV device. Hardware that leaves representor function MACs unset
+	// reports errors or all zeroes, which offers no identity to compare.
+	peerMAC, err := GetDPUOps().GetHostPeerMACAddress(rep, nodeName)
+	switch {
+	case err != nil:
+		klog.V(2).Infof("Host function %s representor %s has no readable host peer MAC, "+
+			"skipping identity verification: %v", function, rep, err)
+	case !IsUsableEthernetMAC(peerMAC):
+		klog.V(2).Infof("Host function %s representor %s host peer MAC %s is unusable, "+
+			"skipping identity verification", function, rep, peerMAC)
+	case !bytes.Equal(peerMAC, hostMAC):
+		return "", fmt.Errorf("representor %s for host function %s peers with MAC %s, not the published host MAC %s",
+			rep, function, peerMAC, hostMAC)
+	}
+	return rep, nil
+}
+
+// HostFunctionName renders a host function as pf<N> or pf<N>vf<M> for logs and
+// error messages.
+func HostFunctionName(pfID int32, vfID *int32) string {
+	if vfID != nil {
+		return fmt.Sprintf("pf%dvf%d", pfID, *vfID)
+	}
+	return fmt.Sprintf("pf%d", pfID)
+}
+
 // ---------------------------------------------------------------------------
 // SwitchdevDPUOps - SR-IOV / switchdev hardware (NVIDIA BlueField, etc.)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📑 Description

On a DPU, gateway programming picked the host representor by scanning the bridge for a representor whose eswitch peer MAC equals the published host MAC. This works for PF-backed uplinks (the PF MAC is hardware-assigned and known to the eswitch) but not for VF-backed ones: the host owns its VF MACs and never writes them into the DPU eswitch. The scan matched nothing and `GatewayReady` stayed `False` with "no representor on bridge peers with host MAC", even though Uplink discovery had already resolved that same representor from the published pf/vf indices.

First commit (test-only, preparatory): extract the scaffolding shared by the DPU unmanaged bridge tests into a common harness.

Second commit:
- share discovery's lookup as `util.FindHostRepresentorByFunction` and use it in gateway programming as well, plumbing the UplinkState host function through to the unmanaged bridge configuration;
- keep the MAC scan as the fallback for hosts that publish no host function, and log a warning when we fall back to it, coherent with what the uplink controller already does for bridge resolution;
- verify the representor's bridge membership against the cached OVSDB rows (as a port of its own or as an interface of another port, same as discovery) instead of shelling out to `ovs-vsctl port-to-br` on every reconcile;
- unit tests cover the host-function happy path and the fallback branches: MAC scan on a failed lookup, rejection of a representor that is not on the bridge, and the combined error when both paths fail.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [x] All the tests have passed in the CI
