### PR TITLE
Advertise secondary user-defined networks over BGP (north-south)

### DIFF
--- a/docs/features/bgp-integration/route-advertisements.md
+++ b/docs/features/bgp-integration/route-advertisements.md
@@ -7,8 +7,9 @@ with OVN-Kubernetes enabling the integration into different BGP user
 environments. The extent of the Route Advertisements feature and corresponding
 API allows importing routes from BGP peers on the provider network into OVN pod
 networks as well as exporting pod network and egress IP routes to BGP peers on
-the provider network. Both default pod network as well as primary Layer 3 and
-Layer 2 cluster-user-defined networks (CUDNs) are supported.
+the provider network. The default pod network, primary Layer 3 and Layer 2
+cluster-user-defined networks (CUDNs), and secondary Layer 3 CUDNs are
+supported.
 
 > [!NOTE]
 > For purposes of this documentation, the external, physical network of the
@@ -326,6 +327,72 @@ spec:
         matchLabels:
           advertise: true
 ```
+
+### Export routes to a secondary CUDN
+
+Secondary CUDNs are normally east/west-only: their pods are isolated within the
+cluster and are not reachable from the provider network. Advertising a secondary
+Layer 3 CUDN over BGP gives its pods a north-south datapath, so external peers on
+the provider network can reach the pod IPs directly, the same way they can for
+the default network or a primary CUDN.
+
+Assuming a secondary Layer 3 CUDN:
+
+```yaml
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: secondarynet
+  labels:
+    advertise: "true"
+spec:
+  namespaceSelector:
+    matchLabels:
+      network: secondarynet
+  network:
+    topology: Layer3
+    layer3:
+      role: Secondary
+      subnets:
+      - cidr: "10.150.0.0/16"
+        hostSubnet: 24
+```
+
+It is advertised with the same `RouteAdvertisements` API used for primary CUDNs;
+the only difference is that the selected network has `role: Secondary`:
+
+```yaml
+apiVersion: k8s.ovn.org/v1
+kind: RouteAdvertisements
+metadata:
+  name: secondarynet
+spec:
+  targetVRF: default
+  advertisements:
+  - PodNetwork
+  nodeSelector: {}
+  frrConfigurationSelector:
+    matchLabels:
+      use-for-advertisements: default
+  networkSelectors:
+  - networkSelectionType: ClusterUserDefinedNetworks
+    clusterUserDefinedNetworkSelector:
+      networkSelector:
+        matchLabels:
+          advertise: true
+```
+
+OVN-Kubernetes builds the north-south gateway topology (gateway router, join
+switch and egress SNATs) for the advertised secondary network on each selected
+node and advertises its per-node host subnets, just as it does for a primary
+network. The [CUDN isolation](#cudn-isolation) guarantees are unchanged: a
+secondary network that is not advertised stays east/west-only, and traffic
+between different advertised networks is still governed by the isolation rules
+described below.
+
+> [!NOTE]
+> North-south advertisement of secondary networks is currently supported for
+> Layer 3 topologies only.
 
 ### Import and export routes to a CUDN over the network VRF (VRF-Lite)
 

--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -611,6 +611,17 @@ func hairpinMasqueradeIPToRoute(isIPv6 bool, gatewayIP net.IP) util.PodRoute {
 	}
 }
 
+// isAdvertisedSecondaryUDN reports whether netinfo is a secondary user-defined
+// network whose pod network is advertised (north-south) at the given node. A
+// secondary network is given a north-south gateway (installed via source-based
+// routing) exactly when it is being advertised.
+func isAdvertisedSecondaryUDN(netinfo util.NetInfo, node *corev1.Node) bool {
+	if node == nil || !netinfo.IsUserDefinedNetwork() || netinfo.IsPrimaryNetwork() {
+		return false
+	}
+	return util.IsPodNetworkAdvertisedAtNode(netinfo, node.Name)
+}
+
 // addRoutesGatewayIP updates the provided pod annotation for the provided pod
 // with the gateways derived from the allocated IPs
 func AddRoutesGatewayIP(
@@ -695,7 +706,20 @@ func AddRoutesGatewayIP(
 						})
 					}
 				}
-				if !util.IsNetworkSegmentationSupportEnabled() || !netinfo.IsPrimaryNetwork() {
+				if !util.IsNetworkSegmentationSupportEnabled() {
+					continue
+				}
+				if !netinfo.IsPrimaryNetwork() {
+					// An advertised secondary UDN gets a north-south gateway too,
+					// but the CNI installs it via source-based routing
+					// (PodAnnotation.NorthSouthSourceRouting) so it does not
+					// compete with the primary network's main-table default.
+					if !isAdvertisedSecondaryUDN(netinfo, node) {
+						continue
+					}
+					podAnnotation.Routes = append(podAnnotation.Routes, serviceCIDRToRoute(isIPv6, gatewayIPnet.IP)...)
+					podAnnotation.Gateways = append(podAnnotation.Gateways, gatewayIPnet.IP)
+					podAnnotation.NorthSouthSourceRouting = true
 					continue
 				}
 				// Ensure default service network traffic always goes to OVN

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -534,8 +534,12 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 		if networkSet.Has(networkName) {
 			continue
 		}
-		if !network.IsDefault() && !network.IsPrimaryNetwork() {
-			return nil, nil, fmt.Errorf("%w: selected network %q is not the default nor a primary network", errConfig, networkName)
+		// Allow secondary user-defined networks to be advertised, not just
+		// primary ones. IsUserDefinedNetwork() covers both primary and secondary
+		// UDNs; the topology check below still restricts to Layer2/Layer3
+		// (excluding localnet).
+		if !network.IsDefault() && !network.IsUserDefinedNetwork() {
+			return nil, nil, fmt.Errorf("%w: selected network %q is not the default nor a user-defined network", errConfig, networkName)
 		}
 		if network.TopologyType() != types.Layer3Topology && network.TopologyType() != types.Layer2Topology {
 			return nil, nil, fmt.Errorf("%w: selected network %q has unsupported topology %q", errConfig, networkName, network.TopologyType())
@@ -1894,8 +1898,11 @@ func nadNeedsUpdate(oldObj, newObj *nadtypes.NetworkAttachmentDefinition) bool {
 		if err != nil {
 			return true
 		}
+		// Treat secondary UDN NADs as advertisement-eligible too, matching the
+		// gate in generateFRRConfigurations. IsUserDefinedNetwork() covers both
+		// primary and secondary UDNs.
 		return network.IsDefault() ||
-			(network.IsPrimaryNetwork() && (network.TopologyType() == types.Layer3Topology || network.TopologyType() == types.Layer2Topology))
+			(network.IsUserDefinedNetwork() && (network.TopologyType() == types.Layer3Topology || network.TopologyType() == types.Layer2Topology))
 	}
 	// ignore if we don't support this NAD
 	if !nadSupported(oldObj) && !nadSupported(newObj) {

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -1294,13 +1294,41 @@ func TestController_reconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "fails to reconcile a secondary network",
+			// A secondary CUDN is advertised just like a primary one. This only
+			// generates FRRConfiguration; north-south forwarding also needs the
+			// per-network Gateway Router datapath.
+			name: "reconciles a secondary network",
 			ra:   &testRA{Name: "ra", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
-			nads: []*testNAD{
-				{Name: "red", Namespace: "red", Network: "red", IsSecondary: true, Labels: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.1.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.1.1.0/24"}},
+						}},
+					},
+				},
 			},
+			nads: []*testNAD{
+				{Name: "red", Namespace: "red", Network: util.GenerateCUDNNetworkName("red"), Topology: "layer3", Subnet: "1.2.0.0/16", IsSecondary: true, Labels: map[string]string{"selected": "true"}},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\", \"cluster_udn_red\":\"1.2.0.0/24\"}"}},
 			reconcile:            "ra",
-			expectAcceptedStatus: metav1.ConditionFalse,
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.2.0.0/24"}, Imports: []string{"red"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.2.0.0/24"}},
+						}},
+						{ASN: 1, VRF: "red", Imports: []string{"default"}},
+					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"red": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
 		},
 		{
 			name: "fails to reconcile an non-cluster UDN",
@@ -3383,8 +3411,11 @@ func TestUpdates(t *testing.T) {
 			newObject: &testNAD{Name: "net", Namespace: "net", OwnUpdate: true, Labels: map[string]string{"select": "2"}, Annotations: map[string]string{types.OvnRouteAdvertisementsKey: "[\"ra2\"]"}},
 		},
 		{
-			name:      "does not reconcile a new unsupported (secondary) NAD",
-			newObject: &testNAD{Name: "net", Namespace: "net", Network: "net", IsSecondary: true, Topology: "layer3", Labels: map[string]string{"select": "2"}},
+			// Secondary L2/L3 UDN NADs are advertisement-eligible, so a new one
+			// enqueues the RAs.
+			name:              "reconciles a new supported secondary NAD",
+			newObject:         &testNAD{Name: "net", Namespace: "net", Network: "net", IsSecondary: true, Topology: "layer3", Labels: map[string]string{"select": "2"}},
+			expectedReconcile: []string{"ra1", "ra2", "ra3"},
 		},
 		{
 			name:              "reconciles all RAs that advertise EIPs on new EIP with status",

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -205,6 +205,17 @@ func setupNetwork(link netlink.Link, ifInfo *PodInterfaceInfo) error {
 			return fmt.Errorf("failed to add IP addr %s to %s: %v", ip, link.Attrs().Name, err)
 		}
 	}
+
+	// An advertised secondary UDN's gateway and routes must not land in the main
+	// table, where they would compete with the pod's primary-owned default route.
+	// Install them into a dedicated per-interface table selected by `ip rule from
+	// <podIP>` so that only traffic sourced from the secondary IP (egress and
+	// ingress replies) uses the secondary gateway — symmetrically, and without
+	// touching primary traffic.
+	if ifInfo.NorthSouthSourceRouting {
+		return setupSourceBasedRouting(link, ifInfo)
+	}
+
 	for _, gw := range ifInfo.Gateways {
 		if err := addRoute(nil, gw, link, ifInfo.RoutableMTU, 0); err != nil {
 			return fmt.Errorf("failed to add gateway route to link '%s': %v", link.Attrs().Name, err)
@@ -300,6 +311,59 @@ func setupNetwork(link netlink.Link, ifInfo *PodInterfaceInfo) error {
 			if err := addRoute(route.Dest, route.NextHop, link, ifInfo.RoutableMTU, iptableNum); err != nil {
 				return fmt.Errorf("failed to add pod route %v nexthop %v via %v table %v: %v", route.Dest, route.NextHop, link.Attrs().Name, iptableNum, err)
 			}
+		}
+	}
+
+	return nil
+}
+
+// setupSourceBasedRouting installs ifInfo's gateway and routes into a dedicated
+// per-interface routing table, selected by a source rule `ip rule from <podIP>
+// lookup <table>`. See the NorthSouthSourceRouting comment in setupNetwork and
+// PodAnnotation for why a secondary UDN's north-south gateway must be kept out
+// of the main table.
+func setupSourceBasedRouting(link netlink.Link, ifInfo *PodInterfaceInfo) error {
+	// per-interface table number, matching the ECMP path convention above
+	table := 100 + link.Attrs().Index
+	linkName := link.Attrs().Name
+
+	// Loose reverse-path filtering so replies routed via the source-routed
+	// table are not dropped by the RP check.
+	if err := setSysctl(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", linkName), 2); err != nil {
+		return fmt.Errorf("failed to set rp_filter for %s: %v", linkName, err)
+	}
+
+	for _, podIP := range ifInfo.IPs {
+		// ip rule from <podIP> lookup <table>
+		rule := netlink.NewRule()
+		rule.Src = util.GetIPNetFullMaskFromIP(podIP.IP)
+		rule.Table = table
+		if err := util.GetNetLinkOps().RuleAdd(rule); err != nil {
+			return fmt.Errorf("failed to add source-routing rule for %s to table %d: %v", podIP.IP, table, err)
+		}
+		// on-link route so the gateway (on this interface's subnet) is
+		// reachable within the dedicated table
+		if err := util.GetNetLinkOps().RouteAdd(&netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Scope:     netlink.SCOPE_LINK,
+			Dst:       util.IPsToNetworkIPs(podIP)[0],
+			Table:     table,
+		}); err != nil {
+			return fmt.Errorf("failed to add link-scope route for %s to table %d: %v", podIP.IP, table, err)
+		}
+	}
+
+	// default route(s) via the secondary gateway, in the dedicated table only
+	for _, gw := range ifInfo.Gateways {
+		if err := addRoute(nil, gw, link, ifInfo.RoutableMTU, table); err != nil {
+			return fmt.Errorf("failed to add source-routed default via %s to table %d: %v", gw, table, err)
+		}
+	}
+
+	// additional routes (e.g. service CIDR) also go to the dedicated table
+	for _, route := range ifInfo.Routes {
+		if err := addRoute(route.Dest, route.NextHop, link, ifInfo.RoutableMTU, table); err != nil {
+			return fmt.Errorf("failed to add source-routed route %v via %v to table %d: %v", route.Dest, route.NextHop, table, err)
 		}
 	}
 

--- a/go-controller/pkg/generator/udn/join_ips.go
+++ b/go-controller/pkg/generator/udn/join_ips.go
@@ -56,8 +56,14 @@ func GetGWRouterIPv6(node *corev1.Node, netInfo util.NetInfo) (net.IP, error) {
 // TODO this can be moved to netInfo to avoid instantiating the same IPGenerator
 func GetGWRouterIPs(node *corev1.Node, netInfo util.NetInfo) ([]*net.IPNet, error) {
 	var gwRouterAddrs []*net.IPNet
-	// we allocate join subnets for L3/L2 primary user defined networks or default network
-	if !(netInfo.IsDefault() || (util.IsNetworkSegmentationSupportEnabled() && netInfo.IsPrimaryNetwork())) {
+	// We allocate join subnets for L3/L2 primary user defined networks or the
+	// default network. A BGP-advertised secondary UDN also needs a gateway-router
+	// join IP so that its per-network Gateway Router can attach to a join switch
+	// and give it a north-south datapath. A plain (non-advertised) secondary
+	// stays east/west-only and keeps returning an empty result.
+	if !(netInfo.IsDefault() ||
+		(util.IsNetworkSegmentationSupportEnabled() &&
+			(netInfo.IsPrimaryNetwork() || isAdvertisedSecondaryUDN(netInfo, node)))) {
 		return gwRouterAddrs, nil
 	}
 	// Allocate the IP address(es) for the node Gateway router port connecting
@@ -82,6 +88,16 @@ func GetGWRouterIPs(node *corev1.Node, netInfo util.NetInfo) ([]*net.IPNet, erro
 		gwRouterAddrs = append(gwRouterAddrs, gwRouterAddr)
 	}
 	return gwRouterAddrs, nil
+}
+
+// isAdvertisedSecondaryUDN reports whether netInfo is a SECONDARY user-defined
+// network that is BGP-advertised at the given node. Secondary-UDN north-south
+// plumbing keys off this same advertisement signal.
+func isAdvertisedSecondaryUDN(netInfo util.NetInfo, node *corev1.Node) bool {
+	return node != nil &&
+		netInfo.IsUserDefinedNetwork() &&
+		!netInfo.IsPrimaryNetwork() &&
+		util.IsPodNetworkAdvertisedAtNode(netInfo, node.Name)
 }
 
 func getGWRouterIP(subnet string, nodeID int) (*net.IPNet, error) {

--- a/go-controller/pkg/generator/udn/join_ips_test.go
+++ b/go-controller/pkg/generator/udn/join_ips_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package udn
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestGetGWRouterIPsSecondaryUDN validates the join-router-IP allocation gate:
+// only an advertised secondary UDN gets a gateway-router join IP; a plain
+// secondary still returns an empty result, while primary and default keep their
+// behavior.
+func TestGetGWRouterIPsSecondaryUDN(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(Succeed())
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+	const (
+		nodeName  = "worker1"
+		networkID = "5"
+	)
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				util.OvnNodeID:            "7",
+				"k8s.ovn.org/network-ids": `{"bluenet": "5"}`,
+			},
+		},
+	}
+
+	mkNet := func(role string) util.NetInfo {
+		nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", role)
+		ovntest.AnnotateNADWithNetworkID(networkID, nad)
+		ni, err := util.ParseNADInfo(nad)
+		g.Expect(err).NotTo(HaveOccurred())
+		return ni
+	}
+	advertisedAt := func(ni util.NetInfo, n string) util.NetInfo {
+		m := util.NewMutableNetInfo(ni)
+		m.SetPodNetworkAdvertisedVRFs(map[string][]string{n: {ni.GetNetworkName()}})
+		return m
+	}
+
+	primary := mkNet(types.NetworkRolePrimary)
+	secondary := mkNet(types.NetworkRoleSecondary)
+	advertisedSecondary := advertisedAt(secondary, nodeName)
+
+	// Primary UDN: gets a join IP (pre-existing behavior).
+	primaryIPs, err := GetGWRouterIPs(node, primary)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(primaryIPs).NotTo(BeEmpty(), "primary UDN must get a join router IP")
+
+	// Non-advertised secondary UDN: stays east/west-only, no join IP.
+	secondaryIPs, err := GetGWRouterIPs(node, secondary)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(secondaryIPs).To(BeEmpty(), "non-advertised secondary UDN must not get a join router IP")
+
+	// Advertised secondary UDN: gets a join IP.
+	advIPs, err := GetGWRouterIPs(node, advertisedSecondary)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(advIPs).NotTo(BeEmpty(), "advertised secondary UDN must get a join router IP")
+
+	// Advertised at a different node only: not advertised here, so no join IP.
+	advElsewhere := advertisedAt(secondary, "otherNode")
+	elsewhereIPs, err := GetGWRouterIPs(node, advElsewhere)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(elsewhereIPs).To(BeEmpty(),
+		"secondary advertised on a different node must not get a join router IP here")
+}

--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -526,7 +526,15 @@ func (c *networkController) gatherNetwork(network util.MutableNetInfo, current u
 }
 
 func (c *networkController) setAdvertisements(network util.MutableNetInfo, current util.NetInfo) error {
-	if !network.IsDefault() && !network.IsPrimaryNetwork() {
+	// Propagate advertised VRFs for the default network and any user-defined
+	// network (primary or secondary) into the running network controller's
+	// netInfo. A BGP-advertised secondary UDN needs this: without it the RA is
+	// accepted and FRRConfigurations are generated (cluster-manager RA
+	// controller, a separate path), but the zone controller's
+	// IsPodNetworkAdvertisedAtNode stays false, so the
+	// GR/join-switch/mgmt-port/SNAT datapath gates never fire. (IsPrimaryNetwork
+	// is a subset of IsUserDefinedNetwork.)
+	if !network.IsDefault() && !network.IsUserDefinedNetwork() {
 		return nil
 	}
 	if !c.hasRouteAdvertisements() {

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -65,7 +65,8 @@ const (
 // UserDefinedNetworkGateway contains information
 // required to program a UDN at each node's
 // gateway.
-// NOTE: Currently invoked only for primary networks.
+// NOTE: Invoked for primary networks and for BGP-advertised secondary
+// networks — see isAdvertisedSecondaryUDNAtNode.
 type UserDefinedNetworkGateway struct {
 	// network information
 	util.NetInfo

--- a/go-controller/pkg/node/user_defined_node_network_controller.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller.go
@@ -33,6 +33,16 @@ type UserDefinedNodeNetworkController struct {
 	gateway *UserDefinedNetworkGateway
 	// management port device manager
 	mpdm *managementport.MgmtPortDeviceManager
+
+	// Dependencies retained so the node-side gateway can be constructed lazily
+	// if a secondary network transitions to advertised at runtime (see
+	// Reconcile). At construction time the gateway is only built for primary
+	// networks and secondary networks that are already advertised; a secondary
+	// CUDN created before its RouteAdvertisements has no gateway yet.
+	vrfManager              *vrfmanager.Controller
+	ruleManager             *iprulemanager.Controller
+	defaultNetworkGateway   Gateway
+	uplinkGatewayController *UplinkGatewayController
 }
 
 // NewUserDefinedNodeNetworkController creates a new OVN controller for creating logical network
@@ -63,27 +73,61 @@ func NewUserDefinedNodeNetworkController(
 			networkManager:                  networkManager,
 			ovsClient:                       ovsClient,
 		},
-		mpdm: mpdm,
+		mpdm:                    mpdm,
+		vrfManager:              vrfManager,
+		ruleManager:             ruleManager,
+		defaultNetworkGateway:   defaultNetworkGateway,
+		uplinkGatewayController: uplinkGatewayController,
 	}
-	if util.IsNetworkSegmentationSupportEnabled() && snnc.IsPrimaryNetwork() {
-		node, err := snnc.watchFactory.GetNode(snnc.name)
-		if err != nil {
-			return nil, fmt.Errorf("error retrieving node %s while creating node network controller for network %s: %v",
-				snnc.name, netInfo.GetNetworkName(), err)
-		}
-
-		var uplinkStateLister uplinklisters.UplinkStateLister
-		if util.IsUplinkEnabled() {
-			uplinkStateLister = snnc.watchFactory.UplinkStateInformer().Lister()
-		}
-		snnc.gateway, err = NewUserDefinedNetworkGateway(snnc.GetNetInfo(), node,
-			snnc.watchFactory.NodeCoreInformer().Lister(), snnc.Kube, vrfManager, ruleManager, defaultNetworkGateway,
-			ovsClient, uplinkStateLister, uplinkGatewayController)
-		if err != nil {
-			return nil, fmt.Errorf("error creating UDN gateway for network %s: %v", netInfo.GetNetworkName(), err)
+	if util.IsNetworkSegmentationSupportEnabled() &&
+		(snnc.IsPrimaryNetwork() || isAdvertisedSecondaryUDNAtNode(snnc.GetNetInfo(), snnc.name)) {
+		if err := snnc.buildGateway(); err != nil {
+			return nil, err
 		}
 	}
 	return snnc, nil
+}
+
+// buildGateway constructs the node-side UDN gateway for this network and stores
+// it on nc.gateway. It is used both at construction time (for primary networks
+// and secondary networks that are already advertised) and lazily from Reconcile
+// when a secondary network transitions to advertised at runtime. It does not
+// program the datapath; the caller must invoke nc.gateway.AddNetwork().
+func (nc *UserDefinedNodeNetworkController) buildGateway() error {
+	node, err := nc.watchFactory.GetNode(nc.name)
+	if err != nil {
+		return fmt.Errorf("error retrieving node %s while creating node network controller for network %s: %v",
+			nc.name, nc.GetNetworkName(), err)
+	}
+
+	var uplinkStateLister uplinklisters.UplinkStateLister
+	if util.IsUplinkEnabled() {
+		uplinkStateLister = nc.watchFactory.UplinkStateInformer().Lister()
+	}
+	gateway, err := NewUserDefinedNetworkGateway(nc.GetNetInfo(), node,
+		nc.watchFactory.NodeCoreInformer().Lister(), nc.Kube, nc.vrfManager, nc.ruleManager, nc.defaultNetworkGateway,
+		nc.ovsClient, uplinkStateLister, nc.uplinkGatewayController)
+	if err != nil {
+		return fmt.Errorf("error creating UDN gateway for network %s: %v", nc.GetNetworkName(), err)
+	}
+	nc.gateway = gateway
+	return nil
+}
+
+// isAdvertisedSecondaryUDNAtNode reports whether netInfo is a SECONDARY
+// user-defined network that is BGP-advertised at the given node.
+//
+// The node-side UDN gateway (management port, per-network VRF/ip-rules, br-ex
+// OpenFlow, advertised UDN isolation) is provisioned for primary UDNs and, when
+// this predicate holds, for advertised secondary UDNs so they get a north-south
+// datapath. A plain (non-advertised) secondary UDN stays east/west-only and
+// unchanged. This depends on the OVN-side datapath (join subnet, management
+// port, NAT) being present for the network.
+func isAdvertisedSecondaryUDNAtNode(netInfo util.NetInfo, nodeName string) bool {
+	return netInfo != nil &&
+		netInfo.IsUserDefinedNetwork() &&
+		!netInfo.IsPrimaryNetwork() &&
+		util.IsPodNetworkAdvertisedAtNode(netInfo, nodeName)
 }
 
 // Start starts the default controller; handles all events and creates all needed logical entities
@@ -98,7 +142,8 @@ func (nc *UserDefinedNodeNetworkController) Start(_ context.Context) error {
 		}
 		nc.podHandler = handler
 	}
-	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
+	if util.IsNetworkSegmentationSupportEnabled() &&
+		(nc.IsPrimaryNetwork() || isAdvertisedSecondaryUDNAtNode(nc.GetNetInfo(), nc.name)) {
 		if err := nc.gateway.AddNetwork(); err != nil {
 			return fmt.Errorf("failed to add network to node gateway for network %s at node %s: %w",
 				nc.GetNetworkName(), nc.name, err)
@@ -133,7 +178,8 @@ func (nc *UserDefinedNodeNetworkController) Cleanup() error {
 			errors = append(errors, fmt.Errorf("deleting network gateway for network %s failed: %v", nc.GetNetworkName(), err))
 		}
 	}
-	if nc.mpdm != nil && util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
+	if nc.mpdm != nil && util.IsNetworkSegmentationSupportEnabled() &&
+		(nc.IsPrimaryNetwork() || isAdvertisedSecondaryUDNAtNode(nc.GetNetInfo(), nc.name)) {
 		if err = nc.mpdm.ReleaseDeviceIDForNetwork(nc.GetNetworkName()); err != nil {
 			errors = append(errors, fmt.Errorf("deleting device ID for network %s failed: %v", nc.GetNetworkName(), err))
 		}
@@ -177,7 +223,33 @@ func (nc *UserDefinedNodeNetworkController) Reconcile(netInfo util.NetInfo) erro
 	}
 
 	if reconcilePodNetwork {
-		if nc.gateway != nil {
+		nowNeedsGateway := util.IsNetworkSegmentationSupportEnabled() &&
+			(nc.IsPrimaryNetwork() || isAdvertisedSecondaryUDNAtNode(netInfo, nc.name))
+		switch {
+		case nc.gateway == nil && nowNeedsGateway:
+			// The network became advertised at runtime (e.g. a secondary CUDN
+			// created before its RouteAdvertisements). The gateway was not built
+			// at construction time, so build it now and program the node-side
+			// datapath (management port, VRF/ip-rules, breth0 OpenFlow). Without
+			// this the NBDB topology exists but there is no north-south datapath.
+			if err := nc.buildGateway(); err != nil {
+				return fmt.Errorf("failed to build node gateway for newly advertised network %s: %w",
+					nc.GetNetworkName(), err)
+			}
+			if err := nc.gateway.AddNetwork(); err != nil {
+				nc.gateway = nil
+				return fmt.Errorf("failed to add newly advertised network %s to node gateway at node %s: %w",
+					nc.GetNetworkName(), nc.name, err)
+			}
+		case nc.gateway != nil && !nowNeedsGateway && !nc.IsPrimaryNetwork():
+			// A secondary network stopped being advertised; tear down the
+			// node-side datapath that buildGateway/AddNetwork installed.
+			if err := nc.gateway.DelNetwork(); err != nil {
+				return fmt.Errorf("failed to remove de-advertised network %s from node gateway: %w",
+					nc.GetNetworkName(), err)
+			}
+			nc.gateway = nil
+		case nc.gateway != nil:
 			nc.gateway.Reconcile()
 		}
 	}

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -175,7 +176,106 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(controller.gateway).To(BeNil())
 	})
+	// An ADVERTISED secondary UDN must reach the node-side gateway path, unlike a
+	// plain secondary which stays east/west-only (the case above). The gateway
+	// object is created; here Start() still fails at management port creation
+	// because the mock does not set it up, which confirms the gate opened.
+	ovntest.OnSupportedPlatformsIt("ensure UDNGateway is invoked for ADVERTISED secondary UDNs", func() {
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		factoryMock := factoryMocks.NodeWatchFactory{}
+		nodeList := []*corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+					},
+				},
+			},
+		}
+		cnnci := CommonNodeNetworkControllerInfo{name: "worker1", watchFactory: &factoryMock}
+		factoryMock.On("GetNode", "worker1").Return(nodeList[0], nil)
+		factoryMock.On("GetNodes").Return(nodeList, nil)
+		nodeInformer := coreinformermocks.NodeInformer{}
+		factoryMock.On("NodeCoreInformer").Return(&nodeInformer)
+		nodeLister := v1mocks.NodeLister{}
+		nodeInformer.On("Lister").Return(&nodeLister)
+		uplinkFactory := uplinkinformerfactory.NewSharedInformerFactory(
+			uplinkfake.NewSimpleClientset(),
+			time.Second,
+		)
+		factoryMock.On("UplinkStateInformer").Return(uplinkFactory.K8s().V1alpha1().UplinkStates())
+		secondaryNAD := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRoleSecondary)
+		ovntest.AnnotateNADWithNetworkID(networkID, secondaryNAD)
+		parsedNetInfo, err := util.ParseNADInfo(secondaryNAD)
+		Expect(err).NotTo(HaveOccurred())
+		// Mark the secondary network as BGP-advertised at this node, which is
+		// what opens the node-side gateway gate for a secondary UDN.
+		NetInfo := util.NewMutableNetInfo(parsedNetInfo)
+		NetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{"worker1": {parsedNetInfo.GetNetworkName()}})
+		getCreationFakeCommands(fexec, "ovn-k8s-mp3", mgtPortMAC, NetInfo.GetNetworkName(), "worker1", NetInfo.MTU())
+		ofm := getDummyOpenflowManager()
+		controller, err := NewUserDefinedNodeNetworkController(
+			&cnnci,
+			NetInfo,
+			nil,
+			nil,
+			nil,
+			nil,
+			&gateway{openflowManager: ofm},
+			nil,
+			nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(controller.gateway).To(Not(BeNil()))
+		err = controller.Start(context.Background())
+		Expect(err).To(HaveOccurred()) // management port is not set up by the mock
+		Expect(err.Error()).To(ContainSubstring("could not create management port"), err.Error())
+	})
 })
+
+// TestIsAdvertisedSecondaryUDNAtNode validates the core decision logic that
+// gates the node-side UDN gateway for an advertised secondary UDN. It is a plain
+// Go test on purpose: unlike the ginkgo specs above it does not touch the OVS
+// mock filesystem, so it runs in unprivileged environments where the
+// OVS-dependent BeforeEach cannot.
+func TestIsAdvertisedSecondaryUDNAtNode(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(Succeed())
+	const nodeName = "worker1"
+
+	mkNet := func(role string) util.NetInfo {
+		nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", role)
+		ovntest.AnnotateNADWithNetworkID("3", nad)
+		ni, err := util.ParseNADInfo(nad)
+		g.Expect(err).NotTo(HaveOccurred())
+		return ni
+	}
+	advertisedAt := func(ni util.NetInfo, node string) util.NetInfo {
+		m := util.NewMutableNetInfo(ni)
+		m.SetPodNetworkAdvertisedVRFs(map[string][]string{node: {ni.GetNetworkName()}})
+		return m
+	}
+
+	primary := mkNet(types.NetworkRolePrimary)
+	secondary := mkNet(types.NetworkRoleSecondary)
+
+	g.Expect(isAdvertisedSecondaryUDNAtNode(nil, nodeName)).To(BeFalse(),
+		"nil netInfo must not open the gate")
+	g.Expect(isAdvertisedSecondaryUDNAtNode(primary, nodeName)).To(BeFalse(),
+		"a primary UDN is not a secondary")
+	g.Expect(isAdvertisedSecondaryUDNAtNode(advertisedAt(primary, nodeName), nodeName)).To(BeFalse(),
+		"an advertised primary is served by the existing primary path, not this predicate")
+	g.Expect(isAdvertisedSecondaryUDNAtNode(secondary, nodeName)).To(BeFalse(),
+		"a non-advertised secondary stays east/west-only")
+	g.Expect(isAdvertisedSecondaryUDNAtNode(advertisedAt(secondary, nodeName), nodeName)).To(BeTrue(),
+		"an advertised secondary opens the node-side gateway gate")
+	g.Expect(isAdvertisedSecondaryUDNAtNode(advertisedAt(secondary, nodeName), "otherNode")).To(BeFalse(),
+		"a secondary advertised on a different node must not open the gate here")
+}
 
 var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality", func() {
 	var (

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -976,7 +976,9 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 	var nat *nbdb.NAT
 	// DisableSNATMultipleGWs is only applicable to cluster default network and not to user defined networks.
 	// For user defined networks, we always add SNAT rules regardless of whether the network is advertised or not.
-	if !config.Gateway.DisableSNATMultipleGWs || gw.netInfo.IsPrimaryNetwork() {
+	// This covers both primary and advertised secondary UDNs: SyncGateway only runs for a secondary once it is
+	// advertised at the node, so non-advertised secondaries never reach here.
+	if !config.Gateway.DisableSNATMultipleGWs || gw.netInfo.IsUserDefinedNetwork() {
 		var v4UUID, v6UUID string
 		var err error
 		snatExemptionNeeded := util.IsNoOverlaySNATExemptionNeeded(gw.netInfo)
@@ -1837,7 +1839,23 @@ func (gw *GatewayManager) SyncGateway(
 }
 
 func physNetName(netInfo util.NetInfo) string {
-	if netInfo.IsDefault() || (netInfo.IsPrimaryNetwork() && netInfo.Uplink() == "") {
+	// The default network and a primary UDN that shares the host uplink
+	// (Uplink == "") both attach their GR external switch to the SHARED physical
+	// network "physnet", which the node gateway maps to the shared uplink bridge
+	// (physnet:breth0). Only a UDN with its own dedicated uplink (localnet
+	// topology, Uplink != "") gets a per-network physnet name.
+	//
+	// A BGP-advertised SECONDARY UDN is north-south over the SAME shared uplink,
+	// so it must likewise use "physnet" and share the existing breth0 patch port.
+	// Without this it falls through to GetNetworkName() (e.g.
+	// "cluster_udn_<net>"), for which no ovn-bridge-mappings entry exists on the
+	// shared uplink, so ovn-controller never programs the br-int<->breth0 patch
+	// port and the node-side gateway readiness wait (setNetworkOfPatchPort)
+	// deadlocks until timeout, crashing ovnkube-controller.
+	sharesUplink := netInfo.Uplink() == "" &&
+		(netInfo.IsPrimaryNetwork() ||
+			(netInfo.IsUserDefinedNetwork() && util.IsPodNetworkAdvertised(netInfo)))
+	if netInfo.IsDefault() || sharesUplink {
 		return types.PhysicalNetworkName
 	}
 	return netInfo.GetNetworkName()

--- a/go-controller/pkg/ovn/gateway_physnetname_test.go
+++ b/go-controller/pkg/ovn/gateway_physnetname_test.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ovn
+
+import (
+	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// TestPhysNetName verifies which networks share the host uplink's physical
+// network ("physnet") versus getting a per-network physical network name. An
+// advertised secondary UDN is north-south over the shared uplink and must share
+// "physnet" so ovn-controller programs the shared br-int<->breth0 patch port; a
+// non-advertised secondary keeps its own name and stays east/west-only.
+func TestPhysNetName(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+	primaryUDN := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+	primary, err := util.NewNetInfo(primaryUDN.netconf())
+	if err != nil {
+		t.Fatalf("failed to build primary netInfo: %v", err)
+	}
+	secondaryUDN := dummySecondaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+	secondary, err := util.NewNetInfo(secondaryUDN.netconf())
+	if err != nil {
+		t.Fatalf("failed to build secondary netInfo: %v", err)
+	}
+	advertisedSecondary := util.NewMutableNetInfo(secondary)
+	advertisedSecondary.SetPodNetworkAdvertisedVRFs(map[string][]string{"node": {"vrf"}})
+
+	tests := []struct {
+		name    string
+		netInfo util.NetInfo
+		want    string
+	}{
+		{"default network shares physnet", &util.DefaultNetInfo{}, types.PhysicalNetworkName},
+		{"primary UDN sharing the uplink shares physnet", primary, types.PhysicalNetworkName},
+		{"advertised secondary UDN sharing the uplink shares physnet", advertisedSecondary, types.PhysicalNetworkName},
+		{"non-advertised secondary UDN keeps its own physical network name", secondary, secondary.GetNetworkName()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := physNetName(tt.netInfo); got != tt.want {
+				t.Errorf("physNetName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -585,6 +585,17 @@ func (oc *Layer3UserDefinedNetworkController) waitForLocalZoneNodeLogicalSwitche
 }
 
 func (oc *Layer3UserDefinedNetworkController) Reconcile(netInfo util.NetInfo) error {
+	// A secondary UDN can become advertised after this controller's init() has
+	// already run (e.g. the RouteAdvertisements is created after the CUDN), in
+	// which case init() is not re-run. Re-drive the advertised-network topology
+	// setup here so the join switch and cluster port groups exist before the
+	// per-node gateway sync that this reconcile triggers depends on them. The
+	// advertised state is read from the incoming netInfo, since oc's NetInfo is
+	// only updated inside BaseNetworkController.reconcile below.
+	clusterRouter := &nbdb.LogicalRouter{Name: oc.GetNetworkScopedClusterRouterName()}
+	if err := oc.ensureJoinSwitchAndClusterPortGroups(clusterRouter, util.IsPodNetworkAdvertised(netInfo)); err != nil {
+		return err
+	}
 	if err := oc.BaseNetworkController.reconcile(
 		netInfo,
 		func(node string) {
@@ -595,6 +606,36 @@ func (oc *Layer3UserDefinedNetworkController) Reconcile(netInfo util.NetInfo) er
 		return err
 	}
 	return oc.ReconcileServiceNetwork()
+}
+
+// ensureJoinSwitchAndClusterPortGroups creates the join switch (and the
+// cluster-router LRP toward it) and the cluster port groups that a per-network
+// Gateway Router depends on for a north-south datapath. It is created for
+// primary networks and for advertised secondary networks; a plain
+// (non-advertised) secondary keeps neither. The operation is idempotent, so it
+// is driven both from init() at startup and from Reconcile() when a secondary
+// UDN becomes advertised after the controller has already started.
+//
+// NewJoinSwitch is network-generic (network-scoped names + UDN external IDs) and
+// only needs the cluster router's name; ovnClusterLRPToJoinIfAddrs is populated
+// unconditionally by gatherJoinSwitchIPs() during init(), so it is valid here
+// for secondaries too. The ACLs that reference the cluster port groups (network
+// policy, default deny) are still added only for primary networks, so for an
+// advertised secondary the port groups stay inert membership-only.
+func (oc *Layer3UserDefinedNetworkController) ensureJoinSwitchAndClusterPortGroups(clusterRouter *nbdb.LogicalRouter, advertised bool) error {
+	if !util.IsNetworkSegmentationSupportEnabled() {
+		return nil
+	}
+	if !oc.IsPrimaryNetwork() && !(oc.IsUserDefinedNetwork() && advertised) {
+		return nil
+	}
+	if err := oc.gatewayTopologyFactory.NewJoinSwitch(clusterRouter, oc.GetNetInfo(), oc.ovnClusterLRPToJoinIfAddrs); err != nil {
+		return fmt.Errorf("failed to create join switch for network %q: %w", oc.GetNetworkName(), err)
+	}
+	if err := oc.setupClusterPortGroups(); err != nil {
+		return fmt.Errorf("failed to create cluster port groups for network %q: %w", oc.GetNetworkName(), err)
+	}
+	return nil
 }
 
 func (oc *Layer3UserDefinedNetworkController) RegisterNodeHandler() error {
@@ -732,16 +773,14 @@ func (oc *Layer3UserDefinedNetworkController) init() (err error) {
 		return fmt.Errorf("failed to create OVN cluster router for network %q: %v", oc.GetNetworkName(), err)
 	}
 
-	// Only configure join switch, GR, cluster port groups and multicast default policies for user defined primary networks.
+	// Configure the join switch and cluster port groups for primary networks and
+	// advertised secondary networks (see ensureJoinSwitchAndClusterPortGroups).
+	if err := oc.ensureJoinSwitchAndClusterPortGroups(clusterRouter, util.IsPodNetworkAdvertised(oc.GetNetInfo())); err != nil {
+		return err
+	}
+
+	// Multicast default policies remain primary-only.
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
-		if err := oc.gatewayTopologyFactory.NewJoinSwitch(clusterRouter, oc.GetNetInfo(), oc.ovnClusterLRPToJoinIfAddrs); err != nil {
-			return fmt.Errorf("failed to create join switch for network %q: %v", oc.GetNetworkName(), err)
-		}
-
-		if err := oc.setupClusterPortGroups(); err != nil {
-			return fmt.Errorf("failed to create cluster port groups for network %q: %w", oc.GetNetworkName(), err)
-		}
-
 		if err := oc.syncDefaultMulticastPolicies(); err != nil {
 			return fmt.Errorf("failed to sync default multicast policies for network %q: %w", oc.GetNetworkName(), err)
 		}
@@ -842,7 +881,13 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 		}
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+	// Sync the OVN-side (nbdb) management port for primary networks and for
+	// secondary networks advertised at this node. This creates the k8s-mgmt LSP
+	// on the node switch (+ local-gateway src-IP route) and is a prerequisite for
+	// the node-side gateway and gateway config (SyncGateway).
+	if util.IsNetworkSegmentationSupportEnabled() &&
+		(oc.IsPrimaryNetwork() ||
+			(oc.IsUserDefinedNetwork() && util.IsPodNetworkAdvertisedAtNode(oc.GetNetInfo(), node.Name))) {
 		if nSyncs.syncMgmtPort {
 			hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
 			if err != nil {
@@ -866,7 +911,14 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 		errs = append(errs, errors...)
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+	// Sync the per-network Gateway Router (SyncGateway: GR, join LRP, SNAT,
+	// external switch, static routes) for primary networks and for secondary
+	// networks advertised at this node. This attaches a GR to the join switch
+	// using the join IP and OVN management port, giving the network its
+	// north-south datapath.
+	if util.IsNetworkSegmentationSupportEnabled() &&
+		(oc.IsPrimaryNetwork() ||
+			(oc.IsUserDefinedNetwork() && util.IsPodNetworkAdvertisedAtNode(oc.GetNetInfo(), node.Name))) {
 		if nSyncs.syncGw {
 			gwManager := oc.gatewayManagerForNode(node.Name)
 			oc.gatewayManagers.Store(node.Name, gwManager)

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -588,6 +588,273 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 		Expect(app.Run([]string{app.Name})).To(Succeed())
 	})
 
+	// A BGP-advertised SECONDARY Layer3 UDN must get the same north-south gateway
+	// topology as a primary: a Gateway Router attached to the join switch, an OVN
+	// management port and egress SNATs. Without the advertisement gate a secondary
+	// gets no GR at all.
+	It("advertised secondary Layer 3 UDN: controller creates a gateway router, join switch, mgmt port and egress SNAT", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		netInfo := dummySecondaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+		app.Action = func(*cli.Context) error {
+			netConf := netInfo.netconf()
+			networkConfig, err := util.NewNetInfo(netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeOvn.startWithDBSetup(
+				initialDB,
+				&corev1.NamespaceList{Items: []corev1.Namespace{*newUDNNamespace(ns)}},
+				&corev1.NodeList{Items: []corev1.Node{*testNode}},
+				&corev1.PodList{Items: []corev1.Pod{}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group",
+			})
+
+			Expect(fakeOvn.controller.WatchNamespaces()).To(Succeed())
+			Expect(fakeOvn.controller.WatchPods()).To(Succeed())
+
+			l3Controller, ok := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			// Mark the secondary network as BGP-advertised on this node BEFORE init()
+			// so the (widened) mgmt-port and GR gates admit it during node sync.
+			mutableNetInfo := util.NewMutableNetInfo(l3Controller.GetNetInfo())
+			mutableNetInfo.SetNetworkID(2)
+			mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
+			Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfo)).To(Succeed())
+
+			// Advertised networks require the global isolation resources to exist.
+			Expect(ConfigureAdvertisedNetworkIsolation(fakeOvn.nbClient)).To(Succeed())
+
+			Expect(l3Controller.init()).To(Succeed())
+			Expect(l3Controller.RegisterNodeHandler()).To(Succeed())
+			Expect(l3Controller.WatchNamespaces()).To(Succeed())
+			Expect(l3Controller.waitForLocalZoneNodeLogicalSwitches()).To(Succeed())
+			Expect(l3Controller.WatchPods()).To(Succeed())
+
+			gwRouterName := networkConfig.GetNetworkScopedGWRouterName(nodeName)
+			joinSwitchName := networkConfig.GetNetworkScopedJoinSwitchName()
+			mgmtPortName := networkConfig.GetNetworkScopedK8sMgmtIntfName(nodeName)
+
+			By("creating the per-network join switch")
+			Eventually(func(g Gomega) {
+				switches, err := libovsdbops.FindLogicalSwitchesWithPredicate(fakeOvn.nbClient, func(ls *nbdb.LogicalSwitch) bool {
+					return ls.Name == joinSwitchName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(switches).NotTo(BeEmpty(), "join switch %q should exist", joinSwitchName)
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("creating the per-node gateway router attached to the join switch")
+			Eventually(func(g Gomega) {
+				routers, err := libovsdbops.FindLogicalRoutersWithPredicate(fakeOvn.nbClient, func(lr *nbdb.LogicalRouter) bool {
+					return lr.Name == gwRouterName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routers).NotTo(BeEmpty(), "gateway router %q should exist for advertised secondary", gwRouterName)
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("creating the OVN management port LSP on the node switch")
+			Eventually(func(g Gomega) {
+				ports, err := libovsdbops.FindLogicalSwitchPortWithPredicate(fakeOvn.nbClient, func(lsp *nbdb.LogicalSwitchPort) bool {
+					return lsp.Name == mgmtPortName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ports).NotTo(BeEmpty(), "management port %q should exist", mgmtPortName)
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("creating egress SNAT(s) on the gateway router for the cluster subnet")
+			Eventually(func(g Gomega) {
+				lr, err := libovsdbops.GetLogicalRouter(fakeOvn.nbClient, &nbdb.LogicalRouter{Name: gwRouterName})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(lr.Nat).NotTo(BeEmpty(), "gateway router %q should have NAT entries", gwRouterName)
+				foundClusterSubnetSNAT := false
+				for _, natUUID := range lr.Nat {
+					nat, err := libovsdbops.GetNAT(fakeOvn.nbClient, &nbdb.NAT{UUID: natUUID})
+					if err != nil {
+						continue
+					}
+					if nat.Type == nbdb.NATTypeSNAT && nat.LogicalIP == netInfo.clustersubnets {
+						foundClusterSubnetSNAT = true
+						break
+					}
+				}
+				g.Expect(foundClusterSubnetSNAT).To(BeTrue(),
+					"an egress SNAT with logical IP %q should exist on %q", netInfo.clustersubnets, gwRouterName)
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			return nil
+		}
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
+	// Negative control: a SECONDARY Layer3 UDN that is NOT advertised must NOT get a
+	// gateway router (it remains east/west-only). Guards against the widened gates
+	// accidentally admitting non-advertised secondaries.
+	It("non-advertised secondary Layer 3 UDN: controller creates NO gateway router", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		netInfo := dummySecondaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+		app.Action = func(*cli.Context) error {
+			netConf := netInfo.netconf()
+			networkConfig, err := util.NewNetInfo(netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeOvn.startWithDBSetup(
+				initialDB,
+				&corev1.NamespaceList{Items: []corev1.Namespace{*newUDNNamespace(ns)}},
+				&corev1.NodeList{Items: []corev1.Node{*testNode}},
+				&corev1.PodList{Items: []corev1.Pod{}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group",
+			})
+
+			Expect(fakeOvn.controller.WatchNamespaces()).To(Succeed())
+			Expect(fakeOvn.controller.WatchPods()).To(Succeed())
+
+			l3Controller, ok := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+			// Give it a network ID but do NOT advertise it.
+			mutableNetInfo := util.NewMutableNetInfo(l3Controller.GetNetInfo())
+			mutableNetInfo.SetNetworkID(2)
+			Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfo)).To(Succeed())
+
+			Expect(l3Controller.init()).To(Succeed())
+			Expect(l3Controller.RegisterNodeHandler()).To(Succeed())
+			Expect(l3Controller.WatchNamespaces()).To(Succeed())
+			Expect(l3Controller.waitForLocalZoneNodeLogicalSwitches()).To(Succeed())
+			Expect(l3Controller.WatchPods()).To(Succeed())
+
+			gwRouterName := networkConfig.GetNetworkScopedGWRouterName(nodeName)
+			Consistently(func(g Gomega) {
+				routers, err := libovsdbops.FindLogicalRoutersWithPredicate(fakeOvn.nbClient, func(lr *nbdb.LogicalRouter) bool {
+					return lr.Name == gwRouterName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routers).To(BeEmpty(), "no gateway router should exist for a non-advertised secondary")
+			}).WithTimeout(2 * time.Second).Should(Succeed())
+			return nil
+		}
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
+	// A secondary UDN can become advertised AFTER its controller's init() has
+	// already run (e.g. the RouteAdvertisements is created after the CUDN). init()
+	// is not re-run, so the north-south topology must be driven from Reconcile():
+	// starting from a non-advertised secondary (no gateway router), Reconcile with
+	// an advertised netInfo must create the join switch and the gateway router.
+	It("secondary Layer 3 UDN advertised after init: Reconcile creates the join switch and gateway router", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		netInfo := dummySecondaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+		app.Action = func(*cli.Context) error {
+			netConf := netInfo.netconf()
+			networkConfig, err := util.NewNetInfo(netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeOvn.startWithDBSetup(
+				initialDB,
+				&corev1.NamespaceList{Items: []corev1.Namespace{*newUDNNamespace(ns)}},
+				&corev1.NodeList{Items: []corev1.Node{*testNode}},
+				&corev1.PodList{Items: []corev1.Pod{}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group",
+			})
+
+			Expect(fakeOvn.controller.WatchNamespaces()).To(Succeed())
+			Expect(fakeOvn.controller.WatchPods()).To(Succeed())
+
+			l3Controller, ok := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			// Global isolation resources are required once the network becomes
+			// advertised (during the reconcile-driven node sync below).
+			Expect(ConfigureAdvertisedNetworkIsolation(fakeOvn.nbClient)).To(Succeed())
+
+			// init() the controller while the secondary is NOT advertised.
+			mutableNetInfo := util.NewMutableNetInfo(l3Controller.GetNetInfo())
+			mutableNetInfo.SetNetworkID(2)
+			Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfo)).To(Succeed())
+
+			Expect(l3Controller.init()).To(Succeed())
+			Expect(l3Controller.RegisterNodeHandler()).To(Succeed())
+			Expect(l3Controller.WatchNamespaces()).To(Succeed())
+			Expect(l3Controller.waitForLocalZoneNodeLogicalSwitches()).To(Succeed())
+			Expect(l3Controller.WatchPods()).To(Succeed())
+
+			gwRouterName := networkConfig.GetNetworkScopedGWRouterName(nodeName)
+			joinSwitchName := networkConfig.GetNetworkScopedJoinSwitchName()
+
+			By("not creating a gateway router while the secondary is not advertised")
+			Consistently(func(g Gomega) {
+				routers, err := libovsdbops.FindLogicalRoutersWithPredicate(fakeOvn.nbClient, func(lr *nbdb.LogicalRouter) bool {
+					return lr.Name == gwRouterName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routers).To(BeEmpty(), "no gateway router should exist before advertisement")
+			}).WithTimeout(2 * time.Second).Should(Succeed())
+
+			By("advertising the secondary after init() and reconciling")
+			advertised := util.NewMutableNetInfo(l3Controller.GetNetInfo())
+			advertised.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
+			Expect(l3Controller.Reconcile(advertised)).To(Succeed())
+
+			By("creating the per-network join switch via Reconcile")
+			Eventually(func(g Gomega) {
+				switches, err := libovsdbops.FindLogicalSwitchesWithPredicate(fakeOvn.nbClient, func(ls *nbdb.LogicalSwitch) bool {
+					return ls.Name == joinSwitchName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(switches).NotTo(BeEmpty(), "join switch %q should be created by Reconcile", joinSwitchName)
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("creating the per-node gateway router via the reconcile-driven node sync")
+			Eventually(func(g Gomega) {
+				routers, err := libovsdbops.FindLogicalRoutersWithPredicate(fakeOvn.nbClient, func(lr *nbdb.LogicalRouter) bool {
+					return lr.Name == gwRouterName
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routers).NotTo(BeEmpty(), "gateway router %q should exist after advertisement", gwRouterName)
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			return nil
+		}
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
 	Describe("Dynamic UDN allocation with remote node", func() {
 		It("activates a remote node when a NAD becomes active and cleans it up when inactive", func() {
 			Expect(config.PrepareTestConfig()).To(Succeed())

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -2067,6 +2067,20 @@ func AllowsPersistentIPs(netInfo NetInfo) bool {
 	}
 }
 
+// IsPodNetworkAdvertised returns true if the pod network is advertised on any
+// node. For networks with NoOverlay or EVPN transport this always returns true
+// as those networks should always be advertised. This is the network-wide
+// counterpart of IsPodNetworkAdvertisedAtNode, for decisions about per-network
+// (rather than per-node) topology such as the join switch.
+func IsPodNetworkAdvertised(netInfo NetInfo) bool {
+	switch netInfo.Transport() {
+	case types.NetworkTransportNoOverlay, types.NetworkTransportEVPN:
+		return true
+	default:
+		return len(netInfo.GetPodNetworkAdvertisedVRFs()) > 0
+	}
+}
+
 // IsPodNetworkAdvertisedAtNode returns true if the pod network is advertised at
 // the given node. For networks with NoOverlay or EVPN transport this always
 // returns true as those networks should always be advertised.

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1093,6 +1093,35 @@ func TestIsPrimaryNetwork(t *testing.T) {
 	}
 }
 
+// TestIsPodNetworkAdvertised covers the network-wide advertised predicate used
+// to decide per-network topology such as the join switch.
+func TestIsPodNetworkAdvertised(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	base, err := NewNetInfo(&ovncnitypes.NetConf{
+		NetConf:  cnitypes.NetConf{Name: "l3-network"},
+		Topology: ovntypes.Layer3Topology,
+		Role:     ovntypes.NetworkRoleSecondary,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Not advertised anywhere.
+	g.Expect(IsPodNetworkAdvertised(base)).To(gomega.BeFalse(),
+		"a network with no advertisement VRFs is not advertised")
+
+	// Advertised on at least one node.
+	advertised := NewMutableNetInfo(base)
+	advertised.SetPodNetworkAdvertisedVRFs(map[string][]string{"worker1": {"l3-network"}})
+	g.Expect(IsPodNetworkAdvertised(advertised)).To(gomega.BeTrue(),
+		"a network advertised on any node is advertised network-wide")
+
+	// Consistency with the per-node predicate.
+	g.Expect(IsPodNetworkAdvertisedAtNode(advertised, "worker1")).To(gomega.BeTrue())
+	g.Expect(IsPodNetworkAdvertisedAtNode(advertised, "worker2")).To(gomega.BeFalse())
+	g.Expect(IsPodNetworkAdvertised(advertised)).To(gomega.BeTrue(),
+		"network-wide advertised is true even if a specific other node is not")
+}
+
 func TestIsDefault(t *testing.T) {
 	type testConfig struct {
 		desc               string

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -123,6 +123,18 @@ type PodAnnotation struct {
 	// the features that run there: the pod (logical switch port) controller,
 	// MultiNetworkPolicy and NetworkQoS.
 	IPAMMode string
+
+	// NorthSouthSourceRouting requests that the CNI install this interface's
+	// gateway and routes into a per-interface, source-based routing table
+	// (ip rule `from <podIP> lookup <table>`) instead of the main table.
+	//
+	// A pod has a single main-table default route, owned by its PRIMARY network.
+	// To give a SECONDARY network real north-south connectivity we must not add a
+	// competing main-table default; source-based routing makes traffic sourced
+	// from the secondary IP (egress and ingress replies) use the secondary
+	// gateway symmetrically, while primary-sourced traffic is untouched. Set only
+	// for advertised secondary UDNs (see AddRoutesGatewayIP).
+	NorthSouthSourceRouting bool
 }
 
 // PodRoute describes any routes to be added to the pod's network namespace
@@ -151,6 +163,9 @@ type podAnnotation struct {
 	TunnelID int    `json:"tunnel_id,omitempty"`
 	Role     string `json:"role,omitempty"`
 	IPAMMode string `json:"ipam_mode,omitempty"`
+
+	// See PodAnnotation.NorthSouthSourceRouting.
+	NorthSouthSourceRouting bool `json:"ns_source_routing,omitempty"`
 }
 
 // Internal struct used to marshal PodRoute to the pod annotation
@@ -175,10 +190,11 @@ func MarshalPodAnnotation(annotations map[string]string, podInfo *PodAnnotation,
 		return nil, err
 	}
 	pa := podAnnotation{
-		TunnelID: podInfo.TunnelID,
-		MAC:      podInfo.MAC.String(),
-		Role:     podInfo.Role,
-		IPAMMode: podInfo.IPAMMode,
+		TunnelID:                podInfo.TunnelID,
+		MAC:                     podInfo.MAC.String(),
+		Role:                    podInfo.Role,
+		IPAMMode:                podInfo.IPAMMode,
+		NorthSouthSourceRouting: podInfo.NorthSouthSourceRouting,
 	}
 
 	if len(podInfo.IPs) == 1 {
@@ -264,9 +280,10 @@ func UnmarshalPodAnnotation(annotations map[string]string, nadKey string) (*PodA
 	a := &tempA
 
 	podAnnotation := &PodAnnotation{
-		TunnelID: a.TunnelID,
-		Role:     a.Role,
-		IPAMMode: a.IPAMMode,
+		TunnelID:                a.TunnelID,
+		Role:                    a.Role,
+		IPAMMode:                a.IPAMMode,
+		NorthSouthSourceRouting: a.NorthSouthSourceRouting,
 	}
 	podAnnotation.MAC, err = net.ParseMAC(a.MAC)
 	if err != nil {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	iputils "github.com/containernetworking/plugins/pkg/ip"
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	rav1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
@@ -1262,6 +1263,185 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			},
 		),
 	)
+	ginkgo.It("provides north-south reachability to a pod on an advertised secondary Layer3 CUDN, while a non-advertised secondary stays unreachable", func() {
+		udnClient, err := udnclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		raClient, err := raclientset.NewForConfig(f.ClientConfig())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Use a dedicated namespace WITHOUT the primary-UDN requirement label:
+		// this test only attaches secondary networks, and pods keep the default
+		// cluster network as their primary. A primary-UDN-required namespace
+		// would instead keep the pods Pending until a primary UDN exists.
+		secNs, err := f.CreateNamespace(context.TODO(), "bgp-secondary-udn", map[string]string{"e2e-framework": f.BaseName})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		nsName := secNs.Name
+
+		namespaceSelector := metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "kubernetes.io/metadata.name",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{nsName},
+		}}}
+
+		// createSecondaryCUDN creates a secondary Layer3 CUDN selecting the test
+		// namespace and carrying labelKey so a RouteAdvertisements can select it.
+		// Secondary networks are east/west-only unless advertised.
+		createSecondaryCUDN := func(labelKey string, subnets []udnv1.Layer3Subnet) *udnv1.ClusterUserDefinedNetwork {
+			cudn := &udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: labelKey + "-",
+					Labels:       map[string]string{labelKey: ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					NamespaceSelector: namespaceSelector,
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role:    udnv1.NetworkRoleSecondary,
+							Subnets: filterL3Subnets(f.ClientSet, subnets),
+						},
+					},
+				},
+			}
+			cudn, err := udnClient.K8sV1().ClusterUserDefinedNetworks().Create(context.Background(), cudn, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.DeferCleanup(func() {
+				udnClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), cudn.Name, metav1.DeleteOptions{})
+			})
+			gomega.Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudn.Name), 5*time.Second, time.Second).Should(gomega.Succeed())
+			return cudn
+		}
+
+		// Secondary Layer3 networks allow at most one CIDR per IP family, so
+		// unlike the primary-network tests we cannot reuse the multi-subnet
+		// cudnLayer3Subnets* helpers. Use a single CIDR per family per network;
+		// filterL3Subnets keeps only the cluster's families.
+		advertisedSubnets := []udnv1.Layer3Subnet{
+			{CIDR: "103.203.0.0/16", HostSubnet: 24},
+			{CIDR: "2014:100:210::0/60", HostSubnet: 64},
+		}
+		nonAdvertisedSubnets := []udnv1.Layer3Subnet{
+			{CIDR: "102.202.0.0/16", HostSubnet: 24},
+			{CIDR: "2013:100:210::0/60", HostSubnet: 64},
+		}
+
+		ginkgo.By("creating an advertised and a non-advertised secondary Layer3 CUDN")
+		advertisedLabel := "bgp-secondary-adv"
+		advertisedCUDN := createSecondaryCUDN(advertisedLabel, advertisedSubnets)
+		nonAdvertisedCUDN := createSecondaryCUDN("bgp-secondary-noadv", nonAdvertisedSubnets)
+
+		ginkgo.By("advertising only the first secondary CUDN with a RouteAdvertisements")
+		ra := &rav1.RouteAdvertisements{
+			ObjectMeta: metav1.ObjectMeta{Name: "bgp-secondary-ra"},
+			Spec: rav1.RouteAdvertisementsSpec{
+				NetworkSelectors: apitypes.NetworkSelectors{
+					apitypes.NetworkSelector{
+						NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+						ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+							NetworkSelector: metav1.LabelSelector{MatchLabels: map[string]string{advertisedLabel: ""}},
+						},
+					},
+				},
+				NodeSelector:             metav1.LabelSelector{},
+				FRRConfigurationSelector: metav1.LabelSelector{},
+				Advertisements:           []rav1.AdvertisementType{rav1.PodNetwork},
+			},
+		}
+		ra, err = raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() { raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), ra.Name, metav1.DeleteOptions{}) })
+		gomega.Eventually(func() string {
+			ra, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ra.Name, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+			if condition == nil {
+				return ""
+			}
+			return condition.Reason
+		}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+		// createServerPod runs an agnhost netexec server attached to the given
+		// secondary CUDN's NAD via the Multus networks annotation.
+		node := nodes.Items[1]
+		createServerPod := func(name, cudnName string) *corev1.Pod {
+			cfg := podConfiguration{
+				name:         name,
+				namespace:    nsName,
+				nodeSelector: map[string]string{"kubernetes.io/hostname": node.Name},
+				containerCmd: httpServerContainerCmd(netexecPort),
+				attachments:  []nadapi.NetworkSelectionElement{{Name: cudnName}},
+			}
+			pod, err := f.ClientSet.CoreV1().Pods(nsName).Create(context.Background(), generatePodSpec(cfg), metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() corev1.PodPhase {
+				p, err := f.ClientSet.CoreV1().Pods(nsName).Get(context.Background(), pod.Name, metav1.GetOptions{})
+				if err != nil {
+					return corev1.PodFailed
+				}
+				return p.Status.Phase
+			}, 2*time.Minute, 6*time.Second).Should(gomega.Equal(corev1.PodRunning))
+			return pod
+		}
+
+		ginkgo.By("running a server pod on each secondary network")
+		advertisedPod := createServerPod("secondary-adv-server", advertisedCUDN.Name)
+		nonAdvertisedPod := createServerPod("secondary-noadv-server", nonAdvertisedCUDN.Name)
+		// Delete pods before the CUDNs (LIFO order) so NAD deletion is not blocked.
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(f.ClientSet.CoreV1().Pods(nsName).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(gomega.Succeed())
+		})
+
+		netexecPortStr := fmt.Sprintf("%d", netexecPort)
+		// The external FRR router image ships busybox wget (no curl), so use
+		// wget to probe HTTP reachability from outside the cluster.
+		httpGetFromFRR := func(podIP string) (string, error) {
+			return infraprovider.Get().ExecExternalContainerCommand(
+				infraapi.ExternalContainer{Name: routerContainerName},
+				[]string{"wget", "-q", "-T", "5", "-O", "-", fmt.Sprintf("http://%s/hostname", net.JoinHostPort(podIP, netexecPortStr))},
+			)
+		}
+
+		for _, serverContainerIP := range serverContainerIPs {
+			family := utilnet.IPFamilyOfString(serverContainerIP)
+
+			advertisedPodIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+				f.ClientSet, nsName, advertisedPod.Name, namespacedName(nsName, advertisedCUDN.Name), family)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(advertisedPodIP).NotTo(gomega.BeEmpty())
+
+			ginkgo.By(fmt.Sprintf("ensuring the advertised secondary pod subnet (%s) is learned by the external FRR router", family))
+			checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+advertisedCUDN.Name)
+
+			ginkgo.By(fmt.Sprintf("ensuring the external FRR router can reach the advertised secondary pod %s over HTTP", advertisedPodIP))
+			gomega.Eventually(func(g gomega.Gomega) {
+				out, err := httpGetFromFRR(advertisedPodIP)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).To(gomega.Equal(advertisedPod.Name))
+			}, 60*time.Second, 2*time.Second).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring the external FRR router can ping the advertised secondary pod %s", advertisedPodIP))
+			gomega.Eventually(func(g gomega.Gomega) {
+				_, err := infraprovider.Get().ExecExternalContainerCommand(
+					infraapi.ExternalContainer{Name: routerContainerName},
+					[]string{"ping", "-c", "3", "-W", "2", advertisedPodIP},
+				)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			}, 60*time.Second, 2*time.Second).Should(gomega.Succeed())
+
+			nonAdvertisedPodIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+				f.ClientSet, nsName, nonAdvertisedPod.Name, namespacedName(nsName, nonAdvertisedCUDN.Name), family)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(nonAdvertisedPodIP).NotTo(gomega.BeEmpty())
+
+			ginkgo.By(fmt.Sprintf("ensuring the external FRR router cannot reach the non-advertised secondary pod %s", nonAdvertisedPodIP))
+			gomega.Consistently(func(g gomega.Gomega) {
+				_, err := httpGetFromFRR(nonAdvertisedPodIP)
+				g.Expect(err).To(gomega.HaveOccurred())
+			}, 5*time.Second, 500*time.Millisecond).Should(gomega.Succeed())
+		}
+	})
 })
 
 // With dynamic UDN allocation, a network only exists on nodes that run


### PR DESCRIPTION
## What

Adds BGP north-south advertisement for **secondary** cluster-user-defined
networks (CUDNs). Today only primary UDNs and the default network get a
north-south datapath; a secondary CUDN is east/west-only. This lets you select
a secondary CUDN with a `RouteAdvertisements` and give its pods a north-south
path, while isolation is preserved for unselected secondary networks.

Motivation: unblocks moving control-plane traffic off Multus onto native BGP by
allowing multiple isolated secondary networks per namespace to be advertised.

## How it works (per commit)

1. **util** — `IsPodNetworkAdvertised` (network-wide predicate) and the
   `NorthSouthSourceRouting` pod-annotation field. Pure additions.
2. **clustermanager, networkmanager** — make secondary UDNs advertisement-
   eligible; propagate advertised VRFs for secondaries. Generates the
   `FRRConfiguration`.
3. **ovn** — build the same north-south OVN topology a primary gets (join IP,
   shared `physnet` patch port, join switch, GR + egress SNATs) for an
   advertised secondary. Driven from one idempotent helper called from both
   `init()` and `Reconcile()`, so a CUDN advertised *after* creation (RA added
   later) still gets its topology.
4. **node** — admit an advertised secondary into the gateway path
   (management port + `UserDefinedNetworkGateway`). The node controller also
   lazily builds the gateway and calls `AddNetwork()` on the
   not-advertised→advertised transition in `Reconcile()`, so a CUDN created
   before its RA gets breth0 flows at runtime (not just at controller startup).
5. **allocator, cni** — install the secondary's north-south route via
   source-based routing (ip rule on the pod's secondary IP) so it doesn't
   compete with the primary network's default route.
6. **docs** + 7. **e2e**.

## Testing

- New `RouteAdvertisements` e2e: two secondary L3 CUDNs in one namespace, only
  one advertised. Verifies the external FRR router learns the advertised
  subnet and can reach that pod (HTTP + ping), while the non-advertised
  secondary pod stays unreachable (isolation intact). Passes on a podman-kind
  cluster, including the **runtime** path (CUDN/RA/pod created after the
  controllers are already running).
- `golangci-lint v2.12.2`, `gofmt`, `go vet`, node unit tests: clean.

## Scope / notes for reviewers

- Current scope is **Layer3** secondary CUDNs.
- The new runtime-advertise transition in the node `Reconcile()` is covered by
  the e2e (it programs OVS/netlink/mgmt-port, which is impractical to unit-test);
  a `isAdvertisedSecondaryUDNAtNode` predicate unit test is included.
- Opening as **draft** for early feedback on the approach.
