### PR TITLE
Small misc fixes from the recent Uplink and UDN work

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -924,6 +924,12 @@ install_metallb() {
     "tag: ${metallb_upstream_frr_image##*:}" \
     "tag: ${FRR_DEPLOYED_IMAGE##*:}"
 
+  # Install the dev-env python dependencies into a private venv: on distros
+  # with a PEP 668 externally-managed Python (e.g. Ubuntu 24.04+) a bare pip
+  # install into the system environment is rejected.
+  python3 -m venv "${builddir}/venv"
+  # shellcheck source=/dev/null
+  . "${builddir}/venv/bin/activate"
   pip install -r dev-env/requirements.txt
 
   local ip_family ipv6_network
@@ -950,6 +956,7 @@ install_metallb() {
   # backend.
   # Override GOBIN until https://github.com/metallb/metallb/issues/2218 is fixed.
   GOBIN="" inv dev-env -n ovn -b frr -p bgp -i "${ip_family}"
+  deactivate
 
   align_metallb_pool_with_ip_family
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1253,15 +1252,18 @@ func (c *Controller) hasTrackedNamespaces(cudnName string) bool {
 // the default network and MaxNetworks bounds the allocator.
 func networkIDFromNADs(nads []netv1.NetworkAttachmentDefinition) int {
 	for i := range nads {
-		annotation := nads[i].Annotations[ovntypes.OvnNetworkIDAnnotation]
-		if annotation == "" {
-			continue
-		}
-		if id, err := strconv.Atoi(annotation); err == nil && id > ovntypes.DefaultNetworkID && id < networkmanager.MaxNetworks {
+		id, err := util.GetAnnotatedNetworkID(&nads[i])
+		switch {
+		case err != nil:
+			klog.Warningf("Ignoring NetworkAttachmentDefinition %s/%s: %v", nads[i].Namespace, nads[i].Name, err)
+		case id == ovntypes.InvalidID:
+			// no network-id annotation
+		case id > ovntypes.DefaultNetworkID && id < networkmanager.MaxNetworks:
 			return id
+		default:
+			klog.Warningf("Ignoring out-of-range network-id annotation %d on NetworkAttachmentDefinition %s/%s",
+				id, nads[i].Namespace, nads[i].Name)
 		}
-		klog.Warningf("Ignoring invalid network-id annotation %q on NetworkAttachmentDefinition %s/%s",
-			annotation, nads[i].Namespace, nads[i].Name)
 	}
 	return ovntypes.InvalidID
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -2700,6 +2700,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		AfterEach(func() {
 			if c != nil {
 				c.Shutdown()
+				c = nil
 			}
 		})
 
@@ -2817,6 +2818,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		AfterEach(func() {
 			if c != nil {
 				c.Shutdown()
+				c = nil
 			}
 		})
 

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -317,7 +317,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName string, ifInfo *PodInter
 		// set host interface name now for default network as it is already known; otherwise for secondary network,
 		// host interface will be renamed later.
 		if ifInfo.NetName == types.DefaultNetworkName {
-			hostIface.Name = containerID[:15]
+			hostIface.Name = containerID[:types.MaxInterfaceNameLength]
 		} else {
 			hostIface.Name = ""
 		}
@@ -369,7 +369,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName string, ifInfo *PodInter
 
 	// rename the host end of veth pair for the secondary network
 	if ifInfo.NetName != types.DefaultNetworkName {
-		hostIface.Name = containerID[:(15-len(ifnameSuffix))] + ifnameSuffix
+		hostIface.Name = containerID[:(types.MaxInterfaceNameLength-len(ifnameSuffix))] + ifnameSuffix
 		if err := renameLink(oldHostVethName, hostIface.Name); err != nil {
 			return nil, nil, fmt.Errorf("failed to rename %s to %s: %v", oldHostVethName, hostIface.Name, err)
 		}
@@ -388,8 +388,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName string, ifInfo *PodInter
 // generate a unique interface name for the temporary netdev that will be moved to pod namespace
 func generateIfName(containerID string) string {
 	randomId := util.GenerateId(5) // random ID with 5 chars
-	// ifname max length is 15
-	return containerID[:(15-len(randomId))] + randomId
+	return containerID[:(types.MaxInterfaceNameLength-len(randomId))] + randomId
 }
 
 // Setup sriov interface in the pod
@@ -966,7 +965,7 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 				oldName := ifInfo.NetdevName
 				if oldName == "" {
 					id := fmt.Sprintf("_0%d", link.Attrs().Index)
-					oldName = pr.SandboxID[:(15-len(id))] + id
+					oldName = pr.SandboxID[:(types.MaxInterfaceNameLength-len(id))] + id
 				}
 				err = util.GetNetLinkOps().LinkSetName(link, oldName)
 				if err != nil {
@@ -996,7 +995,7 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 		var hostIfName string
 		if !util.IsNetworkSegmentationSupportEnabled() || isSecondary {
 			// this is a secondary network (not primary) or segmentation is not enabled
-			hostIfName = pr.SandboxID[:(15-len(ifnameSuffix))] + ifnameSuffix
+			hostIfName = pr.SandboxID[:(types.MaxInterfaceNameLength-len(ifnameSuffix))] + ifnameSuffix
 		}
 		if pr.CNIConf.DeviceID != "" {
 			hostIfName, err = util.GetFunctionRepresentorName(pr.CNIConf.DeviceID)

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -1579,12 +1579,11 @@ func (c *nadController) handleNetworkAnnotations(new util.MutableNetInfo, nad *n
 	}
 	if nad != nil && id == types.InvalidID {
 		// check what ID is currently annotated
-		if nad.Annotations[types.OvnNetworkIDAnnotation] != "" {
-			annotated := nad.Annotations[types.OvnNetworkIDAnnotation]
-			id, err = strconv.Atoi(annotated)
-			if err != nil {
-				return fmt.Errorf("failed to parse annotated network ID: %w", err)
-			}
+		id, err = util.GetAnnotatedNetworkID(nad)
+		if err != nil {
+			return err
+		}
+		if id != types.InvalidID {
 			klog.V(5).Infof("Previously annotated network ID %d found for NAD: %s/%s", id, nad.Namespace, nad.Name)
 		}
 	}

--- a/go-controller/pkg/node/controllers/evpn/utils.go
+++ b/go-controller/pkg/node/controllers/evpn/utils.go
@@ -28,6 +28,7 @@ import (
 
 	utilnet "k8s.io/utils/net"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -61,7 +62,7 @@ func GetEVPNVXLANName(vtepName string, family utilnet.IPFamily) string {
 // is always hex, the two paths can never collide.
 func getEVPNVTEPDeviceName(vtepName, prefix string) string {
 	candidate := prefix + "-" + vtepName
-	if len(candidate) <= 15 {
+	if len(candidate) <= types.MaxInterfaceNameLength {
 		return candidate
 	}
 	h := sha256.Sum256([]byte(vtepName))
@@ -92,7 +93,7 @@ func getEVPNNetworkDeviceName(netInfo util.NetInfo, prefix string) string {
 	udnNamespace, udnName := util.ParseNetworkName(netInfo.GetNetworkName())
 	if udnName != "" && udnNamespace == "" {
 		candidate := prefix + "-" + udnName
-		if len(candidate) <= 15 {
+		if len(candidate) <= types.MaxInterfaceNameLength {
 			return candidate
 		}
 	}

--- a/go-controller/pkg/node/netlinkdevicemanager/link.go
+++ b/go-controller/pkg/node/netlinkdevicemanager/link.go
@@ -15,16 +15,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // managedAliasPrefix is the prefix used in IFLA_IFALIAS to mark devices managed by this controller.
 // This allows safe cleanup: only delete devices with this prefix.
 // Format: "ovn-k8s-ndm:<type>:<name>" for debugging and collision avoidance.
 const managedAliasPrefix = "ovn-k8s-ndm:"
-
-// maxInterfaceNameLength is the maximum length for Linux interface names.
-// Linux's IFNAMSIZ is 16 (including null terminator), so max usable length is 15.
-const maxInterfaceNameLength = 15
 
 const maxVNI = 1<<24 - 1 // 16777215
 const maxVID = 4094
@@ -390,9 +388,9 @@ func validateInterfaceName(name, context string) error {
 	if name == "" {
 		return fmt.Errorf("%s name is empty", context)
 	}
-	if len(name) > maxInterfaceNameLength {
+	if len(name) > types.MaxInterfaceNameLength {
 		return fmt.Errorf("%s name %q exceeds maximum length of %d characters (got %d)",
-			context, name, maxInterfaceNameLength, len(name))
+			context, name, types.MaxInterfaceNameLength, len(name))
 	}
 	if name == "." || name == ".." {
 		return fmt.Errorf("%s name %q is reserved", context, name)

--- a/go-controller/pkg/node/netlinkdevicemanager/link_test.go
+++ b/go-controller/pkg/node/netlinkdevicemanager/link_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/utils/ptr"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -572,6 +575,28 @@ var _ = Describe("Link", func() {
 		Entry("regular IPv6", net.ParseIP("2001:db8::1"), false),
 		Entry("regular IPv4", net.ParseIP("10.0.0.1"), false),
 		Entry("nil", nil, false),
+	)
+
+	DescribeTable("validateInterfaceName",
+		func(name string, valid bool) {
+			err := validateInterfaceName(name, "device")
+			if valid {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		},
+		Entry("empty name", "", false),
+		Entry("regular name", "br0", true),
+		Entry("name at the length limit (IFNAMSIZ-1)", strings.Repeat("a", types.MaxInterfaceNameLength), true),
+		Entry("name one character over the length limit", strings.Repeat("a", types.MaxInterfaceNameLength+1), false),
+		Entry("reserved name", ".", false),
+		Entry("reserved name (dot dot)", "..", false),
+		Entry("name with a slash", "br/0", false),
+		Entry("name with an embedded NUL", "br\x000", false),
+		Entry("name with whitespace", "br 0", false),
+		Entry("name with a tab", "br\t0", false),
+		Entry("name with a newline", "br\n0", false),
 	)
 
 })

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -396,7 +396,16 @@ func (vrfm *Controller) DeleteVRFSlave(name string, slaveInterface string) error
 	if !ok {
 		return fmt.Errorf("failed to find VRF %s", name)
 	}
-	if err = releaseInterfaceFromVRF(slaveInterface, vrfLink.Attrs().Index, vrfDev.table); err != nil {
+	vrf, isVRF := vrfLink.(*netlink.Vrf)
+	if !isVRF {
+		return fmt.Errorf("node has another non VRF device with same name %s, refusing to release its slave %s",
+			name, slaveInterface)
+	}
+	// Release from the table the device actually uses: the cache holds the
+	// desired table id, which can differ from the actual one (recreation on
+	// table conflict), and a release with the wrong table would capture no
+	// routes while LinkSetNoMaster purges the real ones unrestored.
+	if err = releaseInterfaceFromVRF(slaveInterface, vrf.Index, vrf.Table); err != nil {
 		return fmt.Errorf("failed to release interface %s from VRF %s, err: %v",
 			slaveInterface, name, err)
 	}

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -300,8 +300,8 @@ func (vrfm *Controller) AddVRF(name string, slaveInterface string, table uint32,
 	vrfm.mu.Lock()
 	defer vrfm.mu.Unlock()
 
-	if len(name) > 15 {
-		return fmt.Errorf("VRF Manager: VRF name %s must be within 15 characters", name)
+	if len(name) > types.MaxInterfaceNameLength {
+		return fmt.Errorf("VRF Manager: VRF name %s must be within %d characters", name, types.MaxInterfaceNameLength)
 	}
 	if table < uint32(config.OvnKubeNode.RoutingTableIDStart) {
 		return fmt.Errorf("VRF Manager: cannot manage a VRF %s with table %d lower than %d", name, table, config.OvnKubeNode.RoutingTableIDStart)

--- a/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
@@ -360,6 +360,54 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
 		})
 
+		ginkgo.It("refuses to release a slave when a non VRF device holds the VRF name", func() {
+			nonVRFLink := new(netlink_mocks.Link)
+			nonVRFLink.On("Attrs").Return(&netlink.LinkAttrs{Name: "dummy0", Index: 42}, nil)
+			nlMock.On("LinkByName", "dummy0").Return(nonVRFLink, nil)
+			c.vrfs[42] = newVRF("dummy0", 1042, enslaveLinkName1, nil)
+
+			err := c.DeleteVRFSlave("dummy0", enslaveLinkName1)
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("non VRF device")))
+			nlMock.AssertNotCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", mock.Anything)
+		})
+
+		ginkgo.It("releases a slave from the table the VRF device actually uses, not the cached one", func() {
+			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
+			deviceTable := int(getVRFTable(vrfLinkName1))
+			// The cache holds a different desired table id, as in the
+			// recreation window after a table conflict; the slave routes live
+			// in the device's actual table.
+			c.vrfs[getLinkIndex(vrfLinkName1)] = newVRF(vrfLinkName1, getVRFTable(vrfLinkName1)+1, enslaveLinkName1, nil)
+			enslaveLinkMock1.On("Attrs").Return(&netlink.LinkAttrs{Name: enslaveLinkName1, MasterIndex: getLinkIndex(vrfLinkName1), Index: slaveLinkIndex}, nil)
+			migratedRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Gw:        net.ParseIP("192.168.1.1"),
+				Protocol:  unix.RTPROT_DHCP,
+				Table:     deviceTable,
+			}
+			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
+				mock.MatchedBy(func(filter *netlink.Route) bool {
+					return filter.Table == deviceTable
+				}),
+				uint64(netlink.RT_FILTER_TABLE),
+			).Return([]netlink.Route{migratedRoute}, nil)
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
+			nlMock.On("RouteAdd", mock.Anything).Return(nil)
+			// The trailing sync recreates the device over the table conflict.
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), enslaveLinkMock1}, nil)
+			nlMock.On("LinkDelete", buildVRF(vrfLinkName1)).Return(nil)
+
+			err := c.DeleteVRFSlave(vrfLinkName1, enslaveLinkName1)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// The capture read the device's table, so the migrated route made
+			// it back to the main table.
+			expectedRoute := migratedRoute
+			expectedRoute.Table = unix.RT_TABLE_MAIN
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRoute)
+		})
+
 		ginkgo.It("migrates the slave interface routes back to the main table on release, except OVN managed ones", func() {
 			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
 			vrfTable := int(getVRFTable(vrfLinkName1))

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1560,6 +1560,21 @@ func GetAnnotatedNetworkName(netattachdef *nettypes.NetworkAttachmentDefinition)
 	return netattachdef.Annotations[types.OvnNetworkNameAnnotation]
 }
 
+// GetAnnotatedNetworkID gets the network ID annotated by cluster manager
+// nad controller, or types.InvalidID when the NAD carries no network-id
+// annotation. It returns an error when the annotation is not a valid integer.
+func GetAnnotatedNetworkID(netattachdef *nettypes.NetworkAttachmentDefinition) (int, error) {
+	annotation := netattachdef.Annotations[types.OvnNetworkIDAnnotation]
+	if annotation == "" {
+		return types.InvalidID, nil
+	}
+	id, err := strconv.Atoi(annotation)
+	if err != nil {
+		return types.InvalidID, fmt.Errorf("failed to parse annotated network ID %q: %w", annotation, err)
+	}
+	return id, nil
+}
+
 // ParseNADInfo parses config in NAD spec and return a NetAttachDefInfo object for User Defined Networks
 func ParseNADInfo(nad *nettypes.NetworkAttachmentDefinition) (NetInfo, error) {
 	netconf, err := ParseNetConf(nad)
@@ -1580,12 +1595,12 @@ func ParseNADInfo(nad *nettypes.NetworkAttachmentDefinition) (NetInfo, error) {
 	if n.GetNetworkName() == types.DefaultNetworkName {
 		id = types.DefaultNetworkID
 	}
-	if nad.Annotations[types.OvnNetworkIDAnnotation] != "" {
-		annotated := nad.Annotations[types.OvnNetworkIDAnnotation]
-		id, err = strconv.Atoi(annotated)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse annotated network ID: %w", err)
-		}
+	annotatedID, err := GetAnnotatedNetworkID(nad)
+	if err != nil {
+		return nil, err
+	}
+	if annotatedID != types.InvalidID {
+		id = annotatedID
 	}
 	n.SetNetworkID(id)
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -2019,6 +2019,95 @@ func TestSubnetOverlapCheck(t *testing.T) {
 	}
 }
 
+func TestGetAnnotatedNetworkID(t *testing.T) {
+	tests := []struct {
+		desc        string
+		annotations map[string]string
+		expectedID  int
+		expectError bool
+	}{
+		{
+			desc:       "missing annotation returns InvalidID without error",
+			expectedID: ovntypes.InvalidID,
+		},
+		{
+			desc:        "malformed annotation returns an error",
+			annotations: map[string]string{ovntypes.OvnNetworkIDAnnotation: "not-a-number"},
+			expectError: true,
+		},
+		{
+			desc:        "valid annotation",
+			annotations: map[string]string{ovntypes.OvnNetworkIDAnnotation: "7"},
+			expectedID:  7,
+		},
+		{
+			desc:        "zero, the default network ID",
+			annotations: map[string]string{ovntypes.OvnNetworkIDAnnotation: "0"},
+			expectedID:  0,
+		},
+		{
+			desc:        "negative annotation parses, indistinguishable from InvalidID",
+			annotations: map[string]string{ovntypes.OvnNetworkIDAnnotation: "-1"},
+			expectedID:  ovntypes.InvalidID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			nad := applyNADDefaults(&nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Annotations: test.annotations},
+			})
+			id, err := GetAnnotatedNetworkID(nad)
+			if test.expectError {
+				g.Expect(err).To(gomega.HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(id).To(gomega.Equal(test.expectedID))
+		})
+	}
+}
+
+func TestParseNADInfoNetworkIDAnnotation(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	const nadConfig = `
+        {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "layer2",
+            "netAttachDefName": "ns1/nad1"
+        }
+	`
+	newNAD := func(annotations map[string]string) *nadv1.NetworkAttachmentDefinition {
+		return applyNADDefaults(&nadv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+			Spec:       nadv1.NetworkAttachmentDefinitionSpec{Config: nadConfig},
+		})
+	}
+
+	t.Run("annotated network ID overrides the default", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		netInfo, err := ParseNADInfo(newNAD(map[string]string{ovntypes.OvnNetworkIDAnnotation: "7"}))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(netInfo.GetNetworkID()).To(gomega.Equal(7))
+	})
+
+	t.Run("missing annotation leaves InvalidID", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		netInfo, err := ParseNADInfo(newNAD(nil))
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(netInfo.GetNetworkID()).To(gomega.Equal(ovntypes.InvalidID))
+	})
+
+	t.Run("malformed annotation fails the parse", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		_, err := ParseNADInfo(newNAD(map[string]string{ovntypes.OvnNetworkIDAnnotation: "not-a-number"}))
+		g.Expect(err).To(gomega.HaveOccurred())
+	})
+}
+
 func TestValidateNetConfOutboundSNAT(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -1090,8 +1090,6 @@ func SetRPFilterLooseModeForInterface(ifName string) error {
 	return nil
 }
 
-// SetIPv6KeepAddrOnDownForInterface preserves global IPv6 addresses when an
-// interface changes state while it is attached to or detached from a VRF.
 // IsIPv6SysctlSupported reports whether the kernel exposes IPv6 sysctls: a
 // kernel with IPv6 disabled (ipv6.disable=1) has no /proc/sys/net/ipv6 tree.
 func IsIPv6SysctlSupported() bool {
@@ -1099,6 +1097,8 @@ func IsIPv6SysctlSupported() bool {
 	return err == nil
 }
 
+// SetIPv6KeepAddrOnDownForInterface preserves global IPv6 addresses when an
+// interface changes state while it is attached to or detached from a VRF.
 func SetIPv6KeepAddrOnDownForInterface(ifName string) error {
 	setVal := fmt.Sprintf("net.ipv6.conf.%s.keep_addr_on_down = 1", sysctlIfName(ifName))
 	stdout, stderr, err := RunSysctl("-w", setVal)

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -133,8 +133,8 @@ func GetNetworkScopedK8sMgmtHostIntfName(networkID uint) string {
 	intfName := types.K8sMgmtIntfNamePrefix + fmt.Sprintf("%d", networkID)
 	// We are over linux 15 chars limit for network devices, let's trim it
 	// for the prefix so we keep networkID as much as possible
-	if len(intfName) > 15 {
-		return intfName[:15]
+	if len(intfName) > types.MaxInterfaceNameLength {
+		return intfName[:types.MaxInterfaceNameLength]
 	}
 	return intfName
 }

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -22,6 +22,7 @@ import (
 	uplinkv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
@@ -3411,10 +3412,7 @@ func ipv6LinkLocalFromMAC(mac string) string {
 	if err != nil || len(hw) != 6 {
 		return ""
 	}
-	return net.IP{
-		0xfe, 0x80, 0, 0, 0, 0, 0, 0,
-		hw[0] ^ 0x02, hw[1], hw[2], 0xff, 0xfe, hw[3], hw[4], hw[5],
-	}.String()
+	return util.HWAddrToIPv6LLA(hw).String()
 }
 
 func hasRouteInDefaultVRF(node corev1.Node, cidr string, nextHops ...string) (bool, error) {


### PR DESCRIPTION
Small misc leftovers from the recent Uplink and UDN work (#6808, #6820, #6845), mostly review findings that were parked to keep those PRs focused.

What this PR does:

- replaces the hardcoded Linux interface name length limit (15) with `types.MaxInterfaceNameLength` in the places that spelled it out (VRF manager, netlink device manager, mgmt port, CNI host veth, EVPN device naming)
- adds `util.GetAnnotatedNetworkID` and uses it in the three places that inlined the parsing of the network-id NAD annotation; callers keep their own error policy
- `DeleteVRFSlave` releases the slave using the table id read from the VRF device rather than the cached desired one: on divergence (table-conflict recreation window) the release captured no routes while `LinkSetNoMaster` purged the real ones unrestored
- nils the shared controller in two UDN controller test `AfterEach` blocks: a spec that creates no controller otherwise shuts down the previous spec's controller a second time (close of closed channel panic)
- gives `IsIPv6SysctlSupported` its own godoc instead of orphaning `SetIPv6KeepAddrOnDownForInterface`'s
- e2e: derives peer IPv6 link-locals with `util.HWAddrToIPv6LLA` instead of re-implementing EUI-64
- kind: installs the metallb dev-env python deps in a venv, so distros with a PEP 668 externally-managed Python (Ubuntu 24.04+) don't reject the bare pip install
