### PR TITLE
agents: clarify that standard Go tests are acceptable alongside Ginkgo

### DIFF
--- a/go-controller/pkg/AGENTS.md
+++ b/go-controller/pkg/AGENTS.md
@@ -135,10 +135,9 @@ Shared packages used across multiple components:
 
 ## Testing
 
-- Unit tests use Ginkgo suites (`_suite_test.go`) and live alongside the
-  code as `*_test.go` files.
-- See [`docs/developer-guide/developer.md`](../../docs/developer-guide/developer.md)
-  for mock generation and the `.mockery.yaml` config.
+- Unit tests live alongside the code as `*_test.go` files.
+- Some packages use Ginkgo suites (identified by a `_suite_test.go` file);
+  standard Go `testing.T` tests are equally acceptable and common.
 
 ## Test Helpers
 


### PR DESCRIPTION

## 📑 Description
<!-- Add a brief description of the pr -->

The previous wording ("Unit tests use Ginkgo suites") read as a mandate, causing CodeRabbit to flag PRs that use standard testing.T tests. Reword to make clear that both Ginkgo suites and standard Go tests are common and acceptable.

See https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6886#discussion_r3906246226


## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
