### PR TITLE
kind: build missing default node image

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -70,7 +70,8 @@ set_common_default_params() {
   KIND_CREATE=${KIND_CREATE:-true}
   KIND_IMAGE=${KIND_IMAGE:-kindest/node}
   KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
-  K8S_VERSION=${K8S_VERSION:-v1.36.1}
+  K8S_VERSION=${K8S_VERSION:-v1.36.2}
+  KIND_BUILD_NODE_IMAGE=${KIND_BUILD_NODE_IMAGE:-auto}
   KIND_SETTLE_DURATION=${KIND_SETTLE_DURATION:-30}
   KIND_CONFIG=${KIND_CONFIG:-${DIR}/kind.yaml.j2}
   KIND_LOCAL_REGISTRY=${KIND_LOCAL_REGISTRY:-false}
@@ -2250,6 +2251,31 @@ delete() {
   kind delete cluster --name "${KIND_CLUSTER_NAME:-ovn}"
 }
 
+ensure_kind_node_image() {
+  local image="${KIND_IMAGE}:${K8S_VERSION}"
+
+  if "${OCI_BIN}" image inspect "${image}" >/dev/null 2>&1; then
+    echo "Using local kind node image ${image}"
+    return
+  fi
+
+  if "${OCI_BIN}" pull "${image}"; then
+    echo "Pulled kind node image ${image}"
+    return
+  fi
+
+  if [[ "${KIND_BUILD_NODE_IMAGE}" == true || "${KIND_BUILD_NODE_IMAGE}" == auto ]] && [[ "${KIND_IMAGE}" == kindest/node ]]; then
+    echo "Kind node image ${image} is not available locally or from the registry. Building it locally."
+    kind build node-image --image "${image}" "${K8S_VERSION}"
+    return
+  fi
+
+  echo "Failed to find or pull kind node image ${image}."
+  echo "Use a published image, or build it locally with:"
+  echo "  kind build node-image --image ${image} ${K8S_VERSION}"
+  exit 1
+}
+
 create_kind_cluster() {
   # Output of the jinjanate command
   KIND_CONFIG_LCL=${DIR}/kind-${KIND_CLUSTER_NAME}.yaml
@@ -2271,6 +2297,8 @@ create_kind_cluster() {
   if [[ "${KIND_LOCAL_REGISTRY}" == true ]]; then
     create_local_registry
   fi
+
+  ensure_kind_node_image
 
   kind create cluster --name "${KIND_CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}" --image "${KIND_IMAGE}":"${K8S_VERSION}" --config=${KIND_CONFIG_LCL} --retain
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
