### PR TITLE
node: re-assert ovn-remote if ovn-controller loses the SB connection

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -548,6 +548,33 @@ func setEncapPort(ctx context.Context) error {
 	return nil
 }
 
+// ovnRemoteReconcileInterval is how often ovn-controller's southbound
+// connection is checked.
+const ovnRemoteReconcileInterval = 60 * time.Second
+
+// reconcileOVNRemote re-asserts external_ids:ovn-remote when ovn-controller has
+// lost its connection to the local southbound database.
+//
+// SetOVNRemote() only runs from Init(), so if ovn-remote is cleared underneath a
+// running ovn-controller nothing restores it. The node's dataplane then freezes:
+// CNI ADD fails and pods become unreachable from nodes that join later, while
+// kubelet still reports every container as healthy.
+func (nc *DefaultNodeNetworkController) reconcileOVNRemote() {
+	status, _, err := util.RunOVNControllerAppCtl("connection-status")
+	if err != nil {
+		klog.Errorf("Could not get ovn-controller connection status: %v", err)
+		return
+	}
+	if strings.HasPrefix(status, "connected") {
+		return
+	}
+	klog.Warningf("ovn-controller is not connected to the southbound database (status %q), "+
+		"re-asserting ovn-remote", status)
+	if err := config.OvnSouth.SetOVNRemote(); err != nil {
+		klog.Errorf("Unable to re-configure the local OVN Southbound database endpoint: %v", err)
+	}
+}
+
 func isOVNControllerReady(ovsClient client.Client) (bool, error) {
 	// check node's connection status
 	ret, _, err := util.RunOVNControllerAppCtl("connection-status")
@@ -1141,6 +1168,15 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		}()
 		ovspinning.Run(ctx, stopCh, podResClient, nc.ovsClient)
 	}(nc.stopChan)
+
+	// See reconcileOVNRemote.
+	if config.IsModeDPU() || config.IsModeFull() {
+		nc.wg.Add(1)
+		go func(stopCh <-chan struct{}) {
+			defer nc.wg.Done()
+			wait.Until(nc.reconcileOVNRemote, ovnRemoteReconcileInterval, stopCh)
+		}(nc.stopChan)
+	}
 
 	klog.Infof("Default node network controller initialized and ready.")
 	return nil

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
@@ -2306,3 +2307,63 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 func strPtr(s string) *string {
 	return &s
 }
+
+var _ = Describe("reconcileOVNRemote", func() {
+	const (
+		pid       = "4242"
+		appctlCmd = "ovn-appctl -t /var/run/ovn/ovn-controller." + pid + ".ctl connection-status"
+		vsctlSet  = `ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-remote="unix:/var/run/ovn/ovnsb_db.sock"`
+	)
+
+	var (
+		fexec  *ovntest.FakeExec
+		nc     *DefaultNodeNetworkController
+		origFs afero.Fs
+	)
+
+	BeforeEach(func() {
+		origFs = util.AppFs
+		util.AppFs = afero.NewMemMapFs()
+		Expect(afero.WriteFile(util.AppFs, "/var/run/ovn/ovn-controller.pid", []byte(pid+"\n"), 0o644)).To(Succeed())
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		fexec = ovntest.NewFakeExec()
+		nc = &DefaultNodeNetworkController{}
+	})
+
+	AfterEach(func() {
+		util.AppFs = origFs
+	})
+
+	// run wires up the fake exec and config, then invokes reconcileOVNRemote.
+	run := func() {
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+		app.Action = func(ctx *cli.Context) error {
+			defer GinkgoRecover()
+			Expect(util.SetExec(fexec)).To(Succeed())
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+			nc.reconcileOVNRemote()
+			return nil
+		}
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	}
+
+	It("does nothing while ovn-controller is connected", func() {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{Cmd: appctlCmd, Output: "connected"})
+		run()
+	})
+
+	It("re-asserts ovn-remote when ovn-controller is disconnected", func() {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{Cmd: appctlCmd, Output: "not connected"})
+		fexec.AddFakeCmdsNoOutputNoError([]string{vsctlSet})
+		run()
+	})
+
+	It("does not write ovn-remote when the status check fails", func() {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{Cmd: appctlCmd, Err: fmt.Errorf("appctl boom")})
+		run()
+	})
+})


### PR DESCRIPTION
SetOVNRemote() writes external_ids:ovn-remote once, from Init(), and ovnkube-node is its only writer. If anything clears it underneath a running ovn-controller, nothing restores it: ovn-controller targets "invalid::" and retries forever against a target that can never resolve.

The node's OVS flow state freezes at that moment. CNI ADD fails, and pods on the node are unreachable from any node that joins afterwards, while kubelet still reports every container as healthy. Recovery today means deleting the ovnkube-node pod by hand.

Check the connection every 60s and re-assert ovn-remote when it is down.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
