### PR TITLE
ci: find PR by head branch for coredump comments

### DIFF
--- a/.github/workflows/coredump-stacktrace-comment.yml
+++ b/.github/workflows/coredump-stacktrace-comment.yml
@@ -42,14 +42,14 @@ jobs:
       id: pr
       env:
         GH_TOKEN: ${{ github.token }}
-        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        pr_number=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
-        if [ -z "$pr_number" ]; then
-          pr_number=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
-            --jq 'map(select(.state == "open"))[0].number // empty')
-        fi
+        pr_number=$(gh api --method GET \
+          "repos/${GITHUB_REPOSITORY}/pulls" \
+          -f state=open \
+          -f head="${HEAD_OWNER}:${HEAD_BRANCH}" \
+          --jq '.[0].number // empty')
         echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
 
     - name: Find the coredump stack trace artifact


### PR DESCRIPTION
workflow_run does not reliably associate fork commits with their pull requests. Look up the open pull request by its head owner and branch so coredump reports can be posted.

I'm seeing pr_number= being empty in the last "post-comment" phase of the coredump analysis. This should resolve it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

```
  GITHUB_REPOSITORY=ovn-kubernetes/ovn-kubernetes
  HEAD_OWNER=ricky-rav
  HEAD_BRANCH=vrfmanager-migrate-kernel-routes

  pr_number=$(gh api --method GET \
    "repos/${GITHUB_REPOSITORY}/pulls" \
    -f state=open \
    -f head="${HEAD_OWNER}:${HEAD_BRANCH}" \
    --jq '.[0].number // empty')

  echo "pr_number=${pr_number}"
```

gives: `pr_number=6869`.