### PR TITLE
contrib: wire the DPU uplink from the interface reserved by dpu-sim

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -224,7 +224,8 @@ jobs:
           source "${DPU_SIM_PATH}/kubeconfig/helm-values/dpu-sim-dpu-frr-k8s.env"
           export KUBECONFIG="${DPU_SIM_PATH}/kubeconfig/dpu-sim-host.kubeconfig"
           export OVN_TEST_DPU_UPLINK_NETWORK="dpu-sim-uplink"
-          export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="eth0-16"
+          # Keep in sync with DPU_SIM_UPLINK_INDEX in contrib/kind-dpu-sim-no-overlay.sh.
+          export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="eth0-200"
           export OVN_TEST_DPU_UPLINK_EXPECTED_BRIDGE="breth-uplink"
           export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV4="172.29.0.0/16"
           export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV6="fc00:f853:ccd:e797::/64"

--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -224,8 +224,11 @@ jobs:
           source "${DPU_SIM_PATH}/kubeconfig/helm-values/dpu-sim-dpu-frr-k8s.env"
           export KUBECONFIG="${DPU_SIM_PATH}/kubeconfig/dpu-sim-host.kubeconfig"
           export OVN_TEST_DPU_UPLINK_NETWORK="dpu-sim-uplink"
-          # Keep in sync with DPU_SIM_UPLINK_INDEX in contrib/kind-dpu-sim-no-overlay.sh.
-          export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="eth0-200"
+          # The interface dpu-sim reserved for the uplink (from the sourced env
+          # file), or the out-of-range default of kind-dpu-sim-no-overlay.sh.
+          uplink_ifaces="${DPU_SIM_UPLINK_HOST_INTERFACES:-}"
+          export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="${uplink_ifaces%%,*}"
+          [ -n "${OVN_TEST_DPU_UPLINK_HOST_INTERFACE}" ] || export OVN_TEST_DPU_UPLINK_HOST_INTERFACE="eth0-200"
           export OVN_TEST_DPU_UPLINK_EXPECTED_BRIDGE="breth-uplink"
           export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV4="172.29.0.0/16"
           export OVN_TEST_BGP_SERVER_NET_SUBNET_IPV6="fc00:f853:ccd:e797::/64"

--- a/contrib/kind-dpu-sim-no-overlay.sh
+++ b/contrib/kind-dpu-sim-no-overlay.sh
@@ -100,7 +100,9 @@ DPU_SIM_UPLINK_ENABLE=${DPU_SIM_UPLINK_ENABLE:-true}
 DPU_SIM_UPLINK_NETWORK=${DPU_SIM_UPLINK_NETWORK:-dpu-sim-uplink}
 DPU_SIM_UPLINK_SUBNET=${DPU_SIM_UPLINK_SUBNET:-172.31.0.0/24}
 DPU_SIM_UPLINK_BRIDGE=${DPU_SIM_UPLINK_BRIDGE:-breth-uplink}
-DPU_SIM_UPLINK_INDEX=${DPU_SIM_UPLINK_INDEX:-16}
+# dpusim.UplinkInterfaceIndex: outside the pairs created by the dpu-simulator
+# (num_pairs), so the device plugin never advertises the uplink VF as a pod VF.
+DPU_SIM_UPLINK_INDEX=200
 DPU_SIM_UPLINK_HOST_INTERFACE="eth0-${DPU_SIM_UPLINK_INDEX}"
 DPU_SIM_UPLINK_DPU_REPRESENTOR="rep0-${DPU_SIM_UPLINK_INDEX}"
 DPU_SIM_CONFIG=${DPU_SIM_CONFIG:-config-kind-ovnk-offload.yaml}

--- a/contrib/kind-dpu-sim-no-overlay.sh
+++ b/contrib/kind-dpu-sim-no-overlay.sh
@@ -100,8 +100,8 @@ DPU_SIM_UPLINK_ENABLE=${DPU_SIM_UPLINK_ENABLE:-true}
 DPU_SIM_UPLINK_NETWORK=${DPU_SIM_UPLINK_NETWORK:-dpu-sim-uplink}
 DPU_SIM_UPLINK_SUBNET=${DPU_SIM_UPLINK_SUBNET:-172.31.0.0/24}
 DPU_SIM_UPLINK_BRIDGE=${DPU_SIM_UPLINK_BRIDGE:-breth-uplink}
-# dpusim.UplinkInterfaceIndex: outside the pairs created by the dpu-simulator
-# (num_pairs), so the device plugin never advertises the uplink VF as a pod VF.
+# Fallback when dpu-sim publishes no reserved uplink interface: outside the
+# pairs it creates (num_pairs), so the device plugin never advertises it.
 DPU_SIM_UPLINK_INDEX=200
 DPU_SIM_UPLINK_HOST_INTERFACE="eth0-${DPU_SIM_UPLINK_INDEX}"
 DPU_SIM_UPLINK_DPU_REPRESENTOR="rep0-${DPU_SIM_UPLINK_INDEX}"
@@ -285,6 +285,22 @@ configure_dpu_sim_uplink_bridge() {
     return
   fi
 
+  # Prefer the interface dpu-sim reserved for the uplink (published in the
+  # FRR env file, uplink_vfs_count in its config): the veth pair already
+  # exists and only needs wiring. Fall back to creating an out-of-range pair.
+  local reserved=""
+  if [ -f "${FRR_ENV}" ]; then
+    reserved=$(unset DPU_SIM_UPLINK_HOST_INTERFACES; . "${FRR_ENV}"; echo "${DPU_SIM_UPLINK_HOST_INTERFACES:-}")
+  fi
+  local uplink_pair_reserved=false
+  if [ -n "${reserved}" ]; then
+    uplink_pair_reserved=true
+    DPU_SIM_UPLINK_HOST_INTERFACE="${reserved%%,*}"
+    DPU_SIM_UPLINK_INDEX="${DPU_SIM_UPLINK_HOST_INTERFACE##*-}"
+    DPU_SIM_UPLINK_DPU_REPRESENTOR="rep0-${DPU_SIM_UPLINK_INDEX}"
+    echo "Using dpu-sim reserved uplink interface ${DPU_SIM_UPLINK_HOST_INTERFACE}"
+  fi
+
   local prefix subnet_ip subnet_base
   prefix=${DPU_SIM_UPLINK_SUBNET#*/}
   subnet_ip=${DPU_SIM_UPLINK_SUBNET%/*}
@@ -326,28 +342,34 @@ configure_dpu_sim_uplink_bridge() {
     tmp_host="uh${ordinal}${DPU_SIM_UPLINK_INDEX}"
     tmp_dpu="ud${ordinal}${DPU_SIM_UPLINK_INDEX}"
 
-    run_root nsenter -t "${host_pid}" -n ip link del \
-      "${DPU_SIM_UPLINK_HOST_INTERFACE}" >/dev/null 2>&1 || true
-    run_root nsenter -t "${dpu_pid}" -n ip link del \
-      "${DPU_SIM_UPLINK_DPU_REPRESENTOR}" >/dev/null 2>&1 || true
-    run_root ip link del "${tmp_host}" >/dev/null 2>&1 || true
-    run_root ip link add "${tmp_host}" type veth peer name "${tmp_dpu}"
-    run_root ip link set "${tmp_host}" netns "${host_pid}"
-    run_root ip link set "${tmp_dpu}" netns "${dpu_pid}"
+    if [ "${uplink_pair_reserved}" != true ]; then
+      # No reservation published (older dpu-sim): create our own pair at the
+      # out-of-range index. A reserved pair already exists with the right
+      # names and MACs, created by dpu-sim, so this whole block is skipped.
+      run_root nsenter -t "${host_pid}" -n ip link del \
+        "${DPU_SIM_UPLINK_HOST_INTERFACE}" >/dev/null 2>&1 || true
+      run_root nsenter -t "${dpu_pid}" -n ip link del \
+        "${DPU_SIM_UPLINK_DPU_REPRESENTOR}" >/dev/null 2>&1 || true
+      run_root ip link del "${tmp_host}" >/dev/null 2>&1 || true
+      run_root ip link add "${tmp_host}" type veth peer name "${tmp_dpu}"
+      run_root ip link set "${tmp_host}" netns "${host_pid}"
+      run_root ip link set "${tmp_dpu}" netns "${dpu_pid}"
 
-    run_root nsenter -t "${host_pid}" -n ip link set "${tmp_host}" \
-      name "${DPU_SIM_UPLINK_HOST_INTERFACE}"
-    run_root nsenter -t "${host_pid}" -n ip link set \
-      "${DPU_SIM_UPLINK_HOST_INTERFACE}" address "${host_mac}"
+      run_root nsenter -t "${host_pid}" -n ip link set "${tmp_host}" \
+        name "${DPU_SIM_UPLINK_HOST_INTERFACE}"
+      run_root nsenter -t "${host_pid}" -n ip link set \
+        "${DPU_SIM_UPLINK_HOST_INTERFACE}" address "${host_mac}"
+      run_root nsenter -t "${dpu_pid}" -n ip link set "${tmp_dpu}" \
+        name "${DPU_SIM_UPLINK_DPU_REPRESENTOR}"
+      run_root nsenter -t "${dpu_pid}" -n ip link set \
+        "${DPU_SIM_UPLINK_DPU_REPRESENTOR}" address "${dpu_mac}"
+    fi
+
+    # Both paths: address the host side, raise the links, then bridge below.
     run_root nsenter -t "${host_pid}" -n ip addr replace \
       "${host_ip}/${prefix}" dev "${DPU_SIM_UPLINK_HOST_INTERFACE}"
     run_root nsenter -t "${host_pid}" -n ip link set \
       "${DPU_SIM_UPLINK_HOST_INTERFACE}" up
-
-    run_root nsenter -t "${dpu_pid}" -n ip link set "${tmp_dpu}" \
-      name "${DPU_SIM_UPLINK_DPU_REPRESENTOR}"
-    run_root nsenter -t "${dpu_pid}" -n ip link set \
-      "${DPU_SIM_UPLINK_DPU_REPRESENTOR}" address "${dpu_mac}"
     run_root nsenter -t "${dpu_pid}" -n ip link set \
       "${DPU_SIM_UPLINK_DPU_REPRESENTOR}" up
 


### PR DESCRIPTION
The kind-dpu-no-overlay deploy reserved one host-to-DPU veth pair (eth0-16/rep0-16) for the Uplink bridge, but the reservation was invisible to Kubernetes: the dpu-simulator device plugin advertises every eth0-N above the mgmt-port range as a `dpusim.io/vf` pod device, eth0-16 included. Whenever kubelet handed eth0-16 to a pod, the DPU-side ovnkube pulled rep0-16 onto br-int and either the deploy failed (`rep0-16 is actually attached to bridge br-int`, run 30959168870) or the pod wedged on CNI ADD (run 33411543157).

What this PR does:
- wires the uplink from the interface dpu-sim reserves and publishes when available (`DPU_SIM_UPLINK_HOST_INTERFACES` in the FRR env file, from `uplink_vfs_count` in ovn-kubernetes/dpu-simulator#44): the reserved pair is excluded from the device-plugin pools at any `num_pairs`, so no pod can ever claim it, and the script only wires it instead of creating its own pair
- falls back to creating the pair at index 200, outside the pairs the simulator creates, when dpu-simulator publishes no reservation (current dpu-simulator main): kubelet never learns that interface exists either
- the workflow derives the e2e uplink interface from the same env file, with the same fallback

Green against dpu-simulator main both before and after ovn-kubernetes/dpu-simulator#44 merges; merge this first, then #44. A follow-up removes the fallback once dpu-simulator main always publishes the reservation.
