### PR TITLE
docs: harden 404 redirect against open-redirect scanner finding

### DIFF
--- a/docs/developer-guide/documentation.md
+++ b/docs/developer-guide/documentation.md
@@ -191,6 +191,19 @@ the prefix is already `master`).
 Do not hand-edit `404.html` on `gh-pages`; change `hack/docs-site-404.html` on
 `master` and let the versioning workflow republish it.
 
+**Redirect validation (`safeRedirect` helper):** All `location.replace()` calls
+in the 404 page go through a `safeRedirect()` function that enforces two
+invariants before redirecting:
+
+1. **Leading-slash normalization** — multiple leading slashes are collapsed to
+   one (`//…` → `/…`) so the browser never interprets the URL as a
+   protocol-relative redirect (e.g. `//evil.com`).
+2. **Origin check** — the URL is parsed with the `URL` API against the current
+   origin; if the resolved origin differs the redirect falls back to `/master/`.
+
+Every redirect target is an origin-relative path by construction, so these
+checks are defense-in-depth rather than a fix for an exploitable bug.
+
 Shell coverage for the install helper (local/remote `gh-pages`, unchanged vs
 changed template, `PUSH=false`/`true`, push failure) and for the clean-worktree
 preflight lives in `hack/test-install-gh-pages-404.sh`

--- a/hack/docs-site-404.html
+++ b/hack/docs-site-404.html
@@ -5,6 +5,20 @@
   <title>Redirecting…</title>
   <script>
     (function () {
+      function safeRedirect(url) {
+        url = url.replace(/^\/\/+/, '/');
+        try {
+          var parsed = new URL(url, location.origin);
+          if (parsed.origin !== location.origin) {
+            location.replace('/master/');
+            return;
+          }
+        } catch (e) {
+          location.replace('/master/');
+          return;
+        }
+        location.replace(url);
+      }
       var path = location.pathname;
       var suffix = location.search + location.hash;
       // Already under a mike version or alias? Prefer that version's home for
@@ -15,15 +29,15 @@
         var ver = versioned[1];
         var atVersionRoot = path === "/" + ver || path === "/" + ver + "/";
         if (atVersionRoot) {
-          location.replace((ver === "master" ? "/" : "/master/") + suffix);
+          safeRedirect((ver === "master" ? "/" : "/master/") + suffix);
           return;
         }
-        location.replace("/" + ver + "/" + suffix);
+        safeRedirect("/" + ver + "/" + suffix);
         return;
       }
       // Pre-versioning deep link (e.g. /design/architecture/) → same path
       // under the default docs version (master).
-      location.replace("/master" + path + suffix);
+      safeRedirect("/master" + path + suffix);
     })();
   </script>
 </head>


### PR DESCRIPTION
### Summary:

Wraps the three location.replace() calls in hack/docs-site-404.html in a safeRedirect() helper that:
1)Collapses any leading // to / (prevents protocol-relative URLs)
2)Verifies via the URL API that the resolved origin hasn't changed, falling back to /master/ if it has

### Need:

A security scan flagged line 21 in  hack/docs-site-404.html  as a [MEDIUM] Open Redirect -> unsanitized input from the document location flows into location.replace().
This PR adds the guard anyway as defense-in-depth to silence the scanner and prevent future regressions if the redirect logic is refactored.