### PR TITLE
Add trafficDistribution support for Services (KEP-4444)

### DIFF
--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -44,6 +44,14 @@ type lbConfig struct {
 	internalTrafficLocal bool
 	// indicates if this LB is configuring service of type NodePort.
 	hasNodePort bool
+
+	// trafficDistribution: PreferSameZone/PreferClose support
+	preferSameZone    bool
+	zoneHintEndpoints map[string]util.LBEndpoints // zone name -> endpoints from Hints.ForZones
+
+	// trafficDistribution: PreferSameNode support
+	preferSameNode    bool
+	nodeHintEndpoints map[string]util.LBEndpoints // node name -> endpoints from Hints.ForNodes
 }
 
 func makeNodeSwitchTargetIPs(node string, clusterEntry util.LBEndpointEntry, c *lbConfig) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
@@ -151,6 +159,18 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 		klog.Warningf("Failed to get endpoints for service %s/%s during LB config build: %v",
 			service.Namespace, service.Name, err)
 	}
+
+	preferSameZone := util.ServiceHasTrafficDistributionPreferSameZone(service)
+	preferSameNode := util.ServiceHasTrafficDistributionPreferSameNode(service)
+	var portToZoneHintEndpoints util.PortToZoneToLBEndpoints
+	var portToNodeHintEndpoints util.PortToNodeToLBEndpoints
+	if preferSameZone {
+		portToZoneHintEndpoints = util.GetZoneHintEndpointsForService(endpointSlices, service)
+	}
+	if preferSameNode {
+		portToNodeHintEndpoints = util.GetNodeHintEndpointsForService(endpointSlices, service, nodes)
+	}
+
 	for _, svcPort := range service.Spec.Ports {
 		svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
 		clusterEndpoints := portToClusterEndpoints[svcPortKey]
@@ -210,6 +230,9 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 
 		// Build the clusterIP config
 		// This is NEVER influenced by ExternalTrafficPolicy
+		zoneHintEndpoints := portToZoneHintEndpoints[svcPortKey]
+		nodeHintEndpoints := portToNodeHintEndpoints[svcPortKey]
+
 		clusterIPConfig := lbConfig{
 			protocol:             svcPort.Protocol,
 			inport:               svcPort.Port,
@@ -219,12 +242,17 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 			externalTrafficLocal: false, // always false for ClusterIPs
 			internalTrafficLocal: internalTrafficLocal,
 			hasNodePort:          false,
+			preferSameZone:       preferSameZone,
+			zoneHintEndpoints:    zoneHintEndpoints,
+			preferSameNode:       preferSameNode,
+			nodeHintEndpoints:    nodeHintEndpoints,
 		}
 
 		// Normally, the ClusterIP LB is global (on all node switches and routers),
 		// unless any of the following are true:
 		// - Any of the endpoints are host-network
 		// - ETP=local service backed by non-local-host-networked endpoints
+		// - trafficDistribution is set (PreferSameZone, PreferSameNode, or PreferClose)
 		//
 		// In that case, we need to create per-node LBs.
 		ips := []string{}
@@ -232,7 +260,7 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 			ips = append(ips, ep.V4IPs...)
 			ips = append(ips, ep.V6IPs...)
 		}
-		if hasHostEndpoints(ips, netInfo) || internalTrafficLocal {
+		if hasHostEndpoints(ips, netInfo) || internalTrafficLocal || preferSameZone || preferSameNode {
 			perNodeConfigs = append(perNodeConfigs, clusterIPConfig)
 		} else {
 			clusterConfigs = append(clusterConfigs, clusterIPConfig)
@@ -660,8 +688,38 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 					routerV4targets = append(routerV4targets, joinHostsPort(routerV4TargetIPs, entry.Port)...)
 					routerV6targets = append(routerV6targets, joinHostsPort(routerV6TargetIPs, entry.Port)...)
 
-					switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
-					switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+					if cfg.preferSameZone && node.topologyZone != "" {
+						if zoneEps, ok := cfg.zoneHintEndpoints[node.topologyZone]; ok {
+							zoneEntry := zoneEps.GetEntryByPort(entry.Port)
+							if len(zoneEntry.V4IPs) > 0 {
+								switchV4targets = append(switchV4targets, joinHostsPort(zoneEntry.V4IPs, entry.Port)...)
+								switchV6targets = append(switchV6targets, joinHostsPort(zoneEntry.V6IPs, entry.Port)...)
+							} else {
+								switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+								switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+							}
+						} else {
+							switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+							switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+						}
+					} else if cfg.preferSameNode {
+						if nodeEps, ok := cfg.nodeHintEndpoints[node.name]; ok {
+							nodeEntry := nodeEps.GetEntryByPort(entry.Port)
+							if len(nodeEntry.V4IPs) > 0 {
+								switchV4targets = append(switchV4targets, joinHostsPort(nodeEntry.V4IPs, entry.Port)...)
+								switchV6targets = append(switchV6targets, joinHostsPort(nodeEntry.V6IPs, entry.Port)...)
+							} else {
+								switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+								switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+							}
+						} else {
+							switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+							switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+						}
+					} else {
+						switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+						switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+					}
 
 					switchV4LocalTargets = append(switchV4LocalTargets, joinHostsPort(switchV4TargetIPs, entry.Port)...)
 					switchV6LocalTargets = append(switchV6LocalTargets, joinHostsPort(switchV6TargetIPs, entry.Port)...)

--- a/go-controller/pkg/ovn/controller/services/node_info.go
+++ b/go-controller/pkg/ovn/controller/services/node_info.go
@@ -32,6 +32,9 @@ type nodeInfo struct {
 	// if nodePort is disabled on this node?
 	nodePortDisabled bool
 
+	// The Kubernetes availability zone from the topology.kubernetes.io/zone label
+	topologyZone string
+
 	// The list of node's management IPs
 	mgmtIPs []net.IP
 }
@@ -112,6 +115,7 @@ func nodeInfoForNetwork(node *corev1.Node, netInfo util.NetInfo) (*nodeInfo, err
 		switchName:         switchName,
 		chassisID:          chassisID,
 		nodePortDisabled:   !nodePortEnabled,
+		topologyZone:       node.Labels[corev1.LabelTopologyZone],
 	}
 	for i := range hsn {
 		ni.podSubnets = append(ni.podSubnets, *hsn[i])

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -915,3 +915,23 @@ func IsLastUpdatedByManager(manager string, managedFields []metav1.ManagedFields
 	}
 	return lastUpdateOurs.After(lastUpdateTheirs)
 }
+
+func ServiceHasTrafficDistributionPreferSameZone(service *corev1.Service) bool {
+	if service.Spec.TrafficDistribution == nil {
+		return false
+	}
+	td := *service.Spec.TrafficDistribution
+	return td == corev1.ServiceTrafficDistributionPreferSameZone ||
+		td == corev1.ServiceTrafficDistributionPreferClose
+}
+
+func ServiceHasTrafficDistributionPreferSameNode(service *corev1.Service) bool {
+	if service.Spec.TrafficDistribution == nil {
+		return false
+	}
+	return *service.Spec.TrafficDistribution == corev1.ServiceTrafficDistributionPreferSameNode
+}
+
+func ServiceHasTrafficDistribution(service *corev1.Service) bool {
+	return ServiceHasTrafficDistributionPreferSameZone(service) || ServiceHasTrafficDistributionPreferSameNode(service)
+}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -1120,3 +1120,109 @@ func IsNoOverlaySNATExemptionNeeded(netInfo NetInfo) bool {
 		netInfo.OutboundSNAT() == types.NoOverlaySNATEnabled &&
 		config.Gateway.Mode == config.GatewayModeShared
 }
+
+// PortToZoneToLBEndpoints maps service port keys to zone names and their load balancer endpoints.
+type PortToZoneToLBEndpoints map[string]map[string]LBEndpoints
+
+// groupEndpointsByZoneHint organizes endpoints by their Hints.ForZones zone names.
+func groupEndpointsByZoneHint(endpoints []discoveryv1.Endpoint) map[string][]discoveryv1.Endpoint {
+	zoneEndpoints := map[string][]discoveryv1.Endpoint{}
+	for _, endpoint := range endpoints {
+		if endpoint.Hints == nil {
+			continue
+		}
+		for _, forZone := range endpoint.Hints.ForZones {
+			zoneEndpoints[forZone.Name] = append(zoneEndpoints[forZone.Name], endpoint)
+		}
+	}
+	return zoneEndpoints
+}
+
+// groupEndpointsByNodeHint organizes endpoints by their Hints.ForNodes node names.
+func groupEndpointsByNodeHint(endpoints []discoveryv1.Endpoint) map[string][]discoveryv1.Endpoint {
+	nodeEndpoints := map[string][]discoveryv1.Endpoint{}
+	for _, endpoint := range endpoints {
+		if endpoint.Hints == nil {
+			continue
+		}
+		for _, forNode := range endpoint.Hints.ForNodes {
+			nodeEndpoints[forNode.Name] = append(nodeEndpoints[forNode.Name], endpoint)
+		}
+	}
+	return nodeEndpoints
+}
+
+// GetZoneHintEndpointsForService extracts zone-hint-based endpoints from EndpointSlices.
+func GetZoneHintEndpointsForService(endpointSlices []*discoveryv1.EndpointSlice, service *corev1.Service) PortToZoneToLBEndpoints {
+	zoneEndpoints := make(PortToZoneToLBEndpoints)
+
+	forEachEndpointPort(endpointSlices, service, func(slicePortKey string, targetPortNumber int32, endpointList []discoveryv1.Endpoint) {
+		zoneEpsByZone := groupEndpointsByZoneHint(endpointList)
+		for zone, zoneEps := range zoneEpsByZone {
+			entry, err := buildLBEndpointEntry(service, targetPortNumber, zoneEps)
+			if err != nil {
+				continue
+			}
+			if zoneEndpoints[slicePortKey] == nil {
+				zoneEndpoints[slicePortKey] = map[string]LBEndpoints{}
+			}
+			zoneEndpoints[slicePortKey][zone] = append(zoneEndpoints[slicePortKey][zone], entry)
+		}
+	})
+
+	return zoneEndpoints
+}
+
+// GetNodeHintEndpointsForService extracts node-hint-based endpoints from EndpointSlices.
+func GetNodeHintEndpointsForService(endpointSlices []*discoveryv1.EndpointSlice, service *corev1.Service, nodes sets.Set[string]) PortToNodeToLBEndpoints {
+	nodeHintEndpoints := make(PortToNodeToLBEndpoints)
+
+	forEachEndpointPort(endpointSlices, service, func(slicePortKey string, targetPortNumber int32, endpointList []discoveryv1.Endpoint) {
+		nodeEpsByNode := groupEndpointsByNodeHint(endpointList)
+		for node, nodeEps := range nodeEpsByNode {
+			if !nodes.Has(node) {
+				continue
+			}
+			entry, err := buildLBEndpointEntry(service, targetPortNumber, nodeEps)
+			if err != nil {
+				continue
+			}
+			if nodeHintEndpoints[slicePortKey] == nil {
+				nodeHintEndpoints[slicePortKey] = map[string]LBEndpoints{}
+			}
+			nodeHintEndpoints[slicePortKey][node] = append(nodeHintEndpoints[slicePortKey][node], entry)
+		}
+	})
+
+	return nodeHintEndpoints
+}
+
+// forEachEndpointPort iterates over parsed endpoint slices and calls fn for each
+// valid (service-port-key, target-port-number, endpoint-list) combination.
+func forEachEndpointPort(endpointSlices []*discoveryv1.EndpointSlice, service *corev1.Service,
+	fn func(slicePortKey string, targetPortNumber int32, endpointList []discoveryv1.Endpoint)) {
+
+	te := newTargetEndpoints(endpointSlices)
+
+	validServicePortKeys := map[string]bool{}
+	if service != nil {
+		for _, servicePort := range service.Spec.Ports {
+			validServicePortKeys[GetServicePortKey(servicePort.Protocol, servicePort.Name)] = true
+		}
+	}
+
+	for portName, protocolMap := range te {
+		for protocol, portNumberMap := range protocolMap {
+			slicePortKey := GetServicePortKey(protocol, portName)
+			if service != nil && !validServicePortKeys[slicePortKey] {
+				continue
+			}
+
+			portNumbers := slices.Collect(maps.Keys(portNumberMap))
+			slices.Sort(portNumbers)
+			for _, targetPortNumber := range portNumbers {
+				fn(slicePortKey, targetPortNumber, portNumberMap[targetPortNumber])
+			}
+		}
+	}
+}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Read EndpointSlice hints.forZones and program per-node OVN switch load balancers with zone-filtered backends when a Service has trafficDistribution set to PreferSameZone or PreferClose. Falls back to all endpoints when no same-zone endpoint exists

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
Add trafficDistribution support for Services (KEP-4444)
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Tested on an openshift cluster with 3 AZs and running two deployments/services one with `trafficDistribution: preferSameZone` and another one without `trafficDistribution` analyzed the traffic from both deployments to verify traffic distribution is on the same zone if the field is present 
