### PR TITLE
vrfmanager: migrate kernel-protocol routes across enslavement

### DIFF
--- a/docs/features/user-defined-networks/uplinks.md
+++ b/docs/features/user-defined-networks/uplinks.md
@@ -329,6 +329,27 @@ deployments, the DPU-local bridge interface is attached to the CUDN VRF on the
 DPU side. FRR peers in that VRF, and ovnkube reflects the routes learned in
 that VRF into the OVN gateway routers for the CUDN.
 
+On enslavement and release, OVN-Kubernetes migrates the interface's eligible
+unicast routes into and out of the VRF routing table. This includes the
+kernel-protocol prefix routes of `noprefixroute` addresses (for example on
+NetworkManager-managed interfaces) and excludes routes that OVN-Kubernetes or
+routing daemons such as FRR program per routing domain themselves. The
+migration is one-shot: an agent that keeps reconciling its routes only into
+the main table, such as NetworkManager on a lease renewal, leaves the migrated
+copy stale until the next enslavement.
+
+```text
+             OVN-Kubernetes           kernel              main-table agent
+ enslave     capture main routes ---> purges iface routes
+             restore into VRF
+ (running)                                                updates main only:
+                                                          VRF copy now stale
+ release     capture VRF routes ----> purges iface routes
+             restore into main
+ re-enslave  capture main routes ---> purges iface routes
+             restore into VRF: copy fresh again
+```
+
 Multiple Dynamic CUDNs may use the same Uplink with `targetVRF: auto` when
 their active node sets do not overlap. If more than one such CUDN becomes
 active on the same node, the Uplink bridge cannot be attached to both CUDN

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -688,16 +688,30 @@ func listRoutesForLink(link netlink.Link, table int) ([]netlink.Route, error) {
 	return util.FilterRoutesByIfIndex(routes, link.Attrs().Index), nil
 }
 
-// shouldSkipRouteMigration returns true for routes whose owner programs them
-// per routing table on its own: OVN-Kubernetes (and OVN) program their routes
-// in the tables they belong to, the kernel regenerates its routes after a
-// master change, and routing daemons (FRR/zebra and friends) install and
-// withdraw their routes in the routing domain they peer in, so a migrated
-// copy would be a stale duplicate that no one manages.
+// shouldSkipRouteMigration returns true for routes that must not follow the
+// interface across routing tables. Non-unicast routes stay: the kernel
+// derives the local, broadcast, anycast and multicast entries from the
+// interface's addresses in whichever routing domain the interface currently
+// is, so a migrated copy would duplicate entries the kernel maintains itself.
+// Also skipped are routes whose owning daemon programs them per routing
+// domain on its own: OVN-Kubernetes (and OVN) program their routes in the
+// tables they belong to, and routing daemons (FRR/zebra and friends) install
+// and withdraw their routes in the routing domain they peer in, so a migrated
+// copy would be a stale duplicate that no one manages. Kernel-protocol
+// unicast routes are migrated like any other: the kernel only regenerates the
+// prefix route of an address after a master change when it installed that
+// route itself, which it does not for a noprefixroute address (NetworkManager
+// sets noprefixroute on the addresses it manages and installs the prefix
+// route on its own, tagged proto kernel, without being VRF-aware). When the
+// kernel did regenerate a route, restoring the identical captured copy is a
+// benign EEXIST skip.
 func shouldSkipRouteMigration(route netlink.Route) bool {
+	if route.Type != unix.RTN_UNICAST {
+		return true
+	}
 	switch int(route.Protocol) {
 	case types.OVNKProtocol, unix.RTPROT_OVN,
-		unix.RTPROT_KERNEL, unix.RTPROT_ZEBRA, unix.RTPROT_BGP, unix.RTPROT_OSPF,
+		unix.RTPROT_ZEBRA, unix.RTPROT_BGP, unix.RTPROT_OSPF,
 		unix.RTPROT_ISIS, unix.RTPROT_RIP, unix.RTPROT_EIGRP, unix.RTPROT_BABEL:
 		return true
 	}
@@ -767,24 +781,27 @@ func restoreRoutesToTable(routes []netlink.Route, table uint32) error {
 
 const (
 	// routeRestoreTimeout bounds how long a route restore is retried while
-	// the kernel deems the route's gateway unreachable. It has to cover
-	// duplicate address detection (about a second with the default
-	// dad_transmits) plus the addrconf work queue latency, with headroom for
-	// loaded nodes.
+	// the kernel deems the route's gateway or source address unusable. It
+	// has to cover duplicate address detection (about a second with the
+	// default dad_transmits) plus the addrconf work queue latency, with
+	// headroom for loaded nodes.
 	routeRestoreTimeout      = 4 * time.Second
 	routeRestorePollInterval = 100 * time.Millisecond
 )
 
 // addRouteWithRetry adds the route, retrying briefly while the kernel deems
-// its gateway unreachable: IPv6 connected routes are regenerated
-// asynchronously after a master change, so a gateway route restored right
-// after it can transiently fail the kernel's reachability validation.
+// its gateway unreachable (EHOSTUNREACH/ENETUNREACH) or its source address
+// invalid (EINVAL): IPv6 connected routes are regenerated asynchronously
+// after a master change and IPv6 addresses re-run duplicate address
+// detection, so a route restored right after — a gateway route, or one
+// carrying a still-tentative IPv6 source — can transiently fail the kernel's
+// validation.
 func addRouteWithRetry(route *netlink.Route) error {
 	var err error
 	_ = wait.PollUntilContextTimeout(context.Background(), routeRestorePollInterval, routeRestoreTimeout, true,
 		func(context.Context) (bool, error) {
 			err = util.GetNetLinkOps().RouteAdd(route)
-			return err == nil || !(errors.Is(err, unix.EHOSTUNREACH) || errors.Is(err, unix.ENETUNREACH)), nil
+			return err == nil || !(errors.Is(err, unix.EHOSTUNREACH) || errors.Is(err, unix.ENETUNREACH) || errors.Is(err, unix.EINVAL)), nil
 		})
 	return err
 }

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"slices"
 	"sync"
 	"time"
@@ -718,6 +719,46 @@ func shouldSkipRouteMigration(route netlink.Route) bool {
 	return false
 }
 
+// equivalentRouteExists reports whether the route's table holds a route with
+// the same kernel key ({dst, priority}) that is effectively the same route:
+// same output interface, same gateway or nexthops and same preferred source.
+// Such a route is the kernel's regenerated copy of an interface prefix route,
+// or one reinstalled by the route's owner, so a failure to restore the
+// captured copy over it lost nothing.
+func equivalentRouteExists(route netlink.Route) bool {
+	dstEqual := func(a, b *net.IPNet) bool {
+		if a == nil || b == nil {
+			return a == nil && b == nil
+		}
+		return a.String() == b.String()
+	}
+	routes, err := util.GetNetLinkOps().RouteListFiltered(route.Family,
+		&netlink.Route{Table: route.Table}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		klog.Warningf("VRF Manager: unable to list routes of table %d: %v", route.Table, err)
+		return false
+	}
+	for _, existing := range routes {
+		if existing.Priority != route.Priority || !dstEqual(existing.Dst, route.Dst) {
+			continue
+		}
+		if existing.LinkIndex != route.LinkIndex || !existing.Gw.Equal(route.Gw) ||
+			!existing.Src.Equal(route.Src) ||
+			len(existing.MultiPath) != len(route.MultiPath) {
+			return false
+		}
+		for i := range existing.MultiPath {
+			if existing.MultiPath[i].LinkIndex != route.MultiPath[i].LinkIndex ||
+				!existing.MultiPath[i].Gw.Equal(route.MultiPath[i].Gw) ||
+				existing.MultiPath[i].Hops != route.MultiPath[i].Hops {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // restoreRoutesToTable re-adds routes into the given routing table, preserving
 // all their attributes. Routes that their owner reprograms per routing table
 // are skipped. Failures are joined and returned so that the caller can decide
@@ -766,9 +807,19 @@ func restoreRoutesToTable(routes []netlink.Route, table uint32) error {
 		}
 		if err := addRouteWithRetry(&route); err != nil {
 			if util.GetNetLinkOps().IsAlreadyExistsError(err) {
-				// A route with the same kernel key is already in the table
-				// and wins: nothing was added.
-				klog.V(5).Infof("VRF Manager: route %v already present in table %d, not restored", route, table)
+				// A route with the same kernel key ({table, dst, tos, priority})
+				// is already in the table and legitimately wins: nothing was
+				// added. When the existing
+				// route is an equivalent copy -- the kernel regenerating an
+				// interface's prefix route, or the route's owner reinstalling
+				// it -- nothing was lost. Otherwise a restore into the main
+				// table leaves the captured route in no table at all, so make
+				// that visible.
+				if table == unix.RT_TABLE_MAIN && !equivalentRouteExists(route) {
+					klog.Warningf("VRF Manager: route %v not restored into the main table, a different route with the same key already exists", route)
+				} else {
+					klog.V(5).Infof("VRF Manager: route %v already present in table %d, not restored", route, table)
+				}
 				continue
 			}
 			errs = append(errs, fmt.Errorf("failed to restore route %v into table %d: %w", route, table, err))

--- a/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
@@ -448,6 +448,36 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 2)
 		})
 
+		ginkgo.It("treats a same-key route as equivalent only when interface, gateway and source match", func() {
+			// The main-table EEXIST log stays at V(5) only when the route
+			// already there is effectively the captured route; a same-key
+			// route differing in any forwarding attribute means the captured
+			// route is gone from every table.
+			existing := netlink.Route{
+				LinkIndex: getLinkIndex(enslaveLinkName1),
+				Dst:       ovntest.MustParseIPNet("192.168.1.0/24"),
+				Src:       net.ParseIP("192.168.1.10"),
+				Protocol:  unix.RTPROT_KERNEL,
+				Type:      unix.RTN_UNICAST,
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			nlMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{existing}, nil)
+
+			candidate := existing
+			gomega.Expect(equivalentRouteExists(candidate)).To(gomega.BeTrue())
+			candidate.Src = net.ParseIP("192.168.1.11")
+			gomega.Expect(equivalentRouteExists(candidate)).To(gomega.BeFalse(),
+				"a different preferred source is not the same route")
+			candidate = existing
+			candidate.LinkIndex = getLinkIndex(enslaveLinkName2)
+			gomega.Expect(equivalentRouteExists(candidate)).To(gomega.BeFalse(),
+				"a different output interface is not the same route")
+			candidate = existing
+			candidate.Gw = net.ParseIP("192.168.1.1")
+			gomega.Expect(equivalentRouteExists(candidate)).To(gomega.BeFalse(),
+				"a different gateway is not the same route")
+		})
+
 		ginkgo.It("releases enslaved interfaces before deleting a VRF, restoring their routes", func() {
 			slaveLinkIndex := getLinkIndex(enslaveLinkName1)
 			vrfTable := int(getVRFTable(vrfLinkName1))

--- a/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
@@ -149,6 +149,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				LinkIndex: slaveLinkIndex,
 				Gw:        net.ParseIP("192.168.2.1"),
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Flags:     unix.RTNH_F_ONLINK | unix.RTNH_F_LINKDOWN,
 				Table:     unix.RT_TABLE_MAIN,
 			}
@@ -157,12 +158,14 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				Dst:       ovntest.MustParseIPNet("192.168.2.1/32"),
 				Scope:     netlink.SCOPE_LINK,
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Table:     unix.RT_TABLE_MAIN,
 			}
 			kernelConnectedRoute := netlink.Route{
 				LinkIndex: slaveLinkIndex,
 				Dst:       ovntest.MustParseIPNet("192.168.1.0/24"),
 				Protocol:  unix.RTPROT_KERNEL,
+				Type:      unix.RTN_UNICAST,
 				Table:     unix.RT_TABLE_MAIN,
 			}
 			bgpRoute := netlink.Route{
@@ -170,6 +173,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				Dst:       ovntest.MustParseIPNet("10.10.0.0/16"),
 				Gw:        net.ParseIP("192.168.1.253"),
 				Protocol:  unix.RTPROT_BGP,
+				Type:      unix.RTN_UNICAST,
 				Table:     unix.RT_TABLE_MAIN,
 			}
 			// A static ECMP route through the slave interface: the kernel
@@ -178,6 +182,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			ecmpRoute := netlink.Route{
 				Dst:      ovntest.MustParseIPNet("172.16.0.0/16"),
 				Protocol: unix.RTPROT_STATIC,
+				Type:     unix.RTN_UNICAST,
 				Table:    unix.RT_TABLE_MAIN,
 				MultiPath: []*netlink.NexthopInfo{
 					{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.1"), Flags: unix.RTNH_F_LINKDOWN},
@@ -189,6 +194,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			mixedInterfacesEcmpRoute := netlink.Route{
 				Dst:      ovntest.MustParseIPNet("172.17.0.0/16"),
 				Protocol: unix.RTPROT_STATIC,
+				Type:     unix.RTN_UNICAST,
 				Table:    unix.RT_TABLE_MAIN,
 				MultiPath: []*netlink.NexthopInfo{
 					{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.1")},
@@ -207,10 +213,12 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			err := c.AddVRF(vrfLinkName1, enslaveLinkName1, getVRFTable(vrfLinkName1), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			// The DHCP routes and the ECMP route are restored into the VRF
-			// table with kernel state flags stripped; the kernel generated
-			// route is left for the kernel to regenerate, the BGP route for
-			// its daemon, and the mixed-interfaces ECMP route stays behind.
+			// The DHCP routes, the kernel connected route and the ECMP route
+			// are restored into the VRF table with kernel state flags
+			// stripped; the BGP route is left for its daemon and the
+			// mixed-interfaces ECMP route stays behind.
+			expectedConnectedRoute := kernelConnectedRoute
+			expectedConnectedRoute.Table = int(getVRFTable(vrfLinkName1))
 			expectedHostRoute := dhcpGatewayHostRoute
 			expectedHostRoute.Table = int(getVRFTable(vrfLinkName1))
 			expectedDefaultRoute := dhcpDefaultRoute
@@ -222,21 +230,38 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.1")},
 				{LinkIndex: slaveLinkIndex, Gw: net.ParseIP("192.168.1.2")},
 			}
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedConnectedRoute)
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedHostRoute)
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedDefaultRoute)
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedEcmpRoute)
-			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 3)
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 4)
 
-			// The gateway host route must be restored before the gateway
-			// routes that depend on it.
+			// The gateway-less routes must be restored before the gateway
+			// routes that depend on them.
 			var restored []*netlink.Route
 			for _, call := range nlMock.Calls {
 				if call.Method == "RouteAdd" {
 					restored = append(restored, call.Arguments.Get(0).(*netlink.Route))
 				}
 			}
-			gomega.Expect(restored).To(gomega.Equal([]*netlink.Route{&expectedHostRoute, &expectedDefaultRoute, &expectedEcmpRoute}),
-				"expected the gateway host route to be restored before the gateway routes that depend on it")
+			gomega.Expect(restored).To(gomega.Equal([]*netlink.Route{&expectedConnectedRoute, &expectedHostRoute, &expectedDefaultRoute, &expectedEcmpRoute}),
+				"expected the gateway-less routes to be restored before the gateway routes that depend on them")
+		})
+
+		ginkgo.It("retries a route restore the kernel transiently rejects", func() {
+			// A restored route can fail validation right after a master
+			// change, e.g. EINVAL while its IPv6 source address re-runs
+			// duplicate address detection; the retry must absorb it.
+			route := netlink.Route{
+				LinkIndex: getLinkIndex(enslaveLinkName1),
+				Dst:       ovntest.MustParseIPNet("2001:db8:1::/64"),
+				Table:     unix.RT_TABLE_MAIN,
+			}
+			nlMock.On("RouteAdd", mock.Anything).Return(unix.EINVAL).Once()
+			nlMock.On("RouteAdd", mock.Anything).Return(nil).Once()
+
+			gomega.Expect(addRouteWithRetry(&route)).To(gomega.Succeed())
+			nlMock.AssertNumberOfCalls(ginkgo.GinkgoT(), "RouteAdd", 2)
 		})
 
 		ginkgo.It("undoes the enslavement when the route restore into the VRF fails", func() {
@@ -247,6 +272,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				LinkIndex: slaveLinkIndex,
 				Gw:        net.ParseIP("192.168.1.1"),
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Table:     unix.RT_TABLE_MAIN,
 			}
 			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
@@ -346,12 +372,14 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				LinkIndex: slaveLinkIndex,
 				Gw:        net.ParseIP("192.168.1.1"),
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Table:     vrfTable,
 			}
 			migratedDefaultRouteV6 := netlink.Route{
 				LinkIndex: slaveLinkIndex,
 				Gw:        net.ParseIP("2001:db8:1::1"),
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Priority:  1024,
 				Table:     vrfTable,
 			}
@@ -360,6 +388,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				Dst:       ovntest.MustParseIPNet("10.96.0.0/16"),
 				Gw:        net.ParseIP("169.254.169.4"),
 				Protocol:  netlink.RouteProtocol(types.OVNKProtocol),
+				Type:      unix.RTN_UNICAST,
 				Table:     vrfTable,
 			}
 			ovnManagedRouteV6 := netlink.Route{
@@ -367,6 +396,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				Dst:       ovntest.MustParseIPNet("fd00:10:96::/112"),
 				Gw:        net.ParseIP("fd69::4"),
 				Protocol:  netlink.RouteProtocol(types.OVNKProtocol),
+				Type:      unix.RTN_UNICAST,
 				Priority:  1024,
 				Table:     vrfTable,
 			}
@@ -375,6 +405,18 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				Dst:       ovntest.MustParseIPNet("10.10.0.0/16"),
 				Gw:        net.ParseIP("192.168.1.253"),
 				Protocol:  unix.RTPROT_BGP,
+				Type:      unix.RTN_UNICAST,
+				Table:     vrfTable,
+			}
+			// The kernel derives the local route of an enslaved interface's
+			// address in the VRF table itself; on release it maintains it in
+			// the local table, so it must not be migrated.
+			kernelLocalRoute := netlink.Route{
+				LinkIndex: slaveLinkIndex,
+				Dst:       ovntest.MustParseIPNet("192.168.1.10/32"),
+				Protocol:  unix.RTPROT_KERNEL,
+				Scope:     netlink.SCOPE_HOST,
+				Type:      unix.RTN_LOCAL,
 				Table:     vrfTable,
 			}
 			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
@@ -382,7 +424,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 					return filter.Table == vrfTable
 				}),
 				uint64(netlink.RT_FILTER_TABLE),
-			).Return([]netlink.Route{migratedDefaultRoute, migratedDefaultRouteV6, ovnManagedRoute, ovnManagedRouteV6, bgpLearnedRoute}, nil)
+			).Return([]netlink.Route{migratedDefaultRoute, migratedDefaultRouteV6, ovnManagedRoute, ovnManagedRouteV6, bgpLearnedRoute, kernelLocalRoute}, nil)
 			nlMock.On("LinkSetNoMaster", enslaveLinkMock1).Return(nil)
 			nlMock.On("RouteAdd", mock.Anything).Return(nil)
 
@@ -394,8 +436,9 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkSetNoMaster", enslaveLinkMock1)
 
 			// The migrated routes return to the main table; the OVN managed
-			// routes stay with the route manager and the BGP route with its
-			// daemon, recognized by their protocol.
+			// routes stay with the route manager, the BGP route with its
+			// daemon, recognized by their protocol, and the local route with
+			// the kernel, recognized by its type.
 			expectedRoute := migratedDefaultRoute
 			expectedRoute.Table = unix.RT_TABLE_MAIN
 			nlMock.AssertCalled(ginkgo.GinkgoT(), "RouteAdd", &expectedRoute)
@@ -414,6 +457,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				LinkIndex: slaveLinkIndex,
 				Gw:        net.ParseIP("192.168.1.1"),
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Table:     vrfTable,
 			}
 			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
@@ -489,6 +533,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				LinkIndex: slaveLinkIndex,
 				Gw:        net.ParseIP("192.168.1.1"),
 				Protocol:  unix.RTPROT_DHCP,
+				Type:      unix.RTN_UNICAST,
 				Table:     vrfTable,
 			}
 			ovnManagedRoute := netlink.Route{
@@ -496,6 +541,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 				Dst:       ovntest.MustParseIPNet("10.96.0.0/16"),
 				Gw:        net.ParseIP("169.254.169.4"),
 				Protocol:  netlink.RouteProtocol(types.OVNKProtocol),
+				Type:      unix.RTN_UNICAST,
 				Table:     vrfTable,
 			}
 			nlMock.On("RouteListFiltered", netlink.FAMILY_ALL,
@@ -681,35 +727,36 @@ var _ = ginkgo.Describe("VRF manager tests with a network namespace", func() {
 		return err
 	}
 
+	listDefaultRoutes := func(family, table int) []netlink.Route {
+		routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		var defaultRoutes []netlink.Route
+		for _, route := range routes {
+			if route.Gw != nil && (route.Dst == nil || route.Dst.IP.IsUnspecified()) {
+				defaultRoutes = append(defaultRoutes, route)
+			}
+		}
+		return defaultRoutes
+	}
+	expectDefaultRoutesIn := func(table int, gateways ...net.IP) {
+		for _, gateway := range gateways {
+			family := netlink.FAMILY_V4
+			if gateway.To4() == nil {
+				family = netlink.FAMILY_V6
+			}
+			defaultRoutes := listDefaultRoutes(family, table)
+			gomega.Expect(defaultRoutes).To(gomega.HaveLen(1),
+				"expected exactly one default route via %s in table %d, got %v", gateway, table, defaultRoutes)
+			gomega.Expect(defaultRoutes[0].Gw.String()).To(gomega.Equal(gateway.String()),
+				"expected the default route in table %d to go via %s", table, gateway)
+		}
+	}
+
 	ovntest.OnSupportedPlatformsIt("preserves slave interface routes across VRF enslavement and release", func() {
 		slaveLinkName := "dev100"
 		gatewayIP := net.ParseIP("192.168.1.1")
 		gatewayIPv6 := net.ParseIP("2001:db8:1::1")
 		vrfTable := 1010
-		listDefaultRoutes := func(family, table int) []netlink.Route {
-			routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			var defaultRoutes []netlink.Route
-			for _, route := range routes {
-				if route.Gw != nil && (route.Dst == nil || route.Dst.IP.IsUnspecified()) {
-					defaultRoutes = append(defaultRoutes, route)
-				}
-			}
-			return defaultRoutes
-		}
-		expectDefaultRoutesIn := func(table int, gateways ...net.IP) {
-			for _, gateway := range gateways {
-				family := netlink.FAMILY_V4
-				if gateway.To4() == nil {
-					family = netlink.FAMILY_V6
-				}
-				defaultRoutes := listDefaultRoutes(family, table)
-				gomega.Expect(defaultRoutes).To(gomega.HaveLen(1),
-					"expected exactly one default route via %s in table %d, got %v", gateway, table, defaultRoutes)
-				gomega.Expect(defaultRoutes[0].Gw.String()).To(gomega.Equal(gateway.String()),
-					"expected the default route in table %d to go via %s", table, gateway)
-			}
-		}
 		err := testNS.Do(func(ns.NetNS) error {
 			defer ginkgo.GinkgoRecover()
 			// Set up an interface configured with addresses and default
@@ -774,6 +821,104 @@ var _ = ginkgo.Describe("VRF manager tests with a network namespace", func() {
 			expectDefaultRoutesIn(unix.RT_TABLE_MAIN, gatewayIP, gatewayIPv6)
 			gomega.Expect(listEcmpRoutes(vrfTable)).To(gomega.BeEmpty())
 			expectEcmpRouteIn(unix.RT_TABLE_MAIN)
+			return nil
+		})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+
+	ovntest.OnSupportedPlatformsIt("preserves the prefix routes of noprefixroute addresses across VRF enslavement and release", func() {
+		slaveLinkName := "dev200"
+		gatewayIP := net.ParseIP("192.168.5.1")
+		gatewayIPv6 := net.ParseIP("2001:db8:5::1")
+		prefixV4 := ovntest.MustParseIPNet("192.168.5.0/24")
+		prefixV6 := ovntest.MustParseIPNet("2001:db8:5::/64")
+		vrfTable := 1011
+		listPrefixRoutes := func(table int, prefix *net.IPNet) []netlink.Route {
+			family := netlink.FAMILY_V4
+			if prefix.IP.To4() == nil {
+				family = netlink.FAMILY_V6
+			}
+			routes, err := netlink.RouteListFiltered(family,
+				&netlink.Route{Table: table, Dst: prefix}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			return routes
+		}
+		expectPrefixRouteIn := func(table int, prefix *net.IPNet) {
+			routes := listPrefixRoutes(table, prefix)
+			gomega.Expect(routes).To(gomega.HaveLen(1),
+				"expected the %s prefix route in table %d, got %v", prefix, table, routes)
+			gomega.Expect(int(routes[0].Protocol)).To(gomega.Equal(unix.RTPROT_KERNEL),
+				"expected the %s prefix route in table %d to keep proto kernel", prefix, table)
+		}
+		err := testNS.Do(func(ns.NetNS) error {
+			defer ginkgo.GinkgoRecover()
+			// Mimic an interface managed by NetworkManager: it sets
+			// noprefixroute on the addresses it manages and installs their
+			// prefix routes itself, tagged proto kernel, so the kernel does
+			// not regenerate them after a master change and only the
+			// migration can carry them into the VRF table.
+			gomega.Expect(netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: slaveLinkName}})).To(gomega.Succeed())
+			slaveLink, err := netlink.LinkByName(slaveLinkName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(netlink.LinkSetUp(slaveLink)).To(gomega.Succeed())
+			gomega.Expect(os.WriteFile("/proc/sys/net/ipv6/conf/"+slaveLinkName+"/keep_addr_on_down", []byte("1"), 0644)).To(gomega.Succeed())
+			for _, address := range []string{"192.168.5.10/24", "2001:db8:5::10/64"} {
+				addr, err := netlink.ParseAddr(address)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				addr.Flags = unix.IFA_F_NOPREFIXROUTE
+				gomega.Expect(netlink.AddrAdd(slaveLink, addr)).To(gomega.Succeed())
+			}
+			gomega.Expect(netlink.RouteAdd(&netlink.Route{
+				LinkIndex: slaveLink.Attrs().Index,
+				Dst:       prefixV4,
+				Src:       net.ParseIP("192.168.5.10"),
+				Scope:     netlink.SCOPE_LINK,
+				Protocol:  unix.RTPROT_KERNEL,
+				Type:      unix.RTN_UNICAST,
+			})).To(gomega.Succeed())
+			gomega.Expect(netlink.RouteAdd(&netlink.Route{
+				LinkIndex: slaveLink.Attrs().Index,
+				Dst:       prefixV6,
+				Protocol:  unix.RTPROT_KERNEL,
+				Type:      unix.RTN_UNICAST,
+			})).To(gomega.Succeed())
+			for _, gateway := range []net.IP{gatewayIP, gatewayIPv6} {
+				gomega.Expect(netlink.RouteAdd(&netlink.Route{
+					LinkIndex: slaveLink.Attrs().Index,
+					Gw:        gateway,
+				})).To(gomega.Succeed())
+			}
+
+			// On enslavement, the prefix routes migrate into the VRF table
+			// along with the default routes. Without them, the default routes
+			// would fail their restore against an unreachable gateway and the
+			// rollback would undo the enslavement.
+			gomega.Expect(c.AddVRF(vrfLinkName1, slaveLinkName, uint32(vrfTable), nil)).To(gomega.Succeed())
+			expectPrefixRouteIn(vrfTable, prefixV4)
+			expectPrefixRouteIn(vrfTable, prefixV6)
+			expectDefaultRoutesIn(vrfTable, gatewayIP, gatewayIPv6)
+			gomega.Expect(listPrefixRoutes(unix.RT_TABLE_MAIN, prefixV4)).To(gomega.BeEmpty())
+			gomega.Expect(listPrefixRoutes(unix.RT_TABLE_MAIN, prefixV6)).To(gomega.BeEmpty())
+
+			// On release, they all migrate back to the main table.
+			gomega.Expect(c.DeleteVRFSlave(vrfLinkName1, slaveLinkName)).To(gomega.Succeed())
+			expectPrefixRouteIn(unix.RT_TABLE_MAIN, prefixV4)
+			expectPrefixRouteIn(unix.RT_TABLE_MAIN, prefixV6)
+			expectDefaultRoutesIn(unix.RT_TABLE_MAIN, gatewayIP, gatewayIPv6)
+			gomega.Expect(listPrefixRoutes(vrfTable, prefixV4)).To(gomega.BeEmpty())
+			gomega.Expect(listPrefixRoutes(vrfTable, prefixV6)).To(gomega.BeEmpty())
+
+			// The kernel's address-derived entries (local, broadcast, anycast,
+			// multicast) lived in the VRF table while the interface was
+			// enslaved and belong to the local table afterwards: none of them
+			// may be migrated into the main table.
+			mainRoutes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL,
+				&netlink.Route{Table: unix.RT_TABLE_MAIN}, netlink.RT_FILTER_TABLE)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			for _, route := range mainRoutes {
+				gomega.Expect(route.Type).To(gomega.Equal(unix.RTN_UNICAST),
+					"expected no non-unicast route in the main table after release, got %v", route)
+			}
 			return nil
 		})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/test/e2e/uplink.go
+++ b/test/e2e/uplink.go
@@ -447,23 +447,14 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 		testSuffix = framework.RandomSuffix()
 	})
 
+	// The NetworkManager addressing shape is not exercised here: on full-mode
+	// clusters the route-preservation table covers both addressing shapes.
 	ginkgo.It("uses the Uplink interface as the targetVRF auto BGP peering path", func() {
+		if isDPUUplinkE2E() {
+			e2eskipper.Skipf("full-mode Uplink bridge provisioning; the split DPU mode variant covers DPU")
+		}
 		nodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		if isDPUUplinkE2E() {
-			schedulableNodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(schedulableNodes.Items).NotTo(gomega.BeEmpty())
-			runDPUUplinkVRFLiteRouteAdvertisements(
-				f,
-				ictx,
-				schedulableNodes.Items,
-				ipFamilySet,
-				testSuffix,
-			)
-			return
-		}
 
 		schedulableNodes, err := e2enode.GetBoundedReadySchedulableNodes(context.Background(), f.ClientSet, 2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -566,7 +557,38 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 		}
 	})
 
-	ginkgo.It("preserves pre-existing Uplink interface routes across VRF enslavement and release", func(ctx ginkgo.SpecContext) {
+	// Both addressing shapes of the host-side Uplink VF are covered:
+	// kernel-owned, and NetworkManager-style (noprefixroute addresses with
+	// userspace-installed proto kernel prefix routes), which the VF has when
+	// NetworkManager manages it.
+	ginkgo.DescribeTable("uses the Uplink interface as the targetVRF auto BGP peering path in split DPU mode", func(ctx ginkgo.SpecContext, nmStyleAddressing bool) {
+		if !isDPUUplinkE2E() {
+			e2eskipper.Skipf("requires a split DPU deployment")
+		}
+		schedulableNodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(schedulableNodes.Items).NotTo(gomega.BeEmpty())
+		runDPUUplinkVRFLiteRouteAdvertisements(
+			f,
+			ictx,
+			schedulableNodes.Items,
+			ipFamilySet,
+			testSuffix,
+			nmStyleAddressing,
+		)
+	},
+		ginkgo.Entry("with kernel-owned interface addressing", false),
+		ginkgo.Entry("with NetworkManager-style interface addressing", true),
+	)
+
+	// The two addressing shapes cover both route-preservation regimes: with
+	// kernel-owned addressing the kernel regenerates the interface prefix
+	// routes in the target table itself and the migration tolerates them,
+	// while with NetworkManager-style addressing (noprefixroute, prefix
+	// routes installed from userspace as proto kernel) only the migration
+	// can carry the prefix routes across, and the default routes depend on
+	// them for their gateway resolution.
+	ginkgo.DescribeTable("preserves pre-existing Uplink interface routes across VRF enslavement and release", func(ctx ginkgo.SpecContext, nmStyleAddressing bool) {
 		if isDPUUplinkE2E() {
 			e2eskipper.Skipf("preserved-route Uplink e2e uses regular KIND bridge provisioning")
 		}
@@ -602,6 +624,20 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 		bridgeName := uplinkBridgeName("uppre" + testSuffix)
 		gomega.Expect(configureUplinkBridge(f, ictx, bridgeName, nodeIfaces)).To(gomega.Succeed())
 
+		nodeNames := make([]string, 0, len(nodeIfaces))
+		for nodeName := range nodeIfaces {
+			nodeNames = append(nodeNames, nodeName)
+		}
+
+		if nmStyleAddressing {
+			ginkgo.By("reshaping the Uplink bridge addressing to NetworkManager form")
+			bridgeByNode := make(map[string]string, len(nodeIfaces))
+			for nodeName := range nodeIfaces {
+				bridgeByNode[nodeName] = bridgeName
+			}
+			gomega.Expect(configureUplinkNMStyleAddressing(ictx, bridgeByNode)).To(gomega.Succeed())
+		}
+
 		server := infraapi.ExternalContainer{Name: serverName}
 		frr := infraapi.ExternalContainer{Name: networkName + "-frr"}
 		serverNetwork, err := infraprovider.Get().GetNetwork(serverNetworkName)
@@ -628,16 +664,23 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			return "0.0.0.0/0"
 		}
 
+		prefixCIDRFor := func(iface infraapi.NetworkInterface, family utilnet.IPFamily) string {
+			ip, prefix := iface.IPv4, iface.IPv4Prefix
+			if family == utilnet.IPv6 {
+				ip, prefix = iface.IPv6, iface.IPv6Prefix
+			}
+			gomega.Expect(ip).NotTo(gomega.BeEmpty())
+			_, ipNet, err := net.ParseCIDR(ip + "/" + prefix)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			return ipNet.String()
+		}
+
 		ginkgo.By("serving a prefix from the BGP server without advertising it and installing default routes on the Uplink bridge")
 		// Serve the preserved prefix from the BGP server without advertising
 		// it over BGP, and install a default route through the FRR peer on
 		// the Uplink bridge before any enslavement. The default route is the
 		// state another agent (e.g. a DHCP client) would have configured on
 		// the interface, and the only path toward the preserved prefix.
-		nodeNames := make([]string, 0, len(nodeIfaces))
-		for nodeName := range nodeIfaces {
-			nodeNames = append(nodeNames, nodeName)
-		}
 		for _, family := range ipFamilySet.UnsortedList() {
 			preservedCIDR, preservedIP, frrIP := preservedFor(family)
 			serverIP := getFirstIPStringOfFamily(family, []string{serverIface.IPv4, serverIface.IPv6})
@@ -727,6 +770,27 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 			}
 		}
 
+		ginkgo.By("waiting for the interface prefix routes to be present in the CUDN VRF")
+		// With kernel-owned addressing the kernel regenerates the prefix
+		// routes in the VRF table itself; with NetworkManager-style
+		// addressing only the migration can put them there. Either way the
+		// default routes above depend on them for their gateway resolution.
+		for _, family := range ipFamilySet.UnsortedList() {
+			for _, node := range schedulableNodes.Items {
+				node := node
+				prefixCIDR := prefixCIDRFor(nodeIfaces[node.Name], family)
+				gomega.Eventually(func() error {
+					return uplinkKernelRouteShownIn(node.Name, "vrf "+networkName, prefixCIDR)
+				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+					gomega.Succeed(),
+					"expected prefix route %s in CUDN VRF %s on node %s",
+					prefixCIDR,
+					networkName,
+					node.Name,
+				)
+			}
+		}
+
 		ginkgo.By("verifying VRF connectivity through the preserved default routes")
 		// Host traffic in the CUDN VRF rides the preserved default route:
 		// nothing advertises the preserved prefix over BGP, matching a
@@ -790,9 +854,21 @@ var _ = ginkgo.Describe("Network Segmentation Uplink route advertisements", feat
 					frrIP,
 					node.Name,
 				)
+				prefixCIDR := prefixCIDRFor(nodeIfaces[node.Name], family)
+				gomega.Eventually(func() error {
+					return uplinkKernelRouteShownIn(node.Name, "", prefixCIDR)
+				}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+					gomega.Succeed(),
+					"expected prefix route %s back in the main table on node %s",
+					prefixCIDR,
+					node.Name,
+				)
 			}
 		}
-	})
+	},
+		ginkgo.Entry("with kernel-owned interface addressing", false),
+		ginkgo.Entry("with NetworkManager-style interface addressing", true),
+	)
 })
 
 var _ = ginkgo.Describe("Uplink route advertisements with Dynamic UDN allocation", feature.RouteAdvertisementsDynamicUDN, feature.Uplink, func() {
@@ -1646,6 +1722,7 @@ func runDPUUplinkVRFLiteRouteAdvertisements(
 	schedulableNodes []corev1.Node,
 	ipFamilySet sets.Set[utilnet.IPFamily],
 	testSuffix string,
+	nmStyleAddressing bool,
 ) {
 	ginkgo.GinkgoHelper()
 
@@ -1660,6 +1737,20 @@ func runDPUUplinkVRFLiteRouteAdvertisements(
 	dpuHostNodes := filterNodesByLabel(schedulableNodes, uplinkDPUHostNodeLabel)
 	gomega.Expect(dpuHostNodes).NotTo(gomega.BeEmpty(), "expected at least one ready schedulable DPU host node")
 	nodeIfaces := collectDPUHostUplinkInterfaces(dpuHostNodes)
+
+	if nmStyleAddressing {
+		// The host-side Uplink VF can be managed by NetworkManager, which
+		// sets noprefixroute on the addresses it manages and installs their
+		// prefix routes itself, tagged proto kernel: reshape the host
+		// interface the same way, so that the enslavement must migrate those
+		// routes into the host-side CUDN VRF for the gateway programming to
+		// succeed.
+		hostInterfaceByNode := make(map[string]string, len(dpuHostNodes))
+		for _, node := range dpuHostNodes {
+			hostInterfaceByNode[node.Name] = nodeIfaces[node.Name].InfName
+		}
+		gomega.Expect(configureUplinkNMStyleAddressing(ictx, hostInterfaceByNode)).To(gomega.Succeed())
+	}
 
 	// Install a route on each DPU-host Uplink interface before any
 	// enslavement, standing in for routing state another agent (e.g. a DHCP
@@ -1766,6 +1857,26 @@ func runDPUUplinkVRFLiteRouteAdvertisements(
 			vrfName,
 			node.Name,
 		)
+	}
+
+	// The host interface's prefix routes are present in the host-side CUDN
+	// VRF for every enabled IP family: with kernel-owned addressing the
+	// kernel regenerates them there itself, while with NetworkManager-style
+	// noprefixroute addressing only the migration can put them there.
+	for _, family := range ipFamilySet.UnsortedList() {
+		for _, node := range dpuHostNodes {
+			node := node
+			prefixCIDR := nodeInterfacePrefixCIDR(node.Name, nodeIfaces[node.Name].InfName, family)
+			gomega.Eventually(func() error {
+				return uplinkKernelRouteShownIn(node.Name, "vrf "+vrfName, prefixCIDR)
+			}).WithTimeout(uplinkTimeout).WithPolling(uplinkPoll).Should(
+				gomega.Succeed(),
+				"expected prefix route %s in host-side CUDN VRF %s on node %s",
+				prefixCIDR,
+				vrfName,
+				node.Name,
+			)
+		}
 	}
 
 	pod := pods[0]
@@ -2234,21 +2345,131 @@ func configureUplinkStaticRoute(
 	return nil
 }
 
+// configureUplinkNMStyleAddressing reshapes the interfaces' global addresses
+// into NetworkManager form: noprefixroute addresses whose proto kernel prefix
+// routes the kernel does not regenerate across master changes. Cleanup hands
+// the prefix routes back to the kernel. Exotic routes (expires, linkdown,
+// ECMP) fail the reshape loudly.
+func configureUplinkNMStyleAddressing(ictx infraapi.Context, devByNode map[string]string) error {
+	ginkgo.GinkgoHelper()
+
+	// One script, both directions: the noprefixroute flag marks ownership,
+	// so forward reshapes unflagged addresses and cleanup undoes flagged
+	// ones. The OVN-Kubernetes masquerade addresses (169.254.0.0/17,
+	// fd69::/112) and their routes are excluded: ovnkube owns them.
+	reshape := func(nodeName, devName, flag, addrFilter, replayTolerance string) error {
+		return execNodeCommand(nodeName, `
+set -e
+dev=%[1]s
+# Snapshot the routes the address changes below purge; masquerade routes
+# stay out (replaying one can EEXIST against another interface's twin).
+v4routes=$(ip -4 route show table all dev $dev | grep -Ev 'table local|169\.254\.' || true)
+# v6 risks only the kernel prefix routes (see the flag change below).
+v6routes=$(ip -6 route show table all dev $dev proto kernel | grep -Ev '^fe80|table local|fd69:' || true)
+# v4 flags cannot change in place: delete and re-add, purging v4 routes.
+for addr in $(ip -o -4 addr show dev $dev scope global | grep -Ev ' 169\.254\.' | %[3]s | awk '{print $4}'); do
+	ip addr del $addr dev $dev
+	ip addr add $addr dev $dev%[2]s
+done
+# v6 flags change in place: only the address's own prefix route is lost.
+for addr in $(ip -o -6 addr show dev $dev scope global | grep -Ev ' fd69:' | %[3]s | awk '{print $4}'); do
+	ip addr change $addr dev $dev%[2]s
+done
+# The dev-filtered capture omits the dev token: re-state it.
+replay4() { while read -r route; do if [ -n "$route" ]; then ip -4 route replace $route dev $dev%[4]s; fi; done; }
+# Gateway-less routes first: the gateway routes resolve against them.
+echo "$v4routes" | grep -v via | replay4
+echo "$v4routes" | grep via | replay4
+# iproute2 omits the filtered proto from the capture: re-state it.
+echo "$v6routes" | while read -r route; do
+	if [ -n "$route" ]; then ip -6 route replace $route proto kernel dev $dev%[4]s; fi
+done`,
+			devName,
+			flag,
+			addrFilter,
+			replayTolerance,
+		)
+	}
+	// Registered before touching any node so a partial reshape still gets
+	// undone; replay is best-effort, ovnkube may be tearing down concurrently.
+	ictx.AddCleanUpFn(func() error {
+		var errs []error
+		for nodeName, devName := range devByNode {
+			if err := reshape(nodeName, devName, "", "grep noprefixroute", " || true"); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	})
+	for nodeName, devName := range devByNode {
+		if err := reshape(nodeName, devName, " noprefixroute", "grep -v noprefixroute", ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// uplinkKernelRouteShownIn returns nil when a proto kernel route toward the
+// given CIDR is present in the given routing table on the node. The CIDR
+// selects the address family.
+func uplinkKernelRouteShownIn(nodeName, tableSelector, cidr string) error {
+	return uplinkRouteMatchShownIn(nodeName, tableSelector, cidr, "proto kernel")
+}
+
+// nodeInterfacePrefixCIDR returns the network prefix of the first global
+// address of the given family on the node's interface.
+func nodeInterfacePrefixCIDR(nodeName, devName string, family utilnet.IPFamily) string {
+	ginkgo.GinkgoHelper()
+
+	familyFlag := "-4"
+	if family == utilnet.IPv6 {
+		familyFlag = "-6"
+	}
+	// Replicates the relevant fields of the json output of "ip -j addr show".
+	type addrInfo struct {
+		Local     string `json:"local"`
+		PrefixLen int    `json:"prefixlen"`
+	}
+	type ipAddrJSON struct {
+		AddrInfo []addrInfo `json:"addr_info"`
+	}
+
+	out, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{
+		"ip", "-j", familyFlag, "addr", "show", "dev", devName, "scope", "global",
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	var parsed []ipAddrJSON
+	gomega.Expect(json.Unmarshal([]byte(out), &parsed)).To(gomega.Succeed(),
+		"failed to parse ip -j output for %s on node %s", devName, nodeName)
+	gomega.Expect(parsed).NotTo(gomega.BeEmpty())
+	gomega.Expect(parsed[0].AddrInfo).NotTo(gomega.BeEmpty(),
+		"expected a global %s address on %s of node %s", family, devName, nodeName)
+
+	_, ipNet, err := net.ParseCIDR(
+		fmt.Sprintf("%s/%d", parsed[0].AddrInfo[0].Local, parsed[0].AddrInfo[0].PrefixLen))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return ipNet.String()
+}
+
 // uplinkRouteShownIn returns nil when the given route is present in the given
 // routing table on the node. tableSelector is an `ip route show` scope
 // selector such as "vrf <name>", or empty for the main table.
 func uplinkRouteShownIn(nodeName, tableSelector, cidr, via string) error {
+	return uplinkRouteMatchShownIn(nodeName, tableSelector, cidr, "via "+via)
+}
+
+func uplinkRouteMatchShownIn(nodeName, tableSelector, routeSelector, matchSelector string) error {
 	family := ""
-	if utilnet.IsIPv6CIDRString(cidr) {
+	if utilnet.IsIPv6CIDRString(routeSelector) {
 		family = "-6 "
 	}
 	return execNodeCommand(
 		nodeName,
-		"ip %sroute show %s %s via %s | grep -q .",
+		"ip %sroute show %s %s %s | grep -q .",
 		family,
 		tableSelector,
-		cidr,
-		via,
+		routeSelector,
+		matchSelector,
 	)
 }
 


### PR DESCRIPTION
## 📑 Description

Two problems with the slave route migration introduced in #6820:

1. `shouldSkipRouteMigration` skipped `proto kernel` routes, assuming the kernel regenerates them in the target table after a master change. The kernel only does that for prefix routes it installed itself: NetworkManager sets `noprefixroute` on the addresses it manages and installs their prefix routes on its own, tagged `proto kernel`, without being VRF-aware. On enslavement the kernel purged such a route and nothing recreated it in the VRF table, so the migrated default route failed its restore against an unreachable gateway and the rollback undid the enslavement: VRF attachment persistently failed on NetworkManager-managed interfaces.
2. When restoring a released interface's routes back into the main table, a route with the same kernel key ({table, dst, tos, metric}) already present there legitimately wins, but the captured route then exists in no table at all, e.g. an uplink's DHCP default lost to another NIC's default at the same metric. That was logged at V(5) only, leaving no trace of why the route never came back.

What this PR does:

- migrates kernel-protocol unicast routes like any other: where the kernel did regenerate a route, restoring the identical captured copy is a benign EEXIST skip; where it did not, the re-add restores the route verbatim, protocol included
- keeps non-unicast routes out of the migration: the kernel derives the local, broadcast, anycast and multicast entries from the interface's addresses in whichever routing domain the interface currently is, so a migrated copy would leave stale clones behind
- also retries EINVAL on restore, returned while a route's IPv6 source address re-runs duplicate address detection after the master change
- warns when a captured route is not restored into the main table on release, unless the existing route is an equivalent copy (same interface and gateway): the kernel regenerating a prefix route, or the route's owner reinstalling it

e2e: the KIND route preservation spec and the DPU targetVRF auto spec become tables running both addressing shapes, kernel-owned and NetworkManager-style (`noprefixroute` addresses with userspace-installed `proto kernel` prefix routes), through a shared reshape helper.

Known residual, the one-shot semantics of migration: owners that keep reconciling only the main table (NetworkManager on lease renewal, addrconf on RA updates) leave the migrated copy stale until the next enslavement.

## Release Notes

```release-note
Routes with protocol "kernel" now migrate across the VRF enslavement and release of Uplink gateway interfaces, fixing VRF attachment for interfaces whose addresses carry the noprefixroute flag (e.g. managed by NetworkManager). A warning is logged when a captured route cannot be restored to the main table on release because a different route with the same key exists.
```

## Additional Information for reviewers

Follow-up to #6820. Code changes are confined to `go-controller/pkg/node/vrfmanager/vrf_manager.go`; the rest is unit and e2e coverage (`vrf_manager_test.go`, `test/e2e/uplink.go`).

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [x] All the tests have passed in the CI

## How to verify it

- unit (netns specs need user+net+mount namespaces): `cd go-controller && unshare -rmn go test ./pkg/node/vrfmanager/... -count=1`
- KIND: `contrib/kind.sh --gateway-mode shared -mne -nse -rae -adv -i6 -ue`, then `cd test && KUBECONFIG=~/ovn.conf PLATFORM_IPV4_SUPPORT=true PLATFORM_IPV6_SUPPORT=true ENABLE_UPLINK=true ENABLE_ROUTE_ADVERTISEMENTS=true make control-plane WHAT="Network Segmentation preserves pre-existing Uplink interface routes"` runs both addressing shapes

