### PR TITLE
docs: activate unused MkDocs plugins and add useful new ones

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/docs/developer-guide/developer.md
+++ b/docs/developer-guide/developer.md
@@ -53,7 +53,7 @@ make mocksgen
 ### Mock file placement
 
 Mock output locations are determined by `.mockery.yaml` — it is the single
-source of truth. The default output is `pkg/testing/mocks/{{.PackagePath}}/`,
+source of truth. The default output is `pkg/testing/mocks/{{ '{{' }}.PackagePath{{ '}}' }}/`,
 but packages can override this with a `dir` config entry to place mocks
 elsewhere (e.g. `pkg/factory/mocks/`, `pkg/util/mocks/`).
 

--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -239,6 +239,114 @@ Then verify the first merge deploy:
 If Pages is still set to **GitHub Actions**, the workflow can succeed while the
 public site does not update — fix the Source setting above.
 
+## Markdown extensions and plugins
+
+The docs site enables several MkDocs plugins and pymdownx Markdown extensions
+beyond basic Markdown. Use them to make documentation clearer and more
+interactive.
+
+### Tabbed content (`pymdownx.tabbed`)
+
+Show alternatives (e.g. `kubectl` vs `oc`, IPv4 vs IPv6) side-by-side:
+
+```markdown
+=== "kubectl"
+
+    ```bash
+    kubectl get pods -A
+    ```
+
+=== "oc"
+
+    ```bash
+    oc get pods -A
+    ```
+```
+
+### Task lists (`pymdownx.tasklist`)
+
+Render GitHub-style checklists:
+
+```markdown
+- [x] Create the CRD types
+- [x] Run `make codegen`
+- [ ] Add feature documentation
+```
+
+### Keyboard shortcuts (`pymdownx.keys`)
+
+Render keyboard keys with the `++` syntax:
+
+```markdown
+Press ++ctrl+c++ to copy, ++ctrl+v++ to paste.
+```
+
+### Magic links (`pymdownx.magiclink`)
+
+GitHub references are auto-linked. No Markdown link syntax needed:
+
+```markdown
+See #1234 for details.          <!-- links to issue/PR 1234 -->
+Fixed by @username in abc123.   <!-- links to user and commit -->
+```
+
+The config sets `user: ovn-kubernetes` and `repo: ovn-kubernetes` so
+bare `#1234` references resolve to this repository.
+
+### Text highlighting (`pymdownx.mark`)
+
+Highlight important text with double equals:
+
+```markdown
+This is ==highlighted text== in a sentence.
+```
+
+### Macros (`mkdocs-macros-plugin`) and Jinja2 escaping
+
+The macros plugin enables Jinja2 templating in Markdown. It processes
+**all** content, including fenced code blocks.
+
+{% raw %}
+**Escaping rule:** If your docs contain literal `{{ }}` syntax (Go templates,
+Helm charts, Docker inspect commands, etc.), you **must** escape it so the
+macros plugin does not try to evaluate it:
+
+```markdown
+<!-- Raw Go template (will break the build): -->
+The default output is `pkg/testing/mocks/{{.PackagePath}}/`
+
+<!-- Escaped (correct): -->
+The default output is `pkg/testing/mocks/{{ '{{' }}.PackagePath{{ '}}' }}/`
+```
+
+The `{{ '{{' }}` expression outputs a literal `{{` and `{{ '}}' }}` outputs
+a literal `}}`. This applies anywhere `{{ }}` appears in docs — inline code,
+fenced code blocks, or prose.
+{% endraw %}
+
+### Page revision dates (`git-revision-date-localized`)
+
+Each page automatically shows a "Last updated" date at the bottom, pulled
+from git history. No author action is needed. The plugin falls back to the
+build date when full git history is unavailable (e.g. CI shallow clones).
+
+### Redirects (`mkdocs-redirects`)
+
+When a page is moved or renamed, add an entry to the `redirect_maps` in
+`mkdocs.yml` so old URLs do not 404:
+
+```yaml
+plugins:
+  - redirects:
+      redirect_maps:
+        'old/path.md': 'new/path.md'
+```
+
+### HTML minification (`mkdocs-minify-plugin`)
+
+The built site HTML is automatically minified for faster page loads. No
+author action is needed.
+
 ## How to test your documentation changes?
 
 ### Option 1) Build and view docs with a PR

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ plugins:
   - awesome-pages
   - mike
   - mermaid2
+  - macros
   - blog:
       # NOTE: configuration options can be found at
       # https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/
@@ -59,6 +60,14 @@ plugins:
       loop: false
       zoomable: true
       draggable: true
+  - redirects:
+      redirect_maps: {}
+  - minify:
+      minify_html: true
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+      fallback_to_build_date: true
 markdown_extensions:
   - admonition
   - meta
@@ -73,9 +82,19 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:mermaid2.fence_mermaid_custom
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.snippets:
       base_path: site-src
       check_paths: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: ovn-kubernetes
+      repo: ovn-kubernetes
+  - pymdownx.mark
   - toc:
       permalink: true
 nav:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ PyYAML
 six
 tornado
 mkdocs-meta-descriptions-plugin==4.1.0
+mkdocs-redirects==1.2.3
+mkdocs-minify-plugin==0.8.0
+mkdocs-git-revision-date-localized-plugin==1.5.4


### PR DESCRIPTION
### Summary

While evaluating the MkDocs plugin setup for the OVN-Kubernetes docs site, I found that some plugins were already installed (`requirements.txt`) but never activated in `mkdocs.yml`, and other plugins commonly used by Kubernetes-related doc sites were missing entirely. This PR enables the unused ones and adds the missing useful ones.

### Changes

**Activated (installed but not used):**

| Plugin | What It Does |
|--------|-------------|
| `macros` | Jinja2 templating in Markdown variables, conditionals, includes |
| `pymdownx.tabbed` | Tabbed content blocks (e.g. show kubectl vs oc side-by-side) |

**Added (not installed, useful for the site):**

| Plugin | What It Does |
|--------|-------------|
| `mkdocs-redirects` | Redirect old URLs when pages move prevents 404s from external links |
| `mkdocs-minify-plugin` | Minify HTML output for faster page loads |
| `mkdocs-git-revision-date-localized` | Show "Last updated" date on each page |
| `pymdownx.tasklist` | GitHub-style task list checkboxes in Markdown |
| `pymdownx.keys` | Render keyboard shortcuts like ++ctrl+c++ |
| `pymdownx.magiclink` | Auto-link `#1234` -> GitHub issue, `@user` -> profile |
| `pymdownx.mark` | Highlight text with `==marked text==` |

**Bug fix:**
- Escaped Go template syntax (`{{.PackagePath}}`) in `developer.md` that conflicted with the macros plugin's Jinja2 parser.

### Files Changed

- `mkdocs.yml` — enabled plugins and markdown extensions
- `requirements.txt` — added 3 new pip packages
- `docs/developer-guide/developer.md` — escaped `{{ }}` Jinja2 conflict