### PR TITLE
kind: tolerate pod churn in the kube-system readiness wait

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1095,7 +1095,8 @@ wait_for_ovn_daemonset() {
 # DS are actually up. Next, it waits for ovnkube-control-plane pods to post
 # "Ready" when that deployment is part of the mode. If the DNS name resolver
 # replaced the CoreDNS image, it then waits for that rollout to finish. Last,
-# it will do the same with all pods in the kube-system namespace.
+# it waits for every non-terminating pod in the kube-system namespace to be
+# Ready.
 kubectl_wait_pods() {
   # IPv6 cluster seems to take a little longer to come up, so extend the wait time.
   OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT:-300}
@@ -1136,19 +1137,44 @@ kubectl_wait_pods() {
   restart_dpu_sim_multus_after_ovnk
 
   if [ "${OVN_ENABLE_DNSNAMERESOLVER:-false}" == true ]; then
-    # Avoid passing an obsolete CoreDNS pod to the fixed pod list used by the
-    # kube-system wait below while the custom image rollout is still in flight.
+    # Make sure the custom CoreDNS image rollout completed before checking the
+    # kube-system pods, so the check below covers the new replicas.
     timeout=$(calculate_timeout "${endtime}")
     echo "Waiting for the CoreDNS deployment rollout (timeout ${timeout})..."
     kubectl -n kube-system rollout status deployment/coredns --timeout "${timeout}s"
   fi
 
-  timeout=$(calculate_timeout ${endtime})
-  if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
+  if ! kubectl_wait_namespace_pods_ready kube-system ${endtime}; then
     echo "some pods in the system are not running"
     kubectl get pods -A -o wide || true
     exit 1
   fi
+}
+
+# kubectl_wait_namespace_pods_ready waits until every non-terminating pod in the
+# namespace is Ready, giving up at the absolute endtime (in $SECONDS, see
+# calculate_timeout). `kubectl wait --all` is not used because it resolves the
+# pod list once and keeps waiting for a pod deleted mid-wait (e.g. a terminating
+# CoreDNS replica) until its timeout expires; instead the current pods are
+# checked once per poll.
+kubectl_wait_namespace_pods_ready() {
+  local namespace=$1
+  local endtime=$2
+  local pods
+
+  echo "Waiting for pods in ${namespace} to become ready (timeout $(calculate_timeout ${endtime}))..."
+  while true; do
+    pods=$(kubectl get pods -n ${namespace} -o go-template \
+      --template='{{range .items}}{{if not .metadata.deletionTimestamp}}{{.metadata.name}} {{end}}{{end}}')
+    if [ -n "${pods}" ] && \
+      kubectl wait -n ${namespace} --for=condition=ready --timeout=0 pod ${pods} >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ $(( endtime - SECONDS )) -le 0 ]; then
+      return 1
+    fi
+    sleep 2
+  done
 }
 
 # calculate_timeout takes an absolute endtime in seconds (based on bash script runtime, see


### PR DESCRIPTION
Closes #6913.

The kube-system readiness wait in `kubectl_wait_pods` still flakes on DNSNameResolver lanes, even after #6871:

1. `kubectl wait --all` resolves the pod list once and never completes if one of those pods is deleted mid-wait: kubectl keeps watching for that name to reappear until the timeout expires, and then reports every remaining pod as timed out too, although they are all Ready.
2. Waiting for the CoreDNS rollout first (#6871) doesn't close the window: a Deployment is complete as soon as the old replica is Terminating (ReplicaSet status stops counting it), while the pod object is still listable for a few more seconds. The old replica is deleted that late because the image swap happens before there is a CNI, so it stays Pending until ovnkube is up, i.e. seconds before our wait.

What this PR does:
- adds `kubectl_wait_namespace_pods_ready`, which polls every 2s until the deadline: it lists the pods, skips those with a `deletionTimestamp`, and checks them once with `kubectl wait --timeout=0`, so a pod deleted mid-wait is noticed at the next poll
- `kubectl_wait_pods` uses it for kube-system, keeping the CoreDNS rollout wait in place
- the overall `KIND_HELM_OVN_TIMEOUT` budget is unchanged; pods that are genuinely not Ready still fail at the same deadline
