### PR TITLE
docs: use gateway mode terms for egressip host route note

### DIFF
--- a/docs/features/cluster-egress-controls/egress-ip.md
+++ b/docs/features/cluster-egress-controls/egress-ip.md
@@ -128,10 +128,10 @@ network and the host main table also contains `192.168.2.0/24 via 192.168.1.2`,
 EgressIP traffic sourced from an address on that primary interface still leaves
 via `192.168.1.1`. It does not follow the host static route via `192.168.1.2`.
 
-This is true in both shared gateway mode and local gateway mode
-(`routingViaHost=true`). Primary-network EgressIP still follows the shared
-gateway path through the Gateway Router rather than the host kernel, so
-those main-table routes never apply.
+**Note:** this applies in both shared gateway mode and local gateway mode.
+Primary-network EgressIP still follows the shared gateway path through the
+Gateway Router rather than the host kernel, so those main-table routes
+never apply. This is a known design limitation.
 
 ### EgressIP IP is assigned to a secondary host interface
 Note that this is unsupported for user defined networks.
@@ -359,9 +359,10 @@ egressip-node-healthcheck-port=9107
 ## Known Limitations
 
 - Layer 2 networks and localnet are not supported.
-- EgressIP on the **primary node network** (the interface configured as the
-  node's network, typically `br-ex`) does not honor static routes that exist in
-  the host's **main routing table** for that network. Next-hop selection uses
-  the OVN Gateway Router default route. Enabling local gateway mode
-  (`routingViaHost=true`) does not send this traffic through the host kernel, so
-  those main-table routes still do not apply.
+- **Note:** EgressIP on the **primary node network** (the interface configured as
+  the node's network, typically `br-ex`) does not honor static routes that exist
+  in the host's **main routing table** for that network. Next-hop selection uses
+  the OVN Gateway Router default route. This applies in both shared gateway mode
+  and local gateway mode. Local gateway mode does not send this traffic through
+  the host kernel, so those main-table routes still do not apply. This is a
+  known design limitation.


### PR DESCRIPTION
## 📑 Description

Follow-up to #6910. Replaces OpenShift-only `routingViaHost` terminology with **local gateway mode** and **shared gateway mode**. The documented behavior is unchanged: EgressIP on the primary node network does not consult host main-table static routes.

Adds a note that this is a known design limitation in both gateway modes. Local gateway mode does not send this traffic through the host kernel.

Fixes #

## Release Notes
```release-note
Clarify that primary-network EgressIP does not honor host main-table static routes in local and shared gateway modes.
```

## Additional Information for reviewers

Change is in `docs/features/cluster-egress-controls/egress-ip.md`:
- Drop `routingViaHost`
- Keep the same primary node-network limitation from #6910
- Mark it as a note / known design limitation (no future-work language)

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

Read the primary-interface section and Known Limitations in `docs/features/cluster-egress-controls/egress-ip.md`. Confirm `routingViaHost` is gone. No runtime tests.