### PR TITLE
libovsdb: filter router static routes in cache

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -690,32 +690,32 @@ func GetRouterLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Cli
 		return nil, fmt.Errorf("failed to get router: %s, error: %w", router.Name, err)
 	}
 
-	lrsrs := []*nbdb.LogicalRouterStaticRoute{}
+	// Filter in the cache before cloning rows. The previous implementation
+	// fetched every route UUID attached to the router and cloned it before
+	// applying p. Large interconnect routers therefore cloned their whole route
+	// table for every predicate lookup, even when only one route could match.
+	routeUUIDs := sets.New(r.StaticRoutes...)
+	matches, err := FindLogicalRouterStaticRoutesWithPredicate(nbClient, func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+		return routeUUIDs.Has(lrsr.UUID) && p(lrsr)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Preserve the logical router's route ordering. Some callers retain the
+	// first matching route and remove later duplicates.
+	matchesByUUID := make(map[string]*nbdb.LogicalRouterStaticRoute, len(matches))
+	for _, route := range matches {
+		matchesByUUID[route.UUID] = route
+	}
+	lrsrs := make([]*nbdb.LogicalRouterStaticRoute, 0, len(matches))
 	for _, uuid := range r.StaticRoutes {
-		lrsr := &nbdb.LogicalRouterStaticRoute{UUID: uuid}
-		validRoute, err := routeExistsWithPredicate(nbClient, lrsr, p)
-		if err != nil {
-			return nil, err
-		}
-		if validRoute {
-			lrsrs = append(lrsrs, lrsr)
+		if route, ok := matchesByUUID[uuid]; ok {
+			lrsrs = append(lrsrs, route)
 		}
 	}
 
 	return lrsrs, nil
-}
-
-func routeExistsWithPredicate(nbClient libovsdbclient.Client, lrsr *nbdb.LogicalRouterStaticRoute, p logicalRouterStaticRoutePredicate) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
-	defer cancel()
-	err := nbClient.Get(ctx, lrsr)
-	if err != nil {
-		return false, err
-	}
-	if p(lrsr) {
-		return true, nil
-	}
-	return false, nil
 }
 
 // CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps looks up a logical

--- a/go-controller/pkg/libovsdb/ops/router_test.go
+++ b/go-controller/pkg/libovsdb/ops/router_test.go
@@ -6,11 +6,64 @@ package ops
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 )
+
+func TestGetRouterLogicalRouterStaticRoutesWithPredicate(t *testing.T) {
+	route1 := &nbdb.LogicalRouterStaticRoute{
+		UUID:        buildNamedUUID(),
+		IPPrefix:    "10.0.0.0/24",
+		Nexthop:     "100.64.0.2",
+		ExternalIDs: map[string]string{"owner": "node1"},
+	}
+	route2 := &nbdb.LogicalRouterStaticRoute{
+		UUID:        buildNamedUUID(),
+		IPPrefix:    "10.0.1.0/24",
+		Nexthop:     "100.64.0.3",
+		ExternalIDs: map[string]string{"owner": "node1"},
+	}
+	otherRouterRoute := &nbdb.LogicalRouterStaticRoute{
+		UUID:        buildNamedUUID(),
+		IPPrefix:    "10.0.2.0/24",
+		Nexthop:     "100.64.0.4",
+		ExternalIDs: map[string]string{"owner": "node1"},
+	}
+	router := &nbdb.LogicalRouter{
+		UUID:         buildNamedUUID(),
+		Name:         "router1",
+		StaticRoutes: []string{route2.UUID, route1.UUID},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{NBData: []libovsdbtest.TestData{
+		route1,
+		route2,
+		otherRouterRoute,
+		router,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("failed to set up test harness: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	routes, err := GetRouterLogicalRouterStaticRoutesWithPredicate(nbClient, &nbdb.LogicalRouter{Name: router.Name}, func(route *nbdb.LogicalRouterStaticRoute) bool {
+		return route.ExternalIDs["owner"] == "node1"
+	})
+	if err != nil {
+		t.Fatalf("GetRouterLogicalRouterStaticRoutesWithPredicate() error = %v", err)
+	}
+
+	gotPrefixes := make([]string, 0, len(routes))
+	for _, route := range routes {
+		gotPrefixes = append(gotPrefixes, route.IPPrefix)
+	}
+	if wantPrefixes := []string{route2.IPPrefix, route1.IPPrefix}; !reflect.DeepEqual(gotPrefixes, wantPrefixes) {
+		t.Fatalf("GetRouterLogicalRouterStaticRoutesWithPredicate() prefixes = %v, want %v", gotPrefixes, wantPrefixes)
+	}
+}
 
 func TestFindNATsUsingPredicate(t *testing.T) {
 	fakeNAT1 := &nbdb.NAT{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
