### PR TITLE
fix(clustermanager): preserve existing annotations when patching EgressIP mark

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1062,7 +1062,7 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 		// Update the object only on an ADD/UPDATE. If we are processing a
 		// DELETE, new will be nil and we should not update the object.
 		if len(statusToAdd) > 0 || (len(statusToRemove) > 0 && new != nil) {
-			if err := eIPC.patchEgressIP(name, eIPC.generateEgressIPPatches(name, new.Annotations, statusToKeep)...); err != nil {
+			if err := eIPC.patchEgressIP(name, eIPC.generateEgressIPPatches(name, new.Annotations, new.ResourceVersion, statusToKeep)...); err != nil {
 				return err
 			}
 		}
@@ -1090,7 +1090,7 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 			// Update the object only on an ADD/UPDATE. If we are processing a
 			// DELETE, new will be nil and we should not update the object.
 			if new != nil {
-				if err := eIPC.patchEgressIP(name, eIPC.generateEgressIPPatches(name, new.Annotations, statusToKeep)...); err != nil {
+				if err := eIPC.patchEgressIP(name, eIPC.generateEgressIPPatches(name, new.Annotations, new.ResourceVersion, statusToKeep)...); err != nil {
 					return err
 				}
 			}
@@ -1174,7 +1174,7 @@ func (eIPC *egressIPClusterController) syncCloudPrivateIPConfigs(objs []interfac
 		if cloudPrivateIPNotFound {
 			// There could be one or more stale entry found in egress ip object, remove it by patching egressip
 			// object with updated status.
-			err = eIPC.patchEgressIP(egressIP.Name, eIPC.generateEgressIPPatches(egressIP.Name, egressIP.Annotations, updatedStatus)...)
+			err = eIPC.patchEgressIP(egressIP.Name, eIPC.generateEgressIPPatches(egressIP.Name, egressIP.Annotations, egressIP.ResourceVersion, updatedStatus)...)
 			if err != nil {
 				return fmt.Errorf("syncCloudPrivateIPConfigs unable to update EgressIP status: %w", err)
 			}
@@ -1610,7 +1610,7 @@ func (eIPC *egressIPClusterController) reconcileCloudPrivateIPConfig(old, new *o
 					updatedStatus = append(updatedStatus, status)
 				}
 			}
-			if err := eIPC.patchEgressIP(egressIP.Name, eIPC.generateEgressIPPatches(egressIP.Name, egressIP.Annotations, updatedStatus)...); err != nil {
+			if err := eIPC.patchEgressIP(egressIP.Name, eIPC.generateEgressIPPatches(egressIP.Name, egressIP.Annotations, egressIP.ResourceVersion, updatedStatus)...); err != nil {
 				return err
 			}
 		}
@@ -1657,7 +1657,7 @@ func (eIPC *egressIPClusterController) reconcileCloudPrivateIPConfig(old, new *o
 		}
 		if !hasStatus {
 			statusToKeep := append(egressIP.Status.Items, statusItem)
-			if err := eIPC.patchEgressIP(egressIP.Name, eIPC.generateEgressIPPatches(egressIP.Name, egressIP.Annotations, statusToKeep)...); err != nil {
+			if err := eIPC.patchEgressIP(egressIP.Name, eIPC.generateEgressIPPatches(egressIP.Name, egressIP.Annotations, egressIP.ResourceVersion, statusToKeep)...); err != nil {
 				return err
 			}
 		}
@@ -1815,24 +1815,61 @@ func (eIPC *egressIPClusterController) patchEgressIP(name string, patches ...jso
 // mark range exhaustion. Primary default network egress IP currently does not utilize marks to config EgressIP.
 // Generating the status patch is mandatory
 func (eIPC *egressIPClusterController) generateEgressIPPatches(name string, annotations map[string]string,
-	statusItems []egressipv1.EgressIPStatusItem) []jsonPatchOperation {
+	resourceVersion string, statusItems []egressipv1.EgressIPStatusItem) []jsonPatchOperation {
 	patches := make([]jsonPatchOperation, 0, 1)
 	if !util.IsEgressIPMarkSet(annotations) {
 		if mark, _, err := eIPC.getOrAllocMark(name); err != nil {
 			klog.Errorf("Failed to get mark for EgressIP %s: %v", name, err)
 		} else {
-			patches = append(patches, generateMarkPatchOp(mark))
+			patches = append(patches, generateMarkPatchOps(annotations, resourceVersion, mark)...)
 		}
 	}
 	return append(patches, generateStatusPatchOp(statusItems))
 }
 
-func generateMarkPatchOp(mark int) jsonPatchOperation {
-	return jsonPatchOperation{
-		Operation: "add",
-		Path:      "/metadata/annotations",
-		Value:     createAnnotWithMark(mark),
+// generateMarkPatchOps returns the JSON patch operations required to set the
+// egress IP mark annotation without disturbing any other annotations already
+// present on the object. Patching "/metadata/annotations" directly with an
+// "add" op replaces the entire annotations map per RFC 6902, wiping out
+// annotations owned by other controllers/tools (e.g. ArgoCD tracking
+// annotations). Targeting the specific annotation leaf avoids that.
+//
+// When annotations is empty, the parent map has to be created first via a
+// separate "add" op, which itself would blindly replace any annotations
+// added concurrently since resourceVersion was read. Guarding that op with a
+// "test" on resourceVersion makes the whole patch fail instead, so the
+// caller's normal reconcile-retry path picks it up with fresh state rather
+// than silently dropping the concurrent annotation.
+func generateMarkPatchOps(annotations map[string]string, resourceVersion string, mark int) []jsonPatchOperation {
+	ops := make([]jsonPatchOperation, 0, 3)
+	if len(annotations) == 0 {
+		if resourceVersion != "" {
+			ops = append(ops, jsonPatchOperation{
+				Operation: "test",
+				Path:      "/metadata/resourceVersion",
+				Value:     resourceVersion,
+			})
+		}
+		// The "add" op below requires the parent object to exist.
+		ops = append(ops, jsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/annotations",
+			Value:     map[string]string{},
+		})
 	}
+	ops = append(ops, jsonPatchOperation{
+		Operation: "add",
+		Path:      "/metadata/annotations/" + escapeJSONPatchPathKey(util.EgressIPMarkAnnotation),
+		Value:     fmt.Sprintf("%d", mark),
+	})
+	return ops
+}
+
+// escapeJSONPatchPathKey escapes a map key for use as a JSON Pointer (RFC
+// 6901) path segment, as required by JSON Patch (RFC 6902).
+func escapeJSONPatchPathKey(key string) string {
+	key = strings.ReplaceAll(key, "~", "~0")
+	return strings.ReplaceAll(key, "/", "~1")
 }
 
 func createAnnotWithMark(mark int) map[string]string {
@@ -1897,7 +1934,7 @@ func (eIPC *egressIPClusterController) syncEgressIPMarkAllocator(egressIPs []int
 			// Mark range is limited so do not return an error in-order not to block pods attached to the CDN
 			klog.Errorf("Failed to sync mark allocator: unable to allocate for EgressIP %s: %v", egressIP.Name, err)
 		} else {
-			if err = eIPC.patchEgressIP(egressIP.Name, generateMarkPatchOp(mark)); err != nil {
+			if err = eIPC.patchEgressIP(egressIP.Name, generateMarkPatchOps(egressIP.Annotations, egressIP.ResourceVersion, mark)...); err != nil {
 				releaseMarkFn()
 				return fmt.Errorf("failed to patch EgressIP %s: %v", egressIP.Name, err)
 			}

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -5,6 +5,7 @@ package clustermanager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -29,6 +31,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	egressipfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -4947,3 +4950,75 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 		})
 	})
 })
+
+const testEgressIPMarkPatchName = "eip-mark-patch-test"
+
+// applyMarkPatchOps seeds a fake EgressIP clientset (see egressipfake.NewClientset)
+// with an object at the given annotations and resourceVersion, then applies ops
+// via a real JSON Patch request. This exercises the actual patch-application
+// code path rather than a hand-rolled simulation of RFC 6902 semantics.
+// resourceVersion models the object's actual state at apply time, which may
+// differ from what the patch was generated against.
+func applyMarkPatchOps(t *testing.T, annotations map[string]string, resourceVersion string, ops []jsonPatchOperation) (map[string]string, error) {
+	t.Helper()
+	seed := &egressipv1.EgressIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            testEgressIPMarkPatchName,
+			Annotations:     annotations,
+			ResourceVersion: resourceVersion,
+		},
+	}
+	client := egressipfake.NewClientset(seed).K8sV1().EgressIPs()
+
+	data, err := json.Marshal(ops)
+	if err != nil {
+		t.Fatalf("failed to marshal patch ops: %v", err)
+	}
+	updated, err := client.Patch(context.Background(), testEgressIPMarkPatchName, k8stypes.JSONPatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return updated.Annotations, nil
+}
+
+func TestGenerateMarkPatchOpsFailsClosedOnConcurrentAnnotationAdd(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// Patch generated while annotations was still empty at resourceVersion "1".
+	ops := generateMarkPatchOps(nil, "1", 50003)
+
+	// By the time the patch is applied, a concurrent writer has bumped the
+	// resourceVersion by adding its own annotation. The whole patch must be
+	// rejected rather than silently discarding that annotation.
+	concurrentlyAdded := map[string]string{"argocd.argoproj.io/tracking-id": "some-app"}
+	result, err := applyMarkPatchOps(t, concurrentlyAdded, "2", ops)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.BeNil())
+}
+
+func TestGenerateMarkPatchOpsSucceedsWhenResourceVersionMatches(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	ops := generateMarkPatchOps(nil, "1", 50004)
+
+	result, err := applyMarkPatchOps(t, nil, "1", ops)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveKeyWithValue(util.EgressIPMarkAnnotation, "50004"))
+}
+
+func TestGenerateMarkPatchOpsSkipsGuardWhenResourceVersionUnknown(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	ops := generateMarkPatchOps(nil, "", 50005)
+
+	g.Expect(ops).To(gomega.HaveLen(2))
+	g.Expect(ops[0].Path).To(gomega.Equal("/metadata/annotations"))
+	g.Expect(ops[1].Path).To(gomega.Equal("/metadata/annotations/k8s.ovn.org~1egressip-mark"))
+}
+
+func TestEscapeJSONPatchPathKey(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(escapeJSONPatchPathKey(util.EgressIPMarkAnnotation)).To(gomega.Equal("k8s.ovn.org~1egressip-mark"))
+	g.Expect(escapeJSONPatchPathKey("a~b/c")).To(gomega.Equal("a~0b~1c"))
+}

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -3931,6 +3931,80 @@ spec:
 			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("The \"k8s.ovn.org/egressip-mark\" annotation cannot be modified or removed once set. This annotation is managed by the system.")))
 		})
 
+		ginkgo.It("Should preserve a pre-existing foreign annotation when the egressip-mark annotation is added", func() {
+			ginkgo.By("1. Add the \"k8s.ovn.org/egress-assignable\" label to egress1Node node")
+			egressNodeAvailabilityHandler := egressNodeAvailabilityHandlerViaLabel{f}
+			egressNodeAvailabilityHandler.Enable(egress1Node.name)
+			defer egressNodeAvailabilityHandler.Restore(egress1Node.name)
+
+			podNamespace := f.Namespace
+			labels := map[string]string{
+				"name": f.Namespace.Name,
+			}
+			updateNamespaceLabels(f, podNamespace, labels)
+
+			ginkgo.By("2. Create an EgressIP object carrying a foreign annotation, as e.g. a GitOps tool would add")
+			var egressIP1 net.IP
+			var err error
+			if utilnet.IsIPv6String(egress1Node.nodeIP) {
+				egressIP1, err = ipalloc.NewPrimaryIPv6()
+			} else {
+				egressIP1, err = ipalloc.NewPrimaryIPv4()
+			}
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "must allocate new Node IP")
+
+			const foreignAnnotationKey = "example.com/foreign-annotation"
+			const foreignAnnotationValue = "do-not-remove"
+
+			var egressIPConfig = `apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: ` + egressIPName + `
+    annotations:
+      ` + foreignAnnotationKey + `: "` + foreignAnnotationValue + `"
+spec:
+    egressIPs:
+    - ` + egressIP1.String() + `
+    namespaceSelector:
+        matchLabels:
+            name: ` + f.Namespace.Name + `
+`
+			if err := os.WriteFile(egressIPYaml, []byte(egressIPConfig), 0644); err != nil {
+				framework.Failf("Unable to write CRD config to disk: %v", err)
+			}
+			defer func() {
+				if err := os.Remove(egressIPYaml); err != nil {
+					framework.Logf("Unable to remove the CRD config from disk: %v", err)
+				}
+			}()
+
+			framework.Logf("Create the EgressIP configuration")
+			e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml)
+
+			ginkgo.By("3. Wait for the EgressIP to be assigned, which drives the egressip-mark annotation patch")
+			statuses := verifyEgressIPStatusLengthEquals(1, nil)
+			if statuses[0].Node != egress1Node.name {
+				framework.Failf("Step 3. Check that the status is of length one and that it is assigned to egress1Node, failed")
+			}
+
+			ginkgo.By("4. Verify the egressip-mark annotation was added and the foreign annotation was preserved")
+			var annotations map[string]string
+			err = wait.PollUntilContextTimeout(context.TODO(), retryInterval, retryTimeout, true, func(context.Context) (bool, error) {
+				annotationsJSON, err := e2ekubectl.RunKubectl("", "get", "egressip", egressIPName, "-o", "jsonpath={.metadata.annotations}")
+				if err != nil {
+					return false, nil
+				}
+				if unmarshalErr := json.Unmarshal([]byte(annotationsJSON), &annotations); unmarshalErr != nil {
+					return false, nil
+				}
+				_, hasMark := annotations[util.EgressIPMarkAnnotation]
+				return hasMark, nil
+			})
+			framework.ExpectNoError(err, "timed out waiting for the egressip-mark annotation to be set")
+			gomega.Expect(annotations).To(gomega.HaveKeyWithValue(foreignAnnotationKey, foreignAnnotationValue),
+				"foreign annotation must survive the egressip-mark annotation patch")
+		})
+
 		ginkgo.It("Should skip orphaned nodes and assign EgressIPs to valid nodes", func() {
 			if isUserDefinedNetwork(netConfigParams) {
 				ginkgo.Skip("Unsupported for UDNs")


### PR DESCRIPTION
## 📑 Description

The EgressIP mark annotation patch used a JSON Patch `add` operation targeting
`/metadata/annotations` directly. Per RFC 6902, an `add` on an existing object
member replaces its value entirely, so this wiped out any other annotations
already present on the EgressIP object (e.g. annotations added by GitOps
tools such as ArgoCD) every time the controller reconciled the object.

This PR targets the specific annotation leaf
(`/metadata/annotations/k8s.ovn.org~1egressip-mark`) instead, only creating
the parent annotations map when it doesn't already exist — mirroring the
existing per-key JSON patch pattern used for pod annotations in `pkg/kube`.
When the annotations map does need to be created, the patch also carries a
`test` on `resourceVersion` so a concurrent writer adding the object's first
annotation can't be silently overwritten; the existing reconcile-retry path
picks it up with fresh state instead.

Fixes #

## Release Notes

```release-note
Fixed a bug where the EgressIP controller could overwrite other
annotations (e.g. ones added by GitOps tooling) on an EgressIP object
while adding its own mark annotation.
```

## Additional Information for reviewers

- `generateMarkPatchOps` now builds the JSON patch ops for the mark
  annotation instead of the old `generateMarkPatchOp`, targeting the
  specific annotation key rather than the whole annotations map.
- `generateEgressIPPatches` and its callers now also thread through the
  object's `resourceVersion` so the guard above can be applied.
- Unit tests in `pkg/clustermanager/egressip_controller_test.go` cover the
  `resourceVersion` guard's boundary conditions (stale vs. matching
  resourceVersion, guard skipped when resourceVersion is unknown) by
  applying real JSON Patch requests through `egressipfake.NewClientset`
  (introduced in #6743), rather than a hand-rolled simulation of RFC 6902
  semantics.
- Added an e2e test in `test/e2e/egressip.go` (`Should preserve a
  pre-existing foreign annotation when the egressip-mark annotation is
  added`) that creates a real EgressIP with a foreign annotation against a
  live cluster and verifies it survives mark assignment.
- Reproduced and verified against a live OCP 4.22 cluster: creating an
  EgressIP with a custom annotation and forcing an ovnkube-control-plane
  resync previously dropped the custom annotation when the mark was
  applied; with this fix the custom annotation is preserved alongside the
  mark.

## ✅ Checks
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI

## How to verify it

- Unit tests: `TestGenerateMarkPatchOps*` and `TestEscapeJSONPatchPathKey`
  in `pkg/clustermanager`.
- E2E: the new `Should preserve a pre-existing foreign annotation when the
  egressip-mark annotation is added` test in `test/e2e/egressip.go`.
- Manually: create an EgressIP with a custom annotation but no mark yet,
  then trigger a resync (e.g. restart `ovnkube-control-plane`); the custom
  annotation should remain alongside the newly-added
  `k8s.ovn.org/egressip-mark` annotation.