### PR TITLE
udn: clean up pods after NAD deletion

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -331,6 +331,32 @@ func (oc *BaseUserDefinedNetworkController) FilterOutResource(objType reflect.Ty
 	}
 }
 
+// FilterOutDeleteResource keeps pod delete events that still have resources
+// owned by this controller, even if the live primary-NAD mapping is gone.
+func (oc *BaseUserDefinedNetworkController) FilterOutDeleteResource(objType reflect.Type, obj interface{}) bool {
+	filterOut := oc.FilterOutResource(objType, obj)
+	if objType != factory.PodType || !filterOut {
+		return filterOut
+	}
+
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		klog.Errorf("Failed to cast the provided object to a pod")
+		return false
+	}
+	expectedSwitchName, err := oc.getExpectedSwitchName(pod)
+	if err != nil {
+		klog.Errorf("Failed to determine the expected switch for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		return true
+	}
+	for _, portInfo := range oc.getPortInfoForUserDefinedNetwork(pod) {
+		if portInfo != nil && portInfo.logicalSwitch == expectedSwitchName {
+			return false
+		}
+	}
+	return true
+}
+
 // shouldFilterNamespace reports whether namespace's events should be filtered out because
 // it doesn't belong to this network. For primary networks, this asks the network manager
 // for the namespace's actual primary NAD rather than checking this controller's own NetInfo,

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -454,7 +454,22 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 	var alreadyProcessed bool
 	for nadKey, podAnnotation := range podNetworks {
 		networkName := bsnc.networkManager.GetNetworkNameForNADKey(nadKey)
-		if networkName == "" || networkName != bsnc.GetNetworkName() {
+		portInfo := portInfoMap[nadKey]
+		if networkName == "" && portInfo != nil {
+			// The NAD may have been deleted before the Pod delete event is
+			// processed. In that case use the cached switch to determine which
+			// controller owns the port. The port cache is shared by all network
+			// controllers, so the presence of a cached entry alone is not enough.
+			var expectedSwitchName string
+			expectedSwitchName, err = bsnc.getExpectedSwitchName(pod)
+			if err != nil {
+				return fmt.Errorf("failed to determine expected switch for pod %s and NAD %s: %w", podDesc, nadKey, err)
+			}
+			if portInfo.logicalSwitch == expectedSwitchName {
+				networkName = bsnc.GetNetworkName()
+			}
+		}
+		if networkName != bsnc.GetNetworkName() {
 			continue
 		}
 
@@ -478,7 +493,7 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 			}
 		}
 		bsnc.logicalPortCache.remove(pod, nadKey)
-		pInfo, err := bsnc.deletePodLogicalPort(pod, portInfoMap[nadKey], nadKey)
+		pInfo, err := bsnc.deletePodLogicalPort(pod, portInfo, nadKey)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -644,6 +644,168 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 		})
 	})
 
+	It("removes a cached pod port after its NAD mapping is deleted", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		layer2NAD := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer2Topology, "100.128.0.0/16", types.NetworkRoleSecondary)
+		netInfo, err := util.ParseNADInfo(layer2NAD)
+		Expect(err).NotTo(HaveOccurred())
+
+		const (
+			nodeName      = "worker1"
+			podName       = "pod1"
+			nadKey        = "greenamespace/rednad"
+			foreignNADKey = "greenamespace/orangenad"
+			foreignSwitch = "orangenet_ovn-layer2-switch"
+		)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "greenamespace",
+				Name:      podName,
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+		podIPs, err := util.ParseIPNets([]string{"100.128.0.2/16"})
+		Expect(err).NotTo(HaveOccurred())
+		podMAC, err := net.ParseMAC("0a:58:64:80:00:02")
+		Expect(err).NotTo(HaveOccurred())
+		pod.Annotations, err = util.MarshalPodAnnotation(pod.Annotations,
+			&util.PodAnnotation{IPs: podIPs, MAC: podMAC}, nadKey)
+		Expect(err).NotTo(HaveOccurred())
+		pod.Annotations, err = util.MarshalPodAnnotation(pod.Annotations,
+			&util.PodAnnotation{IPs: podIPs, MAC: podMAC}, foreignNADKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		switchName := netInfo.GetNetworkScopedSwitchName(types.OVNLayer2Switch)
+		lspName := util.GetUserDefinedNetworkLogicalPortName(
+			pod.Namespace, pod.Name, nadKey)
+		foreignLSPName := util.GetUserDefinedNetworkLogicalPortName(
+			pod.Namespace, pod.Name, foreignNADKey)
+		lsp := &nbdb.LogicalSwitchPort{UUID: lspName + "-UUID", Name: lspName}
+		foreignLSP := &nbdb.LogicalSwitchPort{
+			UUID: foreignLSPName + "-UUID",
+			Name: foreignLSPName,
+		}
+		logicalSwitch := &nbdb.LogicalSwitch{
+			UUID:  switchName + "-UUID",
+			Name:  switchName,
+			Ports: []string{lsp.UUID},
+		}
+		foreignLogicalSwitch := &nbdb.LogicalSwitch{
+			UUID:  foreignSwitch + "-UUID",
+			Name:  foreignSwitch,
+			Ports: []string{foreignLSP.UUID},
+		}
+
+		fakeOVN := NewFakeOVN(false, nodeName)
+		fakeOVN.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				logicalSwitch,
+				lsp,
+				foreignLogicalSwitch,
+				foreignLSP,
+			},
+		}, pod)
+		DeferCleanup(fakeOVN.shutdown)
+		Expect(fakeOVN.NewUserDefinedNetworkController(layer2NAD)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
+		Expect(ok).To(BeTrue())
+		controller.bnc.networkManager = (&networkmanager.FakeNetworkManager{
+			PrimaryNetworks: map[string]util.NetInfo{},
+			NADNetworks:     map[string]util.NetInfo{},
+		}).Interface()
+
+		portInfoMap := map[string]*lpInfo{
+			nadKey: fakeOVN.portCache.add(
+				pod, switchName, nadKey, lsp.UUID, podMAC, podIPs),
+			foreignNADKey: fakeOVN.portCache.add(
+				pod, foreignSwitch, foreignNADKey,
+				foreignLSP.UUID, podMAC, podIPs),
+		}
+		Expect(controller.bnc.removePodForUserDefinedNetwork(
+			pod, portInfoMap)).To(Succeed())
+
+		expectedSwitch := logicalSwitch.DeepCopy()
+		expectedSwitch.Ports = nil
+		Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(
+			expectedSwitch,
+			foreignLogicalSwitch,
+			foreignLSP,
+		))
+	})
+
+	It("processes a primary UDN pod delete while its namespace exists after the NAD mapping is deleted", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		layer2NAD := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer2Topology, "100.128.0.0/16", types.NetworkRolePrimary)
+		netInfo, err := util.ParseNADInfo(layer2NAD)
+		Expect(err).NotTo(HaveOccurred())
+
+		const (
+			nodeName = "worker1"
+			podName  = "pod1"
+			nadKey   = "greenamespace/rednad"
+		)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "greenamespace",
+				Name:      podName,
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+		podIPs, err := util.ParseIPNets([]string{"100.128.0.2/16"})
+		Expect(err).NotTo(HaveOccurred())
+		podMAC, err := net.ParseMAC("0a:58:64:80:00:02")
+		Expect(err).NotTo(HaveOccurred())
+		pod.Annotations, err = util.MarshalPodAnnotation(pod.Annotations,
+			&util.PodAnnotation{IPs: podIPs, MAC: podMAC}, nadKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		switchName := netInfo.GetNetworkScopedSwitchName(types.OVNLayer2Switch)
+		logicalSwitch := &nbdb.LogicalSwitch{
+			UUID: switchName + "-UUID",
+			Name: switchName,
+		}
+		lspName := util.GetUserDefinedNetworkLogicalPortName(
+			pod.Namespace, pod.Name, nadKey)
+		lsp := &nbdb.LogicalSwitchPort{UUID: lspName + "-UUID", Name: lspName}
+
+		fakeOVN := NewFakeOVN(false, nodeName)
+		fakeOVN.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{logicalSwitch},
+		})
+		DeferCleanup(fakeOVN.shutdown)
+		Expect(fakeOVN.NewUserDefinedNetworkController(layer2NAD)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
+		Expect(ok).To(BeTrue())
+		fakeNetworkManager := &networkmanager.FakeNetworkManager{
+			PrimaryNetworks: map[string]util.NetInfo{pod.Namespace: netInfo},
+			NADNetworks:     map[string]util.NetInfo{},
+		}
+		controller.bnc.networkManager = fakeNetworkManager.Interface()
+		Expect(controller.bnc.WatchPods()).To(Succeed())
+
+		_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).
+			Create(context.Background(), pod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			_, err := fakeOVN.watcher.GetPod(pod.Namespace, pod.Name)
+			return err
+		}).Should(Succeed())
+
+		Expect(libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(
+			fakeOVN.nbClient, &nbdb.LogicalSwitch{Name: switchName}, lsp)).To(Succeed())
+		fakeOVN.portCache.add(pod, switchName, nadKey, lsp.UUID, podMAC, podIPs)
+		_, err = fakeNetworkManager.GetPrimaryNADForNamespace(pod.Namespace)
+		Expect(err).To(MatchError(util.IsInvalidPrimaryNetworkError, "IsInvalidPrimaryNetworkError"))
+		Expect(controller.bnc.FilterOutResource(factory.PodType, pod)).To(BeTrue())
+
+		Expect(fakeOVN.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).
+			Delete(context.Background(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
+		Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(logicalSwitch))
+	})
+
 })
 
 func TestAdvertisedSharedGatewaySNATUsesLiveAllowedExtIPSets(t *gotesting.T) {

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -59,6 +59,11 @@ func (h *layer2UserDefinedNetworkControllerEventHandler) FilterOutResource(obj i
 	return h.oc.FilterOutResource(h.objType, obj)
 }
 
+// FilterOutDeleteResource applies delete-specific filtering for the configured resource type.
+func (h *layer2UserDefinedNetworkControllerEventHandler) FilterOutDeleteResource(obj interface{}) bool {
+	return h.oc.FilterOutDeleteResource(h.objType, obj)
+}
+
 // AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
 // type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
 // equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -52,6 +52,11 @@ func (h *Layer3UserDefinedNetworkControllerEventHandler) FilterOutResource(obj i
 	return h.oc.FilterOutResource(h.objType, obj)
 }
 
+// FilterOutDeleteResource applies delete-specific filtering for the configured resource type.
+func (h *Layer3UserDefinedNetworkControllerEventHandler) FilterOutDeleteResource(obj interface{}) bool {
+	return h.oc.FilterOutDeleteResource(h.objType, obj)
+}
+
 // AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
 // type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
 // equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -42,6 +42,11 @@ func (h *LocalnetUserDefinedNetworkControllerEventHandler) FilterOutResource(obj
 	return h.oc.FilterOutResource(h.objType, obj)
 }
 
+// FilterOutDeleteResource applies delete-specific filtering for the configured resource type.
+func (h *LocalnetUserDefinedNetworkControllerEventHandler) FilterOutDeleteResource(obj interface{}) bool {
+	return h.oc.FilterOutDeleteResource(h.objType, obj)
+}
+
 // AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
 // type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
 // equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -71,6 +71,12 @@ type EventHandler interface {
 	FilterOutResource(obj interface{}) bool
 }
 
+// deleteResourceFilter allows handlers to use delete-specific filtering when
+// ownership can no longer be determined from the live object state.
+type deleteResourceFilter interface {
+	FilterOutDeleteResource(obj interface{}) bool
+}
+
 // DefaultEventHandler has the default implementations for some EventHandler
 // methods, that are not required for every handler
 type DefaultEventHandler struct{}
@@ -776,7 +782,13 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 				})
 			},
 			DeleteFunc: func(obj interface{}) {
-				if r.ResourceHandler.FilterOutResource(obj) {
+				var filterOut bool
+				if handler, ok := r.ResourceHandler.EventHandler.(deleteResourceFilter); ok {
+					filterOut = handler.FilterOutDeleteResource(obj)
+				} else {
+					filterOut = r.ResourceHandler.FilterOutResource(obj)
+				}
+				if filterOut {
 					return
 				}
 				r.ResourceHandler.RecordDeleteEvent(obj)


### PR DESCRIPTION
A terminating namespace is removed from a CUDN's selected namespaces. The CUDN controller removes its NAD once the pod is absent from the shared informer cache, but that does not guarantee the OVN controller has processed the queued pod deletion. The network manager may remove the NAD mapping first, causing pod cleanup to skip the network.

When the live NAD mapping is missing, use the cached logical switch to identify the controller that owns the port. The port cache is shared between controllers, so require the cached switch to match the controller's expected switch before deleting anything.

Add coverage that deletes the owned port while preserving a cached port from another network.

Assisted-by: OpenAI Codex <noreply@openai.com>

