### PR TITLE
e2e: add UDN foreign NAD status and non-admin user UDN creation tests

### DIFF
--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,8 +40,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/util/podutils"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -1702,6 +1705,128 @@ spec:
 			Reason:  "SyncError",
 			Message: expectedMessage,
 		}))
+	})
+
+	It("when foreign NAD exists, UserDefinedNetwork status should report not-ready", func() {
+		const nadName = "udn-network"
+
+		By("create primary NAD without UDN owner reference")
+		foreignNAD := generateNAD(newNetworkAttachmentConfig(networkAttachmentConfigParams{
+			role:        "primary",
+			topology:    "layer3",
+			name:        nadName,
+			networkName: nadName,
+			cidr:        primaryLayer3MultiCIDRs(),
+		}), f.ClientSet)
+		_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), foreignNAD, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("create primary UDN CR with the same name as the foreign NAD")
+		cleanup, err := createManifest(f.Namespace.Name, newPrimaryUserDefinedNetworkManifest(cs, nadName))
+		DeferCleanup(cleanup)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verify UDN status reports foreign NAD conflict")
+		expectedMessage := fmt.Sprintf("foreign NetworkAttachmentDefinition with the desired name already exist [%s/%s]",
+			f.Namespace.Name, nadName)
+		Eventually(func(g Gomega) []metav1.Condition {
+			conditionsJSON, err := e2ekubectl.RunKubectl(f.Namespace.Name, "get", "userdefinednetwork", nadName, "-o", "jsonpath={.status.conditions}")
+			g.Expect(err).NotTo(HaveOccurred())
+			var actualConditions []metav1.Condition
+			g.Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
+			return normalizeConditions(actualConditions)
+		}, 5*time.Second, 1*time.Second).Should(ConsistOf(metav1.Condition{
+			Type:    "NetworkCreated",
+			Status:  metav1.ConditionFalse,
+			Reason:  "SyncError",
+			Message: expectedMessage,
+		}))
+	})
+
+	Context("RBAC for UserDefinedNetwork", func() {
+		It("should allow users with namespace UDN permissions to create primary UDN", func() {
+			const (
+				saName   = "udn-manager"
+				roleName = "udn-manager"
+				udnName  = "l3-network"
+			)
+			ns := f.Namespace.Name
+
+			By("create service account, Role, and RoleBinding")
+			_, err := cs.CoreV1().ServiceAccounts(ns).Create(context.Background(), &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: ns},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() error {
+				return cs.CoreV1().ServiceAccounts(ns).Delete(context.Background(), saName, metav1.DeleteOptions{})
+			})
+
+			_, err = cs.RbacV1().Roles(ns).Create(context.Background(), &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: ns},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{"k8s.ovn.org"},
+					Resources: []string{"userdefinednetworks"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				}},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() error {
+				return cs.RbacV1().Roles(ns).Delete(context.Background(), roleName, metav1.DeleteOptions{})
+			})
+
+			_, err = cs.RbacV1().RoleBindings(ns).Create(context.Background(), &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: ns},
+				Subjects: []rbacv1.Subject{{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      saName,
+					Namespace: ns,
+				}},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     roleName,
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() error {
+				return cs.RbacV1().RoleBindings(ns).Delete(context.Background(), roleName, metav1.DeleteOptions{})
+			})
+
+			impersonatedConfig := rest.CopyConfig(f.ClientConfig())
+			impersonatedConfig.Impersonate = rest.ImpersonationConfig{
+				UserName: fmt.Sprintf("system:serviceaccount:%s:%s", ns, saName),
+			}
+			impersonatedClient, err := dynamic.NewForConfig(impersonatedConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("create primary UDN as service account user")
+			udnManifest := newPrimaryUserDefinedNetworkManifest(cs, udnName)
+			jsonManifest, err := yaml.ToJSON([]byte(udnManifest))
+			Expect(err).NotTo(HaveOccurred())
+			udnObj := &unstructured.Unstructured{}
+			Expect(json.Unmarshal(jsonManifest, &udnObj.Object)).To(Succeed())
+
+			Eventually(func() error {
+				_, err := impersonatedClient.Resource(udnGVR).Namespace(ns).Create(context.Background(), udnObj, metav1.CreateOptions{})
+				if err != nil && kerrors.IsAlreadyExists(err) {
+					return nil
+				}
+				return err
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+			DeferCleanup(func() error {
+				return f.DynamicClient.Resource(udnGVR).Namespace(ns).Delete(context.Background(), udnName, metav1.DeleteOptions{})
+			})
+
+			By("verify UDN is ready")
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns, udnName), 30*time.Second, 1*time.Second).Should(Succeed())
+
+			By("verify NAD is created")
+			nad, err := nadClient.NetworkAttachmentDefinitions(ns).Get(context.Background(), udnName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nad.OwnerReferences).To(HaveLen(1))
+			Expect(nad.OwnerReferences[0].Kind).To(Equal("UserDefinedNetwork"))
+			Expect(nad.OwnerReferences[0].Name).To(Equal(udnName))
+		})
 	})
 
 	Context("ClusterUserDefinedNetwork CRD Controller", func() {


### PR DESCRIPTION
Add two Network Segmentation e2e tests:
- Verify UserDefinedNetwork reports NetworkCreated=False when a foreign NetworkAttachmentDefinition with the same name already exists.
- Verify a namespace-scoped user with userdefinednetworks RBAC can create a primary UDN and that the controller reconciles it successfully.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

- Add an e2e test that verifies `UserDefinedNetwork` status reports `NetworkCreated=False` with a `SyncError` when a foreign `NetworkAttachmentDefinition` with the same name already exists in the namespace.
- Add an e2e test that verifies a namespace-scoped ServiceAccount with `userdefinednetworks` Role permissions can create a primary `UserDefinedNetwork`, and that the controller reconciles it into a ready state with the expected NAD.
 
These tests extend existing Network Segmentation coverage described in [OKEP-5193](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/okeps/okep-5193-user-defined-networks.md) : foreign NAD conflict and UDN CR-based network management

## Test plan
- [x] Ran locally on KIND with network segmentation enabled
 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Release Notes
<!--
REQUIRED. Add a short, user-facing release note in the block below describing any
user-visible change (new/changed/removed flags or APIs, behavior changes,
deprecations, etc.).
Write `NONE` if this PR has no user-facing impact (tests, refactors, CI,
internal-only changes) — `NONE` is a valid entry.
-->
```release-note
NONE
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
