### PR TITLE
docs: add orphan pages to mkdocs nav and fix blank sidebars

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,7 @@
+# Maintainers
+
+## Current Maintainers
+
 The current Maintainers Group for the ovn-kubernetes Project consists of:
 
 | Name | Employer | Responsibilities |
@@ -9,10 +13,12 @@ The current Maintainers Group for the ovn-kubernetes Project consists of:
 | [Surya Seetharaman](https://github.com/tssurya)   | Red Hat | All things ovnkube |
 | [Tim Rozet](https://github.com/trozet)   | NVIDIA | All things ovnkube |
 
+## Related Resources
+
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
 See [GOVERNANCE.md](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
 
-Emeritus Maintainers
+## Emeritus Maintainers
 
 | Name | Employer | Responsibilities |
 | ---- | -------- | ---------------- |

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -47,3 +47,15 @@ How external IPs and LoadBalancer ingress addresses are handled.
 **[Internal Subnets](ovn-kubernetes-subnets.md)**
 
 Subnet allocation for join, transit, and masquerade networks.
+
+**[ACLs](acls.md)**
+
+OVN ACLs used by ovn-kubernetes, their IDs, priorities, and directions.
+
+**[EgressIP](egressip.md)**
+
+EgressIP mechanism for pods to use a predictable source IP for egress traffic.
+
+**[Gateway Accelerated Interface](gateway-accelerated-interface-configuration.md)**
+
+Using switchdev VF/SF as gateway interfaces for hardware-accelerated external traffic.

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -20,6 +20,22 @@ Project governance structure, roles, and decision-making process.
 
 Guidelines and expectations for reviewing pull requests.
 
+**[Maintainers](../governance/MAINTAINERS.md)**
+
+Current maintainers and emeritus maintainers of the project.
+
+**[Community Meetings](../governance/MEETINGS.md)**
+
+Meeting schedule, location, and agenda for community meetings.
+
+**[Code of Conduct](../governance/CODE_OF_CONDUCT.md)**
+
+Community standards and enforcement guidelines.
+
+**[Security Policy](../governance/SECURITY.md)**
+
+How to report vulnerabilities and security update process.
+
 **[Project Areas](areas.md)**
 
 Component ownership areas and their maintainers.
@@ -51,3 +67,7 @@ Techniques for debugging OVN-Kubernetes components during development.
 **[Release Guide](release.md)**
 
 Steps to cut a new OVN-Kubernetes release.
+
+**[Maintenance Guide](maintenance.md)**
+
+Ongoing maintenance tasks and dependency management.

--- a/docs/developer-guide/maintenance.md
+++ b/docs/developer-guide/maintenance.md
@@ -2,27 +2,50 @@
 
 For this repo to stay healthy, we need to make sure that we are doing regular maintenance. This includes:
 
-- Issue triage (No one is doing this now)
-    - review newly created/updated issues (bugs and questions) and try to find assignees
-    - ensure issues don't get stale and eventually get fixed/answered
-    - use community meeting for sync and help
-- CI flakes triage (@npinaeva)
-    - review newly created/updated flakes and try to find assignees
-    - ensure flakes don't get stale and eventually get fixed
-    - review/find reviewers for the CI flake fixes
-    - use community meeting for sync and help
-- Release tracking and management (@tssurya)
-    - Define target date for the next release, add Milestone and track the progress of the release
-    - Share updates on the release progress in the community meetings
-    - Track the scope of the release as we get closer to the release date and make sure we are on track to meet the release goals
-    - Cut the release and share the release notes with the community
-- Members and contributors (now also for areas) management (now is done by all maintainers)
-    - ensure that we have the right people with the right permissions in the repo and in the org
-    - remove stale members and contributors
-    - add new members and contributors (follow the process defined in the [GOVERNANCE](../governance/GOVERNANCE.md#becoming-a-member) file)
-- Project healthcheck (no one is doing this now)
-     - close stale PRs and issues (we have stale label)
-     - delete stale branches
-- Facilitating the community meetings and keeping the notes up to date (@npinaeva and @tssurya)
-    - facilitate the meetings and ensure that we are having productive discussions and that we are making progress on the topics discussed
-    - ensure that we are taking notes during the meetings and sharing them with the community
+## Issue Triage
+
+*No one is doing this now*
+
+- Review newly created/updated issues (bugs and questions) and try to find assignees
+- Ensure issues don't get stale and eventually get fixed/answered
+- Use community meeting for sync and help
+
+## CI Flakes Triage
+
+*Owner: @npinaeva*
+
+- Review newly created/updated flakes and try to find assignees
+- Ensure flakes don't get stale and eventually get fixed
+- Review/find reviewers for the CI flake fixes
+- Use community meeting for sync and help
+
+## Release Tracking and Management
+
+*Owner: @tssurya*
+
+- Define target date for the next release, add Milestone and track the progress of the release
+- Share updates on the release progress in the community meetings
+- Track the scope of the release as we get closer to the release date and make sure we are on track to meet the release goals
+- Cut the release and share the release notes with the community
+
+## Members and Contributors Management
+
+*Now is done by all maintainers (now also for areas)*
+
+- Ensure that we have the right people with the right permissions in the repo and in the org
+- Remove stale members and contributors
+- Add new members and contributors (follow the process defined in the [GOVERNANCE](../governance/GOVERNANCE.md#becoming-a-member) file)
+
+## Project Healthcheck
+
+*No one is doing this now*
+
+- Close stale PRs and issues (we have stale label)
+- Delete stale branches
+
+## Community Meetings
+
+*Owners: @npinaeva and @tssurya*
+
+- Facilitate the meetings and ensure that we are having productive discussions and that we are making progress on the topics discussed
+- Ensure that we are taking notes during the meetings and sharing them with the community

--- a/docs/features/hardware-offload/index.md
+++ b/docs/features/hardware-offload/index.md
@@ -15,3 +15,15 @@ Offload OVS flow processing to SmartNIC hardware using the kernel TC datapath.
 **[OVS Acceleration with DOCA datapath](ovs-doca.md)**
 
 Offload OVS to NVIDIA BlueField DPUs using the DOCA-based datapath.
+
+**[DPU Support](dpu-support.md)**
+
+Overview of Data Processing Unit support, the switchdev model, and VF/PF representors.
+
+**[DPU Gateway Interface](dpu-gateway-interface.md)**
+
+Automatic gateway interface resolution from PCI address in DPU host mode.
+
+**[Derive Gateway Interface from Management Port](derive-from-mgmt-port.md)**
+
+Automatic gateway interface resolution by deriving the PF from the management port VF.

--- a/docs/features/network-security-controls/index.md
+++ b/docs/features/network-security-controls/index.md
@@ -19,3 +19,7 @@ Standard Kubernetes NetworkPolicy enforcement via OVN ACLs.
 **[EgressFirewall](egress-firewall.md)**
 
 Restrict which external destinations pods in a namespace can reach.
+
+**[DNS Name Resolution](dns-name-resolution.md)**
+
+EgressFirewall DNS rule integration with CoreDNS, including wildcard DNS support.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -24,6 +24,10 @@ Install OVN-Kubernetes with hardware offload to SmartNICs and DPUs.
 
 Set up OVN-Kubernetes as the CNI plugin on a kubeadm-managed cluster.
 
+**[Installing OVS and OVN on Ubuntu](../installation/INSTALL.UBUNTU.md)**
+
+Step-by-step guide for installing OVS and OVN packages on Ubuntu.
+
 **[Configuration Guide](configuration.md)**
 
 Tune OVN-Kubernetes settings and customize cluster networking behavior.

--- a/docs/governance/index.md
+++ b/docs/governance/index.md
@@ -19,3 +19,19 @@ Project governance structure, roles, and decision-making process.
 **[Reviewing Guide](REVIEWING.md)**
 
 Guidelines and expectations for reviewing pull requests.
+
+**[Maintainers](MAINTAINERS.md)**
+
+Current maintainers and emeritus maintainers of the project.
+
+**[Community Meetings](MEETINGS.md)**
+
+Meeting schedule, location, and agenda for community meetings.
+
+**[Code of Conduct](CODE_OF_CONDUCT.md)**
+
+Community standards and enforcement guidelines.
+
+**[Security Policy](SECURITY.md)**
+
+How to report vulnerabilities and security update process.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -23,3 +23,7 @@ Install OVN-Kubernetes with hardware offload to SmartNICs and DPUs.
 **[Launching OVN-Kubernetes with kubeadm](INSTALL.KUBEADM.md)**
 
 Set up OVN-Kubernetes as the CNI plugin on a kubeadm-managed cluster.
+
+**[Installing OVS and OVN on Ubuntu](INSTALL.UBUNTU.md)**
+
+Step-by-step guide for installing OVS and OVN packages on Ubuntu.

--- a/docs/okeps/index.md
+++ b/docs/okeps/index.md
@@ -8,6 +8,10 @@ hide:
 
 OVN-Kubernetes Enhancement Proposals (OKEPs) describe design and implementation plans for new features.
 
+**[OKEP Template](okep-4368-template.md)**
+
+Template and instructions for writing new OKEPs.
+
 **[Localnet API](okep-5085-localnet-api.md)**
 
 Native API for connecting pods directly to external physical networks.
@@ -67,3 +71,15 @@ VRF-Lite shared gateway mode with external bridge uplinks.
 **[Disable MAC Spoof Protection on Secondary Networks](okep-3926-disable-port-security.md)**
 
 Allow disabling port security on secondary network interfaces.
+
+**[OVN Observability API](okep-5212-ovnobserv-api.md)**
+
+API for observing OVN networking events and packet flows.
+
+**[DHCP IPAM for Localnet Networks](okep-6224-dhcp-ipam-localnet.md)**
+
+DHCP IPAM mode for localnet CUDNs delegating IP assignment to external DHCP.
+
+**[Connecting UDNs Discarded Alternatives](okep-5224-connecting-udns/discarded-alternatives.md)**
+
+Discarded network topology proposals for connecting Layer3-type UDN networks.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -19,3 +19,7 @@ Trace packet paths through OVN logical flows to diagnose connectivity problems.
 **[Logging](logging.md)**
 
 Configure and interpret OVN-Kubernetes component logs.
+
+**[User Defined Networks](udn.md)**
+
+Debugging UDN topology with ovnkube-trace and VRF table diagnostics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,9 @@ nav:
     - Internal Subnets: design/ovn-kubernetes-subnets.md
     - External Bridge (breth0) Flows: design/bridge-flows.md
     - Masquerade IPs: design/masquerade-ips.md
+    - ACLs: design/acls.md
+    - EgressIP: design/egressip.md
+    - Gateway Accelerated Interface: design/gateway-accelerated-interface-configuration.md
     - Kubevirt VM Live Migration: features/live-migration.md
   - Getting Started:
     - getting-started/index.md
@@ -100,6 +103,7 @@ nav:
     - Launching OVN-Kubernetes Using Helm: installation/launching-ovn-kubernetes-with-helm.md
     - Launching OVN-Kubernetes with DPU Acceleration: installation/launching-ovn-kubernetes-with-dpu.md
     - Launching OVN-Kubernetes with kubeadm: installation/INSTALL.KUBEADM.md
+    - Installing OVS and OVN on Ubuntu: installation/INSTALL.UBUNTU.md
     - Configuration Guide: getting-started/configuration.md
     - Requirements: features/requirements.md
     - CLI Guide: getting-started/cli-guide.md
@@ -111,6 +115,10 @@ nav:
       - Contributing Guide: governance/CONTRIBUTING.md
       - Governance: governance/GOVERNANCE.md
       - Reviewing Guide: governance/REVIEWING.md
+      - Maintainers: governance/MAINTAINERS.md
+      - Community Meetings: governance/MEETINGS.md
+      - Code of Conduct: governance/CODE_OF_CONDUCT.md
+      - Security Policy: governance/SECURITY.md
       - Project Areas: developer-guide/areas.md
       - Coding Guide: developer-guide/developer.md
       - OVN-Kubernetes Container Images: developer-guide/image-build.md
@@ -145,6 +153,7 @@ nav:
       - AdminNetworkPolicy: features/network-security-controls/admin-network-policy.md
       - NetworkPolicy: features/network-security-controls/network-policy.md
       - EgressFirewall: features/network-security-controls/egress-firewall.md
+      - DNS Name Resolution: features/network-security-controls/dns-name-resolution.md
     - ClusterEgressControls:
       - features/cluster-egress-controls/index.md
       - EgressIP: features/cluster-egress-controls/egress-ip.md
@@ -171,6 +180,9 @@ nav:
       - features/hardware-offload/index.md
       - OVS Acceleration with kernel datapath: features/hardware-offload/ovs-kernel.md
       - OVS Acceleration with DOCA datapath: features/hardware-offload/ovs-doca.md
+      - DPU Support: features/hardware-offload/dpu-support.md
+      - DPU Gateway Interface: features/hardware-offload/dpu-gateway-interface.md
+      - Derive Gateway Interface from Management Port: features/hardware-offload/derive-from-mgmt-port.md
     - BGP Integration:
       - features/bgp-integration/index.md
       - Route Advertisements: features/bgp-integration/route-advertisements.md
@@ -181,6 +193,7 @@ nav:
     - Introduction: troubleshooting/debugging.md
     - OVNKube Trace: troubleshooting/ovnkube-trace.md
     - Logging: troubleshooting/logging.md
+    - User Defined Networks: troubleshooting/udn.md
   - Observability:
     - observability/index.md
     - Metrics: observability/metrics.md
@@ -188,7 +201,7 @@ nav:
     - OVN observability: observability/ovn-observability.md
   - Enhancement Proposals:
     - okeps/index.md
-    # - FeatureName: okeps/<filename.md>
+    - OKEP Template: okeps/okep-4368-template.md
     - Localnet API: okeps/okep-5085-localnet-api.md
     - Network QoS: okeps/okep-4380-network-qos.md
     - User Defined Networks: okeps/okep-5193-user-defined-networks.md
@@ -198,6 +211,8 @@ nav:
     - MCP for Troubleshooting: okeps/okep-5494-ovn-kubernetes-mcp-server.md
     - Dynamic UDN Node Allocation: okeps/okep-5552-dynamic-udn-node-allocation.md
     - Connecting User Defined Networks: okeps/okep-5224-connecting-udns/okep-5224-connecting-udns.md
+    - Connecting UDNs Discarded Alternatives: okeps/okep-5224-connecting-udns/discarded-alternatives.md
+    - DHCP IPAM for Localnet Networks: okeps/okep-6224-dhcp-ipam-localnet.md
     - No-Overlay Mode: okeps/okep-5259-no-overlay.md
     - EVPN: okeps/okep-5088-evpn.md
     - DPU Healthcheck: okeps/okep-5674-dpu-healthcheck.md


### PR DESCRIPTION
## Problem

Several documentation pages had blank primary sidebars (left nav) and some had blank secondary sidebars (right TOC) when accessed via direct URL on the website.

Affected pages included governance pages (MEETINGS, MAINTAINERS, SECURITY, CODE_OF_CONDUCT), the OKEP template, design docs (ACLs, EgressIP, Gateway Accelerated Interface), hardware offload pages (DPU Support, DPU Gateway Interface, Derive from Mgmt Port), DNS Name Resolution, Ubuntu install guide, UDN troubleshooting, and two OKEPs.

## Root Cause

These markdown files existed in the docs/ directory but were not listed in the nav section of mkdocs.yml. MkDocs still builds orphan pages and makes them accessible via URL, but without nav context the MkDocs Material theme renders an
empty primary sidebar.

For MAINTAINERS.md and maintenance.md, the secondary sidebar (TOC) was also blank because the files had no `##` headings for the TOC to render.

## Changes

- **mkdocs.yml**: Added 15 orphan content pages to the nav under their appropriate sections (Overview, Getting Started, Developer Guide, Features, Troubleshooting, Enhancement Proposals).
- **Section index pages**: Updated 7 index pages to include links to the newly added subtopics (developer-guide, getting-started, design, installation, network-security-controls, hardware-offload, troubleshooting, okeps).
- **governance/MAINTAINERS.md**: Added heading structure so the TOC renders.
- **developer-guide/maintenance.md**: Added ## headings to populate the TOC.
- **governance/index.md**: Added links to all governance pages.

Before :
<img width="1903" height="1038" alt="Screenshot From 2026-09-03 23-20-53" src="https://github.com/user-attachments/assets/86854d72-4518-419f-8e84-91166418622b" />
 
After:
<img width="1903" height="1038" alt="Screenshot From 2026-09-03 23-20-31" src="https://github.com/user-attachments/assets/c34b2086-9a36-4fca-80ba-b14a5885be07" />

**Note: 4 empty stub files and 1 internal template remain unlisted as orphans intentionally, as they currently contain no display content and were not previously included in the navigation. They will be integrated into the navigation tree once content is added.**