### PR TITLE
docs: lint CI check for absolute links that 404 under versioning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,8 @@ jobs:
           pip install mkdocs-awesome-pages-plugin
           pip install $(mkdocs-get-deps)
       - run: mkdocs build --strict
+      - name: Lint docs links
+        run: python3 hack/lint-docs-links.py
       - name: Test root 404 install helper
         run: ./hack/test-install-gh-pages-404.sh
       - name: Upload Artifact (Test)

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -40,7 +40,7 @@ feel free to write it. If you are unsure where this should be placed; reach out 
 
 * **Blog Posts**: Are you an end-user of OVN-Kubernetes? Is there something you wish to share with
 the community about your awesome use cases and how you used our CNI to solve your problems? We
-welcome blog post contributions from all! See [here](https://ovn-kubernetes.io/blog/) for details.
+welcome blog post contributions from all! See [here](../blog/index.md) for details.
 Open a commit adding your post to `docs/blog/posts/`. Each post must include
 YAML front matter with a `date` and `authors` list, for example:
 ```yaml
@@ -169,6 +169,14 @@ avoid introducing new unversioned `ovn-kubernetes.io/<page>/` URLs.
 Repo files outside `docs/` that must deep-link into the published site (for
 example `README.md`) should use a versioned absolute URL under `/master/…`,
 not an unversioned path.
+
+These conventions are enforced by `hack/lint-docs-links.py`, which runs in the
+**Test Docs Build** CI workflow on every pull request. Run it locally before
+pushing:
+
+```bash
+python3 hack/lint-docs-links.py
+```
 
 ### Root `404.html` (pre-versioning deep links)
 

--- a/hack/lint-docs-links.py
+++ b/hack/lint-docs-links.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lint Markdown docs for incorrect ovn-kubernetes.io link conventions.
+
+Exits 0 when every link follows the conventions, 1 otherwise.
+
+Conventions (documented in docs/developer-guide/documentation.md,
+"Linking between docs pages"):
+
+  docs/ files (except governance symlinks to the repo root)
+      Cross-reference other docs pages with relative Markdown paths.
+      Do NOT use https://ovn-kubernetes.io/… URLs for in-docs links.
+
+  Governance symlinks (repo-root files served via docs/governance/)
+  and other repo-root Markdown files
+      Deep-links into the published site MUST include a version prefix
+      (master/, latest/, or a release number like 1.3/).
+
+  A bare homepage link — https://ovn-kubernetes.io or
+  https://ovn-kubernetes.io/ with nothing after the slash — is always
+  fine everywhere.
+
+Links inside fenced code blocks are ignored (they are documentation
+examples, not live references).
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Inline Markdown link: [text](https://ovn-kubernetes.io/…)
+# Also matches angle-bracket form: [text](<https://ovn-kubernetes.io/…>)
+_INLINE_LINK_RE = re.compile(
+    r"\]\(\s*<?(https?://(?:www\.)?ovn-kubernetes\.io(?:/[^)\s>]*)?)>?"
+)
+
+# Reference-style link definition: [label]: https://ovn-kubernetes.io/…
+# Also matches angle-bracket form: [label]: <https://ovn-kubernetes.io/…>
+_REF_DEF_RE = re.compile(
+    r"^\s{0,3}\[.*\]:\s+<?(https?://(?:www\.)?ovn-kubernetes\.io(?:/[^\s>]*)?)>?",
+    re.MULTILINE,
+)
+
+# Versioned path prefix: /master/…, /latest/…, /1.3/… etc
+_VERSION_PREFIX_RE = re.compile(r"^/(master|latest|\d+\.\d+)(/|$)")
+
+# Fenced code block delimiter
+_FENCE_OPEN_RE = re.compile(r"^(\s*(`{3,}|~{3,}))")
+
+def _fenced_line_set(lines):
+    """Return the set of 0-based line indices that are inside fenced code blocks."""
+    inside = set()
+    in_fence = False
+    fence_char = None
+    fence_indent = 0
+    fence_len = 0
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        m = _FENCE_OPEN_RE.match(line)
+        if m:
+            char = m.group(2)[0]
+            length = len(m.group(2))
+            indent = len(line) - len(stripped)
+            if not in_fence:
+                in_fence = True
+                fence_char = char
+                fence_indent = indent
+                fence_len = length
+                continue
+            if char == fence_char and length >= fence_len and indent <= fence_indent:
+                in_fence = False
+                continue
+        if in_fence:
+            inside.add(idx)
+    return inside
+
+
+def _extract_site_path(url):
+    """Return the path portion after the hostname, or None for a bare homepage"""
+    remainder = re.sub(r"^https?://(?:www\.)?ovn-kubernetes\.io", "", url)
+    if not remainder or remainder == "/":
+        return None
+    return remainder
+
+
+def _is_governance_symlink(filepath, docs_dir):
+    """True when filepath is a symlink under docs/governance/ pointing outside docs/."""
+    governance_dir = docs_dir / "governance"
+    try:
+        filepath.relative_to(governance_dir)
+    except ValueError:
+        return False
+    if not filepath.is_symlink():
+        return False
+    resolved = filepath.resolve()
+    try:
+        resolved.relative_to(docs_dir.resolve())
+        return False
+    except ValueError:
+        return True
+
+def lint_file(filepath, repo_root):
+    """Return a list of ``(line_number, message)`` tuples for violations."""
+    docs_dir = repo_root / "docs"
+    errors = []
+
+    try:
+        text = filepath.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [(0, f"cannot read file: {exc}")]
+
+    lines = text.splitlines()
+    fenced = _fenced_line_set(lines)
+
+    # Determine which rule set applies.
+    resolved = filepath.resolve()
+    try:
+        resolved.relative_to(docs_dir.resolve())
+        is_docs_file = True
+    except ValueError:
+        is_docs_file = False
+
+    is_gov_symlink = _is_governance_symlink(filepath, docs_dir)
+
+    require_relative = is_docs_file and not is_gov_symlink
+
+    for idx, line in enumerate(lines):
+        if idx in fenced:
+            continue
+        for m in list(_INLINE_LINK_RE.finditer(line)) + list(
+            _REF_DEF_RE.finditer(line)
+        ):
+            url = m.group(1)
+            site_path = _extract_site_path(url)
+            if site_path is None:
+                continue
+
+            if require_relative:
+                errors.append(
+                    (idx + 1, f"use a relative Markdown path instead of {url}")
+                )
+            else:
+                if not _VERSION_PREFIX_RE.match(site_path):
+                    errors.append(
+                        (
+                            idx + 1,
+                            f"use a versioned URL (e.g. /master/…) instead of {url}",
+                        )
+                    )
+
+    return errors
+
+def main(argv=None):
+    repo_root = Path(__file__).resolve().parent.parent
+
+    docs_dir = repo_root / "docs"
+    targets = []
+
+    for md in sorted(docs_dir.rglob("*.md")):
+        targets.append(md)
+
+    for md in sorted(repo_root.glob("*.md")):
+        targets.append(md)
+
+    total_errors = 0
+    for filepath in targets:
+        errors = lint_file(filepath, repo_root)
+        for lineno, msg in errors:
+            relpath = filepath.relative_to(repo_root)
+            print(f"{relpath}:{lineno}: {msg}")
+            total_errors += 1
+
+    if total_errors:
+        print(f"\n{total_errors} link convention violation(s) found.")
+        print(
+            'See docs/developer-guide/documentation.md, "Linking between docs pages".'
+        )
+        return 1
+
+    print("All docs links follow conventions. ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Summary:

Added a CI lint check to the Test Docs Build workflow that catches incorrect `ovn-kubernetes.io` absolute URLs on every pull request before merge.
Since the site is now versioned with mike, unversioned absolute URLs like `https://ovn-kubernetes.io/design/architecture/` cause 404 errors on the published site. The linter blocks the PR until the author fixes the link.

### Rules Enforced

| File Location | Required Link Style |
| :--- | :--- |
| `docs/` files (excluding governance symlinks) | Relative Markdown paths (e.g., `../design/architecture.md`) |
| Repo-root files & governance symlinks | Versioned absolute URLs (e.g., `/master/…`, `/latest/…`, `/1.3/…`) |
| Bare homepage (`https://ovn-kubernetes.io/`) | Always allowed |

---

### Changes

* **`hack/lint-docs-links.py`**: Standalone Python 3 linter (no external dependencies).
* **`.github/workflows/docs.yml`**: Runs the linter inside the Test Docs Build CI job.
* **`docs/developer-guide/documentation.md`**: Fixes the one existing violation (`/blog/` -> `../blog/index.md`) and documents the linter usage.

---

### Run Locally

To test the linter locally run this: 
python3 hack/lint-docs-links.py

If all link are correct as per convention then it prints:
All docs links follow conventions. ✓

If link violates then it prints:
docs/design/architecture.md:10: use a relative Markdown path instead of https://ovn-kubernetes.io/getting-started/
1 link convention violation(s) found.
See docs/developer-guide/documentation.md, "Linking between docs pages".
 