### PR TITLE
Revamp blog landing page with mkdocs-material blog plugin

### DIFF
--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -1,0 +1,9 @@
+authors:
+  trozet:
+    name: Tim Rozet
+    description: Software Engineer at NVIDIA.
+    avatar: https://github.com/trozet.png
+  npinaeva:
+    name: Nadia Pinaeva
+    description: Software Engineer at Red Hat.
+    avatar: https://github.com/npinaeva.png

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,17 +1,1 @@
----
-title: Blog
-hide:
-  - toc
----
-
-# Blog Posts
-
-Community blog posts on OVN-Kubernetes features, integrations, and guides.
-
-**[Accelerating and Securing Kubernetes Networking: Leveraging DPUs with OVN-Kubernetes](dpu-acceleration.md)**
-
-Deploy OVN-Kubernetes with DPU offload for high-performance networking and per-tenant isolation.
-
-**[Debugging NetworkPolicies with NetObserv](netobserv.md)**
-
-Use OVN observability and NetObserv to understand why connections are allowed or denied by network policies.
+# OVN-Kubernetes Blog

--- a/docs/blog/posts/dpu-acceleration.md
+++ b/docs/blog/posts/dpu-acceleration.md
@@ -1,3 +1,9 @@
+---
+date: 2026-02-12
+authors:
+  - trozet
+---
+
 # Accelerating and Offloading Kubernetes Networking: Leveraging DPUs with OVN-Kubernetes
 
 ## Introduction
@@ -6,6 +12,8 @@ This blog post provides a comprehensive guide on deploying OVN-Kubernetes in an 
 This setup is crucial for high-performance networking in cloud-native applications, offloading network processing from the host CPU to the
 DPU, and providing better security for the networking control-plane. Additionally, OVN-Kubernetes brings in robust features like User Defined
 Networks (UDNs) that enable per tenant network isolation into the Kubernetes environment and integrates with the DPU solution.
+
+<!-- more -->
 
 In this guide, **offloading** means moving OVN-Kubernetes SDN control and data plane work from the host into the DPU to free host CPU and memory
 resources. Note, this is different from **OVS offloading**, where datapath processing is offloaded from kernel to hardware
@@ -20,7 +28,7 @@ In an unaccelerated+non-offloaded environment, OVN-Kubernetes behaves the same w
 Open Virtual Network (OVN), and Open vSwitch (OVS). OVN-Kubernetes listens for KAPI events, configures a logical topology in OVN,
 and then OVN translates that into OpenFlow which is programmed into the OVS datapath. Here is an overview of a typical setup:
 
-![Regular OVN-Kubernetes Worker Node](../images/ovnk-unaccelerated.svg)
+![Regular OVN-Kubernetes Worker Node](../../images/ovnk-unaccelerated.svg)
 
 ---
 
@@ -47,7 +55,7 @@ This solves the aforementioned issues by:
 
 Here is a diagram of a DPU accelerated worker node with OVN-Kubernetes:
 
-![Accelerated OVN-Kubernetes Worker Node](../images/ovnk-accelerated.svg)
+![Accelerated OVN-Kubernetes Worker Node](../../images/ovnk-accelerated.svg)
 
 ---
 
@@ -206,12 +214,12 @@ The DPU must be configured to handle networking functions for the host. The foll
 
 A version of OVN-Kubernetes at least with 1.3 is required for DPUs. At the time of this writing, 1.3 is in Alpha state. The following steps should be done from a jumphost that has Kubeconfig access to both the Host and DPU cluster.
 
-1.  Build or download the OVN-Kubernetes container images. Refer to this [image build guide](../developer-guide/image-build.md) on how to build/obtain the artifacts.
+1.  Build or download the OVN-Kubernetes container images. Refer to this [image build guide](../../developer-guide/image-build.md) on how to build/obtain the artifacts.
 2.  Upload the images to a container registry that is reachable by both clusters.
 3.  Label all Host nodes with DPU with **k8s.ovn.org/dpu-host=""**
 4.  Label all DPU nodes with **k8s.ovn.org/dpu=""**
 5.  `git clone https://github.com/ovn-kubernetes/ovn-kubernetes` to obtain the helm charts.
-6.  Follow the [upstream installation guide](../installation/launching-ovn-kubernetes-with-dpu.md) to configure the helm charts correctly and install OVN-Kubernetes to the Host and DPU.
+6.  Follow the [upstream installation guide](../../installation/launching-ovn-kubernetes-with-dpu.md) to configure the helm charts correctly and install OVN-Kubernetes to the Host and DPU.
 
 ## Install SR-IOV Device Plugin
 
@@ -393,4 +401,3 @@ Now that we have configured everything it is time to create a pod and verify tha
 
 Deploying OVN-Kubernetes in a DPU-accelerated environment provides significant performance and security benefits by offloading network processing. By carefully following the configuration steps for both the DPU and the host, and verifying the OVN-Kubernetes setup, you can establish a high-performance network foundation for your Kubernetes workloads.
 
-*Posted on* *February 12, 2026* *by* *Tim Rozet*.

--- a/docs/blog/posts/netobserv.md
+++ b/docs/blog/posts/netobserv.md
@@ -1,3 +1,9 @@
+---
+date: 2026-03-12
+authors:
+  - npinaeva
+---
+
 # Debugging NetworkPolicies with NetObserv
 
 Observability is a key part of any system, and Kubernetes networking is no exception.
@@ -7,12 +13,15 @@ a given connection is allowed or denied.
 
 To solve this problem, OVN-Kubernetes has introduced a new observability feature together with the NetObserv project
 that adds explicit communication between observability and networking.
+
+<!-- more -->
+
 This post will walk you through the installation steps and some examples of how to use it to understand the behavior of your network policies.
-See feature guide for more information on limitations/requirements [OVN observability](../observability/ovn-observability.md).
+See feature guide for more information on limitations/requirements [OVN observability](../../observability/ovn-observability.md).
 
 ## Install
 
-- Run kind cluster with [OVN observability](../observability/ovn-observability.md) feature enabled
+- Run kind cluster with [OVN observability](../../observability/ovn-observability.md) feature enabled
 - Install NetObserv operator in Standalone mode following the [README guide](https://github.com/netobserv/netobserv-operator/tree/main?tab=readme-ov-file#getting-started)
 - Some tweaks are required to the suggested flowCollector configuration 
 Enable NetworkEvents to see OVN observability samples in NetObserv like so:
@@ -147,7 +156,7 @@ because it is not set by default, you can configure visible columns by clicking 
 Also make sure to either put some non-zero `Refresh interval` or manually refresh when checking for the latest data.
 You should see something like this:
 
-![netobserv-anp-drop](images/netobserv-anp-drop.png)
+![netobserv-anp-drop](../images/netobserv-anp-drop.png)
 
 We didn't create any `NetworkPolicies`, but cluster admin can create cluster-wide policies using `AdminNetworkPolicy`,
 that may affect any namespace in the cluster, and without the right observability tools, it may be hard to understand
@@ -208,7 +217,7 @@ $ kubectl exec -n blue server -- curl 10.244.0.11:8080
 ```
 that was unexpected, what now? Let's check the NetObserv console again (don't forget to refresh)
 
-![netobserv-netpol-drop](images/netobserv-netpol-drop.png)
+![netobserv-netpol-drop](../images/netobserv-netpol-drop.png)
 
 it says "Dropped by network policies isolation in namespace blue, direction Egress"
 

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -40,12 +40,23 @@ feel free to write it. If you are unsure where this should be placed; reach out 
 
 * **Blog Posts**: Are you an end-user of OVN-Kubernetes? Is there something you wish to share with
 the community about your awesome use cases and how you used our CNI to solve your problems? We
-welcome blog post contributions from all! See [here](../blog/index.md) for details.
-Open a commit adding it to our `docs/blog` folder.
+welcome blog post contributions from all! See [here](https://ovn-kubernetes.io/blog/) for details.
+Open a commit adding your post to `docs/blog/posts/`. Each post must include
+YAML front matter with a `date` and `authors` list, for example:
+```yaml
+---
+date: 2026-03-12
+authors:
+  - githubhandle
+---
+```
+The author handle must have a matching entry in `docs/blog/.authors.yml` with
+your name, a short description, and a GitHub avatar URL. See existing entries
+for reference.
 
 * **Performance Enhancements**: We love performance enhancements! Did you write a cool patch
 to reduce the time it takes for iptables to sync up on startup? Think about writing a good blog post
-around this! Open a commit adding it to our `docs/blog` folder.
+around this! Open a commit adding it to our `docs/blog/posts/` folder.
 
 * **API Reference**: Did you introduce a new CRD? OR Did you add a watcher a new CRD? Include API
 Reference documentation changes to `docs/api-reference` folder. See [here](../api-reference/introduction.md)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -530,6 +530,19 @@ a.md-tabs__link {
   }
 }
 
+/* BLOG POST PAGES: Reset aggressive sidebar/content offsets so the author
+   metadata sidebar doesn't overlap post content. The :not(:has(.md-post--excerpt))
+   excludes the blog index page (which lists excerpts) from this override. */
+.md-main__inner:has(.md-post):not(:has(.md-post--excerpt)) .md-sidebar--primary:not([hidden]) {
+  transform: none;
+}
+[dir="ltr"] .md-main__inner:has(.md-post):not(:has(.md-post--excerpt)) .md-sidebar--primary:not([hidden]) ~ .md-content > .md-content__inner,
+[dir="ltr"] .md-main__inner:has(.md-post):not(:has(.md-post--excerpt)) .md-content > .md-content__inner {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: left;
+}
+
 img[alt="ovn-kubernetes-logo"] {
   width: clamp(240px, 20vw, 300px);
   display: block;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -319,6 +319,50 @@ a.md-tabs__link {
   box-shadow: var(--ok-shadow), 0 0 0 1px rgba(82, 108, 254, 0.08);
 }
 
+/* BLOG POST SIDEBAR: Visual-only floating card for the blog plugin's
+   post metadata sidebar (.md-sidebar--post). Unlike --primary, this
+   sidebar lives INSIDE .md-content--post so we pull it left with a
+   negative margin to align with the primary sidebar card on other pages. */
+.md-sidebar--post {
+  width: min(15rem, 80vw);
+  transform: translateX(clamp(-20rem, 2.5% - 10vw, -5rem));
+}
+
+.md-sidebar--post .md-sidebar__scrollwrap {
+  box-sizing: border-box;
+  background: var(--ok-sidebar-gradient);
+  background-clip: padding-box;
+  border: 1px solid var(--ok-sidebar-border);
+  border-radius: var(--ok-radius);
+  box-shadow: var(--ok-shadow);
+  overflow-y: auto;
+  overflow-x: hidden;
+  transition: transform var(--ok-med), box-shadow var(--ok-med);
+}
+
+.md-sidebar--post .md-sidebar__inner {
+  background: var(--ok-sidebar-bg);
+  border-radius: var(--ok-radius-sm);
+  margin: 0 clamp(1px, 0.2vw, 2px);
+  padding: clamp(0.5rem, 0.5rem + 0.3vw, 0.85rem) clamp(0.4rem, 0.4rem + 0.3vw, 0.7rem);
+}
+
+.md-sidebar--post .md-sidebar__scrollwrap:hover {
+  transform: translateY(clamp(-2px, -0.2vw, -4px));
+  box-shadow: var(--ok-shadow), rgba(24, 23, 23, 0.1) 0 2px 0;
+}
+
+[data-md-color-scheme="slate"] .md-sidebar--post .md-sidebar__scrollwrap:hover {
+  box-shadow: var(--ok-shadow), 0 0 0 1px rgba(82, 108, 254, 0.08);
+}
+
+/* Blog post pages: reset the aggressive negative content margin so the
+   article text does not overlap the in-content post sidebar. The [dir]
+   attribute selector matches the specificity of the global rule. */
+[dir="ltr"] .md-content--post > .md-content__inner {
+  margin-left: 1.2rem;
+}
+
 .md-main__inner {
   grid-template-columns: minmax(min(10rem, 15vw), 12.5rem) 1fr minmax(min(10rem, 15vw), 12.5rem);
   margin-top: 1rem;
@@ -528,19 +572,6 @@ a.md-tabs__link {
   .md-typeset details {
     transition: none !important;
   }
-}
-
-/* BLOG POST PAGES: Reset aggressive sidebar/content offsets so the author
-   metadata sidebar doesn't overlap post content. The :not(:has(.md-post--excerpt))
-   excludes the blog index page (which lists excerpts) from this override. */
-.md-main__inner:has(.md-post):not(:has(.md-post--excerpt)) .md-sidebar--primary:not([hidden]) {
-  transform: none;
-}
-[dir="ltr"] .md-main__inner:has(.md-post):not(:has(.md-post--excerpt)) .md-sidebar--primary:not([hidden]) ~ .md-content > .md-content__inner,
-[dir="ltr"] .md-main__inner:has(.md-post):not(:has(.md-post--excerpt)) .md-content > .md-content__inner {
-  margin-left: auto;
-  margin-right: auto;
-  text-align: left;
 }
 
 img[alt="ovn-kubernetes-logo"] {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,4 @@ nav:
     - Disable Port Security: okeps/okep-3926-disable-port-security.md
     - OVN Observability API: okeps/okep-5212-ovnobserv-api.md
   - Blog:
-    - blog/index.md
-    - Accelerating and Securing Kubernetes Networking with DPUs: blog/dpu-acceleration.md
-    - Debugging NetworkPolicies with NetObserv: blog/netobserv.md
+    - OVN-Kubernetes Blog: blog/index.md


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

The blog landing page was a manually curated list of links with no uniformity for authors, dates, or excerpts. Restructure it to use the mkdocs-material blog plugin's auto-generated listing, matching the style used by network-policy-api (https://network-policy-api.sigs.k8s.io/blog/).

Changes:
- Move blog posts from docs/blog/ to docs/blog/posts/ so the blog plugin auto-discovers them.
- Add YAML front matter (date, authors) and <!-- more --> excerpt markers to each post so the plugin renders author avatars, dates, read times, and excerpts on the landing page.
- Add docs/blog/.authors.yml with author metadata (name, description, GitHub avatar) for Tim Rozet and Nadia Pinaeva.
- Simplify docs/blog/index.md to a single heading; the plugin generates the post listing automatically.
- Update mkdocs.yml nav to only reference blog/index.md and let the plugin handle individual post entries and archive navigation.
- Fix relative paths in posts (images, doc links) since they moved one directory deeper into posts/.
- Remove the manual "Posted on ... by ..." line from the DPU post since date/author now comes from front matter.
- Add CSS override in extra.css for individual blog post pages to prevent the custom sidebar transform and negative content margins from causing the author metadata sidebar to overlap post content. Uses :has(.md-post):not(:has(.md-post--excerpt)) to scope the fix to individual posts without affecting the blog index.
- Fix blog archive navigation which was broken on the main website (clicking archive links would redirect back to the main page instead of filtering posts by year). The old setup had posts listed explicitly in the nav rather than using the blog plugin's posts/ directory, so the plugin could not generate proper archive pages.


## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
Old

<img width="1750" height="953" alt="Screenshot From 2026-08-31 11-33-15" src="https://github.com/user-attachments/assets/294b6dac-24ca-48b8-b26f-931888f9e16b" />

New
<img width="1750" height="953" alt="Screenshot From 2026-08-31 11-33-09" src="https://github.com/user-attachments/assets/610db1c1-4ae8-4dde-bbcf-22ecc8eaa648" />

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
