### PR TITLE
cni: don't give the primary UDN the default network's VF

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -427,7 +427,8 @@ func (s *Server) getPrimaryUDNPodRequest(originalPodRequest *PodRequest) (*PodRe
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod %s/%s: %v", podNamespace, podName, err)
 		}
-		deviceID, err := udn.GetPodPrimaryUDNDeviceID(pod, resourceName)
+		// exclude the device the default network already consumed
+		deviceID, err := udn.GetPodPrimaryUDNDeviceID(pod, resourceName, originalPodRequest.CNIConf.DeviceID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get primary UDN device ID for pod %s/%s resource %s: %v",
 				pod.Namespace, pod.Name, resourceName, err)

--- a/go-controller/pkg/cni/udn/resource.go
+++ b/go-controller/pkg/cni/udn/resource.go
@@ -31,14 +31,34 @@ func getPodResourceInfo(pod *corev1.Pod, resourceName string) (*types.ResourceIn
 	return entry, nil
 }
 
-// GetPodPrimaryUDNDeviceID gets last deviceId of the specified resources allocated for the given Pod
-func GetPodPrimaryUDNDeviceID(pod *corev1.Pod, resourceName string) (string, error) {
+// GetPodPrimaryUDNDeviceID gets the last deviceId of the specified resources
+// allocated for the given Pod, skipping excludedDeviceID: the device already
+// consumed by another attachment of the same pod (the default network in DPU
+// mode), whose position in the allocation list is not deterministic. Devices
+// that multus handed to other NADs from the same pool are not visible here,
+// so only collisions with the default network are prevented.
+func GetPodPrimaryUDNDeviceID(pod *corev1.Pod, resourceName, excludedDeviceID string) (string, error) {
 	entry, err := getPodResourceInfo(pod, resourceName)
 	if err != nil {
 		return "", err
 	}
-	if len(entry.DeviceIDs) == 0 {
-		return "", fmt.Errorf("no device IDs found for pod %s/%s, resource %s", pod.Namespace, pod.Name, resourceName)
+	deviceID := pickDeviceID(entry.DeviceIDs, excludedDeviceID)
+	if deviceID == "" {
+		return "", fmt.Errorf("no available device IDs found for pod %s/%s, resource %s (allocated: %v, excluded: %q)",
+			pod.Namespace, pod.Name, resourceName, entry.DeviceIDs, excludedDeviceID)
 	}
-	return entry.DeviceIDs[len(entry.DeviceIDs)-1], nil
+	klog.V(4).Infof("Picked device ID %s for the primary UDN of pod %s/%s (allocated: %v, excluded: %q)",
+		deviceID, pod.Namespace, pod.Name, entry.DeviceIDs, excludedDeviceID)
+	return deviceID, nil
+}
+
+// pickDeviceID returns the last device ID that differs from excludedDeviceID,
+// or "" if there is none.
+func pickDeviceID(deviceIDs []string, excludedDeviceID string) string {
+	for i := len(deviceIDs) - 1; i >= 0; i-- {
+		if deviceIDs[i] != excludedDeviceID {
+			return deviceIDs[i]
+		}
+	}
+	return ""
 }

--- a/go-controller/pkg/cni/udn/resource_test.go
+++ b/go-controller/pkg/cni/udn/resource_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package udn
+
+import "testing"
+
+func TestPickDeviceID(t *testing.T) {
+	tests := []struct {
+		name      string
+		deviceIDs []string
+		excluded  string
+		expected  string
+	}{
+		{
+			name:      "no exclusion picks last",
+			deviceIDs: []string{"eth0-34", "eth0-53"},
+			excluded:  "",
+			expected:  "eth0-53",
+		},
+		{
+			name:      "excluded last picks previous",
+			deviceIDs: []string{"eth0-34", "eth0-53"},
+			excluded:  "eth0-53",
+			expected:  "eth0-34",
+		},
+		{
+			name:      "single device excluded picks none",
+			deviceIDs: []string{"eth0-34"},
+			excluded:  "eth0-34",
+			expected:  "",
+		},
+		{
+			name:      "empty list picks none",
+			deviceIDs: nil,
+			excluded:  "",
+			expected:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pickDeviceID(tt.deviceIDs, tt.excluded); got != tt.expected {
+				t.Errorf("pickDeviceID(%v, %q) = %q, expected %q", tt.deviceIDs, tt.excluded, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In DPU-host mode, a pod attached to both the default network and a primary UDN requests two VFs, but both attachments can end up on the same one:

1. Multus assigns the default network's `deviceID` from kubelet's PodResources list, which is no longer sorted since the revert of pod-wide DeviceIDs sorting (k8snetworkplumbingwg/multus-cni#1540, reverting k8snetworkplumbingwg/multus-cni#1481 which had regressed multi-container pods sharing a resource name). The cniserver picks the *last* deviceID of its own (vendored, still sorted) read of the same list for the primary UDN. Whenever kubelet's nondeterministic order puts the sorted-last device first, both attachments get the same VF: the default network claims the representor on the DPU side and the UDN attachment retries forever, wedging the pod in ContainerCreating. This permafails the Uplink specs in the dpu-simulator lanes, which deploy multus master.

What this PR does:
- `getPrimaryUDNPodRequest` passes the deviceID the default network consumed (it's on the very pod request being served) down to `GetPodPrimaryUDNDeviceID`, which now picks the last allocated device that differs from it: the default + primary UDN pair never collides, regardless of multus ordering
- logs the picked device and the exclusion at verbosity 4

Out of scope: devices that multus hands to secondary NADs from the same resource pool are not visible to the cniserver, so that case still needs deterministic ordering on the multus side (k8snetworkplumbingwg/multus-cni#1539) or an explicit device handoff.

Fixes #6882
