### PR TITLE
node: scope service resync on UDN gateway changes

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -1779,6 +1779,12 @@ func (wf *WatchFactory) GetServices() ([]*corev1.Service, error) {
 	return serviceLister.List(labels.Everything())
 }
 
+// GetServicesByNamespace returns all services in the given namespace
+func (wf *WatchFactory) GetServicesByNamespace(namespace string) ([]*corev1.Service, error) {
+	serviceLister := wf.informers[ServiceType].lister.(listers.ServiceLister)
+	return serviceLister.Services(namespace).List(labels.Everything())
+}
+
 func (wf *WatchFactory) GetCloudPrivateIPConfig(name string) (*ocpcloudnetworkapi.CloudPrivateIPConfig, error) {
 	cloudPrivateIPConfigLister := wf.informers[CloudPrivateIPConfigType].lister.(ocpcloudnetworklister.CloudPrivateIPConfigLister)
 	return cloudPrivateIPConfigLister.Get(name)

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -536,8 +536,36 @@ func (g *gateway) SetDefaultBridgeGARPDropFlows(isDropped bool) {
 	g.openflowManager.setDefaultBridgeGARPDrop(isDropped)
 }
 
-// Reconcile handles triggering updates to different components of a gateway, like OFM, Services
+// Reconcile handles triggering updates to different components of a gateway, like
+// OFM and Services, in response to a change with cluster-wide reach (node IP/MAC
+// change, EgressIP, default-network advertised change, init). It resyncs every
+// service because any service's flows may be affected.
 func (g *gateway) Reconcile() error {
+	return g.reconcile(g.resyncAllServices)
+}
+
+// ReconcileNetwork rebuilds the shared bridge flows after a primary UDN is added
+// and resyncs only that network's namespaces' services. Advertised-state changes
+// must go through UserDefinedNetworkGateway.Reconcile (doReconcile), not this.
+func (g *gateway) ReconcileNetwork(netInfo util.NetInfo) error {
+	return g.reconcile(func() []error {
+		return g.resyncNetworkServices(netInfo)
+	})
+}
+
+// ReconcileNetworkRemoval refreshes the shared gateway OpenFlow/SNAT state after a
+// network's config has been removed, dropping its bridge flows. Services are not
+// resynced: a UDN namespace cannot revert to the default network (the reserved label
+// is immutable), so the removed network's services are either already gone (their own
+// delete events clean their per-service flows) or their namespace still carries the
+// label with no NAD, leaving them with no valid network to reprogram onto.
+func (g *gateway) ReconcileNetworkRemoval() error {
+	return g.reconcile(nil)
+}
+
+// reconcile refreshes the gateway's OpenFlow/SNAT state and, if syncServices is
+// non-nil, resyncs the selected services through the retry framework.
+func (g *gateway) reconcile(syncServices func() []error) error {
 	klog.Info("Reconciling gateway with updates")
 	if config.IsModeDPU() || config.IsModeFull() {
 		if g.openflowManager != nil {
@@ -560,30 +588,49 @@ func (g *gateway) Reconcile() error {
 			return err
 		}
 	}
-	// Services create OpenFlow flows as well, need to update them all
-	if g.servicesRetryFramework != nil {
-		if errs := g.addAllServices(); errs != nil {
-			err := utilerrors.Join(errs...)
-			return err
+	// Services create OpenFlow flows as well, need to resync the affected ones.
+	if g.servicesRetryFramework != nil && syncServices != nil {
+		if errs := syncServices(); errs != nil {
+			return utilerrors.Join(errs...)
 		}
 	}
 	return nil
 }
 
-func (g *gateway) addAllServices() []error {
-	errs := []error{}
+// resyncAllServices enqueues every service in the cluster for reprogramming. Used
+// for cluster-wide changes where any service's flows may be affected.
+func (g *gateway) resyncAllServices() []error {
 	svcs, err := g.watchFactory.GetServices()
 	if err != nil {
-		errs = append(errs, err)
-	} else {
-		for _, svc := range svcs {
-			svc := *svc
-			klog.V(5).Infof("Adding service %s/%s to retryServices", svc.Namespace, svc.Name)
-			err = g.servicesRetryFramework.AddRetryObjWithAddNoBackoff(&svc)
-			if err != nil {
-				err = fmt.Errorf("failed to add service %s/%s to retry framework: %w", svc.Namespace, svc.Name, err)
-				errs = append(errs, err)
-			}
+		return []error{err}
+	}
+	return g.resyncServices(svcs)
+}
+
+// resyncNetworkServices enqueues only the services in netInfo's namespaces
+// (GetNADNamespaces) for reprogramming, instead of scanning every service. A selected
+// namespace whose NAD has not landed yet recovers via its own per-service retry.
+func (g *gateway) resyncNetworkServices(netInfo util.NetInfo) []error {
+	var svcs []*corev1.Service
+	for _, namespace := range netInfo.GetNADNamespaces() {
+		nsSvcs, err := g.watchFactory.GetServicesByNamespace(namespace)
+		if err != nil {
+			return []error{err}
+		}
+		svcs = append(svcs, nsSvcs...)
+	}
+	return g.resyncServices(svcs)
+}
+
+// resyncServices adds the given services to the retry framework with no backoff and
+// requests an immediate retry.
+func (g *gateway) resyncServices(svcs []*corev1.Service) []error {
+	var errs []error
+	for _, svc := range svcs {
+		svc := *svc
+		klog.V(5).Infof("Adding service %s/%s to retryServices", svc.Namespace, svc.Name)
+		if err := g.servicesRetryFramework.AddRetryObjWithAddNoBackoff(&svc); err != nil {
+			errs = append(errs, fmt.Errorf("failed to add service %s/%s to retry framework: %w", svc.Namespace, svc.Name, err))
 		}
 	}
 	g.servicesRetryFramework.RequestRetryObjs()

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1808,7 +1808,7 @@ func newGateway(
 			}
 			// Services create OpenFlow flows as well, need to update them all
 			if gw.servicesRetryFramework != nil {
-				if errs := gw.addAllServices(); len(errs) > 0 {
+				if errs := gw.resyncAllServices(); len(errs) > 0 {
 					err := utilerrors.Join(errs...)
 					klog.Errorf("Failed to sync all services after node IP change: %v", err)
 				}

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -598,7 +598,7 @@ func (udng *UserDefinedNetworkGateway) addNetwork() error {
 			return true, nil
 		}
 		postFunc := func() error {
-			if err := udng.gateway.Reconcile(); err != nil {
+			if err := udng.gateway.ReconcileNetwork(udng.NetInfo); err != nil {
 				return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", udng.GetNetworkName(), err)
 			}
 			if udng.Uplink() != "" {
@@ -613,7 +613,7 @@ func (udng *UserDefinedNetworkGateway) addNetwork() error {
 			return newUplinkGatewayError(uplinkv1alpha1.UplinkStateReasonBridgeMappingFailed, err)
 		}
 	} else {
-		if err := udng.gateway.Reconcile(); err != nil {
+		if err := udng.gateway.ReconcileNetwork(udng.NetInfo); err != nil {
 			return fmt.Errorf("failed to reconcile flows on bridge for network %s; error: %v", udng.GetNetworkName(), err)
 		}
 	}
@@ -684,7 +684,8 @@ func (udng *UserDefinedNetworkGateway) delNetwork() error {
 		}
 	}
 	if udng.openflowManager != nil || config.IsModeDPUHost() {
-		if err := udng.gateway.Reconcile(); err != nil {
+		// Network config already removed: regenerate the shared bridge flows without it.
+		if err := udng.gateway.ReconcileNetworkRemoval(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile default gateway for network %s, err: %v", udng.GetNetworkName(), err))
 		}
 	}
@@ -1234,6 +1235,10 @@ func (udng *UserDefinedNetworkGateway) run() {
 	}()
 }
 
+// Reconcile signals doReconcile for advertised-state updates (VRF, isolation,
+// DEFAULT OpenFlow). It does not implement Gateway.Reconcile: the signature has
+// no error, and it must not be confused with the embedded *gateway.Reconcile
+// which resyncs services.
 func (udng *UserDefinedNetworkGateway) Reconcile() {
 	select {
 	case udng.reconcile <- struct{}{}:


### PR DESCRIPTION
gateway.Reconcile() re-added every service in the cluster to the node service retry framework on any gateway change. Since UDN add/delete and pod-network-advertised changes all funnel through it, one UDN change triggered a full cluster-wide resync, proportional to total service count.

Split reconcile() into intent-named entry points sharing one core:

  - Reconcile()             full resync; cluster-wide triggers (node
                            IP/MAC, EgressIP, default-net advertised, init).
  - ReconcileNetwork(ni)    resync only ni's namespaces' services; UDN add
                            and pod-network-advertised change.
  - ReconcileNetworkRemoval flows only, no service resync; UDN removal.

The per-network resync lists only the network's own namespaces' services (netInfo.GetNADNamespaces via the new
factory.GetServicesByNamespace) instead of scanning all services.

Removal skips the service resync: the OpenFlow rebuild (global) already drops the removed network's bridge flows, and its namespaces' services cannot revert to the default network (the reserved label is immutable), so there is nothing to reprogram.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
