### PR TITLE
gateway: add nodeport-addresses restriction

### DIFF
--- a/docs/installation/ovn_k8s.conf.5
+++ b/docs/installation/ovn_k8s.conf.5
@@ -157,6 +157,13 @@ This is the VLAN tag to apply to traffic exiting the OVN logical network in
 "shared" mode. A value of 0 means traffic should be untagged.
 \fBnodeport\fR=true
 When set to true Kubernetes NodePort services will be supported.
+\fBnodeport-addresses\fR=
+Comma-separated list of CIDRs and/or the keyword \fBprimary\fR that restrict
+which local node IPs may receive NodePort traffic. When unset, NodePort traffic
+is accepted on all local node IPs. Use \fBprimary\fR to allow only the gateway
+interface addresses. Example dual-stack configuration:
+\fBnodeport-addresses\fR=10.0.0.0/8,2001:db8::/32,primary
+Invalid CIDR values or an empty-only value are rejected at startup.
 
 .SH "SEE ALso"
 .BR ovnkube (1),

--- a/docs/installation/ovnkube.1
+++ b/docs/installation/ovnkube.1
@@ -63,6 +63,11 @@ DEPRECATED; use \fB\--gateway-mode\fR instead.
 Setup nodeport based entries in OVN gateways for ingress into the k8s cluster.
 By default, it is disabled.
 .TP
+\fB\--nodeport-addresses\fR string
+Comma-separated CIDRs and/or the keyword \fBprimary\fR that restrict which local
+node IPs may receive NodePort traffic. When unset, NodePort traffic is accepted
+on all local node IPs.
+.TP
 \fB\--gateway-v4-join-subnet\fR string
 The v4 join subnet to use for assigning join switch IPv4 addresses\fR.
 .TP

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -600,6 +600,12 @@ type GatewayConfig struct {
 	VLANID uint `gcfg:"vlan-id"`
 	// NodeportEnable sets whether to provide Kubernetes NodePort service or not
 	NodeportEnable bool `gcfg:"nodeport"`
+	// RawNodePortAddresses is a comma-separated list of CIDRs and/or the keyword
+	// "primary" that restrict which local node IPs may receive NodePort traffic.
+	// When empty, NodePort traffic is accepted on all local node IPs.
+	RawNodePortAddresses string `gcfg:"nodeport-addresses"`
+	// NodePortAddresses holds the parsed nodeport-addresses configuration.
+	NodePortAddresses *NodePortAddressConfig
 	// DisableSNATMultipleGws sets whether to disable SNAT of egress traffic in namespaces with external gateways configured via AdminPolicyBasedExternalRoute CRs
 	// only applicable to the default network not for UDNs
 	DisableSNATMultipleGWs bool `gcfg:"disable-snat-multiple-gws"`
@@ -1706,6 +1712,13 @@ var OVNGatewayFlags = []cli.Flag{
 		Usage:       "Setup nodeport based ingress on gateways.",
 		Destination: &cliConfig.Gateway.NodeportEnable,
 	},
+	&cli.StringFlag{
+		Name: "nodeport-addresses",
+		Usage: "Comma-separated CIDRs and/or the keyword \"primary\" that restrict " +
+			"which local node IPs may receive NodePort traffic. When unset, NodePort " +
+			"traffic is accepted on all local node IPs.",
+		Destination: &cliConfig.Gateway.RawNodePortAddresses,
+	},
 	&cli.BoolFlag{
 		Name:        "disable-snat-multiple-gws",
 		Usage:       "Disable SNAT for egress traffic with multiple gateways.",
@@ -2325,6 +2338,11 @@ func completeGatewayConfig(allSubnets *ConfigSubnets, masqueradeIPs *MasqueradeI
 
 	allSubnets.Append(ConfigSubnetMasquerade, v4MasqueradeCIDR)
 	allSubnets.Append(ConfigSubnetMasquerade, v6MasqueradeCIDR)
+
+	Gateway.NodePortAddresses, err = ParseNodePortAddresses(Gateway.RawNodePortAddresses)
+	if err != nil {
+		return fmt.Errorf("invalid nodeport-addresses: %w", err)
+	}
 
 	return nil
 }

--- a/go-controller/pkg/config/nodeport_addresses.go
+++ b/go-controller/pkg/config/nodeport_addresses.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	utilnet "k8s.io/utils/net"
+)
+
+const nodePortAddressesPrimary = "primary"
+
+// NodePortAddressConfig restricts which local node IP addresses may receive
+// NodePort traffic. When unset, all local node IPs are allowed.
+type NodePortAddressConfig struct {
+	cidrs      []*net.IPNet
+	usePrimary bool
+}
+
+// ParseNodePortAddresses parses the nodeport-addresses configuration value.
+// An empty string means NodePort traffic is accepted on all local node IPs.
+func ParseNodePortAddresses(raw string) (*NodePortAddressConfig, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return &NodePortAddressConfig{}, nil
+	}
+
+	cfg := &NodePortAddressConfig{}
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if entry == nodePortAddressesPrimary {
+			cfg.usePrimary = true
+			continue
+		}
+		_, cidr, err := utilnet.ParseCIDRSloppy(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid nodeport-addresses entry %q: %w", entry, err)
+		}
+		cfg.cidrs = append(cfg.cidrs, cidr)
+	}
+
+	if !cfg.usePrimary && len(cfg.cidrs) == 0 {
+		return nil, fmt.Errorf("invalid nodeport-addresses value %q", raw)
+	}
+	return cfg, nil
+}
+
+// Restricted reports whether NodePort traffic should be limited to specific
+// local node IP addresses.
+func (c *NodePortAddressConfig) Restricted() bool {
+	if c == nil {
+		return false
+	}
+	return c.usePrimary || len(c.cidrs) > 0
+}
+
+// FilterHostAddresses returns the subset of hostAddresses that may receive
+// NodePort traffic. primaryAddresses are used when "primary" is configured.
+func (c *NodePortAddressConfig) FilterHostAddresses(hostAddresses, primaryAddresses []net.IP) []net.IP {
+	if c == nil || !c.Restricted() {
+		return append([]net.IP(nil), hostAddresses...)
+	}
+
+	allowed := make(map[string]net.IP)
+	if c.usePrimary {
+		for _, ip := range primaryAddresses {
+			if ip != nil {
+				allowed[ip.String()] = ip
+			}
+		}
+	}
+	for _, ip := range hostAddresses {
+		if ip == nil {
+			continue
+		}
+		if _, ok := allowed[ip.String()]; ok {
+			continue
+		}
+		for _, cidr := range c.cidrs {
+			if cidr.Contains(ip) {
+				allowed[ip.String()] = ip
+				break
+			}
+		}
+	}
+
+	filtered := make([]net.IP, 0, len(allowed))
+	for _, ip := range hostAddresses {
+		if _, ok := allowed[ip.String()]; ok {
+			filtered = append(filtered, ip)
+		}
+	}
+	return filtered
+}

--- a/go-controller/pkg/config/nodeport_addresses_test.go
+++ b/go-controller/pkg/config/nodeport_addresses_test.go
@@ -13,35 +13,80 @@ import (
 var _ = ginkgo.Describe("NodePortAddressConfig", func() {
 	ginkgo.It("treats empty configuration as unrestricted", func() {
 		cfg, err := ParseNodePortAddresses("")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(cfg.Restricted()).To(gomega.BeFalse())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "empty nodeport-addresses should parse successfully")
+		gomega.Expect(cfg.Restricted()).To(gomega.BeFalse(), "empty configuration should not restrict NodePort addresses")
 
 		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
-		gomega.Expect(cfg.FilterHostAddresses(hosts, nil)).To(gomega.Equal(hosts))
+		gomega.Expect(cfg.FilterHostAddresses(hosts, nil)).To(gomega.Equal(hosts), "unrestricted config should return all host addresses")
 	})
 
 	ginkgo.It("filters host addresses by CIDR", func() {
 		cfg, err := ParseNodePortAddresses("10.0.0.0/8")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(cfg.Restricted()).To(gomega.BeTrue())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "valid IPv4 CIDR should parse successfully")
+		gomega.Expect(cfg.Restricted()).To(gomega.BeTrue(), "CIDR configuration should restrict NodePort addresses")
 
 		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
 		filtered := cfg.FilterHostAddresses(hosts, nil)
-		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("10.0.0.5")}))
+		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("10.0.0.5")}), "only addresses in the configured CIDR should remain")
+	})
+
+	ginkgo.It("filters host addresses by IPv6 CIDR", func() {
+		cfg, err := ParseNodePortAddresses("2001:db8::/32")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "valid IPv6 CIDR should parse successfully")
+
+		hosts := []net.IP{net.ParseIP("2001:db8::5"), net.ParseIP("2001:db9::5")}
+		filtered := cfg.FilterHostAddresses(hosts, nil)
+		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("2001:db8::5")}), "only IPv6 addresses in the configured CIDR should remain")
 	})
 
 	ginkgo.It("uses primary addresses when configured", func() {
 		cfg, err := ParseNodePortAddresses("primary")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "primary selector should parse successfully")
 
 		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
 		primary := []net.IP{net.ParseIP("10.0.0.5")}
 		filtered := cfg.FilterHostAddresses(hosts, primary)
-		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("10.0.0.5")}))
+		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("10.0.0.5")}), "only primary addresses should remain")
+	})
+
+	ginkgo.It("returns no addresses when nothing matches", func() {
+		cfg, err := ParseNodePortAddresses("172.16.0.0/12")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "valid CIDR should parse successfully")
+
+		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
+		filtered := cfg.FilterHostAddresses(hosts, nil)
+		gomega.Expect(filtered).To(gomega.BeEmpty(), "no host addresses should match an unrelated CIDR")
+	})
+
+	ginkgo.It("combines primary and CIDR selectors", func() {
+		cfg, err := ParseNodePortAddresses("primary,192.168.0.0/16")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "combined selectors should parse successfully")
+
+		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5"), net.ParseIP("172.16.0.5")}
+		primary := []net.IP{net.ParseIP("10.0.0.5")}
+		filtered := cfg.FilterHostAddresses(hosts, primary)
+		gomega.Expect(filtered).To(gomega.Equal([]net.IP{
+			net.ParseIP("10.0.0.5"),
+			net.ParseIP("192.168.1.5"),
+		}), "primary and CIDR selectors should both contribute allowed addresses")
+	})
+
+	ginkgo.It("preserves host address order in filtered results", func() {
+		cfg, err := ParseNodePortAddresses("10.0.0.0/8,192.168.0.0/16")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "multiple CIDRs should parse successfully")
+
+		hosts := []net.IP{net.ParseIP("192.168.1.5"), net.ParseIP("10.0.0.5")}
+		filtered := cfg.FilterHostAddresses(hosts, nil)
+		gomega.Expect(filtered).To(gomega.Equal(hosts), "filtered addresses should preserve the original host order")
 	})
 
 	ginkgo.It("rejects invalid CIDR values", func() {
 		_, err := ParseNodePortAddresses("not-a-cidr")
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred(), "invalid CIDR values should be rejected")
+	})
+
+	ginkgo.It("rejects empty-only configuration", func() {
+		_, err := ParseNodePortAddresses(", , ")
+		gomega.Expect(err).To(gomega.HaveOccurred(), "comma-only configuration should be rejected")
 	})
 })

--- a/go-controller/pkg/config/nodeport_addresses_test.go
+++ b/go-controller/pkg/config/nodeport_addresses_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"net"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("NodePortAddressConfig", func() {
+	ginkgo.It("treats empty configuration as unrestricted", func() {
+		cfg, err := ParseNodePortAddresses("")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(cfg.Restricted()).To(gomega.BeFalse())
+
+		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
+		gomega.Expect(cfg.FilterHostAddresses(hosts, nil)).To(gomega.Equal(hosts))
+	})
+
+	ginkgo.It("filters host addresses by CIDR", func() {
+		cfg, err := ParseNodePortAddresses("10.0.0.0/8")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(cfg.Restricted()).To(gomega.BeTrue())
+
+		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
+		filtered := cfg.FilterHostAddresses(hosts, nil)
+		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("10.0.0.5")}))
+	})
+
+	ginkgo.It("uses primary addresses when configured", func() {
+		cfg, err := ParseNodePortAddresses("primary")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		hosts := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
+		primary := []net.IP{net.ParseIP("10.0.0.5")}
+		filtered := cfg.FilterHostAddresses(hosts, primary)
+		gomega.Expect(filtered).To(gomega.Equal([]net.IP{net.ParseIP("10.0.0.5")}))
+	})
+
+	ginkgo.It("rejects invalid CIDR values", func() {
+		_, err := ParseNodePortAddresses("not-a-cidr")
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+})

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -509,6 +509,16 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 				return fmt.Errorf("unable to configure UDN nftables: %w", err)
 			}
 		}
+		hostAddresses, _ := gw.nodeIPManager.ListAddresses()
+		if err := SyncNodePortAllowedAddresses(hostAddresses, nil); err != nil {
+			return err
+		}
+		gw.nodeIPManager.AddOnAddressesChangedHandler(func() {
+			hostAddresses, _ := gw.nodeIPManager.ListAddresses()
+			if err := SyncNodePortAllowedAddresses(hostAddresses, nil); err != nil {
+				klog.Errorf("Failed to sync NodePort allowed addresses after address change: %v", err)
+			}
+		})
 		gw.nodePortWatcherNFTables = newNodePortWatcherNFTables(nc.networkManager)
 		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(nc.name, nc.watchFactory)
 		portClaimWatcher, err := newPortClaimWatcher(nc.recorder)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -490,6 +490,31 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP ne
 	return nil
 }
 
+// dpuHostPrimaryAddresses returns the primary gateway interface addresses on a
+// DPU host node.
+func dpuHostPrimaryAddresses() ([]net.IP, error) {
+	if config.Gateway.Interface == "" {
+		return nil, nil
+	}
+	ifAddrs, err := nodeutil.GetNetworkInterfaceIPAddresses(config.Gateway.Interface)
+	if err != nil {
+		return nil, fmt.Errorf("get DPU host primary addresses from %s: %w", config.Gateway.Interface, err)
+	}
+	return gatewayIPsFromIPNets(ifAddrs), nil
+}
+
+func syncDPUHostNodePortAllowedAddresses(nodeIPManager *addressManager) error {
+	hostAddresses, _ := nodeIPManager.ListAddresses()
+	primaryAddresses, err := dpuHostPrimaryAddresses()
+	if err != nil {
+		return fmt.Errorf("get DPU host primary addresses for NodePort filtering: %w", err)
+	}
+	if err := SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses); err != nil {
+		return fmt.Errorf("sync NodePort allowed addresses on DPU host: %w", err)
+	}
+	return nil
+}
+
 func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	// A DPU host gateway is complementary to the shared gateway running
 	// on the DPU embedded CPU. it performs some initializations and
@@ -509,13 +534,11 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 				return fmt.Errorf("unable to configure UDN nftables: %w", err)
 			}
 		}
-		hostAddresses, _ := gw.nodeIPManager.ListAddresses()
-		if err := SyncNodePortAllowedAddresses(hostAddresses, nil); err != nil {
+		if err := syncDPUHostNodePortAllowedAddresses(gw.nodeIPManager); err != nil {
 			return err
 		}
 		gw.nodeIPManager.AddOnAddressesChangedHandler(func() {
-			hostAddresses, _ := gw.nodeIPManager.ListAddresses()
-			if err := SyncNodePortAllowedAddresses(hostAddresses, nil); err != nil {
+			if err := syncDPUHostNodePortAllowedAddresses(gw.nodeIPManager); err != nil {
 				klog.Errorf("Failed to sync NodePort allowed addresses after address change: %v", err)
 			}
 		})

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -52,10 +52,14 @@ const (
 	nftablesITPServicesMapV6 = "itp-services-to-redirect-v6"
 )
 
+// nodePortAddressesRestricted reports whether NodePort traffic is limited to
+// specific local node IP addresses.
 func nodePortAddressesRestricted() bool {
 	return config.Gateway.NodePortAddresses != nil && config.Gateway.NodePortAddresses.Restricted()
 }
 
+// addNodePortAllowedAddressSets creates nftables sets that hold the local node
+// IPs allowed to receive NodePort traffic.
 func addNodePortAllowedAddressSets(tx *knftables.Transaction) {
 	tx.Add(&knftables.Set{
 		Name:    nftablesNodePortAllowedV4,
@@ -71,6 +75,8 @@ func addNodePortAllowedAddressSets(tx *knftables.Transaction) {
 	tx.Flush(&knftables.Set{Name: nftablesNodePortAllowedV6})
 }
 
+// nodePortLocalDestMatch returns the nftables destination match for NodePort
+// traffic, optionally restricted to allowed local addresses.
 func nodePortLocalDestMatch(isIPv6 bool) []string {
 	if !nodePortAddressesRestricted() {
 		return []string{"fib daddr type local"}
@@ -81,6 +87,7 @@ func nodePortLocalDestMatch(isIPv6 bool) []string {
 	return []string{"fib daddr type local", "ip daddr", "@", nftablesNodePortAllowedV4}
 }
 
+// nftConcat builds an nftables concatenation expression from string parts.
 func nftConcat(parts ...string) string {
 	args := make([]interface{}, len(parts))
 	for i, part := range parts {
@@ -99,7 +106,7 @@ func SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses []net.IP) erro
 	filtered := config.Gateway.NodePortAddresses.FilterHostAddresses(hostAddresses, primaryAddresses)
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
-		return err
+		return fmt.Errorf("get nftables helper for NodePort allowed addresses: %w", err)
 	}
 
 	tx := nft.NewTransaction()
@@ -115,7 +122,10 @@ func SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses []net.IP) erro
 			tx.Add(&knftables.Element{Set: nftablesNodePortAllowedV4, Key: []string{ip.String()}})
 		}
 	}
-	return nft.Run(context.TODO(), tx)
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("sync NodePort allowed addresses: %w", err)
+	}
+	return nil
 }
 
 // initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -36,6 +36,9 @@ const (
 	nftablesETPNodePortsV4 = "nodeports-etp-local-v4"
 	nftablesETPNodePortsV6 = "nodeports-etp-local-v6"
 
+	nftablesNodePortAllowedV4 = "nodeport-allowed-v4"
+	nftablesNodePortAllowedV6 = "nodeport-allowed-v6"
+
 	nftablesExternalIPsV4    = "external-ips-v4"
 	nftablesExternalIPsV6    = "external-ips-v6"
 	nftablesETPExternalIPsV4 = "external-ips-etp-local-v4"
@@ -48,6 +51,72 @@ const (
 	nftablesITPServicesMapV4 = "itp-services-to-redirect-v4"
 	nftablesITPServicesMapV6 = "itp-services-to-redirect-v6"
 )
+
+func nodePortAddressesRestricted() bool {
+	return config.Gateway.NodePortAddresses != nil && config.Gateway.NodePortAddresses.Restricted()
+}
+
+func addNodePortAllowedAddressSets(tx *knftables.Transaction) {
+	tx.Add(&knftables.Set{
+		Name:    nftablesNodePortAllowedV4,
+		Type:    "ipv4_addr",
+		Comment: knftables.PtrTo("Local node IPs allowed to receive NodePort traffic"),
+	})
+	tx.Flush(&knftables.Set{Name: nftablesNodePortAllowedV4})
+	tx.Add(&knftables.Set{
+		Name:    nftablesNodePortAllowedV6,
+		Type:    "ipv6_addr",
+		Comment: knftables.PtrTo("Local node IPs allowed to receive NodePort traffic"),
+	})
+	tx.Flush(&knftables.Set{Name: nftablesNodePortAllowedV6})
+}
+
+func nodePortLocalDestMatch(isIPv6 bool) []string {
+	if !nodePortAddressesRestricted() {
+		return []string{"fib daddr type local"}
+	}
+	if isIPv6 {
+		return []string{"fib daddr type local", "ip6 daddr", "@", nftablesNodePortAllowedV6}
+	}
+	return []string{"fib daddr type local", "ip daddr", "@", nftablesNodePortAllowedV4}
+}
+
+func nftConcat(parts ...string) string {
+	args := make([]interface{}, len(parts))
+	for i, part := range parts {
+		args[i] = part
+	}
+	return knftables.Concat(args...)
+}
+
+// SyncNodePortAllowedAddresses updates the nftables sets that restrict which
+// local node IPs may receive NodePort traffic.
+func SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses []net.IP) error {
+	if !nodePortAddressesRestricted() {
+		return nil
+	}
+
+	filtered := config.Gateway.NodePortAddresses.FilterHostAddresses(hostAddresses, primaryAddresses)
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+	tx.Flush(&knftables.Set{Name: nftablesNodePortAllowedV4})
+	tx.Flush(&knftables.Set{Name: nftablesNodePortAllowedV6})
+	for _, ip := range filtered {
+		if ip == nil {
+			continue
+		}
+		if utilnet.IsIPv6(ip) {
+			tx.Add(&knftables.Element{Set: nftablesNodePortAllowedV6, Key: []string{ip.String()}})
+		} else {
+			tx.Add(&knftables.Element{Set: nftablesNodePortAllowedV4, Key: []string{ip.String()}})
+		}
+	}
+	return nft.Run(context.TODO(), tx)
+}
 
 // initGatewayNFTables initializes chains/sets/maps used for Service proxying rules.
 //
@@ -154,6 +223,9 @@ func initGatewayNFTables() error {
 		Type:    "inet_proto . inet_service : ipv6_addr . inet_service",
 		Comment: knftables.PtrTo("DNAT mappings for IPv6 NodePort traffic with ExternalTrafficPolicy: Local"),
 	})
+	if nodePortAddressesRestricted() {
+		addNodePortAllowedAddressSets(tx)
+	}
 	tx.Add(&knftables.Rule{
 		Chain: "services-etp",
 		Rule: knftables.Concat(
@@ -170,19 +242,15 @@ func initGatewayNFTables() error {
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services-etp",
-		Rule: knftables.Concat(
-			"fib daddr type local",
+		Rule: nftConcat(append(nodePortLocalDestMatch(false),
 			"dnat ip addr . port to",
-			"meta l4proto . th dport map", "@", nftablesETPNodePortsV4,
-		),
+			"meta l4proto . th dport map", "@", nftablesETPNodePortsV4)...),
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services-etp",
-		Rule: knftables.Concat(
-			"fib daddr type local",
+		Rule: nftConcat(append(nodePortLocalDestMatch(true),
 			"dnat ip6 addr . port to",
-			"meta l4proto . th dport map", "@", nftablesETPNodePortsV6,
-		),
+			"meta l4proto . th dport map", "@", nftablesETPNodePortsV6)...),
 	})
 
 	// Create the maps and rules for ordinary (ETP:Cluster) services
@@ -223,19 +291,15 @@ func initGatewayNFTables() error {
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services",
-		Rule: knftables.Concat(
-			"fib daddr type local",
+		Rule: nftConcat(append(nodePortLocalDestMatch(false),
 			"dnat ip addr . port to",
-			"meta l4proto . th dport map", "@", nftablesNodePortsV4,
-		),
+			"meta l4proto . th dport map", "@", nftablesNodePortsV4)...),
 	})
 	tx.Add(&knftables.Rule{
 		Chain: "services",
-		Rule: knftables.Concat(
-			"fib daddr type local",
+		Rule: nftConcat(append(nodePortLocalDestMatch(true),
 			"dnat ip6 addr . port to",
-			"meta l4proto . th dport map", "@", nftablesNodePortsV6,
-		),
+			"meta l4proto . th dport map", "@", nftablesNodePortsV6)...),
 	})
 
 	// Add the remaining chains/sets/maps for InternalTrafficPolicy: Local.

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -256,9 +256,13 @@ func (npw *nodePortWatcher) syncNodePortAllowedAddresses() error {
 	}
 	hostAddresses, _ := npw.nodeIPManager.ListAddresses()
 	primaryAddresses := gatewayIPsFromIPNets(npw.gwBridge.GetIPs())
-	return SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses)
+	if err := SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses); err != nil {
+		return fmt.Errorf("sync NodePort allowed addresses for node port watcher: %w", err)
+	}
+	return nil
 }
 
+// gatewayIPsFromIPNets extracts IP addresses from a slice of IP networks.
 func gatewayIPsFromIPNets(addrs []*net.IPNet) []net.IP {
 	ips := make([]net.IP, 0, len(addrs))
 	for _, addr := range addrs {
@@ -1934,7 +1938,7 @@ func newNodePortWatcher(
 		networkManager: networkManager,
 	}
 	if err := npw.syncNodePortAllowedAddresses(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initialize NodePort allowed addresses: %w", err)
 	}
 	return npw, nil
 }

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -159,12 +159,25 @@ func configureUDNServicesNFTables() error {
 		Type:    "ipv6_addr . inet_proto . inet_service : verdict",
 	})
 
-	tx.Add(&knftables.Rule{
-		Chain: nftablesUDNServiceMarkChain,
-		Rule: knftables.Concat(
-			"fib daddr type local meta l4proto . th dport vmap", "@", nftablesUDNMarkNodePortsMap,
-		),
-	})
+	if nodePortAddressesRestricted() {
+		tx.Add(&knftables.Rule{
+			Chain: nftablesUDNServiceMarkChain,
+			Rule: nftConcat(append(nodePortLocalDestMatch(false),
+				"meta l4proto . th dport vmap", "@", nftablesUDNMarkNodePortsMap)...),
+		})
+		tx.Add(&knftables.Rule{
+			Chain: nftablesUDNServiceMarkChain,
+			Rule: nftConcat(append(nodePortLocalDestMatch(true),
+				"meta l4proto . th dport vmap", "@", nftablesUDNMarkNodePortsMap)...),
+		})
+	} else {
+		tx.Add(&knftables.Rule{
+			Chain: nftablesUDNServiceMarkChain,
+			Rule: knftables.Concat(
+				"fib daddr type local meta l4proto . th dport vmap", "@", nftablesUDNMarkNodePortsMap,
+			),
+		})
+	}
 	tx.Add(&knftables.Rule{
 		Chain: nftablesUDNServiceMarkChain,
 		Rule: knftables.Concat(
@@ -235,6 +248,25 @@ func (npw *nodePortWatcher) updateGatewayIPs() {
 	defer npw.gatewayIPLock.Unlock()
 	npw.gatewayIPv4 = gatewayIPv4
 	npw.gatewayIPv6 = gatewayIPv6
+}
+
+func (npw *nodePortWatcher) syncNodePortAllowedAddresses() error {
+	if npw.nodeIPManager == nil || npw.gwBridge == nil {
+		return nil
+	}
+	hostAddresses, _ := npw.nodeIPManager.ListAddresses()
+	primaryAddresses := gatewayIPsFromIPNets(npw.gwBridge.GetIPs())
+	return SyncNodePortAllowedAddresses(hostAddresses, primaryAddresses)
+}
+
+func gatewayIPsFromIPNets(addrs []*net.IPNet) []net.IP {
+	ips := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr != nil {
+			ips = append(ips, addr.IP)
+		}
+	}
+	return ips
 }
 
 // updateServiceFlowCache handles managing breth0 gateway flows for ingress traffic towards kubernetes services
@@ -1804,6 +1836,9 @@ func newGateway(
 			if gw.nodePortWatcher != nil {
 				npw, _ := gw.nodePortWatcher.(*nodePortWatcher)
 				npw.updateGatewayIPs()
+				if err := npw.syncNodePortAllowedAddresses(); err != nil {
+					klog.Errorf("Failed to sync NodePort allowed addresses after address change: %v", err)
+				}
 			}
 			// Services create OpenFlow flows as well, need to update them all
 			if gw.servicesRetryFramework != nil {
@@ -1897,6 +1932,9 @@ func newNodePortWatcher(
 		ofm:            ofm,
 		watchFactory:   watchFactory,
 		networkManager: networkManager,
+	}
+	if err := npw.syncNodePortAllowedAddresses(); err != nil {
+		return nil, err
 	}
 	return npw, nil
 }

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -673,7 +673,7 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 				for _, vip := range cfg.vips {
 					if vip == placeholderNodeIPs {
 						if !node.nodePortDisabled {
-							vips = append(vips, node.hostAddressesStr()...)
+							vips = append(vips, node.nodePortHostAddressesStr()...)
 						}
 					} else {
 						vips = append(vips, vip)

--- a/go-controller/pkg/ovn/controller/services/node_info.go
+++ b/go-controller/pkg/ovn/controller/services/node_info.go
@@ -44,6 +44,8 @@ func (ni *nodeInfo) hostAddressesStr() []string {
 	return out
 }
 
+// nodePortHostAddressesStr returns the node host addresses that may receive
+// NodePort traffic after applying the nodeport-addresses policy.
 func (ni *nodeInfo) nodePortHostAddressesStr() []string {
 	filtered := globalconfig.Gateway.NodePortAddresses.FilterHostAddresses(ni.hostAddresses, ni.l3gatewayAddresses)
 	out := make([]string, 0, len(filtered))

--- a/go-controller/pkg/ovn/controller/services/node_info.go
+++ b/go-controller/pkg/ovn/controller/services/node_info.go
@@ -44,6 +44,15 @@ func (ni *nodeInfo) hostAddressesStr() []string {
 	return out
 }
 
+func (ni *nodeInfo) nodePortHostAddressesStr() []string {
+	filtered := globalconfig.Gateway.NodePortAddresses.FilterHostAddresses(ni.hostAddresses, ni.l3gatewayAddresses)
+	out := make([]string, 0, len(filtered))
+	for _, ip := range filtered {
+		out = append(out, ip.String())
+	}
+	return out
+}
+
 func (ni *nodeInfo) l3gatewayAddressesStr() []string {
 	out := make([]string, 0, len(ni.l3gatewayAddresses))
 	for _, ip := range ni.l3gatewayAddresses {

--- a/go-controller/pkg/ovn/controller/services/node_info_test.go
+++ b/go-controller/pkg/ovn/controller/services/node_info_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	globalconfig "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+)
+
+func TestNodePortHostAddressesStr(t *testing.T) {
+	t.Parallel()
+
+	hostAddresses := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("192.168.1.5")}
+	primaryAddresses := []net.IP{net.ParseIP("10.0.0.5")}
+	ni := &nodeInfo{
+		hostAddresses:      hostAddresses,
+		l3gatewayAddresses: primaryAddresses,
+	}
+
+	t.Run("unrestricted", func(t *testing.T) {
+		t.Cleanup(func() {
+			globalconfig.Gateway.NodePortAddresses = nil
+		})
+		cfg, err := globalconfig.ParseNodePortAddresses("")
+		require.NoError(t, err, "empty nodeport-addresses should parse successfully")
+		globalconfig.Gateway.NodePortAddresses = cfg
+
+		require.Equal(t, []string{"10.0.0.5", "192.168.1.5"}, ni.nodePortHostAddressesStr(),
+			"unrestricted configuration should expose all host addresses")
+	})
+
+	t.Run("primary", func(t *testing.T) {
+		t.Cleanup(func() {
+			globalconfig.Gateway.NodePortAddresses = nil
+		})
+		cfg, err := globalconfig.ParseNodePortAddresses("primary")
+		require.NoError(t, err, "primary selector should parse successfully")
+		globalconfig.Gateway.NodePortAddresses = cfg
+
+		require.Equal(t, []string{"10.0.0.5"}, ni.nodePortHostAddressesStr(),
+			"primary selector should expose only gateway addresses")
+	})
+
+	t.Run("cidr", func(t *testing.T) {
+		t.Cleanup(func() {
+			globalconfig.Gateway.NodePortAddresses = nil
+		})
+		cfg, err := globalconfig.ParseNodePortAddresses("192.168.0.0/16")
+		require.NoError(t, err, "CIDR selector should parse successfully")
+		globalconfig.Gateway.NodePortAddresses = cfg
+
+		require.Equal(t, []string{"192.168.1.5"}, ni.nodePortHostAddressesStr(),
+			"CIDR selector should expose only matching host addresses")
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		t.Cleanup(func() {
+			globalconfig.Gateway.NodePortAddresses = nil
+		})
+		cfg, err := globalconfig.ParseNodePortAddresses("172.16.0.0/12")
+		require.NoError(t, err, "CIDR selector should parse successfully")
+		globalconfig.Gateway.NodePortAddresses = cfg
+
+		require.Empty(t, ni.nodePortHostAddressesStr(),
+			"unmatched CIDR selector should expose no NodePort addresses")
+	})
+}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -886,6 +886,7 @@ func (c *Controller) syncNodeInfoMapForNetwork(state *networkState, nodeInfoByNa
 					nodeInfo.hostAddresses, nodeInfo.name, state.netInfo.GetNetworkName(), err)
 				validNodeInfo = false
 			} else {
+				ips = globalconfig.Gateway.NodePortAddresses.FilterHostAddresses(ips, nodeInfo.l3gatewayAddresses)
 				for _, ip := range ips {
 					state.nodeIPv4Templates.AddIP(nodeInfo.chassisID, ip)
 				}
@@ -898,6 +899,7 @@ func (c *Controller) syncNodeInfoMapForNetwork(state *networkState, nodeInfoByNa
 				klog.Warningf("Error while searching for IPv6 host addresses in %v for node[%s] for network=%s: %v",
 					nodeInfo.hostAddresses, nodeInfo.name, state.netInfo.GetNetworkName(), err)
 			} else {
+				ips = globalconfig.Gateway.NodePortAddresses.FilterHostAddresses(ips, nodeInfo.l3gatewayAddresses)
 				for _, ip := range ips {
 					state.nodeIPv6Templates.AddIP(nodeInfo.chassisID, ip)
 				}


### PR DESCRIPTION
## 📑 Description

Add kube-proxy-compatible `nodeport-addresses` support so NodePort traffic can be limited to specific local node IPs (CIDR list and/or `primary`), instead of all local addresses.

**Problem:** Today OVN-Kubernetes accepts NodePort on every local node IP (`fib daddr type local` in nftables, and all `host-cidrs` IPs as OVN NodePort VIPs). In zero-trust / multi-NIC setups (e.g. Egress IP on a secondary interface), NodePort can be reached on interfaces that were not intended for ingress.

**Solution:**
- New config: `[gateway] nodeport-addresses` / `--nodeport-addresses`
- Values: comma-separated CIDRs and/or `primary` (same semantics as kube-proxy `nodePortAddresses`)
- **Default unset:** behavior unchanged — all local node IPs remain valid NodePort destinations
- When set:
  - nftables NodePort DNAT rules also match `ip daddr @nodeport-allowed-v4/v6`
  - OVN NodePort VIPs and node IP templates use filtered host addresses only
  - Allowed address sets refresh when node IPs change

**Out of scope (unchanged):** Egress IP, IP forwarding, `host-cidrs`, ClusterIP / ExternalIP / LoadBalancer behavior.


Add optional `nodeport-addresses` gateway setting to restrict which local node IP addresses accept NodePort traffic. Supports CIDRs and `primary`, matching kube-proxy `nodePortAddresses`. When unset, behavior is unchanged.

How to vefiry?
~~~
cd go-controller
go test ./pkg/config/ -ginkgo.focus=NodePortAddressConfig -count=1
GOOS=linux go build -o /dev/null ./pkg/node/... ./pkg/ovn/controller/services/...
~~~

## Release Notes
```release-note
Added the gateway nodeport-addresses setting and --nodeport-addresses flag to restrict NodePort traffic to selected local node IPs using CIDRs and/or primary addresses.