### PR TITLE
docs: fix blog post page layout consistency across all screen sizes

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -330,7 +330,7 @@ a.md-tabs__link {
 
 .md-sidebar--post .md-sidebar__scrollwrap {
   box-sizing: border-box;
-  background: var(--ok-sidebar-gradient);
+  background: var(--ok-sidebar-bg);
   background-clip: padding-box;
   border: 1px solid var(--ok-sidebar-border);
   border-radius: var(--ok-radius);
@@ -356,11 +356,80 @@ a.md-tabs__link {
   box-shadow: var(--ok-shadow), 0 0 0 1px rgba(82, 108, 254, 0.08);
 }
 
-/* Blog post pages: reset the aggressive negative content margin so the
-   article text does not overlap the in-content post sidebar. The [dir]
-   attribute selector matches the specificity of the global rule. */
-[dir="ltr"] .md-content--post > .md-content__inner {
-  margin-left: 1.2rem;
+@media screen and (min-width: 76.25em) {
+  [dir="ltr"] .md-sidebar--secondary:not([hidden]) ~ .md-content.md-content--post > .md-content__inner {
+    margin-right: clamp(-40px, -4vw, 0px);
+  }
+}
+
+/* Blog post pages on mobile & mid-screen */
+@media screen and (max-width: 86.25em) {
+  .md-content.md-content--post {
+    flex-flow: column !important;
+  }
+
+  .md-content.md-content--post > .md-content__inner {
+    margin-left: 0.8rem !important;
+    margin-right: 0.8rem !important;
+    min-height: 0 !important;
+    flex-grow: 1 !important;
+    visibility: visible !important;
+    display: block !important;
+  }
+
+  .md-sidebar.md-sidebar--post {
+    width: 100% !important;
+    height: auto !important;
+    transform: none !important;
+    position: static !important;
+    padding: 0 !important;
+    flex-shrink: 0 !important;
+    align-self: stretch !important;
+  }
+
+  .md-sidebar--post .md-sidebar__scrollwrap {
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    transform: none !important;
+    overflow: visible !important;
+  }
+
+  .md-sidebar--post .md-sidebar__scrollwrap:hover {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+
+  .md-sidebar--post .md-sidebar__inner {
+    background: transparent !important;
+    border-radius: 0 !important;
+    margin: 0 !important;
+    padding: 0.6rem 0.8rem !important;
+  }
+
+  .md-sidebar--post .md-nav {
+    height: auto !important;
+    margin-bottom: 0 !important;
+    position: static !important;
+  }
+
+  .md-sidebar--post .md-nav__item {
+    border: none !important;
+    display: inline !important;
+  }
+
+  .md-sidebar--post .md-nav__list {
+    display: inline-flex !important;
+    flex-wrap: wrap !important;
+    gap: 0.6rem !important;
+    padding-bottom: 0.6rem !important;
+    padding-top: 0.6rem !important;
+  }
+
+  .md-sidebar--post .md-nav__link {
+    padding: 0 !important;
+  }
 }
 
 .md-main__inner {
@@ -1051,6 +1120,111 @@ body:has(#__drawer:checked) {
   /* Hide the standalone TOC sidebar (right column) */
   .md-sidebar--secondary {
     display: none !important;
+  }
+
+  /* Blog post pages inside the mid-screen range */
+  .md-content.md-content--post {
+    display: flex !important;
+    flex-flow: column !important;
+    width: 100% !important;
+    gap: 0 !important;
+  }
+
+  .md-content.md-content--post > .md-content__inner {
+    display: block !important;
+    visibility: visible !important;
+    margin: 0 0.8rem 1.2rem !important;
+    padding-top: 0.6rem !important;
+    width: auto !important;
+    max-width: none !important;
+    flex-grow: 0 !important;
+    flex-shrink: 1 !important;
+    flex-basis: auto !important;
+  }
+
+  .md-sidebar.md-sidebar--post {
+    width: 100% !important;
+    height: auto !important;
+    max-height: none !important;
+    transform: none !important;
+    position: static !important;
+    padding: 0 !important;
+    flex-shrink: 0 !important;
+    flex-grow: 0 !important;
+    flex-basis: auto !important;
+    align-self: stretch !important;
+    overflow: visible !important;
+  }
+
+  .md-sidebar--post .md-sidebar__scrollwrap {
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    transform: none !important;
+    overflow: visible !important;
+    max-height: none !important;
+    height: auto !important;
+    position: static !important;
+  }
+
+  .md-sidebar--post .md-sidebar__scrollwrap:hover {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+
+  .md-sidebar--post .md-sidebar__inner {
+    background: transparent !important;
+    border-radius: 0 !important;
+    margin: 0 !important;
+    padding: 0.6rem 0.8rem !important;
+    height: auto !important;
+    position: static !important;
+  }
+
+  .md-sidebar--post .md-nav,
+  .md-sidebar--post .md-nav.md-nav--primary {
+    height: auto !important;
+    max-height: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    position: static !important;
+    display: block !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    transform: none !important;
+    pointer-events: auto !important;
+    background: transparent !important;
+    left: auto !important;
+    right: auto !important;
+    top: auto !important;
+    z-index: auto !important;
+    flex-direction: unset !important;
+  }
+
+  .md-sidebar--post .md-nav__title {
+    height: auto !important;
+    padding: 0 !important;
+    background: transparent !important;
+    position: static !important;
+  }
+
+  .md-sidebar--post .md-nav__item {
+    border: none !important;
+    display: inline !important;
+  }
+
+  .md-sidebar--post .md-nav__list {
+    display: inline-flex !important;
+    flex-wrap: wrap !important;
+    gap: 0.6rem !important;
+    padding-bottom: 0.6rem !important;
+    padding-top: 0.6rem !important;
+    flex: none !important;
+  }
+
+  .md-sidebar--post .md-nav__link {
+    padding: 0 !important;
   }
 
   .md-nav--primary .md-nav__link[for=__toc] {


### PR DESCRIPTION
## Summary

Fixes the blog post page layout in `extra.css` so individual blog post pages (`/master/blog/<date>/<slug>/`) are visually consistent with the blog index page and other documentation pages across all screen sizes.

## Changes done

### 1. Post sidebar background consistency:
The post sidebar's scrollwrap used `var(--ok-sidebar-gradient)` while other sidebars use `var(--ok-sidebar-bg)`. Updated to match.

### 2. Mobile & tablet layout (≤86.25em / ≤1380px):
- Flipped `flex-flow` from `column-reverse` (theme default) to  `column` so the author/metadata sidebar appears **above** the article content instead of below.
- Stripped desktop card styling (border, shadow, border-radius, background) from the post sidebar for a clean inline look.
- Reflowed nav items (`md-nav__item`) as `inline-flex` with wrapping for compact metadata display (date, read time).

### 3. Mid-screen drawer conflict fix (959px–1380px)
The mid-screen breakpoint replicates the mobile drawer behavior for `.md-nav--primary` (setting `height: 100%`, `position: absolute`, `display: flex`, etc.). These rules leaked into the post sidebar's internal `nav.md-nav--primary`, causing blank content and a large gap between metadata and article text.

### 4. Blog content width spacing
Added a `margin-right: clamp(-40px, -4vw, 0px)` override on blog post content (at ≥76.25em) so the gap between the TOC sidebar and the article matches the gap between the primary sidebar and content on other pages.

https://github.com/user-attachments/assets/78db195c-e8ed-456d-a478-fbe3fcd87f83

It is part of blog page UI improvements following #6873.