### PR TITLE
docs: backport versioned-site deep link fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ In some cases, other changes may conflict with your PR. If this happens, you wil
 
 ## Development Environment Setup
 
-You can easily setup a developer environment by following the instructions [here](https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/kind.md).
+You can easily setup a developer environment by following the instructions [here](https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-on-kind/).
 
 ## Sign Your Commits
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ CNI (Container Network Interface) specifications.
 Here are some links to help in your ovn-kubernetes journey:
 
 - [Welcome to ovn-kubernetes](https://ovn-kubernetes.io/) for overview of ovn-kubernetes.
-- [Architecture of ovn-kubernetes](https://ovn-kubernetes.io/design/architecture/)
-- [Deploying OVN Kubernetes cluster using KIND](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-on-kind/)
-- [Deploying OVN Kubernetes CNI using Helm](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-with-helm/)
-- [Contributing to OVN Kubernetes](https://ovn-kubernetes.io/governance/CONTRIBUTING/) for how to get involved
+- [Architecture of ovn-kubernetes](https://ovn-kubernetes.io/master/design/architecture/)
+- [Deploying OVN Kubernetes cluster using KIND](https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-on-kind/)
+- [Deploying OVN Kubernetes CNI using Helm](https://ovn-kubernetes.io/master/installation/launching-ovn-kubernetes-with-helm/)
+- [Contributing to OVN Kubernetes](https://ovn-kubernetes.io/master/governance/CONTRIBUTING/) for how to get involved
   in our project
-- [Meet the Community](https://ovn-kubernetes.io/governance/MEETINGS/) for details on community
+- [Meet the Community](https://ovn-kubernetes.io/master/governance/MEETINGS/) for details on community
   meeting details.
 
 ## License

--- a/docs/api-reference/introduction.md
+++ b/docs/api-reference/introduction.md
@@ -32,10 +32,10 @@ Kubernetes ecosystem APIs that is watched and implemented by OVN-Kubernetes
 This section contains the API Reference guide for features
 designed and implemented by OVN-Kubernetes
 
-* [EgressIP](https://ovn-kubernetes.io/api-reference/egress-ip-api-spec/)
-* [EgressService](https://ovn-kubernetes.io/api-reference/egress-service-api-spec/)
-* [EgressQoS](https://ovn-kubernetes.io/api-reference/egress-qos-api-spec/)
-* [EgressFirewall](https://ovn-kubernetes.io/api-reference/egress-firewall-api-spec/)
-* [AdminPolicyBasedExternalRoutes](https://ovn-kubernetes.io/api-reference/admin-epbr-api-spec/)
-* [UserDefinedNetwork](https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/)
+* [EgressIP](egress-ip-api-spec.md)
+* [EgressService](egress-service-api-spec.md)
+* [EgressQoS](egress-qos-api-spec.md)
+* [EgressFirewall](egress-firewall-api-spec.md)
+* [AdminPolicyBasedExternalRoutes](admin-epbr-api-spec.md)
+* [UserDefinedNetwork](userdefinednetwork-api-spec.md)
 * [RouteAdvertisements](routeadvertisements-api-spec.md)

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -17,7 +17,7 @@ where we mandate docs include:
 
 * **Enhancement Proposals**: If you are planning to do a new feature, then start
 with an enhancement proposal a.k.a OKEP so that maintainers and other reviewers
-can get an understanding of what your goals are. See [here](https://ovn-kubernetes.io/okeps/okep-4368-template/)
+can get an understanding of what your goals are. See [here](../okeps/okep-4368-template.md)
 for more details and open a commit adding it to our `docs/okeps` folder.
 
 * **Architecture and Topology docs**: Did you change the architecture or topology?
@@ -48,7 +48,7 @@ to reduce the time it takes for iptables to sync up on startup? Think about writ
 around this! Open a commit adding it to our `docs/blog` folder.
 
 * **API Reference**: Did you introduce a new CRD? OR Did you add a watcher a new CRD? Include API
-Reference documentation changes to `docs/api-reference` folder. See [here](https://ovn-kubernetes.io/api-reference/introduction/)
+Reference documentation changes to `docs/api-reference` folder. See [here](../api-reference/introduction.md)
 for more details.
 
 ## Website Guide

--- a/docs/features/hardware-offload/ovs-doca.md
+++ b/docs/features/hardware-offload/ovs-doca.md
@@ -6,7 +6,7 @@ OVS supports [Hardware Acceleration features](https://docs.openvswitch.org/en/la
 
 DOCA (Data Center Infrastructure-on-a-Chip Architecture) is a software stack for NVIDIA Smart NIC (ConnectX) and Data Processing Unit (BlueField) product lines. It contains a runtime and development environment, including libraries and drivers for device management and programmability, for the host (Smart NIC) or as part of the Data Processing Unit (DPU).
 
-OVS-DOCA extends traditional OVS-DPDK and OVS-Kernel data-path offload interfaces (DPIF), adds  OVS-DOCA as an additional DPIF implementation. It preserves the same interfaces as OVS-DPDK and OVS-Kernel while utilizing the DOCA Flow library. OVS-DOCA uses unique hardware offload mechanisms and application techniques to maximize performance and adds other features. OVS Acceleration with kernel datapath is documented [here](https://ovn-kubernetes.io/features/hardware-offload/ovs_acceleration/)
+OVS-DOCA extends traditional OVS-DPDK and OVS-Kernel data-path offload interfaces (DPIF), adds  OVS-DOCA as an additional DPIF implementation. It preserves the same interfaces as OVS-DPDK and OVS-Kernel while utilizing the DOCA Flow library. OVS-DOCA uses unique hardware offload mechanisms and application techniques to maximize performance and adds other features. OVS Acceleration with kernel datapath is documented [here](ovs-kernel.md)
 
 ![ovs-datapath-offload-interfaces](../../images/ovs-datapath-offload-interfaces.png)
 

--- a/docs/features/network-security-controls/admin-network-policy.md
+++ b/docs/features/network-security-controls/admin-network-policy.md
@@ -1123,7 +1123,7 @@ packet which is the `action` on the ACL.
 Using this method each policy rule can be debugged to
 see if constructs at OVN level are created correctly.
 An easier way is to simply run an
-[ovnkube-trace](https://ovn-kubernetes.io/troubleshooting/ovnkube-trace/).
+[ovnkube-trace](../../troubleshooting/ovnkube-trace.md).
 
 ### OVN Tracing
 

--- a/docs/features/user-defined-networks/user-defined-networks.md
+++ b/docs/features/user-defined-networks/user-defined-networks.md
@@ -23,13 +23,13 @@ can use the same IP address ranges for pods, expanding deployment scenarios.
 
 See the [enhancement] for more details.
 
-[enhancement]: https://ovn-kubernetes.io/okeps/okep-5193-user-defined-networks/
+[enhancement]: ../../okeps/okep-5193-user-defined-networks.md
 
 ### User-Stories/Use-Cases
 
 See the [user-stories] defined in the enhancement.
 
-[user-stories]: https://ovn-kubernetes.io/okeps/okep-5193-user-defined-networks/#user-storiesuse-cases
+[user-stories]: ../../okeps/okep-5193-user-defined-networks.md#user-storiesuse-cases
 
 The two main user stories are:
 
@@ -93,7 +93,7 @@ will not be considered for UDN creation.
 
 See the [api-specification-docs] for information on each of the fields
 
-[api-specification-docs]: https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/
+[api-specification-docs]: ../../api-reference/userdefinednetwork-api-spec.md
 
 ### OVN-Kubernetes Implementation Details
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ to be a highly scalable and performant Networking Platform.
 
 For more details, please see the following:
 
-- [OVN-Kubernetes Architecture](https://ovn-kubernetes.io/design/architecture/)
+- [OVN-Kubernetes Architecture](design/architecture.md)
 - [Deploying OVN-Kubernetes cluster using KIND](installation/launching-ovn-kubernetes-on-kind.md)
 - [Deploying OVN-Kubernetes CNI using Helm](installation/launching-ovn-kubernetes-with-helm.md)
 - [Setup and Building OVN-Kubernetes](developer-guide/documentation.md) for instructions

--- a/docs/okeps/okep-5193-user-defined-networks.md
+++ b/docs/okeps/okep-5193-user-defined-networks.md
@@ -439,7 +439,7 @@ an error status can be reported to the CR, rather than relying on the user to ch
 
 #### API Overview
 
-Two CRDs shall be introduced. Note for the final implementation, see the [official api](https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/).
+Two CRDs shall be introduced. Note for the final implementation, see the [official api](../api-reference/userdefinednetwork-api-spec.md).
 - Namespace scoped CRD - represent user request for creating namespace scoped OVN network.
   - Shall be defined with `namespace` scope.
   - Targeted for cluster admin and non-admin users, enable creating OVN network in a specific namespace.


### PR DESCRIPTION
## Summary
- Backport docs deep-link fixes so published `/1.1/` pages use relative links (and `/master/...` where needed for README/CONTRIBUTING).
- Content-only; does not include master-only mike/404 harness (those live on master).

## Related
- Follows the master link-fix work (Link-fix / PR #6827).

## Release Notes
```release-note
NONE