### PR TITLE
metrics: decouple OVN/OVS metric extraction from scraping

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
@@ -54,6 +54,9 @@ var OvsExporterCommand = cli.Command{
 			EnableOVSMetrics: true,
 			OnFatalError:     cancel,
 			OVSDBClient:      ovsClient,
+			// CollectionInterval left unset: the standalone exporter uses the
+			// default (defaultCollectionInterval) since it does not parse the
+			// full metrics config.
 		}
 
 		_ = metrics.StartMetricsServer(opts, innerCtx.Done(), wg)

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -620,6 +620,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				EnableOVNDBMetrics:         true,
 				OVSDBClient:                ovsClient,
 				ApplyTLSOptions:            config.TLS.ApplyOptions,
+				CollectionInterval:         time.Duration(config.Metrics.CollectionInterval) * time.Second,
 			}
 
 			if combineMetricsEndpoints(runMode) {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -482,6 +482,11 @@ type KubernetesConfig struct {
 	DNSServiceName      string `gcfg:"dns-service-name"`
 }
 
+// DefaultMetricsCollectionInterval is the default interval, in seconds, at which
+// OVS/OVN metric values are extracted into the registry when
+// MetricsConfig.CollectionInterval is unset or non-positive.
+const DefaultMetricsCollectionInterval = 30 * time.Second
+
 // MetricsConfig holds Prometheus metrics-related parameters.
 type MetricsConfig struct {
 	BindAddress           string `gcfg:"bind-address"`
@@ -494,6 +499,10 @@ type MetricsConfig struct {
 	// configuration duration and optionally, its application to all nodes
 	EnableConfigDuration bool `gcfg:"enable-config-duration"`
 	EnableScaleMetrics   bool `gcfg:"enable-scale-metrics"`
+	// CollectionInterval is how often (in seconds) OVS/OVN metric values are
+	// extracted into the registry, independent of Prometheus scrapes. A
+	// non-positive value uses DefaultMetricsCollectionInterval.
+	CollectionInterval int `gcfg:"collection-interval"`
 }
 
 // TLSConfig holds TLS-related configuration parameters.
@@ -1578,6 +1587,13 @@ var MetricsFlags = []cli.Flag{
 		Name:        "metrics-enable-scale",
 		Usage:       "Enables metrics related to scaling",
 		Destination: &cliConfig.Metrics.EnableScaleMetrics,
+	},
+	&cli.IntFlag{
+		Name: "metrics-collection-interval",
+		Usage: fmt.Sprintf("Interval in seconds at which OVS/OVN metric values are extracted "+
+			"into the registry, independent of Prometheus scrapes. Non-positive uses the "+
+			"default (%fs).", DefaultMetricsCollectionInterval.Seconds()),
+		Destination: &cliConfig.Metrics.CollectionInterval,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -673,6 +673,7 @@ routing-table-id-start=2002
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/tls/nodecert"))
 			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.BeTrue())
 			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.BeTrue())
+			gomega.Expect(Metrics.CollectionInterval).To(gomega.Equal(15))
 
 			gomega.Expect(TLS.MinVersion).To(gomega.Equal("VersionTLS13"))
 			gomega.Expect(TLS.ParseCipherSuites()).To(gomega.Equal([]string{
@@ -768,6 +769,7 @@ routing-table-id-start=2002
 			"-metrics-enable-pprof=false",
 			"-ofctrl-wait-before-clear=5000",
 			"-metrics-enable-config-duration=true",
+			"-metrics-collection-interval=15",
 			"-tls-min-version=VersionTLS13",
 			"-tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384",
 			"-egressip-reachability-total-timeout=5",

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -31,6 +31,10 @@ const (
 
 	metricsUpdateInterval = 5 * time.Minute
 
+	// defaultCollectionInterval is how often the background loop refreshes OVS/OVN
+	// metric values when MetricServerOptions.CollectionInterval is unset.
+	defaultCollectionInterval = config.DefaultMetricsCollectionInterval
+
 	// metricsAppctlTimeout (seconds) bounds every ovs-appctl/ovn-appctl subprocess on
 	// the scrape path via --timeout=N. A saturated daemon (e.g. ovn-controller) would
 	// otherwise block the call and pin the scrape past Prometheus' scrape_timeout,
@@ -452,6 +456,14 @@ func StartMetricsServer(opts MetricServerOptions, stopChan <-chan struct{}, wg *
 		defer wg.Done()
 		klog.Infof("Metrics Server starts to run ...")
 		metricsServer.Run(stopChan)
+	}()
+
+	// Extraction runs out of band from scraping: the loop refreshes the registry
+	// on its own interval and the scrape handler only serializes it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		metricsServer.runCollectionLoop(stopChan)
 	}()
 
 	return metricsServer

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -20,6 +20,12 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
+const (
+	// ovsOfctlTimeout (seconds) bounds the ovs-ofctl dump-aggregate command used to
+	// extract integration bridge OpenFlow flow counts.
+	ovsOfctlTimeout = "5"
+)
+
 // ovnController Configuration metrics
 var metricRemoteProbeInterval = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: types.MetricOvnNamespace,
@@ -349,7 +355,7 @@ func setOvnControllerConfigurationMetrics(ovsDBClient libovsdbclient.Client) (er
 	return nil
 }
 
-func getPortCount(ovsDBClient libovsdbclient.Client, portType string) float64 {
+func getPortCount(ovsDBClient libovsdbclient.Client, portType string) (float64, error) {
 	var portCount float64
 	p := func(item *vswitchd.Interface) bool {
 		return item.Type == portType
@@ -358,7 +364,7 @@ func getPortCount(ovsDBClient libovsdbclient.Client, portType string) float64 {
 	intfList, err := ovsops.FindInterfacesWithPredicate(ovsDBClient, p)
 	if err != nil {
 		klog.Errorf("Failed to get %s interface count: %v", portType, err)
-		return 0
+		return 0, fmt.Errorf("failed to query %s interfaces: %v", portType, err)
 	}
 	if portType == "patch" {
 		for _, intf := range intfList {
@@ -371,32 +377,45 @@ func getPortCount(ovsDBClient libovsdbclient.Client, portType string) float64 {
 		portCount = float64(len(intfList))
 	}
 
-	return portCount
+	return portCount, nil
 }
 
 // getIntegrationBridgeOpenFlowCount returns the OpenFlow flow count of br-int.
-func getIntegrationBridgeOpenFlowCount() float64 {
-	stdout, stderr, err := util.RunOVSOfctl("-t", "5", "dump-aggregate", "br-int")
+func getIntegrationBridgeOpenFlowCount() (float64, error) {
+	stdout, stderr, err := util.RunOVSOfctl("-t", ovsOfctlTimeout, "dump-aggregate", "br-int")
 	if err != nil {
 		klog.Errorf("Failed to get flow count for br-int, stderr(%s): (%v)", stderr, err)
-		return 0
+		return 0, fmt.Errorf("failed to dump br-int OpenFlow flows: %v", err)
 	}
 	for _, kvPair := range strings.Fields(stdout) {
 		if strings.HasPrefix(kvPair, "flow_count=") {
 			value := strings.Split(kvPair, "=")[1]
-			return parseMetricToFloat(types.MetricOvnSubsystemController, "integration_bridge_openflow_total", value)
+			flowCount := parseMetricToFloat(types.MetricOvnSubsystemController, "integration_bridge_openflow_total", value)
+			return flowCount, nil
 		}
 	}
-	return 0
+	klog.Errorf("Failed to find flow_count in ovs-ofctl dump-aggregate output: %q", stdout)
+	return 0, fmt.Errorf("flow_count not found in dump-aggregate output")
 }
 
 // updateOvnControllerIntegrationBridgeMetrics refreshes the br-int flow/port
 // metrics. Called from the background collection loop so the ovs-ofctl exec and
 // OVSDB queries never run on the scrape path.
+// Metrics are conditionally updated upon extraction success, otherwise
+// maintained with the previous value, this makes the zero value representative.
 func updateOvnControllerIntegrationBridgeMetrics(ovsDBClient libovsdbclient.Client) {
-	metricIntegrationBridgeOpenFlowTotal.Set(getIntegrationBridgeOpenFlowCount())
-	metricIntegrationBridgePatchPorts.Set(getPortCount(ovsDBClient, "patch"))
-	metricIntegrationBridgeGenevePorts.Set(getPortCount(ovsDBClient, "geneve"))
+	bridgeofCount, err := getIntegrationBridgeOpenFlowCount()
+	if err == nil {
+		metricIntegrationBridgeOpenFlowTotal.Set(bridgeofCount)
+	}
+	portCountPatch, err := getPortCount(ovsDBClient, "patch")
+	if err == nil {
+		metricIntegrationBridgePatchPorts.Set(portCountPatch)
+	}
+	portCountGeneve, err := getPortCount(ovsDBClient, "geneve")
+	if err == nil {
+		metricIntegrationBridgeGenevePorts.Set(portCountGeneve)
+	}
 }
 
 // updateSBDBConnectionMetric updates the connection status with southbound database

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -102,6 +102,31 @@ var metricOVNControllerSBDBConnection = prometheus.NewGauge(prometheus.GaugeOpts
 	Help:      "Specifies if OVN controller is connected to OVN southbound database (1) or not (0)",
 })
 
+// integration_bridge_openflow_total is a point-in-time flow count, not a
+// monotonic counter; modeled as a gauge. The name keeps the _total suffix for
+// backward compatibility with existing dashboards/alerts.
+var metricIntegrationBridgeOpenFlowTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemController,
+	Name:      "integration_bridge_openflow_total",
+	Help:      "The total number of OpenFlow flows in the integration bridge.",
+})
+
+var metricIntegrationBridgePatchPorts = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemController,
+	Name:      "integration_bridge_patch_ports",
+	Help: "Captures the number of patch ports that connect br-int OVS " +
+		"bridge to physical OVS bridge and br-local OVS bridge.",
+})
+
+var metricIntegrationBridgeGenevePorts = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemController,
+	Name:      "integration_bridge_geneve_ports",
+	Help:      "Captures the number of geneve ports that are on br-int OVS bridge.",
+})
+
 var metricUDNNBDBProgrammedDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: types.MetricOvnkubeNamespace,
 	Subsystem: types.MetricOvnkubeSubsystemController,
@@ -294,7 +319,10 @@ func setOvnControllerConfigurationMetrics(ovsDBClient libovsdbclient.Client) (er
 	}
 	metricMonitorAll.Set(ovnMonitorValue)
 
-	// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value
+	// To update not only values but also labels for metrics, we use Reset() to delete previous labels+value.
+	// Notice: Reset()+Set() is not atomic, so a scrape landing in the sub-ms gap sees the series briefly
+	// missing. Acceptable for these always-1 info metrics (self-heals next scrape); revisit with a custom
+	// collector only if a snapshot-consistent view of the label value is ever required.
 	encapIPValue := openvSwitch.ExternalIDs["ovn-encap-ip"]
 	metricEncapIP.Reset()
 	metricEncapIP.WithLabelValues(encapIPValue).Set(1)
@@ -346,6 +374,31 @@ func getPortCount(ovsDBClient libovsdbclient.Client, portType string) float64 {
 	return portCount
 }
 
+// getIntegrationBridgeOpenFlowCount returns the OpenFlow flow count of br-int.
+func getIntegrationBridgeOpenFlowCount() float64 {
+	stdout, stderr, err := util.RunOVSOfctl("-t", "5", "dump-aggregate", "br-int")
+	if err != nil {
+		klog.Errorf("Failed to get flow count for br-int, stderr(%s): (%v)", stderr, err)
+		return 0
+	}
+	for _, kvPair := range strings.Fields(stdout) {
+		if strings.HasPrefix(kvPair, "flow_count=") {
+			value := strings.Split(kvPair, "=")[1]
+			return parseMetricToFloat(types.MetricOvnSubsystemController, "integration_bridge_openflow_total", value)
+		}
+	}
+	return 0
+}
+
+// updateOvnControllerIntegrationBridgeMetrics refreshes the br-int flow/port
+// metrics. Called from the background collection loop so the ovs-ofctl exec and
+// OVSDB queries never run on the scrape path.
+func updateOvnControllerIntegrationBridgeMetrics(ovsDBClient libovsdbclient.Client) {
+	metricIntegrationBridgeOpenFlowTotal.Set(getIntegrationBridgeOpenFlowCount())
+	metricIntegrationBridgePatchPorts.Set(getPortCount(ovsDBClient, "patch"))
+	metricIntegrationBridgeGenevePorts.Set(getPortCount(ovsDBClient, "geneve"))
+}
+
 // updateSBDBConnectionMetric updates the connection status with southbound database
 func updateSBDBConnectionMetric(ovsAppctl ovsClient) {
 	// NOTE: This metric had a retry logic, which is removed because metrics should reflect the reality.
@@ -376,7 +429,7 @@ func updateSBDBConnectionMetric(ovsAppctl ovsClient) {
 }
 
 // RegisterOvnControllerMetrics registers the ovn-controller metrics
-func RegisterOvnControllerMetrics(ovsDBClient libovsdbclient.Client, ovnRegistry prometheus.Registerer) {
+func RegisterOvnControllerMetrics(ovnRegistry prometheus.Registerer) {
 	getOvnControllerVersionInfo()
 	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
@@ -398,49 +451,9 @@ func RegisterOvnControllerMetrics(ovsDBClient libovsdbclient.Client, ovnRegistry
 	if config.Metrics.EnableScaleMetrics {
 		ovnRegistry.MustRegister(metricUDNNBDBProgrammedDuration)
 	}
-	ovnRegistry.MustRegister(prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemController,
-			Name:      "integration_bridge_openflow_total",
-			Help:      "The total number of OpenFlow flows in the integration bridge.",
-		}, func() float64 {
-			stdout, stderr, err := util.RunOVSOfctl("-t", "5", "dump-aggregate", "br-int")
-			if err != nil {
-				klog.Errorf("Failed to get flow count for br-int, stderr(%s): (%v)",
-					stderr, err)
-				return 0
-			}
-			for _, kvPair := range strings.Fields(stdout) {
-				if strings.HasPrefix(kvPair, "flow_count=") {
-					value := strings.Split(kvPair, "=")[1]
-					return parseMetricToFloat(types.MetricOvnSubsystemController, "integration_bridge_openflow_total",
-						value)
-				}
-			}
-			return 0
-		}))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemController,
-			Name:      "integration_bridge_patch_ports",
-			Help: "Captures the number of patch ports that connect br-int OVS " +
-				"bridge to physical OVS bridge and br-local OVS bridge.",
-		},
-		func() float64 {
-			return getPortCount(ovsDBClient, "patch")
-		}))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemController,
-			Name:      "integration_bridge_geneve_ports",
-			Help:      "Captures the number of geneve ports that are on br-int OVS bridge.",
-		},
-		func() float64 {
-			return getPortCount(ovsDBClient, "geneve")
-		}))
+	ovnRegistry.MustRegister(metricIntegrationBridgeOpenFlowTotal)
+	ovnRegistry.MustRegister(metricIntegrationBridgePatchPorts)
+	ovnRegistry.MustRegister(metricIntegrationBridgeGenevePorts)
 
 	// register ovn-controller configuration metrics
 	ovnRegistry.MustRegister(metricRemoteProbeInterval)

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -56,10 +56,6 @@ func updateOvnDBSizeMetrics(dbProps *util.OvsDbProperties) {
 	}
 }
 
-func resetOvnDbSizeMetric() {
-	metricDBSize.Reset()
-}
-
 // isOvnDBFoundViaPath attempts to find the OVN DBs, return false if not found.
 func isOvnDBFoundViaPath(dbProperties []*util.OvsDbProperties) bool {
 	enabled := true
@@ -113,11 +109,6 @@ func updateOvnDBMemoryMetrics(dbProperties *util.OvsDbProperties) {
 			}
 		}
 	}
-}
-
-func resetOvnDbMemoryMetrics() {
-	metricOVNDBMonitor.Reset()
-	metricOVNDBSessions.Reset()
 }
 
 var (

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -24,6 +24,56 @@ var (
 	ovnNorthdOvsLibVersion string
 )
 
+var metricOvnNorthdStatus = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemNorthd,
+	Name:      "status",
+	Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
+})
+
+var metricOvnNorthdNbConnectionStatus = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemNorthd,
+	Name:      "nb_connection_status",
+	Help:      "Specifies nb-connection-status of ovn-northd, not connected(0) or connected(1).",
+})
+
+var metricOvnNorthdSbConnectionStatus = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemNorthd,
+	Name:      "sb_connection_status",
+	Help:      "Specifies sb-connection-status of ovn-northd, not connected(0) or connected(1).",
+})
+
+func getOvnNorthdStatusInfo() float64 {
+	stdout, stderr, err := util.RunOVNNorthAppCtlWithTimeout(metricsAppctlTimeout, "status")
+	if err != nil {
+		klog.Errorf("Failed to get ovn-northd status stderr(%s) :(%v)", stderr, err)
+		return -1
+	}
+	northdStatusMap := map[string]float64{
+		"standby": 0,
+		"active":  1,
+		"paused":  2,
+	}
+	if strings.HasPrefix(stdout, "Status:") {
+		output := strings.TrimSpace(strings.Split(stdout, ":")[1])
+		if value, ok := northdStatusMap[output]; ok {
+			return value
+		}
+	}
+	return -1
+}
+
+// updateOvnNorthdStatusMetrics refreshes the ovn-northd status and connection
+// metrics by exec-ing ovn-appctl. Called from the background collection loop so
+// these appctls never run on the scrape path.
+func updateOvnNorthdStatusMetrics() {
+	metricOvnNorthdStatus.Set(getOvnNorthdStatusInfo())
+	metricOvnNorthdNbConnectionStatus.Set(getOvnNorthdConnectionStatusInfo(nbConnectionStatus))
+	metricOvnNorthdSbConnectionStatus.Set(getOvnNorthdConnectionStatusInfo(sbConnectionStatus))
+}
+
 func getOvnNorthdVersionInfo() {
 	stdout, _, err := util.RunOVNNorthAppCtl("version")
 	if err != nil {
@@ -131,53 +181,9 @@ func RegisterOvnNorthdMetrics(ovnRegistry prometheus.Registerer) {
 		},
 		func() float64 { return 1 },
 	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "status",
-			Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
-		}, func() float64 {
-			stdout, stderr, err := util.RunOVNNorthAppCtlWithTimeout(metricsAppctlTimeout, "status")
-			if err != nil {
-				klog.Errorf("Failed to get ovn-northd status "+
-					"stderr(%s) :(%v)", stderr, err)
-				return -1
-			}
-			northdStatusMap := map[string]float64{
-				"standby": 0,
-				"active":  1,
-				"paused":  2,
-			}
-			if strings.HasPrefix(stdout, "Status:") {
-				output := strings.TrimSpace(strings.Split(stdout, ":")[1])
-				if value, ok := northdStatusMap[output]; ok {
-					return value
-				}
-			}
-			return -1
-		},
-	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "nb_connection_status",
-			Help:      "Specifies nb-connection-status of ovn-northd, not connected(0) or connected(1).",
-		}, func() float64 {
-			return getOvnNorthdConnectionStatusInfo(nbConnectionStatus)
-		},
-	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: types.MetricOvnNamespace,
-			Subsystem: types.MetricOvnSubsystemNorthd,
-			Name:      "sb_connection_status",
-			Help:      "Specifies sb-connection-status of ovn-northd, not connected(0) or connected(1).",
-		}, func() float64 {
-			return getOvnNorthdConnectionStatusInfo(sbConnectionStatus)
-		},
-	))
+	ovnRegistry.MustRegister(metricOvnNorthdStatus)
+	ovnRegistry.MustRegister(metricOvnNorthdNbConnectionStatus)
+	ovnRegistry.MustRegister(metricOvnNorthdSbConnectionStatus)
 
 	// Register the ovn-northd coverage/show metrics with prometheus
 	componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime/debug"
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,43 +26,16 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
-const (
-	// metricsScrapeBudgetFallback bounds metric collection when Prometheus does not
-	// advertise its scrape timeout. Kept below the typical 10s scrape_timeout so the
-	// handler still returns in time to serve the last known values (up stays 1).
-	metricsScrapeBudgetFallback = 8 * time.Second
-
-	// metricsScrapeBudgetSlack is subtracted from the advertised scrape timeout to
-	// leave promhttp room to serialize and write the response before Prometheus'
-	// deadline; without it a cached write can lose the race and flap up to 0.
-	metricsScrapeBudgetSlack = 500 * time.Millisecond
-)
-
-// scrapeBudget returns how long metric collection may run before the handler gives
-// up and serves the last known values. It honors Prometheus'
-// X-Prometheus-Scrape-Timeout-Seconds header (minus slack) when present, otherwise
-// falls back to metricsScrapeBudgetFallback.
-func scrapeBudget(r *http.Request) time.Duration {
-	if v := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"); v != "" {
-		if secs, err := strconv.ParseFloat(v, 64); err == nil && secs > 0 {
-			// Honor the advertised deadline minus slack, never the larger fallback.
-			// If that leaves no room, use the full advertised value rather than skip
-			// collection entirely.
-			advertised := time.Duration(secs * float64(time.Second))
-			if budget := advertised - metricsScrapeBudgetSlack; budget > 0 {
-				return budget
-			}
-			return advertised
-		}
-	}
-	// No header, or an unparseable/non-positive one: fall back.
-	return metricsScrapeBudgetFallback
-}
-
 // MetricServerOptions defines the configuration options for the new MetricServer
 type MetricServerOptions struct {
 	// Server configuration
 	BindAddress string
+
+	// CollectionInterval is how often the background loop extracts OVS/OVN metric
+	// values into the registry. Scrapes only serialize the registry, so scrape
+	// latency is independent of extraction latency. Non-positive falls back to
+	// defaultCollectionInterval.
+	CollectionInterval time.Duration
 
 	// TLS configuration
 	CertFile        string
@@ -120,13 +92,12 @@ func NewMetricServer(opts MetricServerOptions) *MetricServer {
 	tg := prometheus.ToTransactionalGatherer(server.registerer.(prometheus.Gatherer))
 	metricsHandler := promhttp.HandlerForTransactional(tg, promhttp.HandlerOpts{})
 
+	// The scrape path only serializes the registry. Metric values are refreshed
+	// out of band by runCollectionLoop, so scrape latency is independent of how
+	// expensive extraction is.
 	server.mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
 		server.registerer,
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Update metrics in the registry before emitting them.
-			server.handleMetrics(r)
-			metricsHandler.ServeHTTP(w, r)
-		}),
+		metricsHandler,
 	))
 
 	if opts.EnablePprof {
@@ -155,7 +126,7 @@ func (s *MetricServer) registerMetrics() {
 	}
 	if s.opts.EnableOVNControllerMetrics {
 		klog.Infof("MetricServer registers OVN Controller metrics")
-		RegisterOvnControllerMetrics(s.opts.OVSDBClient, s.registerer)
+		RegisterOvnControllerMetrics(s.registerer)
 	}
 	if s.opts.EnableOVNNorthdMetrics {
 		klog.Infof("MetricServer registers OVN Northd metrics")
@@ -189,6 +160,7 @@ func (s *MetricServer) updateOvnControllerMetrics() {
 		klog.Errorf("Setting ovn controller config metrics failed: %s", err.Error())
 	}
 
+	updateOvnControllerIntegrationBridgeMetrics(s.opts.OVSDBClient)
 	coverageShowMetricsUpdate(ovnController)
 	stopwatchShowMetricsUpdate(ovnController)
 	updateSBDBConnectionMetric(func(args ...string) (string, string, error) {
@@ -199,17 +171,13 @@ func (s *MetricServer) updateOvnControllerMetrics() {
 
 // updateOvnNorthdMetrics updates the OVN Northd metrics
 func (s *MetricServer) updateOvnNorthdMetrics() {
+	updateOvnNorthdStatusMetrics()
 	coverageShowMetricsUpdate(ovnNorthd)
 	stopwatchShowMetricsUpdate(ovnNorthd)
 }
 
 // updateOvnDBMetrics updates the OVN DB metrics
 func (s *MetricServer) updateOvnDBMetrics() {
-	if s.opts.dbFoundViaPath {
-		resetOvnDbSizeMetric()
-	}
-	resetOvnDbMemoryMetrics()
-
 	for _, dbProperty := range s.ovsDbProperties {
 		if s.opts.dbFoundViaPath {
 			updateOvnDBSizeMetrics(dbProperty)
@@ -218,48 +186,60 @@ func (s *MetricServer) updateOvnDBMetrics() {
 	}
 }
 
-// handleMetrics refreshes the OVS/OVN metrics before they are emitted. Collection
-// execs ovs-appctl/ovn-appctl subprocesses (each bounded by metricsAppctlTimeout)
-// in a separate goroutine under a scrape budget: if the daemons are slow and it
-// overruns, the handler returns and promhttp serves the last known values, keeping
-// the scrape under Prometheus' scrape_timeout (up stays 1). The goroutine keeps
-// running to refresh the registry for the next scrape.
-func (s *MetricServer) handleMetrics(r *http.Request) {
-	klog.V(5).Infof("MetricServer starts to handle metrics request from %s", r.RemoteAddr)
-
-	ctx, cancel := context.WithTimeout(r.Context(), scrapeBudget(r))
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		// Nothing recovers this detached goroutine, so recover here: a panic in a
-		// metric path must only fail this scrape, not crash ovnkube-node.
-		defer func() {
-			if r := recover(); r != nil {
-				klog.Errorf("MetricServer recovered from panic during metric collection: %v\n%s", r, debug.Stack())
-			}
-		}()
-
-		if s.opts.EnableOVSMetrics {
-			s.updateOvsMetrics()
-		}
-		if s.opts.EnableOVNDBMetrics {
-			s.updateOvnDBMetrics()
-		}
-		if s.opts.EnableOVNControllerMetrics {
-			s.updateOvnControllerMetrics()
-		}
-		if s.opts.EnableOVNNorthdMetrics {
-			s.updateOvnNorthdMetrics()
+// collect refreshes all enabled OVS/OVN metric values in the registry. It execs
+// ovs-appctl/ovn-appctl subprocesses (each bounded by metricsAppctlTimeout) and
+// queries OVSDB. It runs off the scrape path, driven by runCollectionLoop, so a
+// slow daemon never blocks a scrape. A panic in any metric path only fails the
+// current cycle rather than crashing the process.
+func (s *MetricServer) collect() {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Errorf("MetricServer recovered from panic during metric collection: %v\n%s", r, debug.Stack())
 		}
 	}()
 
-	select {
-	case <-done:
-	case <-ctx.Done():
-		klog.Errorf("MetricServer metric collection exceeded the scrape budget for request from %s; "+
-			"serving last known values (%v)", r.RemoteAddr, ctx.Err())
+	if s.opts.EnableOVSMetrics {
+		s.updateOvsMetrics()
+	}
+	if s.opts.EnableOVNDBMetrics {
+		s.updateOvnDBMetrics()
+	}
+	if s.opts.EnableOVNControllerMetrics {
+		s.updateOvnControllerMetrics()
+	}
+	if s.opts.EnableOVNNorthdMetrics {
+		s.updateOvnNorthdMetrics()
+	}
+}
+
+// resolveCollectionInterval clamps a non-positive configured interval to
+// defaultCollectionInterval so a missing or invalid flag still ticks.
+func resolveCollectionInterval(d time.Duration) time.Duration {
+	if d <= 0 {
+		return defaultCollectionInterval
+	}
+	return d
+}
+
+// runCollectionLoop refreshes the registry once synchronously (so the first
+// scrape has data) and then on every CollectionInterval tick until stopChan is
+// closed. A plain ticker loop serializes cycles: an over-running collect just
+// delays the next one, so cycles never overlap and no locking is needed.
+func (s *MetricServer) runCollectionLoop(stopChan <-chan struct{}) {
+	interval := resolveCollectionInterval(s.opts.CollectionInterval)
+	klog.Infof("MetricServer collection loop running every %s", interval)
+
+	s.collect()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.collect()
+		case <-stopChan:
+			return
+		}
 	}
 }
 

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -225,6 +225,8 @@ func resolveCollectionInterval(d time.Duration) time.Duration {
 // scrape has data) and then on every CollectionInterval tick until stopChan is
 // closed. A plain ticker loop serializes cycles: an over-running collect just
 // delays the next one, so cycles never overlap and no locking is needed.
+// Each collect runs in a goroutine so shutdown can proceed without waiting for
+// a stalled extraction operation to finish.
 func (s *MetricServer) runCollectionLoop(stopChan <-chan struct{}) {
 	interval := resolveCollectionInterval(s.opts.CollectionInterval)
 	klog.Infof("MetricServer collection loop running every %s", interval)
@@ -236,7 +238,19 @@ func (s *MetricServer) runCollectionLoop(stopChan <-chan struct{}) {
 	for {
 		select {
 		case <-ticker.C:
-			s.collect()
+			collectDone := make(chan struct{})
+			go func() {
+				defer close(collectDone)
+				s.collect()
+			}()
+			// Wait for this cycle to complete or shutdown to signal. If shutdown
+			// signals while collection is in-flight, we exit immediately without
+			// waiting; the in-flight goroutine finishes asynchronously.
+			select {
+			case <-collectDone:
+			case <-stopChan:
+				return
+			}
 		case <-stopChan:
 			return
 		}

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -82,8 +82,9 @@ var _ = Describe("MetricServer", func() {
 			})
 
 			It(fmt.Sprintf("should handle %s metrics", desc), func() {
-				var response string
-
+				// Extraction runs out of band, so some GaugeVec series only appear
+				// after the background loop's first collect() has Set() them. Retry
+				// the whole fetch+compare until the registry has converged.
 				Eventually(func(g Gomega) {
 					// Make actual HTTP request to the /metrics endpoint
 					metricsURL := fmt.Sprintf("http://%s/metrics", t.opts.BindAddress)
@@ -96,22 +97,22 @@ var _ = Describe("MetricServer", func() {
 					body, err := io.ReadAll(resp.Body)
 					g.Expect(err).NotTo(HaveOccurred())
 
-					response = string(body)
+					response := string(body)
 					g.Expect(response).NotTo(BeEmpty())
-				}).Within(5 * time.Second).Should(Succeed())
 
-				gotMetrics := []string{}
-				for _, line := range strings.Split(response, "\n") {
-					if strings.HasPrefix(line, "# TYPE ") {
-						m := strings.Split(line, " ")[2]
-						gotMetrics = append(gotMetrics, m)
+					gotMetrics := []string{}
+					for _, line := range strings.Split(response, "\n") {
+						if strings.HasPrefix(line, "# TYPE ") {
+							m := strings.Split(line, " ")[2]
+							gotMetrics = append(gotMetrics, m)
+						}
 					}
-				}
 
-				diff := cmp.Diff(gotMetrics, tc.expectedMetrics, cmpopts.SortSlices(func(x, y string) bool {
-					return x < y
-				}))
-				Expect(diff).To(BeEmpty(), "metrics mismatch (-got +want):\n%s", diff)
+					diff := cmp.Diff(gotMetrics, tc.expectedMetrics, cmpopts.SortSlices(func(x, y string) bool {
+						return x < y
+					}))
+					g.Expect(diff).To(BeEmpty(), "metrics mismatch (-got +want):\n%s", diff)
+				}).Within(5 * time.Second).Should(Succeed())
 			})
 		},
 
@@ -269,56 +270,27 @@ var _ = Describe("MetricServer", func() {
 	})
 })
 
-var _ = Describe("scrapeBudget", func() {
-	DescribeTable("derives the collection budget from the scrape-timeout header",
-		func(header string, expected time.Duration) {
-			r, err := http.NewRequest(http.MethodGet, "/metrics", nil)
-			Expect(err).NotTo(HaveOccurred())
-			if header != "" {
-				r.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", header)
-			}
-			Expect(scrapeBudget(r)).To(Equal(expected))
-		},
-		Entry("no header falls back", "", metricsScrapeBudgetFallback),
-		Entry("valid header minus slack", "12", 12*time.Second-metricsScrapeBudgetSlack),
-		Entry("fractional header minus slack", "5.5", time.Duration(5.5*float64(time.Second))-metricsScrapeBudgetSlack),
-		Entry("valid header at slack falls back to advertised", "0.5", time.Duration(0.5*float64(time.Second))),
-		Entry("valid header below slack falls back to advertised", "0.2", time.Duration(0.2*float64(time.Second))),
-		Entry("garbage header falls back", "nope", metricsScrapeBudgetFallback),
-		Entry("zero header falls back", "0", metricsScrapeBudgetFallback),
-	)
-})
-
-// stallingExecRunner is an ExecRunner that blocks the metric collection commands
-// (coverage/show, stopwatch/show) on the release channel to simulate a saturated
-// daemon that cannot answer, while returning immediately for every other command.
-// It lets the overrun test stall only the on-scrape collection path without also
-// blocking promhttp's gather tail.
-//
-// Because the fix runs collection in a detached goroutine, that goroutine outlives
-// the scrape. connectionStatusDone is closed once the goroutine finishes its final
-// runner call (connection-status), which is the last thing it does that reads any
-// process-global; the test waits on it before restoring globals so cleanup does not
-// race the still-running collection.
-type stallingExecRunner struct {
-	release              chan struct{}
-	connectionStatusDone chan struct{}
+// blockingExecRunner blocks the collection commands (coverage/show,
+// stopwatch/show) on the release channel to simulate a saturated daemon that
+// cannot answer, while returning immediately for every other command. It lets a
+// background collection cycle stall so we can prove a scrape still returns
+// promptly instead of waiting on extraction.
+type blockingExecRunner struct {
+	release chan struct{}
 }
 
-func (r *stallingExecRunner) RunCmd(_ kexec.Cmd, _ string, _ []string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+func (r *blockingExecRunner) RunCmd(_ kexec.Cmd, _ string, _ []string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
 	for _, a := range args {
 		switch a {
 		case "coverage/show", "stopwatch/show":
 			<-r.release
-		case "connection-status":
-			defer close(r.connectionStatusDone)
 		}
 	}
 	return bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil
 }
 
-var _ = Describe("scrape budget overrun", func() {
-	It("returns within the budget and serves the registry when collection stalls", func() {
+var _ = Describe("scrape decoupled from extraction", func() {
+	It("serves the registry promptly while a collection cycle is stalled", func() {
 		savedRunner := util.RunCmdExecRunner
 		DeferCleanup(func() { util.RunCmdExecRunner = savedRunner })
 
@@ -343,7 +315,7 @@ var _ = Describe("scrape budget overrun", func() {
 		DeferCleanup(cleanup.Cleanup)
 
 		// Build a mock kexec interface so the appctl wrappers can construct a Cmd;
-		// the actual exec is intercepted by stallingExecRunner below.
+		// the actual exec is intercepted by blockingExecRunner below.
 		mockCmd := new(mock_k8s_io_utils_exec.Cmd)
 		mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 		for _, n := range []int{3, 4, 5, 6} {
@@ -356,12 +328,9 @@ var _ = Describe("scrape budget overrun", func() {
 		_ = util.SetSpecificExec(mockKexecIface)
 		DeferCleanup(util.ResetRunner)
 
-		// The collection path (coverage/show, stopwatch/show) blocks until released,
-		// far past the budget; everything else returns immediately.
-		runner := &stallingExecRunner{
-			release:              make(chan struct{}),
-			connectionStatusDone: make(chan struct{}),
-		}
+		// The collection path (coverage/show) blocks until released; everything
+		// else returns immediately.
+		runner := &blockingExecRunner{release: make(chan struct{})}
 		util.RunCmdExecRunner = runner
 
 		opts := MetricServerOptions{
@@ -372,16 +341,22 @@ var _ = Describe("scrape budget overrun", func() {
 		server := NewMetricServer(opts)
 		server.registerMetrics()
 
+		// Start the background collection loop; its first cycle stalls on
+		// coverage/show and never completes until released.
+		stop := make(chan struct{})
+		loopDone := make(chan struct{})
+		go func() {
+			server.runCollectionLoop(stop)
+			close(loopDone)
+		}()
+
 		ts := httptest.NewServer(server.mux)
 		DeferCleanup(ts.Close)
 
-		req, err := http.NewRequest(http.MethodGet, ts.URL+"/metrics", nil)
-		Expect(err).NotTo(HaveOccurred())
-		// budget = 2s - 500ms slack = 1.5s; collection stays blocked past it.
-		req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", "2")
-
+		// Even though extraction is stuck, the scrape only serializes the registry,
+		// so it must return promptly rather than waiting on the stalled cycle.
 		start := time.Now()
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.Get(ts.URL + "/metrics")
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 		elapsed := time.Since(start)
@@ -389,23 +364,26 @@ var _ = Describe("scrape budget overrun", func() {
 		body, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Handler must shed the stalled collection at the budget rather than
-		// blocking on it, and still serve the registry (up stays 1).
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		Expect(body).NotTo(BeEmpty())
-		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
-			"scrape blocked on stalled collection instead of returning within the budget")
-		// It should also not return early - the handler is expected to wait out the
-		// ~1.5s budget (2s header minus 500ms slack) because collection never
-		// completes, which proves the budget, not a fast collection, released it.
-		Expect(elapsed).To(BeNumerically(">", time.Second),
-			"scrape returned before the budget elapsed; collection was not actually stalled")
+		Expect(elapsed).To(BeNumerically("<", time.Second),
+			"scrape blocked on stalled extraction instead of serving the registry")
 
-		// Let the detached collection goroutine finish and wait for it before the
-		// DeferCleanups restore the process-global exec runner, otherwise cleanup
-		// races the still-running collection.
+		// Release the stalled cycle and let the loop stop before the DeferCleanups
+		// restore the process-global exec runner, otherwise cleanup races the loop.
 		close(runner.release)
-		Eventually(runner.connectionStatusDone).Within(5 * time.Second).Should(BeClosed())
+		close(stop)
+		Eventually(loopDone).Within(5 * time.Second).Should(BeClosed())
+	})
+})
+
+var _ = Describe("resolveCollectionInterval", func() {
+	It("clamps non-positive intervals to the default", func() {
+		Expect(resolveCollectionInterval(0)).To(Equal(defaultCollectionInterval))
+		Expect(resolveCollectionInterval(-5 * time.Second)).To(Equal(defaultCollectionInterval))
+	})
+	It("keeps a positive interval as configured", func() {
+		Expect(resolveCollectionInterval(10 * time.Second)).To(Equal(10 * time.Second))
 	})
 })
 
@@ -501,12 +479,25 @@ func newMetricsTestDriver() *metricsTestDriver {
 			close(serverDone)
 		}()
 
+		// Extraction runs out of band from scraping (as in production). The loop
+		// does one synchronous collect then ticks; the test's Eventually on
+		// /metrics waits for that first collect to populate the registry.
+		collectionDone := make(chan struct{})
+		go func() {
+			server.runCollectionLoop(ctx.Done())
+			close(collectionDone)
+		}()
+
 		DeferCleanup(func() {
 			shutdownStart := time.Now()
 			cancel()
 
 			// Wait for server to stop with timeout
 			Eventually(serverDone, 10*time.Second).Should(BeClosed())
+
+			// Wait for the collection loop to stop before later DeferCleanups
+			// restore the process-global exec runner.
+			Eventually(collectionDone, 10*time.Second).Should(BeClosed())
 
 			// Validate shutdown was reasonably fast (should be under 6 seconds, allowing for 5s grace period)
 			Expect(time.Since(shutdownStart)).To(BeNumerically("<", 6*time.Second))

--- a/test/e2e/feature/features.go
+++ b/test/e2e/feature/features.go
@@ -40,6 +40,7 @@ var (
 	Unidle                        = New("Unidle")
 	NetworkQos                    = New("NetworkQos")
 	NetworkConnect                = New("NetworkConnect")
+	Metrics                       = New("Metrics")
 )
 
 func New(name string) ginkgo.Labels {

--- a/test/e2e/metrics.go
+++ b/test/e2e/metrics.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
+)
+
+// These smoke tests guard what the metrics unit tests structurally cannot: that
+// the OVN/OVS metric endpoints actually serve their expected series against real
+// daemons (catching parser-vs-real-output drift) and that the metrics servers
+// are wired up in a real deployment. They deliberately assert only presence of a
+// representative subset, not exact values, to stay stable across environments.
+var _ = ginkgo.Describe("e2e OVN/OVS metrics", feature.Metrics, func() {
+	const (
+		ovnMetricsPort = 9476 // --ovn-metrics-bind-address, see dist/images/ovnkube.sh
+		ovsMetricsPort = 9310 // ovs-metrics exporter
+	)
+
+	f := wrappedTestFramework("metrics")
+
+	var (
+		ovnNamespace string
+		nodePod      corev1.Pod
+	)
+
+	ginkgo.BeforeEach(func() {
+		ovnNamespace = deploymentconfig.Get().OVNKubernetesNamespace()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		pods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+		})
+		framework.ExpectNoError(err, "listing ovnkube-node pods")
+		gomega.Expect(pods.Items).NotTo(gomega.BeEmpty(), "no ovnkube-node pods found")
+		nodePod = pods.Items[0]
+		gomega.Expect(nodePod.Status.PodIP).NotTo(gomega.BeEmpty(), "ovnkube-node pod has no IP")
+	})
+
+	// scrapeNoError curls a metrics endpoint and returns the response body or error,
+	// allowing caller to decide whether to assert or retry. Used by Eventually().
+	scrapeNoError := func(container string, port int) (string, error) {
+		url := "http://" + net.JoinHostPort(nodePod.Status.PodIP, strconv.Itoa(port)) + "/metrics"
+		stdout, stderr, err := ExecCommandInContainerWithFullOutput(
+			f, ovnNamespace, nodePod.Name, container,
+			"curl", "-sS", "--max-time", "10", url,
+		)
+		if err != nil {
+			return "", fmt.Errorf("curl %s failed: %s", url, stderr)
+		}
+		if stdout == "" {
+			return "", fmt.Errorf("empty metrics response from %s", url)
+		}
+		return stdout, nil
+	}
+
+	// scrape is a convenience wrapper that asserts success, for non-retrying contexts.
+	scrape := func(container string, port int) string {
+		body, err := scrapeNoError(container, port)
+		framework.ExpectNoError(err)
+		return body
+	}
+
+	assertPresent := func(body string, names ...string) {
+		for _, name := range names {
+			// Match the metric name at the start of a sample line, with or
+			// without a label set, e.g. `name 1` or `name{db_name="..."} 1`.
+			present := false
+			for _, line := range strings.Split(body, "\n") {
+				if strings.HasPrefix(line, name+" ") || strings.HasPrefix(line, name+"{") {
+					present = true
+					break
+				}
+			}
+			gomega.Expect(present).To(gomega.BeTrue(), "expected metric %q missing from endpoint", name)
+		}
+	}
+
+	ginkgo.It("delivers OVN controller and northd metrics, including the loop-collected ones", func() {
+		body := scrape("ovnkube-controller", ovnMetricsPort)
+		assertPresent(body,
+			// northd status/connection metrics (background-loop gauges)
+			"ovn_northd_status",
+			"ovn_northd_nb_connection_status",
+			"ovn_northd_sb_connection_status",
+			// integration-bridge metrics (background-loop gauges)
+			"ovn_controller_integration_bridge_openflow_total",
+			"ovn_controller_integration_bridge_patch_ports",
+			"ovn_controller_integration_bridge_geneve_ports",
+			// a representative always-registered controller metric
+			"ovn_controller_southbound_database_connected",
+			// OVN DB gauges refreshed by the loop
+			"ovn_db_db_size_bytes",
+		)
+	})
+
+	ginkgo.It("delivers OVS metrics from the standalone exporter", func() {
+		body := scrape("ovs-metrics-exporter", ovsMetricsPort)
+		assertPresent(body,
+			"ovs_build_info",
+			"ovs_vswitchd_dp_flows_total",
+		)
+	})
+
+	ginkgo.It("keeps the endpoint responsive to repeated scrapes", func() {
+		// The scrape handler only serializes the in-memory registry (extraction
+		// runs on its own loop), so repeated back-to-back scrapes must all return
+		// promptly and non-empty regardless of daemon load.
+		for i := 0; i < 5; i++ {
+			gomega.Eventually(func(g gomega.Gomega) {
+				body, err := scrapeNoError("ovnkube-controller", ovnMetricsPort)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(body).To(gomega.ContainSubstring("ovn_northd_status"))
+			}).Within(20 * time.Second).ProbeEvery(time.Second).Should(gomega.Succeed())
+		}
+	})
+})


### PR DESCRIPTION
OVN/OVS metrics were extracted on the scrape path: every GET /metrics ran the appctl/ofctl/OVSDB work that produces the values, so scrape latency was bound to extraction latency and grew with OVN state, risking scrape timeouts and `up` flapping at scale.

Move extraction to a single background loop on a configurable interval; the scrape handler now only serializes the in-memory registry.

- server.go: add collect() + runCollectionLoop() (ticker serializes cycles, no overlap guard needed); remove the per-scrape extraction path (handleMetrics/scrapeBudget). Clamp non-positive interval via resolveCollectionInterval.
- ovn_northd.go / ovn.go: convert the status/connection and integration-bridge GaugeFunc/CounterFunc metrics (which exec'd inside Collect, bypassing any budget) to plain gauges set in the loop. integration_bridge_openflow_total stays a gauge under its old name for backward compatibility.
- ovn_db.go: drop the Reset() helpers; the label set is static and every cycle re-Set()s, so Reset just opened a Collect race under concurrent collection.
- config.go / call sites: add metrics-collection-interval flag (default 30s via defaultCollectionInterval when unset).

Tests:
- server_test.go: run collection out of band as in production; assert the full metric set inside Eventually so GaugeVec series populated by the first collect() are awaited. New case proves a scrape returns in <1s while a collection cycle is stalled on a blocked appctl. resolveCollection Interval clamp unit test.
- config_test.go: assert metrics-collection-interval parses.
- Validated on a Kind cluster: converted metrics report live values, scrape latency ~1ms and flat, counters identical across back-to-back scrapes and only advance after a collection cycle.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6839

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
Adds  "metrics-collection-interval" flag: Interval in seconds at which OVS/OVN metric values are extracted 
into the registry, independent of Prometheus scrapes. Non-positive uses the default (30s).
The flag is added because of moving the metrics extraction to a single background loop
on a configurable interval; the scrape handler now only serializes the in-memory registry.
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
