### PR TITLE
docs: document multi-subnets for primary UDNs

### DIFF
--- a/docs/features/multiple-networks/multi-homing.md
+++ b/docs/features/multiple-networks/multi-homing.md
@@ -102,7 +102,7 @@ spec:
             "name": "tenantblue",
             "type": "ovn-k8s-cni-overlay",
             "topology":"layer3",
-            "subnets": "10.128.0.0/16/24",
+            "subnets": "10.128.0.0/16/24,10.129.0.0/16/24",
             "mtu": 1300,
             "netAttachDefName": "ns1/l3-network"
     }
@@ -113,16 +113,20 @@ spec:
 - `name` (string, required): the name of the network. This attribute is **not** namespaced.
 - `type` (string, required): "ovn-k8s-cni-overlay".
 - `topology` (string, required): "layer3".
-- `subnets` (string, required): a comma separated list of subnets. When multiple subnets
-  are provided, the user will get an IP from each subnet.
+- `subnets` (string, required): a comma-separated list of cluster subnets from
+  which per-node subnets are allocated. Each node receives one subnet per IP
+  family.
 - `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 - `netAttachDefName` (string, required): must match `<namespace>/<net-attach-def name>`
   of the surrounding object.
 
 > [!NOTE]
-> the `subnets` attribute indicates both the subnet across the cluster, and per node.
-  The example above means you have a /16 subnet for the network, but each **node** has
-  a /24 subnet.
+> The `subnets` attribute defines the cluster subnet allocation pool for each IP
+  family. Each node receives one subnet per IP family from that pool.
+  In the example above, the IPv4 pool consists of two `/16` cluster subnets,
+  each divided into `/24` per-node subnets. Cluster subnets must not overlap,
+  and all subnets in the same IP family must use the same per-node subnet
+  prefix length.
 
 > [!NOTE]
 > routed - layer3 - topology networks **only** allow for east/west traffic.

--- a/docs/features/user-defined-networks/user-defined-networks.md
+++ b/docs/features/user-defined-networks/user-defined-networks.md
@@ -262,6 +262,51 @@ spec:
       hostSubnet: 24
 ```
 
+### Expanding a Primary Layer3 UDN with additional cluster subnets
+
+A Primary Layer3 UDN or CUDN can have multiple cluster subnets in each IP
+family. This allows an operator to add address space when the existing cluster
+subnet no longer has enough host subnets for additional nodes.
+
+Each node is allocated one host subnet per IP family from the configured
+cluster subnet pool.
+
+To expand the pool, append a subnet to `spec.layer3.subnets`. For example, the
+`blue-network` UDN from the previous section can be expanded with another IPv4
+cluster subnet:
+
+```yaml
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: blue-network
+  namespace: blue
+spec:
+  topology: Layer3
+  layer3:
+    role: Primary
+    subnets:
+    - cidr: 103.103.0.0/16
+      hostSubnet: 24
+    - cidr: 103.104.0.0/16
+      hostSubnet: 24
+```
+
+Existing node and pod assignments remain unchanged. The added range is
+available for nodes that do not yet have a host subnet, including newly added
+nodes.
+
+The following restrictions apply:
+
+* Multiple cluster subnets are supported only for Primary Layer3 UDNs and
+  CUDNs.
+* Existing subnet entries cannot be removed or modified; expansion is
+  append-only.
+* Cluster subnets must not overlap or contain one another.
+* All cluster subnets in the same IP family must use the same `hostSubnet`
+  value. IPv4 and IPv6 can use different values and can be expanded
+  independently.
+
 ### Inspecting a UDN Pod
 
 Now if you create pods on these two namespaces and try to ping one pod from


### PR DESCRIPTION
 ## 📑 Description
Describe Layer3 subnet expansion and clarify per-node subnet allocation.

## Release Notes
```release-note
Primary Layer3 UserDefinedNetworks and ClusterUserDefinedNetworks now support multiple cluster subnets per IP family. 
```

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI 
