### PR TITLE
vtep: fix VTEP reconcile lost when EVPN CUDN create/delete coalesce

### DIFF
--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,17 +52,6 @@ type Controller struct {
 	cudnController controllerutil.Controller
 	nodeController controllerutil.Controller
 	eventRecorder  record.EventRecorder
-
-	// cudnVTEPIndex tracks which VTEP each EVPN-enabled CUDN references
-	// (cudnName → vtepName). Populated on CUDN create, consulted on CUDN
-	// delete so we can re-queue only the specific VTEP instead of scanning
-	// all VTEPs for every single CUDN deletion (since onDelete simply requeues
-	// we don't even get to evaluate whether it was an EVPN-enabled CUDN or not).
-	// Currently only accessed from cudnController, but protected by a mutex
-	// since vtepController and cudnController run on separate goroutines and
-	// future work may require cross-controller access.
-	cudnVTEPIndexMu sync.RWMutex
-	cudnVTEPIndex   map[string]string
 }
 
 // NewController creates a new VTEP controller.
@@ -79,7 +67,6 @@ func NewController(
 		cudnLister:    wf.ClusterUserDefinedNetworkInformer().Lister(),
 		nodeLister:    wf.NodeCoreInformer().Lister(),
 		eventRecorder: recorder,
-		cudnVTEPIndex: make(map[string]string),
 	}
 
 	vtepCfg := &controllerutil.ControllerConfig[vtepv1.VTEP]{
@@ -102,6 +89,7 @@ func NewController(
 		Lister:         cudnLister.List,
 		Reconcile:      c.reconcileCUDN,
 		ObjNeedsUpdate: cudnNeedsUpdate,
+		OnDelete:       c.onCUDNDeleted,
 		Threadiness:    1,
 	}
 	c.cudnController = controllerutil.NewController(
@@ -470,56 +458,63 @@ func (c *Controller) handleManagedModeNotSupported(vtep *vtepv1.VTEP) error {
 		"Managed VTEP mode is not yet implemented; only Unmanaged mode is currently supported")
 }
 
-// reconcileCUDN handles CUDN create and delete events relevant to VTEP
-// management. On create, it populates the reverse index and re-queues the
-// referenced VTEP so validations like IPv6 rejection can fire. On delete,
-// it re-queues the VTEP to allow finalizer removal and re-evaluation of
-// EVPN-specific constraints (e.g. clearing IPv6NotSupported when no EVPN
-// CUDNs reference the VTEP any longer).
+// reconcileCUDN handles CUDN create events relevant to VTEP management. It
+// re-queues the referenced VTEP so validations like IPv6 rejection can fire.
+// Deletions are not handled here (the object is already gone from the lister
+// by the time the key is reconciled, so we couldn't tell which VTEP to
+// re-queue); onCUDNDeleted handles them from the informer's delete handler
+// where the deleted object is still available.
 func (c *Controller) reconcileCUDN(key string) error {
-	cudnName := key
-	cudn, err := c.cudnLister.Get(cudnName)
+	cudn, err := c.cudnLister.Get(key)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			c.cudnVTEPIndexMu.Lock()
-			vtepName, ok := c.cudnVTEPIndex[cudnName]
-			if ok {
-				delete(c.cudnVTEPIndex, cudnName)
-			}
-			c.cudnVTEPIndexMu.Unlock()
-			if !ok {
-				return nil
-			}
-			// Re-queue the VTEP so reconcileVTEP can re-evaluate whether
-			// the finalizer can be removed now that this CUDN is gone,
-			// or if the VTEP had Accepted=False due to IPv6 CIDRs
-			// referenced by this EVPN CUDN, it can recover.
-			klog.V(5).Infof("CUDN %s deleted, re-queuing VTEP %s", cudnName, vtepName)
-			c.vtepController.Reconcile(vtepName)
+			// Handled by onCUDNDeleted, which has the deleted object.
 			return nil
 		}
-		return fmt.Errorf("failed to get CUDN %s: %w", cudnName, err)
+		return fmt.Errorf("failed to get CUDN %s: %w", key, err)
 	}
 
 	if cudn.Spec.Network.EVPN != nil && cudn.Spec.Network.EVPN.VTEP != "" {
-		vtepName := cudn.Spec.Network.EVPN.VTEP
-		c.cudnVTEPIndexMu.Lock()
-		_, alreadyIndexed := c.cudnVTEPIndex[cudnName]
-		c.cudnVTEPIndex[cudnName] = vtepName
-		c.cudnVTEPIndexMu.Unlock()
-		if !alreadyIndexed {
-			// fresh create event
-			klog.V(5).Infof("Indexed CUDN %s -> VTEP %s, re-queuing VTEP", cudnName, vtepName)
-			c.vtepController.Reconcile(vtepName)
-		}
+		klog.V(5).Infof("EVPN CUDN %s created, re-queuing VTEP %s", key, cudn.Spec.Network.EVPN.VTEP)
+		c.vtepController.Reconcile(cudn.Spec.Network.EVPN.VTEP)
 	}
 	return nil
 }
 
-// cudnNeedsUpdate determines if a CUDN event is relevant for VTEP finalizer
-// management. We allow creates of EVPN-enabled CUDNs through so reconcileCUDN
-// can populate the reverse index (cudnName → vtepName). The spec is immutable
-// so updates never matter. Deletions bypass ObjNeedsUpdate entirely.
+// onCUDNDeleted runs synchronously from the CUDN informer's delete handler with
+// the deleted object in hand, so it can read EVPN.VTEP directly and re-queue
+// exactly that VTEP.
+//
+// A CUDN deletion changes the set of CUDNs referencing the VTEP, which two VTEP
+// behaviours depend on (both evaluated via getCUDNsReferencingVTEP in
+// reconcileVTEP):
+//   - finalizer removal: if the VTEP is being deleted but was blocked because
+//     this was the last CUDN referencing it, deletion can now be unblocked
+//     (handleVTEPDeletion).
+//   - IPv6-for-EVPN recovery: if the VTEP has an IPv6 CIDR and was set
+//     Accepted=False/EVPNIPv6NotSupported because this was the last EVPN CUDN
+//     referencing it, it can now recover to Accepted=True
+//     (validateNoIPv6VTEPsForEVPN).
+//
+// Only EVPN CUDNs with a VTEP set can ever reference a VTEP (see
+// cudnReferencesVTEP), so non-EVPN deletions cannot affect either behaviour and
+// are ignored here.
+//
+// Handling deletes here (rather than in reconcileCUDN) avoids relying on
+// remembered state: the decision is made from the deleted object itself, so it
+// cannot be lost if a CUDN's create and delete coalesce in the workqueue.
+func (c *Controller) onCUDNDeleted(cudn *udnv1.ClusterUserDefinedNetwork) {
+	if cudn.Spec.Network.EVPN == nil || cudn.Spec.Network.EVPN.VTEP == "" {
+		return
+	}
+	klog.V(5).Infof("EVPN CUDN %s deleted, re-queuing VTEP %s", cudn.Name, cudn.Spec.Network.EVPN.VTEP)
+	c.vtepController.Reconcile(cudn.Spec.Network.EVPN.VTEP)
+}
+
+// cudnNeedsUpdate determines if a CUDN event is relevant for VTEP management.
+// We allow creates of EVPN-enabled CUDNs through so reconcileCUDN can re-queue
+// the referenced VTEP. The spec is immutable so updates never matter.
+// Deletions bypass ObjNeedsUpdate entirely and are handled by onCUDNDeleted.
 func cudnNeedsUpdate(oldObj, newObj *udnv1.ClusterUserDefinedNetwork) bool {
 	if oldObj == nil && newObj != nil {
 		return newObj.Spec.Network.EVPN != nil

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -1054,43 +1054,6 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 	})
 
 	ginkgo.Context("CUDN watch for finalizer re-evaluation", func() {
-		ginkgo.It("indexes EVPN CUDNs on create and ignores non-EVPN CUDNs", func() {
-			evpnCUDN := newCUDNWithEVPN("cudn-evpn", "vtep-indexed")
-			nonEVPNCUDN := &udnv1.ClusterUserDefinedNetwork{
-				ObjectMeta: metav1.ObjectMeta{Name: "cudn-plain"},
-				Spec: udnv1.ClusterUserDefinedNetworkSpec{
-					NamespaceSelector: metav1.LabelSelector{},
-					Network: udnv1.NetworkSpec{
-						Topology: udnv1.NetworkTopologyLayer3,
-						Layer3: &udnv1.Layer3Config{
-							Subnets: []udnv1.Layer3Subnet{{CIDR: "10.0.0.0/16"}},
-						},
-					},
-				},
-			}
-			vtep := newVTEP("vtep-indexed", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
-			start(vtep, evpnCUDN, nonEVPNCUDN)
-
-			// EVPN CUDN should be indexed
-			gomega.Eventually(func() bool {
-				controller.cudnVTEPIndexMu.RLock()
-				_, ok := controller.cudnVTEPIndex["cudn-evpn"]
-				controller.cudnVTEPIndexMu.RUnlock()
-				return ok
-			}).WithTimeout(5 * time.Second).Should(gomega.BeTrue())
-
-			controller.cudnVTEPIndexMu.RLock()
-			val := controller.cudnVTEPIndex["cudn-evpn"]
-			controller.cudnVTEPIndexMu.RUnlock()
-			gomega.Expect(val).To(gomega.Equal("vtep-indexed"))
-
-			// Non-EVPN CUDN should NOT be indexed
-			controller.cudnVTEPIndexMu.RLock()
-			_, ok := controller.cudnVTEPIndex["cudn-plain"]
-			controller.cudnVTEPIndexMu.RUnlock()
-			gomega.Expect(ok).To(gomega.BeFalse())
-		})
-
 		ginkgo.It("unblocks VTEP deletion when the referencing CUDN is deleted", func() {
 			cudn := newCUDNWithEVPN("cudn-ref", "vtep-cudn-del")
 			vtep := newVTEP("vtep-cudn-del", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
@@ -1121,12 +1084,6 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				_, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-cudn-del", metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
 			}).WithTimeout(5 * time.Second).Should(gomega.BeTrue())
-
-			// Index entry should be cleaned up
-			controller.cudnVTEPIndexMu.RLock()
-			_, ok := controller.cudnVTEPIndex["cudn-ref"]
-			controller.cudnVTEPIndexMu.RUnlock()
-			gomega.Expect(ok).To(gomega.BeFalse())
 		})
 
 		ginkgo.It("keeps VTEP blocked until all referencing CUDNs are deleted", func() {

--- a/go-controller/pkg/controller/controller.go
+++ b/go-controller/pkg/controller/controller.go
@@ -87,6 +87,18 @@ type ControllerConfig[T any] struct {
 	// ObjNeedsUpdate tells if object should be reconciled.
 	// May be called with oldObj = nil on Add, won't be called on Delete.
 	ObjNeedsUpdate func(oldObj, newObj *T) bool
+	// OnDelete, if non-nil, is invoked synchronously from the informer's delete
+	// handler with the last-known object (unwrapped from a
+	// cache.DeletedFinalStateUnknown tombstone when the delete was missed and
+	// detected on relist). It runs in informer-delivery order, before the
+	// object's key is enqueued for Reconcile. This is the only place a consumer
+	// can observe a deleted object's content: Reconcile receives just a key, by
+	// which point the object is gone from the lister. Use it to react to a
+	// deletion whose effect depends on the deleted object's own fields (e.g. to
+	// re-queue a related object identified only by a field on the deleted one).
+	// It must be fast and non-blocking since it runs on the informer's handler
+	// goroutine. Optional; nil preserves existing behavior.
+	OnDelete func(obj *T)
 }
 
 // controller has the basic functionality, and may have some wrappers to provide
@@ -251,6 +263,16 @@ func (c *controller[T]) onUpdate(oldObjInterface, newObjInterface interface{}) {
 }
 
 func (c *controller[T]) onDelete(objInterface interface{}) {
+	if c.config.OnDelete != nil {
+		// OnDelete is an auxiliary, best-effort hook. If the object can't be
+		// extracted (deletedObj logged and returned nil), we intentionally do
+		// not return: enqueueing the key below is the primary, level-driven
+		// behavior and must still run so the deletion gets reconciled.
+		if obj := c.deletedObj(objInterface); obj != nil {
+			c.config.OnDelete(obj)
+		}
+	}
+
 	// A deletion that the watch missed (detected later by a relist) is
 	// delivered as a DeletedFinalStateUnknown wrapper, not as the object
 	// itself. This key func handles both; the plain one errors on the
@@ -261,6 +283,28 @@ func (c *controller[T]) onDelete(objInterface interface{}) {
 		return
 	}
 	c.queue.Add(key)
+}
+
+// deletedObj extracts the typed object from a delete event, unwrapping a
+// cache.DeletedFinalStateUnknown tombstone (delivered when a delete was missed
+// and detected later on relist) to its last-known object. It logs and returns
+// nil if the (unwrapped) object is not of the expected type.
+func (c *controller[T]) deletedObj(objInterface interface{}) *T {
+	obj := objInterface
+	if tombstone, isTombstone := objInterface.(cache.DeletedFinalStateUnknown); isTombstone {
+		obj = tombstone.Obj
+	}
+	typed, ok := obj.(*T)
+	if !ok {
+		// Log and return nil rather than making this fatal: onDelete treats a
+		// nil result as "skip the OnDelete hook" but still enqueues the key so
+		// the deletion gets reconciled. This branch is defense-in-depth; a
+		// correctly-wired typed informer only ever delivers *T (or a tombstone
+		// wrapping *T).
+		utilruntime.HandleError(fmt.Errorf("controller %s: OnDelete received unexpected type %T", c.name, obj))
+		return nil
+	}
+	return typed
 }
 
 // processNextQueueItem returns false when the queue is shutdown and the

--- a/go-controller/pkg/controller/controller_test.go
+++ b/go-controller/pkg/controller/controller_test.go
@@ -226,6 +226,49 @@ var _ = Describe("Level-driven controller", func() {
 			return keys
 		}).Should(BeEquivalentTo(sets.New(pod1Key, pod2Key)))
 	})
+	It("invokes OnDelete with the deleted object", func() {
+		namespace := util.NewNamespace(namespace1Name)
+		pod := &corev1.Pod{
+			ObjectMeta: util.NewObjectMeta("pod1", namespace.Name),
+		}
+		config := getDefaultConfig()
+		// Record namespace by name to prove OnDelete receives the actual
+		// object (not just a key).
+		deleted := sync.Map{}
+		config.OnDelete = func(obj *corev1.Pod) {
+			deleted.Store(obj.Name, obj.Namespace)
+		}
+		startController(config, nil, namespace, pod)
+		checkReconcileCounter(1)
+
+		err := fakeClient.KubeClient.CoreV1().Pods(namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			ns, ok := deleted.Load("pod1")
+			return ok && ns == namespace.Name
+		}).Should(BeTrue(), "OnDelete should be called with the deleted pod object")
+	})
+})
+
+var _ = Describe("Level-driven controller deletedObj", func() {
+	c := &controller[corev1.Pod]{name: "test"}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}
+
+	It("returns the object for a plain delete", func() {
+		Expect(c.deletedObj(pod)).To(BeIdenticalTo(pod))
+	})
+	It("unwraps a DeletedFinalStateUnknown tombstone", func() {
+		tombstone := cache.DeletedFinalStateUnknown{Key: "ns1/pod1", Obj: pod}
+		Expect(c.deletedObj(tombstone)).To(BeIdenticalTo(pod))
+	})
+	It("returns nil for an unexpected type", func() {
+		Expect(c.deletedObj("not-a-pod")).To(BeNil())
+	})
+	It("returns nil for a tombstone wrapping an unexpected type", func() {
+		tombstone := cache.DeletedFinalStateUnknown{Key: "ns1/pod1", Obj: "not-a-pod"}
+		Expect(c.deletedObj(tombstone)).To(BeNil())
+	})
 })
 
 var _ = Describe("Level-driven controllers with shared initialSync", func() {


### PR DESCRIPTION

## 📑 Description


c.cudnVTEPIndex was a side cache mapping a CUDN name to its referenced
VTEP. It existed because a CUDN delete event only carries a key by the time
Reconcile runs the object (and its Spec.Network.EVPN.VTEP) is already gone
from the lister, so on delete we had no way to know which VTEP to re-queue.
Without the index the only alternative would be to reconcile every VTEP on
every CUDN delete, which is wasteful for CUDNs that reference no VTEP at all.
The index, populated on the create edge, was consulted on the delete edge to
recover that VTEP name and re-queue only the affected VTEP.
    
This is racy. The controller is level-driven with a key-coalescing
workqueue: a fast create-then-delete of a CUDN collapses into a single
reconcile that observes the object already deleted and an empty index, so
the referenced VTEP is never re-queued. The VTEP then stays stuck in its
current condition (e.g. IPv6NotSupported never clears, or its deletion stays
blocked by the finalizer) until an unrelated event happens to re-queue it.

Fix: drop the index entirely and use the framework's new OnDelete hook,
which delivers the deleted object itself. onCUDNDeleted reads
Spec.Network.EVPN.VTEP directly off the deleted CUDN and re-queues the VTEP,
so the reconcile can no longer be lost to coalescing.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6804

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Fixes #6804 

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
