### PR TITLE
docs: fix broken MkDocs nav and section index links

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,8 @@
 # Maintainers
 
-The current Maintainers Group for the ovn-kubernetes Project consists of:
-
 ## Current Maintainers
+
+The current Maintainers Group for the ovn-kubernetes Project consists of:
 
 | Name | Employer | Responsibilities |
 | ---- | -------- | ---------------- |
@@ -12,6 +12,8 @@ The current Maintainers Group for the ovn-kubernetes Project consists of:
 | [Patryk Diak](https://github.com/kyrtapz)   | Red Hat | All things ovnkube |
 | [Surya Seetharaman](https://github.com/tssurya)   | Red Hat | All things ovnkube |
 | [Tim Rozet](https://github.com/trozet)   | NVIDIA | All things ovnkube |
+
+## Related Resources
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
 See [GOVERNANCE.md](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,8 @@
+# Maintainers
+
 The current Maintainers Group for the ovn-kubernetes Project consists of:
+
+## Current Maintainers
 
 | Name | Employer | Responsibilities |
 | ---- | -------- | ---------------- |
@@ -12,7 +16,7 @@ The current Maintainers Group for the ovn-kubernetes Project consists of:
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
 See [GOVERNANCE.md](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
 
-Emeritus Maintainers
+## Emeritus Maintainers
 
 | Name | Employer | Responsibilities |
 | ---- | -------- | ---------------- |

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -16,22 +16,6 @@ Components, pods, and containers that make up an OVN-Kubernetes deployment.
 
 Logical switches, routers, and how they map to the physical cluster.
 
-**[Gateway Modes](gateway-modes.md)**
-
-Local vs shared gateway modes and how they affect traffic paths.
-
-**[Traffic Flows](traffic-flows.md)**
-
-End-to-end packet paths for pod-to-pod, pod-to-service, and external traffic.
-
-**[Pod Creation Workflow](pod-creation-workflow.md)**
-
-What happens in OVN when a new pod is scheduled on a node.
-
-**[Service Creation Workflow](service-creation-workflow.md)**
-
-How Kubernetes Services are translated into OVN load balancers.
-
 **[Service Traffic Policy](service-traffic-policy.md)**
 
 Internal and external traffic policy behavior for OVN-backed services.
@@ -44,6 +28,26 @@ Traffic flow when a node accesses its own NodePort service.
 
 How external IPs and LoadBalancer ingress addresses are handled.
 
-**[Internal Subnets](ovn-kubernetes-subnets.md)**
+**[External Bridge (breth0) Flows](bridge-flows.md)**
 
-Subnet allocation for join, transit, and masquerade networks.
+OpenFlow tables and steering on the external gateway bridge.
+
+**[Masquerade IPs](masquerade-ips.md)**
+
+Node-local masquerade addresses used for SNAT and overlapping UDN subnets.
+
+**[ACLs](acls.md)**
+
+How OVN ACLs implement network policy and related features.
+
+**[EgressIP Design](egressip.md)**
+
+How EgressIP assignment, failover, and GARP handling work.
+
+**[Gateway Accelerated Interface](gateway-accelerated-interface-configuration.md)**
+
+Using a switchdev VF or SF as the gateway interface for hardware acceleration.
+
+**[KubeVirt VM Live Migration](../features/live-migration.md)**
+
+Persistent IPs and networking for KubeVirt VM live migrations.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -16,6 +16,22 @@ Components, pods, and containers that make up an OVN-Kubernetes deployment.
 
 Logical switches, routers, and how they map to the physical cluster.
 
+**[Gateway Modes](gateway-modes.md)**
+
+Local vs shared gateway modes and how they affect traffic paths.
+
+**[Traffic Flows](traffic-flows.md)**
+
+End-to-end packet paths for pod-to-pod, pod-to-service, and external traffic.
+
+**[Pod Creation Workflow](pod-creation-workflow.md)**
+
+What happens in OVN when a new pod is scheduled on a node.
+
+**[Service Creation Workflow](service-creation-workflow.md)**
+
+How Kubernetes Services are translated into OVN load balancers.
+
 **[Service Traffic Policy](service-traffic-policy.md)**
 
 Internal and external traffic policy behavior for OVN-backed services.

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -8,7 +8,7 @@ become hard to maintain such code.
 All OVN-Kubernetes docs are kept under the `docs/` folder in the main path.
 There are specific folders such as `features` and `developer-guide` where
 you can add your commit against. These simple `.md` files are referred from
-the navigation tile in `mkdocs.yaml` file which is what is used to
+the navigation tile in `mkdocs.yml` file which is what is used to
 build our [website](https://ovn-kubernetes.io/).
 
 As a developer and contributor to this project; it is recommended that you

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -51,3 +51,8 @@ Techniques for debugging OVN-Kubernetes components during development.
 **[Release Guide](release.md)**
 
 Steps to cut a new OVN-Kubernetes release.
+
+**[Maintenance Guide](maintenance.md)**
+
+Ongoing maintenance tasks for the OVN-Kubernetes project.
+

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -20,6 +20,22 @@ Project governance structure, roles, and decision-making process.
 
 Guidelines and expectations for reviewing pull requests.
 
+**[Meetings](../governance/MEETINGS.md)**
+
+Community meeting schedule and how to join.
+
+**[Maintainers](../governance/MAINTAINERS.md)**
+
+Current and emeritus project maintainers.
+
+**[Security](../governance/SECURITY.md)**
+
+How to report vulnerabilities.
+
+**[Code of Conduct](../governance/CODE_OF_CONDUCT.md)**
+
+Community behavior standards.
+
 **[Project Areas](areas.md)**
 
 Component ownership areas and their maintainers.

--- a/docs/developer-guide/maintenance.md
+++ b/docs/developer-guide/maintenance.md
@@ -2,27 +2,44 @@
 
 For this repo to stay healthy, we need to make sure that we are doing regular maintenance. This includes:
 
+## Issue triage
+
 - Issue triage (No one is doing this now)
     - review newly created/updated issues (bugs and questions) and try to find assignees
     - ensure issues don't get stale and eventually get fixed/answered
     - use community meeting for sync and help
+
+## CI flakes triage
+
 - CI flakes triage (@npinaeva)
     - review newly created/updated flakes and try to find assignees
     - ensure flakes don't get stale and eventually get fixed
     - review/find reviewers for the CI flake fixes
     - use community meeting for sync and help
+
+## Release tracking and management
+
 - Release tracking and management (@tssurya)
     - Define target date for the next release, add Milestone and track the progress of the release
     - Share updates on the release progress in the community meetings
     - Track the scope of the release as we get closer to the release date and make sure we are on track to meet the release goals
     - Cut the release and share the release notes with the community
+
+## Members and contributors
+
 - Members and contributors (now also for areas) management (now is done by all maintainers)
     - ensure that we have the right people with the right permissions in the repo and in the org
     - remove stale members and contributors
     - add new members and contributors (follow the process defined in the [GOVERNANCE](../governance/GOVERNANCE.md#becoming-a-member) file)
+
+## Project healthcheck
+
 - Project healthcheck (no one is doing this now)
      - close stale PRs and issues (we have stale label)
      - delete stale branches
+
+## Community meetings
+
 - Facilitating the community meetings and keeping the notes up to date (@npinaeva and @tssurya)
     - facilitate the meetings and ensure that we are having productive discussions and that we are making progress on the topics discussed
     - ensure that we are taking notes during the meetings and sharing them with the community

--- a/docs/developer-guide/maintenance.md
+++ b/docs/developer-guide/maintenance.md
@@ -2,44 +2,48 @@
 
 For this repo to stay healthy, we need to make sure that we are doing regular maintenance. This includes:
 
-## Issue triage
+## Issue Triage
 
-- Issue triage (No one is doing this now)
-    - review newly created/updated issues (bugs and questions) and try to find assignees
-    - ensure issues don't get stale and eventually get fixed/answered
-    - use community meeting for sync and help
+- Review newly created/updated issues (bugs and questions) and try to find assignees
+- Ensure issues don't get stale and eventually get fixed/answered
+- Use community meeting for sync and help
 
-## CI flakes triage
+## CI Flakes Triage
 
-- CI flakes triage (@npinaeva)
-    - review newly created/updated flakes and try to find assignees
-    - ensure flakes don't get stale and eventually get fixed
-    - review/find reviewers for the CI flake fixes
-    - use community meeting for sync and help
+*Owner: @npinaeva*
 
-## Release tracking and management
+- Review newly created/updated flakes and try to find assignees
+- Ensure flakes don't get stale and eventually get fixed
+- Review/find reviewers for the CI flake fixes
+- Use community meeting for sync and help
 
-- Release tracking and management (@tssurya)
-    - Define target date for the next release, add Milestone and track the progress of the release
-    - Share updates on the release progress in the community meetings
-    - Track the scope of the release as we get closer to the release date and make sure we are on track to meet the release goals
-    - Cut the release and share the release notes with the community
+## Release Tracking and Management
 
-## Members and contributors
+*Owner: @tssurya*
 
-- Members and contributors (now also for areas) management (now is done by all maintainers)
-    - ensure that we have the right people with the right permissions in the repo and in the org
-    - remove stale members and contributors
-    - add new members and contributors (follow the process defined in the [GOVERNANCE](../governance/GOVERNANCE.md#becoming-a-member) file)
+- Define target date for the next release, add Milestone and track the progress of the release
+- Share updates on the release progress in the community meetings
+- Track the scope of the release as we get closer to the release date and make sure we are on track to meet the release goals
+- Cut the release and share the release notes with the community
 
-## Project healthcheck
+## Members and Contributors Management
 
-- Project healthcheck (no one is doing this now)
-     - close stale PRs and issues (we have stale label)
-     - delete stale branches
+All maintainers, including area maintainers, are responsible for this.
 
-## Community meetings
+- Ensure that we have the right people with the right permissions in the repo and in the org
+- Remove stale members and contributors
+- Add new members and contributors (follow the process defined in the [GOVERNANCE](../governance/GOVERNANCE.md#becoming-a-member) file)
 
-- Facilitating the community meetings and keeping the notes up to date (@npinaeva and @tssurya)
-    - facilitate the meetings and ensure that we are having productive discussions and that we are making progress on the topics discussed
-    - ensure that we are taking notes during the meetings and sharing them with the community
+## Project Healthcheck
+
+*No one is doing this now*
+
+- Close stale PRs and issues (we have stale label)
+- Delete stale branches
+
+## Community Meetings
+
+*Owners: @npinaeva and @tssurya*
+
+- Facilitate the meetings and ensure that we are having productive discussions and that we are making progress on the topics discussed
+- Ensure that we are taking notes during the meetings and sharing them with the community

--- a/docs/features/cluster-egress-controls/index.md
+++ b/docs/features/cluster-egress-controls/index.md
@@ -19,7 +19,3 @@ Route egress traffic from pods through a Service's load balancer IP.
 **[EgressQoS](egress-qos.md)**
 
 Apply DSCP marking rules to egress traffic on a per-namespace basis.
-
-**[EgressGateway](egress-gateway.md)**
-
-Direct egress traffic through designated gateway nodes using policy-based routing.

--- a/docs/features/hardware-offload/index.md
+++ b/docs/features/hardware-offload/index.md
@@ -15,3 +15,15 @@ Offload OVS flow processing to SmartNIC hardware using the kernel TC datapath.
 **[OVS Acceleration with DOCA datapath](ovs-doca.md)**
 
 Offload OVS to NVIDIA BlueField DPUs using the DOCA-based datapath.
+
+**[DPU Support](dpu-support.md)**
+
+Running OVN-Kubernetes with DPU offload.
+
+**[DPU Gateway Interface](dpu-gateway-interface.md)**
+
+Gateway interface configuration on DPU-accelerated nodes.
+
+**[Derive From Management Port](derive-from-mgmt-port.md)**
+
+Deriving hardware-offload configuration from the management port.

--- a/docs/features/network-security-controls/index.md
+++ b/docs/features/network-security-controls/index.md
@@ -22,4 +22,4 @@ Restrict which external destinations pods in a namespace can reach.
 
 **[DNS Name Resolution](dns-name-resolution.md)**
 
-DNS-based matching for network policy and egress firewall rules.
+DNS-based matching for EgressFirewall rules.

--- a/docs/features/network-security-controls/index.md
+++ b/docs/features/network-security-controls/index.md
@@ -19,3 +19,7 @@ Standard Kubernetes NetworkPolicy enforcement via OVN ACLs.
 **[EgressFirewall](egress-firewall.md)**
 
 Restrict which external destinations pods in a namespace can reach.
+
+**[DNS Name Resolution](dns-name-resolution.md)**
+
+DNS-based matching for network policy and egress firewall rules.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -24,6 +24,10 @@ Install OVN-Kubernetes with hardware offload to SmartNICs and DPUs.
 
 Set up OVN-Kubernetes as the CNI plugin on a kubeadm-managed cluster.
 
+**[Launching OVN-Kubernetes on Ubuntu](../installation/INSTALL.UBUNTU.md)**
+
+Install OVN-Kubernetes on Ubuntu hosts.
+
 **[Configuration Guide](configuration.md)**
 
 Tune OVN-Kubernetes settings and customize cluster networking behavior.
@@ -31,19 +35,3 @@ Tune OVN-Kubernetes settings and customize cluster networking behavior.
 **[Requirements](../features/requirements.md)**
 
 Minimum system and software requirements for running OVN-Kubernetes.
-
-**[CLI Guide](cli-guide.md)**
-
-Command-line options and flags for ovnkube binaries.
-
-**[Deploying Workloads](example-pod-creation.md)**
-
-Create pods and verify pod-to-pod connectivity on your cluster.
-
-**[Deploying Services](example-service-creation.md)**
-
-Expose workloads using Kubernetes Services backed by OVN load balancers.
-
-**[Setup and Building](building-ovn-kubernetes.md)**
-
-Build OVN-Kubernetes from source and set up a development environment.

--- a/docs/governance/index.md
+++ b/docs/governance/index.md
@@ -19,3 +19,19 @@ Project governance structure, roles, and decision-making process.
 **[Reviewing Guide](REVIEWING.md)**
 
 Guidelines and expectations for reviewing pull requests.
+
+**[Meetings](MEETINGS.md)**
+
+Community meeting schedule and how to join.
+
+**[Maintainers](MAINTAINERS.md)**
+
+Current and emeritus project maintainers.
+
+**[Security](SECURITY.md)**
+
+How to report vulnerabilities.
+
+**[Code of Conduct](CODE_OF_CONDUCT.md)**
+
+Community behavior standards.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -23,3 +23,7 @@ Install OVN-Kubernetes with hardware offload to SmartNICs and DPUs.
 **[Launching OVN-Kubernetes with kubeadm](INSTALL.KUBEADM.md)**
 
 Set up OVN-Kubernetes as the CNI plugin on a kubeadm-managed cluster.
+
+**[Launching OVN-Kubernetes on Ubuntu](INSTALL.UBUNTU.md)**
+
+Install OVN-Kubernetes on Ubuntu hosts.

--- a/docs/okeps/index.md
+++ b/docs/okeps/index.md
@@ -67,3 +67,11 @@ VRF-Lite shared gateway mode with external bridge uplinks.
 **[Disable MAC Spoof Protection on Secondary Networks](okep-3926-disable-port-security.md)**
 
 Allow disabling port security on secondary network interfaces.
+
+**[OVN Observability API](okep-5212-ovnobserv-api.md)**
+
+API for OVN observability sampling and tracing.
+
+**[DHCP IPAM for Localnet](okep-6224-dhcp-ipam-localnet.md)**
+
+DHCP-based IPAM for localnet secondary networks.

--- a/docs/okeps/index.md
+++ b/docs/okeps/index.md
@@ -44,6 +44,10 @@ On-demand subnet allocation for UDN nodes as pods are scheduled.
 
 Controlled inter-UDN connectivity via ClusterNetworkConnect.
 
+**[Connecting UDNs: Discarded Alternatives](okep-5224-connecting-udns/discarded-alternatives.md)**
+
+Discarded network topology proposals for connecting Layer3-type Cluster User Defined Networks (CUDNs).
+
 **[No-Overlay Mode](okep-5259-no-overlay.md)**
 
 Direct pod routing using BGP-learned routes without encapsulation.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -19,3 +19,7 @@ Trace packet paths through OVN logical flows to diagnose connectivity problems.
 **[Logging](logging.md)**
 
 Configure and interpret OVN-Kubernetes component logs.
+
+**[User Defined Networks](udn.md)**
+
+Diagnose connectivity and configuration issues on User Defined Networks.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -16,10 +16,6 @@ General debugging strategies and common issues in OVN-Kubernetes clusters.
 
 Trace packet paths through OVN logical flows to diagnose connectivity problems.
 
-**[Logging](logging.md)**
-
-Configure and interpret OVN-Kubernetes component logs.
-
 **[User Defined Networks](udn.md)**
 
 Diagnose connectivity and configuration issues on User Defined Networks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,10 @@ nav:
     - index.md
     - Architecture: design/architecture.md
     - Network Topology: design/topology.md
+    - Gateway Modes: design/gateway-modes.md
+    - Traffic Flows: design/traffic-flows.md
+    - Pod Creation Workflow: design/pod-creation-workflow.md
+    - Service Creation Workflow: design/service-creation-workflow.md
     - Service Traffic Policy: design/service-traffic-policy.md
     - Host To NodePort Hairpin: design/host-to-node-port-hairpin-trafficflow.md
     - ExternalIPs/LoadBalancerIngress: design/external-ip-and-loadbalancer-ingress.md
@@ -106,6 +110,10 @@ nav:
       - Contributing Guide: governance/CONTRIBUTING.md
       - Governance: governance/GOVERNANCE.md
       - Reviewing Guide: governance/REVIEWING.md
+      - Meetings: governance/MEETINGS.md
+      - Maintainers: governance/MAINTAINERS.md
+      - Security: governance/SECURITY.md
+      - Code of Conduct: governance/CODE_OF_CONDUCT.md
       - Project Areas: developer-guide/areas.md
       - Coding Guide: developer-guide/developer.md
       - OVN-Kubernetes Container Images: developer-guide/image-build.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,16 +83,14 @@ nav:
     - index.md
     - Architecture: design/architecture.md
     - Network Topology: design/topology.md
-    - Gateway Modes: design/gateway-modes.md
-    - Traffic Flows: design/traffic-flows.md
-    - Pod Creation Workflow: design/pod-creation-workflow.md
-    - Service Creation Workflow: design/service-creation-workflow.md
     - Service Traffic Policy: design/service-traffic-policy.md
     - Host To NodePort Hairpin: design/host-to-node-port-hairpin-trafficflow.md
     - ExternalIPs/LoadBalancerIngress: design/external-ip-and-loadbalancer-ingress.md
-    - Internal Subnets: design/ovn-kubernetes-subnets.md
     - External Bridge (breth0) Flows: design/bridge-flows.md
     - Masquerade IPs: design/masquerade-ips.md
+    - ACLs: design/acls.md
+    - EgressIP Design: design/egressip.md
+    - Gateway Accelerated Interface: design/gateway-accelerated-interface-configuration.md
     - Kubevirt VM Live Migration: features/live-migration.md
   - Getting Started:
     - getting-started/index.md
@@ -100,12 +98,9 @@ nav:
     - Launching OVN-Kubernetes Using Helm: installation/launching-ovn-kubernetes-with-helm.md
     - Launching OVN-Kubernetes with DPU Acceleration: installation/launching-ovn-kubernetes-with-dpu.md
     - Launching OVN-Kubernetes with kubeadm: installation/INSTALL.KUBEADM.md
+    - Launching OVN-Kubernetes on Ubuntu: installation/INSTALL.UBUNTU.md
     - Configuration Guide: getting-started/configuration.md
     - Requirements: features/requirements.md
-    - CLI Guide: getting-started/cli-guide.md
-    - Deploying Workloads on OVN-Kubernetes cluster: getting-started/example-pod-creation.md
-    - Deploying Services on OVN-Kubernetes cluster: getting-started/example-service-creation.md
-    - Setup and Building: getting-started/building-ovn-kubernetes.md
   - Developer Guide:
       - developer-guide/index.md
       - Contributing Guide: governance/CONTRIBUTING.md
@@ -146,6 +141,7 @@ nav:
       - AdminNetworkPolicy: features/network-security-controls/admin-network-policy.md
       - NetworkPolicy: features/network-security-controls/network-policy.md
       - EgressFirewall: features/network-security-controls/egress-firewall.md
+      - DNS Name Resolution: features/network-security-controls/dns-name-resolution.md
     - ClusterEgressControls:
       - features/cluster-egress-controls/index.md
       - EgressIP: features/cluster-egress-controls/egress-ip.md
@@ -172,6 +168,9 @@ nav:
       - features/hardware-offload/index.md
       - OVS Acceleration with kernel datapath: features/hardware-offload/ovs-kernel.md
       - OVS Acceleration with DOCA datapath: features/hardware-offload/ovs-doca.md
+      - DPU Support: features/hardware-offload/dpu-support.md
+      - DPU Gateway Interface: features/hardware-offload/dpu-gateway-interface.md
+      - Derive From Management Port: features/hardware-offload/derive-from-mgmt-port.md
     - BGP Integration:
       - features/bgp-integration/index.md
       - Route Advertisements: features/bgp-integration/route-advertisements.md
@@ -182,6 +181,7 @@ nav:
     - Introduction: troubleshooting/debugging.md
     - OVNKube Trace: troubleshooting/ovnkube-trace.md
     - Logging: troubleshooting/logging.md
+    - User Defined Networks: troubleshooting/udn.md
   - Observability:
     - observability/index.md
     - Metrics: observability/metrics.md
@@ -206,6 +206,7 @@ nav:
     - VRF-Lite Shared Gateway Mode with Uplinks: okeps/okep-6019-vrf-lite-shared-gateway-external-bridges.md
     - Disable Port Security: okeps/okep-3926-disable-port-security.md
     - OVN Observability API: okeps/okep-5212-ovnobserv-api.md
+    - DHCP IPAM for Localnet: okeps/okep-6224-dhcp-ipam-localnet.md
     - EgressIP Node Selector: okeps/okep-6800-egressip-node-selector.md
   - Blog:
     - OVN-Kubernetes Blog: blog/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ nav:
     - MCP for Troubleshooting: okeps/okep-5494-ovn-kubernetes-mcp-server.md
     - Dynamic UDN Node Allocation: okeps/okep-5552-dynamic-udn-node-allocation.md
     - Connecting User Defined Networks: okeps/okep-5224-connecting-udns/okep-5224-connecting-udns.md
+    - Connecting UDNs Discarded Alternatives: okeps/okep-5224-connecting-udns/discarded-alternatives.md
     - No-Overlay Mode: okeps/okep-5259-no-overlay.md
     - EVPN: okeps/okep-5088-evpn.md
     - DPU Healthcheck: okeps/okep-5674-dpu-healthcheck.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,7 +147,6 @@ nav:
       - EgressIP: features/cluster-egress-controls/egress-ip.md
       - EgressService: features/cluster-egress-controls/egress-service.md
       - EgressQoS: features/cluster-egress-controls/egress-qos.md
-      - EgressGateway: features/cluster-egress-controls/egress-gateway.md
     - InfrastructureSecurityControls:
       - features/infrastructure-security-controls/index.md
       - NodeIdentity: features/infrastructure-security-controls/node-identity.md
@@ -180,7 +179,6 @@ nav:
     - troubleshooting/index.md
     - Introduction: troubleshooting/debugging.md
     - OVNKube Trace: troubleshooting/ovnkube-trace.md
-    - Logging: troubleshooting/logging.md
     - User Defined Networks: troubleshooting/udn.md
   - Observability:
     - observability/index.md


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
MkDocs nav and section `index.md` pages linked to docs that were never published, so those entries 404 or render with a blank sidebar. This PR points nav and indexes at files that exist, adds existing pages that were left out of the site nav, and keeps a small set of empty design stubs that have content PRs in flight.

Fixes #

## Release Notes
```release-note
NONE
```

## Additional Information for reviewers
Docs-only. No Go, Helm, or test changes.

**Nav / index: existing pages now listed**

- Design: `acls.md`, `egressip.md`, `gateway-accelerated-interface-configuration.md`, plus `bridge-flows.md` / `masquerade-ips.md` on the design index
- Install: `INSTALL.UBUNTU.md`
- Features: DNS name resolution (EgressFirewall-only; not NetworkPolicy); DPU hardware-offload pages
- Troubleshooting: `udn.md`
- OKEPs: `okep-5212-ovnobserv-api.md`, `okep-6224-dhcp-ipam-localnet.md`, `okep-5224-connecting-udns/discarded-alternatives.md`
- Developer guide: maintenance guide on the section index

**Governance (empty primary sidebar on direct URL)**

Meetings, Maintainers, Security, and Code of Conduct are in Developer Guide nav and on `docs/governance/index.md` / `docs/developer-guide/index.md`. They resolve through the existing `docs/governance/*` symlinks.

**Secondary TOC**

`MAINTAINERS.md` and `docs/developer-guide/maintenance.md` now have `##` headings so the right-hand TOC renders. Maintenance ownership for members/contributors is stated as all maintainers, including area maintainers.

**Empty placeholders still in nav (Ayushi: content PRs incoming)**

- `design/gateway-modes.md`
- `design/traffic-flows.md`
- `design/pod-creation-workflow.md`
- `design/service-creation-workflow.md`

**Empty / unpublished still not in nav**

- Design: `ovn-kubernetes-subnets.md`
- Getting started: `cli-guide.md`, `example-pod-creation.md`, `example-service-creation.md`, `building-ovn-kubernetes.md`
- Troubleshooting: `logging.md`
- Features: `egress-gateway.md`
- OKEP template (`okep-4368-template.md`) stays unlisted (internal template)

Also corrects `mkdocs.yaml` → `mkdocs.yml` in `docs/developer-guide/documentation.md`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
No unit or e2e tests (docs/nav only).

1. Confirm every `nav:` path in `mkdocs.yml` is a real file under `docs/`.
2. Confirm relative links in section `index.md` files resolve.
3. Preview with `mkdocs serve` or `make -C docs build-docs` and walk Overview, Getting Started, Developer Guide, Features, Troubleshooting, and Enhancement Proposals.
4. Open Meetings / Maintainers / Security / Code of Conduct and confirm the left sidebar is populated.
5. Open `MAINTAINERS.md` and the maintenance guide and confirm the right-hand TOC is populated.
6. Confirm Overview still lists Gateway Modes, Traffic Flows, and the pod/service workflow pages.
