### PR TITLE
e2e: add kube infrastructure provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ make test           # Run unit tests
 ```
 
 E2E tests run via CI on Kind clusters. See `test/e2e/` for Ginkgo test suites.
-To run E2E locally, first set up a Kind cluster using `contrib/kind.sh`, then run the tests.
+To run E2E locally, first set up a Kind cluster using `contrib/kind.sh` (the default), then run the tests.
+To run them against an existing cluster instead, see `docs/developer-guide/kube-provider.md`.
 See `docs/developer-guide/local_testing_guide.md` for more details.
 
 ## Key Conventions

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -38,7 +38,8 @@ Writing and previewing documentation for the OVN-Kubernetes website.
 
 **[Local Testing Guide](local_testing_guide.md)**
 
-Run unit and end-to-end tests locally using Kind clusters.
+Run unit tests locally. Run end-to-end tests using Kind clusters (the default), or against an
+existing cluster with the [kube provider](kube-provider.md).
 
 **[CI Testing Guide](../ci/ci.md)**
 

--- a/docs/developer-guide/kube-provider.md
+++ b/docs/developer-guide/kube-provider.md
@@ -1,0 +1,140 @@
+# Running the e2e suite against an existing cluster
+
+The `kube` infra provider runs the e2e tests against a cluster that already exists and already
+runs OVN-Kubernetes. It reaches that cluster through `KUBECONFIG` instead of building a KinD
+cluster first.
+
+KinD stays the default. If you do not set `OVN_TEST_INFRA_PROVIDER`, nothing changes.
+
+## Running it
+
+You need:
+
+- a cluster running OVN-Kubernetes
+- a kubeconfig with cluster-admin
+- `kubectl` on `PATH`, which is how the suite runs commands on nodes
+
+```bash
+export KUBECONFIG=/path/to/kubeconfig
+export OVN_TEST_INFRA_PROVIDER=kube
+
+cd test/e2e
+go test -test.timeout 60m -v . \
+    -ginkgo.v \
+    -ginkgo.fail-on-empty \
+    -ginkgo.focus "Network Segmentation: API validations" \
+    -provider skeleton \
+    -kubeconfig "${KUBECONFIG}"
+```
+
+Start with that focus. Those specs only create resources and check that the API rejects bad ones,
+so they never touch a node. Try `Services` next, then widen as specs come back clean.
+
+Always pass `-ginkgo.fail-on-empty`. Without it, a focus matching no specs exits `SUCCESS` with
+everything skipped, which looks like a passing run.
+
+## If your cluster is not laid out like upstream
+
+The suite reads where OVN-K lives from the cluster rather than asking you: the namespace from the
+`app=ovnkube-node` pods, and the gateway bridge and its uplink from OVS on one of those nodes.
+Set a variable when what it reads is wrong, or when your cluster has more than one answer.
+
+| Variable | If you leave it unset | What it is |
+| --- | --- | --- |
+| `OVN_TEST_OVNK_NAMESPACE` | namespace of the `app=ovnkube-node` pods | Namespace OVN-K runs in |
+| `OVN_TEST_FRRK8S_NAMESPACE` | namespace of the `app=frr-k8s` pods, or `frr-k8s-system` if there are none | Namespace FRR-K8s runs in |
+| `OVN_TEST_EXTERNAL_BRIDGE` | the bridge OVN-K recorded an uplink on | OVS gateway bridge |
+| `OVN_TEST_PRIMARY_INTERFACE` | the uplink recorded on that bridge | Uplink OVN-K owns |
+| `OVN_TEST_PRIMARY_IP_POOL` | derived from the Node subnets | CIDR to allocate test addresses from |
+
+The bridge and the uplink are read together, from the `bridge-uplink` external-id that OVN-K
+writes on the bridge it moved the uplink onto. That is the same thing OVN-K reads back to find
+its own uplink. If no bridge carries it, which happens when the bridge was provisioned before
+OVN-K rather than by it, or if more than one does, the specs that need the uplink skip and name
+both variables. They skip rather than guess because several of them run `ip addr add` against this
+name, and a wrong name means they configure nothing and fail later for no visible reason.
+
+Both are one value for the whole cluster. Uplink-dependent specs may use any schedulable Node, so
+clusters whose Nodes use different bridge-uplink pairs are unsupported.
+
+Naming the namespace also narrows where the suite looks for those pods, so it is the way to pick
+between two OVN-K installs on one cluster.
+
+### When your Nodes do not share a subnet
+
+Some specs need a spare address on the Node network, usually to assign as an egress IP. By
+default the suite takes one from the subnet that every Node is on.
+
+That works when the Nodes sit on one L2. It does not work when each Node has its own routed link:
+disjoint subnets have no address in common, and a `/31` has no spare address in it. On a cluster
+like that, those specs skip and the rest of the run is unaffected.
+
+Set `OVN_TEST_PRIMARY_IP_POOL` to hand them a range instead. It has to be routable to the cluster
+and free for the suite to use:
+
+- `10.100.0.0/24` for a single family
+- `10.100.0.0/24,fd00:10:100::/64` for dual stack, one entry per family
+
+Specs asking for a family you did not give will skip. Allocation starts at the first usable
+address after the one you write: last-octet `0` and `1` are skipped, and so is the IPv4
+broadcast, so `10.100.0.0/24` begins at `10.100.0.2`. It stops at the end of the CIDR, so
+`10.100.0.128/24` uses the top half of that `/24`. Every parallel Ginkgo process starts from
+the same address, so run a single process.
+
+## Specs that need a container outside the cluster
+
+Some specs need a container that is not part of the cluster: an external gateway, a BGP peer, or
+an off-cluster HTTP server. KinD runs these on the same
+container runtime it built the cluster with. Here you have to say where they can run.
+
+| Variable | Default | What it is |
+| --- | --- | --- |
+| `OVN_TEST_CONTAINER_HOST` | unset, so those specs skip | Host whose container runtime the suite may use |
+| `OVN_TEST_PRIMARY_NETWORK` | none | Network on that host that reaches the Nodes |
+| `OVN_TEST_CONTAINER_HOST_USER` | `root` | SSH user |
+| `OVN_TEST_CONTAINER_HOST_PORT` | `22` | SSH port |
+| `OVN_TEST_CONTAINER_HOST_KEY` | none | Private key file for that user; required when the host is set |
+| `CONTAINER_RUNTIME` | `docker` | `docker` or `podman`, as for KinD |
+
+The host has to sit next to the Nodes on the network, not just be able to reach the API server.
+The specs route traffic through these containers and expect the Nodes to answer on the same L2.
+If your Nodes are VMs, their hypervisor is usually the host you want.
+
+`OVN_TEST_PRIMARY_NETWORK` is the network on that host that the containers attach to. It is the
+equivalent of KinD's `kind` network.
+
+The suite checks one part of this: if the Nodes hold no address inside
+`OVN_TEST_PRIMARY_NETWORK`, it tells you the variable is wrong. It cannot check the rest, so a
+host that is reachable but not adjacent shows up as failing specs.
+
+Specs that call the provider's generic network-attachment operation skip. That API does not say
+whether its target is a Node or an external container, and this provider cannot safely attach an
+interface to a Node. Reading a Node's existing interface does work, but only for
+`OVN_TEST_PRIMARY_NETWORK`.
+
+## Reading the results
+
+Skips are the normal outcome here. This provider cannot power nodes off, cannot treat a Node as a
+container, and cannot run external containers unless you give it a host. Each skip tells you
+which case it hit:
+
+- something this provider will never do names the operation
+- something you have not configured yet names the variable that would enable it
+
+If the run fails in `BeforeSuite` with `k8s.ovn.org/node-primary-ifaddr annotation not found`,
+OVN-K is not healthy on the cluster and no focus will get past it. Check the CNI, not the
+provider.
+
+## Before you widen the focus
+
+**Some specs touch your nodes before they skip.** The egress IP specs restore kubelet and
+iptables state on every node during setup, then ask for something the provider cannot do. They
+are reported as skipped, but they have already run against your cluster.
+
+**Specs that restart the kubelet cannot recover.** Node commands go over `kubectl exec`, which
+the kubelet proxies. Restarting or reconfiguring the kubelet cuts that path, and the rollback
+needs the same path to undo it. Under KinD these ran over `docker exec`, which does not depend on
+the kubelet. Keep them out of your focus:
+
+- the node IP and MAC migration specs
+- the kubelet restart in the network segmentation specs

--- a/docs/developer-guide/kube-provider.md
+++ b/docs/developer-guide/kube-provider.md
@@ -35,22 +35,22 @@ everything skipped, which looks like a passing run.
 
 ## If your cluster is not laid out like upstream
 
-The suite reads where OVN-K lives from the cluster rather than asking you: the namespace from the
-`app=ovnkube-node` pods, and the gateway bridge and its uplink from OVS on one of those nodes.
+The suite reads where OVN-Kubernetes lives from the cluster rather than asking you: the namespace
+from the `app=ovnkube-node` pods, and the gateway bridge and its uplink from OVS on one of those nodes.
 Set a variable when what it reads is wrong, or when your cluster has more than one answer.
 
 | Variable | If you leave it unset | What it is |
 | --- | --- | --- |
-| `OVN_TEST_OVNK_NAMESPACE` | namespace of the `app=ovnkube-node` pods | Namespace OVN-K runs in |
+| `OVN_TEST_OVNK_NAMESPACE` | namespace of the `app=ovnkube-node` pods | Namespace OVN-Kubernetes runs in |
 | `OVN_TEST_FRRK8S_NAMESPACE` | namespace of the `app=frr-k8s` pods, or `frr-k8s-system` if there are none | Namespace FRR-K8s runs in |
-| `OVN_TEST_EXTERNAL_BRIDGE` | the bridge OVN-K recorded an uplink on | OVS gateway bridge |
-| `OVN_TEST_PRIMARY_INTERFACE` | the uplink recorded on that bridge | Uplink OVN-K owns |
+| `OVN_TEST_EXTERNAL_BRIDGE` | the bridge OVN-Kubernetes recorded an uplink on | OVS gateway bridge |
+| `OVN_TEST_PRIMARY_INTERFACE` | the uplink recorded on that bridge | Uplink OVN-Kubernetes owns |
 | `OVN_TEST_PRIMARY_IP_POOL` | derived from the Node subnets | CIDR to allocate test addresses from |
 
-The bridge and the uplink are read together, from the `bridge-uplink` external-id that OVN-K
-writes on the bridge it moved the uplink onto. That is the same thing OVN-K reads back to find
+The bridge and the uplink are read together, from the `bridge-uplink` external-id that OVN-Kubernetes
+writes on the bridge it moved the uplink onto. That is the same thing OVN-Kubernetes reads back to find
 its own uplink. If no bridge carries it, which happens when the bridge was provisioned before
-OVN-K rather than by it, or if more than one does, the specs that need the uplink skip and name
+OVN-Kubernetes rather than by it, or if more than one does, the specs that need the uplink skip and name
 both variables. They skip rather than guess because several of them run `ip addr add` against this
 name, and a wrong name means they configure nothing and fail later for no visible reason.
 
@@ -58,7 +58,7 @@ Both are one value for the whole cluster. Uplink-dependent specs may use any sch
 clusters whose Nodes use different bridge-uplink pairs are unsupported.
 
 Naming the namespace also narrows where the suite looks for those pods, so it is the way to pick
-between two OVN-K installs on one cluster.
+between two OVN-Kubernetes installs on one cluster.
 
 ### When your Nodes do not share a subnet
 
@@ -76,9 +76,8 @@ and free for the suite to use:
 - `10.100.0.0/24,fd00:10:100::/64` for dual stack, one entry per family
 
 Specs asking for a family you did not give will skip. Allocation starts at the first usable
-address after the one you write: last-octet `0` and `1` are skipped, and so is the IPv4
-broadcast, so `10.100.0.0/24` begins at `10.100.0.2`. It stops at the end of the CIDR, so
-`10.100.0.128/24` uses the top half of that `/24`. Every parallel Ginkgo process starts from
+address after the network address: last-octet `0` and `1` are skipped, and so is the IPv4
+broadcast, so `10.100.0.0/24` begins at `10.100.0.2`. Every parallel Ginkgo process starts from
 the same address, so run a single process.
 
 ## Specs that need a container outside the cluster
@@ -122,7 +121,7 @@ which case it hit:
 - something you have not configured yet names the variable that would enable it
 
 If the run fails in `BeforeSuite` with `k8s.ovn.org/node-primary-ifaddr annotation not found`,
-OVN-K is not healthy on the cluster and no focus will get past it. Check the CNI, not the
+OVN-Kubernetes is not healthy on the cluster and no focus will get past it. Check the CNI, not the
 provider.
 
 ## Before you widen the focus

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - OVN-Kubernetes Container Images: developer-guide/image-build.md
       - Documentation Guide: developer-guide/documentation.md
       - Local Testing Guide: developer-guide/local_testing_guide.md
+      - Running e2e Against an Existing Cluster: developer-guide/kube-provider.md
       - CI Testing Guide: ci/ci.md
       - Debugging: developer-guide/debugging.md
       - Release Guide: developer-guide/release.md

--- a/test/e2e/deploymentconfig/configs/kube/kube.go
+++ b/test/e2e/deploymentconfig/configs/kube/kube.go
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kube reads deployment configuration from a cluster the suite did not create.
+package kube
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	"k8s.io/kubernetes/test/utils/image"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig/api"
+)
+
+const (
+	ovnKubeNamespaceEnvVar = "OVN_TEST_OVNK_NAMESPACE"
+	frrK8sNamespaceEnvVar  = "OVN_TEST_FRRK8S_NAMESPACE"
+	externalBridgeEnvVar   = "OVN_TEST_EXTERNAL_BRIDGE"
+	primaryInterfaceEnvVar = "OVN_TEST_PRIMARY_INTERFACE"
+)
+
+type kube struct{}
+
+func New() api.DeploymentConfig {
+	return kube{}
+}
+
+func (kube) OVNKubernetesNamespace() string {
+	if namespace := os.Getenv(ovnKubeNamespaceEnvVar); namespace != "" {
+		return namespace
+	}
+	namespace, err := ovnKubeNamespace()
+	if err != nil {
+		panic(fmt.Sprintf("failed to find where OVN-Kubernetes runs, set %s to name its namespace: %v",
+			ovnKubeNamespaceEnvVar, err))
+	}
+	return namespace
+}
+
+func (kube) FRRK8sNamespace() string {
+	if namespace := os.Getenv(frrK8sNamespaceEnvVar); namespace != "" {
+		return namespace
+	}
+	// FRR-K8s is not on every cluster, so its absence keeps the upstream name and fails only
+	// the specs that reach for it, rather than failing whatever asked.
+	namespace, err := frrK8sNamespace()
+	if err != nil {
+		return "frr-k8s-system"
+	}
+	return namespace
+}
+
+func (kube) ExternalBridgeName() string {
+	if bridge := os.Getenv(externalBridgeEnvVar); bridge != "" {
+		return bridge
+	}
+	return gatewayOrSkip().bridge
+}
+
+func (kube) PrimaryInterfaceName() string {
+	if uplink := os.Getenv(primaryInterfaceEnvVar); uplink != "" {
+		return uplink
+	}
+	return gatewayOrSkip().uplink
+}
+
+func (kube) GetAgnHostContainerImage() string {
+	return image.GetE2EImage(image.Agnhost)
+}
+
+// IsConfigurationEnabled reports false for every flag: the flags select which inputs a spec builds,
+// and false picks the input any cluster accepts.
+func (kube) IsConfigurationEnabled(api.Config) bool {
+	return false
+}
+
+var (
+	ovnKubeNamespace = cached(func() (string, error) { return namespaceOf("app=ovnkube-node") })
+	frrK8sNamespace  = cached(func() (string, error) { return namespaceOf("app=frr-k8s") })
+	gatewayBridge    = cached(discoverGateway)
+)
+
+// cached keeps an answer the cluster gave once, and keeps nothing when it failed, so that a
+// lookup which timed out on one spec does not answer for the whole run.
+func cached[T any](resolve func() (T, error)) func() (T, error) {
+	var (
+		mu     sync.Mutex
+		answer T
+		known  bool
+	)
+	return func() (T, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if known {
+			return answer, nil
+		}
+		resolved, err := resolve()
+		if err != nil {
+			return answer, err
+		}
+		answer, known = resolved, true
+		return answer, nil
+	}
+}
+
+func namespaceOf(label string) (string, error) {
+	pod, err := runningPod("", label)
+	if err != nil {
+		return "", fmt.Errorf("find pod labelled %s: %w", label, err)
+	}
+	return pod.Namespace, nil
+}
+
+func runningPod(namespace, label string) (*corev1.Pod, error) {
+	client, err := framework.LoadClientset()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: label,
+		FieldSelector: "status.phase=Running",
+		Limit:         1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pods labelled %s: %w", label, err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no running pod labelled %s in %s", label, cmp.Or(namespace, "any namespace"))
+	}
+	return &pods.Items[0], nil
+}
+
+type gateway struct {
+	bridge string
+	uplink string
+}
+
+// gatewayOrSkip skips rather than fails, because a cluster that keeps its uplink off OVS metadata
+// is one the spec cannot run on, not one OVN-K is broken on.
+func gatewayOrSkip() gateway {
+	discovered, err := gatewayBridge()
+	if err != nil {
+		ginkgo.Skip(fmt.Sprintf("this cluster does not name a gateway bridge and uplink; set %s and %s to run this spec: %v",
+			externalBridgeEnvVar, primaryInterfaceEnvVar, err), 2)
+	}
+	return discovered
+}
+
+// discoverGateway reads the uplink OVN-K recorded on the bridge it put it on, rather than looking
+// for a physical interface, which on a node running pods is every pod's veth as well. One node is
+// asked, since the suite keeps a single answer for the whole cluster.
+func discoverGateway() (gateway, error) {
+	pod, err := runningPod(kube{}.OVNKubernetesNamespace(), "app=ovnkube-node")
+	if err != nil {
+		return gateway{}, err
+	}
+	bridges, err := ovsVsctl(pod, "list-br")
+	if err != nil {
+		return gateway{}, fmt.Errorf("list OVS bridges on %s: %w", pod.Spec.NodeName, err)
+	}
+
+	var found []gateway
+	for _, bridge := range strings.Fields(bridges) {
+		uplink, err := ovsVsctl(pod, "--if-exists", "get", "bridge", bridge, "external_ids:bridge-uplink")
+		if err != nil {
+			return gateway{}, fmt.Errorf("read bridge-uplink on %s: %w", bridge, err)
+		}
+		if uplink = strings.Trim(uplink, "\"\n "); uplink != "" {
+			found = append(found, gateway{bridge: bridge, uplink: uplink})
+		}
+	}
+	if len(found) != 1 {
+		return gateway{}, fmt.Errorf("%d of the OVS bridges on node %s name an uplink %v, and the specs mean exactly one",
+			len(found), pod.Spec.NodeName, found)
+	}
+	return found[0], nil
+}
+
+func ovsVsctl(pod *corev1.Pod, args ...string) (string, error) {
+	return e2ekubectl.RunKubectl(pod.Namespace,
+		append([]string{"exec", pod.Name, "-c", "ovnkube-controller", "--", "ovs-vsctl"}, args...)...)
+}

--- a/test/e2e/deploymentconfig/configs/kube/kube.go
+++ b/test/e2e/deploymentconfig/configs/kube/kube.go
@@ -149,7 +149,7 @@ type gateway struct {
 }
 
 // gatewayOrSkip skips rather than fails, because a cluster that keeps its uplink off OVS metadata
-// is one the spec cannot run on, not one OVN-K is broken on.
+// is one the spec cannot run on, not one OVN-Kubernetes is broken on.
 func gatewayOrSkip() gateway {
 	discovered, err := gatewayBridge()
 	if err != nil {
@@ -159,9 +159,9 @@ func gatewayOrSkip() gateway {
 	return discovered
 }
 
-// discoverGateway reads the uplink OVN-K recorded on the bridge it put it on, rather than looking
-// for a physical interface, which on a node running pods is every pod's veth as well. One node is
-// asked, since the suite keeps a single answer for the whole cluster.
+// discoverGateway reads the uplink OVN-Kubernetes recorded on the bridge it put it on, rather
+// than looking for a physical interface, which on a node running pods is every pod's veth as
+// well. One node is asked, since the suite keeps a single answer for the whole cluster.
 func discoverGateway() (gateway, error) {
 	pod, err := runningPod(kube{}.OVNKubernetesNamespace(), "app=ovnkube-node")
 	if err != nil {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/label"
 
 	deploymentkind "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig/configs/kind"
+	deploymentkube "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig/configs/kube"
 	infraproviderkind "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/providers/kind"
+	infraproviderkube "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/providers/kube"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -29,6 +31,8 @@ import (
 )
 
 // https://github.com/kubernetes/kubernetes/blob/v1.16.4/test/e2e/e2e_test.go#L62
+
+const infraProviderEnvVar = "OVN_TEST_INFRA_PROVIDER"
 
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
@@ -56,7 +60,12 @@ var _ = ginkgo.BeforeSuite(func() {
 	framework.ExpectNoError(err, "k8 clientset is required to list nodes")
 	if os.Getenv(uplinkDPUGatewayNetworkEnv) == "" {
 		err = ipalloc.InitPrimaryIPAllocator(client.CoreV1().Nodes())
-		framework.ExpectNoError(err, "failed to initialize node primary IP allocator")
+		// Under KinD no derivable range is a fault in a cluster the suite built, and still fails the run.
+		if ipalloc.IsNoRangeError(err) && infraprovider.Get().Name() == infraproviderkube.ProviderName {
+			framework.Logf("No addresses can be allocated on this cluster, specs that need one will skip: %v", err)
+		} else {
+			framework.ExpectNoError(err, "failed to initialize node primary IP allocator")
+		}
 	} else {
 		framework.Logf("Skipping primary IP allocator initialization for DPU Uplink e2e")
 	}
@@ -68,11 +77,17 @@ func TestMain(m *testing.M) {
 	handleFlags()
 	ProcessTestContextAndSetupLogging()
 
-	// Set up infrastructure provider and deployment config
-	// Upstream currently uses KinD as its preferred platform infra
-	// So TestMain is expected to run only there.
-	infraprovider.Set(infraproviderkind.New())
-	deploymentconfig.Set(deploymentkind.New())
+	switch provider := os.Getenv(infraProviderEnvVar); provider {
+	case "", infraproviderkind.ProviderName:
+		infraprovider.Set(infraproviderkind.New())
+		deploymentconfig.Set(deploymentkind.New())
+	case infraproviderkube.ProviderName:
+		infraprovider.Set(infraproviderkube.New())
+		deploymentconfig.Set(deploymentkube.New())
+	default:
+		klog.Fatalf("unsupported %s=%q, want %q or %q", infraProviderEnvVar, provider,
+			infraproviderkind.ProviderName, infraproviderkube.ProviderName)
+	}
 
 	os.Exit(m.Run())
 }

--- a/test/e2e/infraprovider/providers/kind/kind.go
+++ b/test/e2e/infraprovider/providers/kind/kind.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+const ProviderName = "kind"
+
 type kind struct {
 	engine   *container.Engine
 	HostPort *portalloc.PortAllocator
@@ -44,7 +46,7 @@ func New() api.Provider {
 }
 
 func (k *kind) Name() string {
-	return "kind"
+	return ProviderName
 }
 
 func (k *kind) PrimaryNetwork() (api.Network, error) {

--- a/test/e2e/infraprovider/providers/kube/kube.go
+++ b/test/e2e/infraprovider/providers/kube/kube.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -57,6 +58,7 @@ type kube struct {
 	engine         *container.Engine
 	primaryNetwork string
 	hostPort       *portalloc.PortAllocator
+	nodeShellMu    sync.Mutex
 	nodeShells     map[string]*corev1.Pod
 }
 
@@ -126,6 +128,8 @@ func (k *kube) PreloadImages(_ []string) {
 }
 
 func (k *kube) deleteNodeShells() error {
+	k.nodeShellMu.Lock()
+	defer k.nodeShellMu.Unlock()
 	if len(k.nodeShells) == 0 {
 		return nil
 	}
@@ -149,9 +153,9 @@ func (k *kube) PrimaryNetwork() (api.Network, error) {
 	return k.containerEngine().GetNetwork(k.primaryNetwork)
 }
 
-// GetK8NodeNetworkInterface takes the address OVN-K publishes for its own uplink, rather than
-// choosing among the addresses a Node carries, where an egress IP and an API VIP are
-// indistinguishable from the Node's own.
+// GetK8NodeNetworkInterface takes the address OVN-Kubernetes publishes for its own uplink,
+// rather than choosing among the addresses a Node carries, where an egress IP and an API VIP
+// are indistinguishable from the Node's own.
 func (k *kube) GetK8NodeNetworkInterface(instance string, network api.Network) (api.NetworkInterface, error) {
 	if network.Name() != k.primaryNetwork {
 		return api.NetworkInterface{}, skip("GetK8NodeNetworkInterface",
@@ -255,8 +259,10 @@ func (k *kube) ExecK8NodeCommand(nodeName string, cmd []string) (string, error) 
 }
 
 // nodeShell returns a running shell pod on nodeName, one per node for the whole run. It lives in
-// the OVN-K namespace because a privileged host-network pod is already admitted there.
+// the OVN-Kubernetes namespace because a privileged host-network pod is already admitted there.
 func (k *kube) nodeShell(nodeName string) (*corev1.Pod, error) {
+	k.nodeShellMu.Lock()
+	defer k.nodeShellMu.Unlock()
 	client, err := framework.LoadClientset()
 	if err != nil {
 		return nil, err

--- a/test/e2e/infraprovider/providers/kube/kube.go
+++ b/test/e2e/infraprovider/providers/kube/kube.go
@@ -1,0 +1,423 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kube runs the e2e suite against a cluster it did not create.
+package kube
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/container"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/portalloc"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/runner"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/engine/testcontext"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
+)
+
+const ProviderName = "kube"
+
+const (
+	// ContainerHostEnvVar names a host reachable over SSH whose container runtime runs the
+	// external containers some specs need.
+	ContainerHostEnvVar = "OVN_TEST_CONTAINER_HOST"
+	// PrimaryNetworkEnvVar names the network on that host over which it reaches the Nodes.
+	PrimaryNetworkEnvVar = "OVN_TEST_PRIMARY_NETWORK"
+
+	containerHostUserEnvVar = "OVN_TEST_CONTAINER_HOST_USER"
+	containerHostPortEnvVar = "OVN_TEST_CONTAINER_HOST_PORT"
+	containerHostKeyEnvVar  = "OVN_TEST_CONTAINER_HOST_KEY"
+	containerRuntimeEnvVar  = "CONTAINER_RUNTIME"
+)
+
+const whyNodeNotContainer = "the Nodes are not containers on any host the suite can reach"
+
+type kube struct {
+	engine         *container.Engine
+	primaryNetwork string
+	hostPort       *portalloc.PortAllocator
+	nodeShells     map[string]*corev1.Pod
+}
+
+func New() api.Provider {
+	return &kube{
+		engine:         newContainerEngine(),
+		primaryNetwork: os.Getenv(PrimaryNetworkEnvVar),
+		hostPort:       portalloc.New(1024, 65535),
+		nodeShells:     map[string]*corev1.Pod{},
+	}
+}
+
+// newContainerEngine returns nil where no host is declared, leaving the specs needing one to
+// skip. A declared host that cannot be used stops the run before any spec reports success.
+func newContainerEngine() *container.Engine {
+	host := os.Getenv(ContainerHostEnvVar)
+	if host == "" {
+		return nil
+	}
+	if os.Getenv(PrimaryNetworkEnvVar) == "" {
+		klog.Fatalf("%s is set, so %s must name the network on it that reaches the Nodes",
+			ContainerHostEnvVar, PrimaryNetworkEnvVar)
+	}
+	sshRunner, err := runner.NewSSHRunner(host, cmp.Or(os.Getenv(containerHostUserEnvVar), "root"),
+		cmp.Or(os.Getenv(containerHostPortEnvVar), "22"), os.Getenv(containerHostKeyEnvVar))
+	if err != nil {
+		klog.Fatalf("%s is set to %q but cannot be used: %v", ContainerHostEnvVar, host, err)
+	}
+	return container.NewEngine(cmp.Or(os.Getenv(containerRuntimeEnvVar), "docker"), sshRunner)
+}
+
+var noContainerHost = fmt.Sprintf("this spec needs a container outside the cluster; set %s to a host that can run one",
+	ContainerHostEnvVar)
+
+func (k *kube) containerEngine() *container.Engine {
+	if k.engine == nil {
+		ginkgo.Skip(noContainerHost, 2)
+	}
+	return k.engine
+}
+
+// skip panics out of the calling spec, so the returned error never reaches the caller. The
+// callerSkip of 2 attributes the skip to the spec rather than to this file.
+func skip(op, why string) error {
+	err := fmt.Errorf("%s provider does not serve %s: %s", ProviderName, op, why)
+	ginkgo.Skip(err.Error(), 2)
+	return err
+}
+
+func (k *kube) Name() string {
+	return ProviderName
+}
+
+func (k *kube) GetDefaultTimeoutContext() *framework.TimeoutContext {
+	return framework.NewTimeoutContext()
+}
+
+func (k *kube) GetK8HostPort() uint16 {
+	return k.hostPort.Allocate()
+}
+
+// PreloadImages is the only hook the provider gets inside BeforeSuite, and so the one place it can
+// register cleanup: Ginkgo ends the process if DeferCleanup is called from within a cleanup, as the
+// suite's node commands would.
+func (k *kube) PreloadImages(_ []string) {
+	ginkgo.DeferCleanup(k.deleteNodeShells)
+}
+
+func (k *kube) deleteNodeShells() error {
+	if len(k.nodeShells) == 0 {
+		return nil
+	}
+	client, err := framework.LoadClientset()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var errs []error
+	for _, shell := range k.nodeShells {
+		err := client.CoreV1().Pods(shell.Namespace).Delete(ctx, shell.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (k *kube) PrimaryNetwork() (api.Network, error) {
+	return k.containerEngine().GetNetwork(k.primaryNetwork)
+}
+
+// GetK8NodeNetworkInterface takes the address OVN-K publishes for its own uplink, rather than
+// choosing among the addresses a Node carries, where an egress IP and an API VIP are
+// indistinguishable from the Node's own.
+func (k *kube) GetK8NodeNetworkInterface(instance string, network api.Network) (api.NetworkInterface, error) {
+	if network.Name() != k.primaryNetwork {
+		return api.NetworkInterface{}, skip("GetK8NodeNetworkInterface",
+			fmt.Sprintf("network %s is not the one the Nodes are on, and they cannot be put on another", network.Name()))
+	}
+	client, err := framework.LoadClientset()
+	if err != nil {
+		return api.NetworkInterface{}, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	node, err := client.CoreV1().Nodes().Get(ctx, instance, metav1.GetOptions{})
+	if err != nil {
+		return api.NetworkInterface{}, fmt.Errorf("get node %s: %w", instance, err)
+	}
+	primary, err := util.ParseNodePrimaryIfAddr(node)
+	if util.IsAnnotationNotSetError(err) {
+		return api.NetworkInterface{}, skip("GetK8NodeNetworkInterface",
+			fmt.Sprintf("node %s does not publish the address of its uplink yet", instance))
+	}
+	if err != nil {
+		return api.NetworkInterface{}, err
+	}
+	v4Subnet, v6Subnet, err := network.IPv4IPv6Subnets()
+	if err != nil {
+		return api.NetworkInterface{}, err
+	}
+
+	inf := api.NetworkInterface{}
+	if subnetHolds(v4Subnet, primary.V4.IP) {
+		inf.IPv4, inf.IPv4Prefix = primary.V4.IP.String(), prefixOf(primary.V4.Net)
+	}
+	if subnetHolds(v6Subnet, primary.V6.IP) {
+		inf.IPv6, inf.IPv6Prefix = primary.V6.IP.String(), prefixOf(primary.V6.Net)
+	}
+	if inf.IPv4 == "" && inf.IPv6 == "" {
+		return api.NetworkInterface{}, fmt.Errorf("node %s is on neither subnet of network %s (%q and %q), so %s does not name a network that reaches the Nodes",
+			instance, network.Name(), v4Subnet, v6Subnet, PrimaryNetworkEnvVar)
+	}
+	if inf.InfName, inf.MAC, err = k.nodeLinkHolding(instance, cmp.Or(inf.IPv4, inf.IPv6)); err != nil {
+		return api.NetworkInterface{}, err
+	}
+	return inf, nil
+}
+
+func prefixOf(subnet *net.IPNet) string {
+	ones, _ := subnet.Mask.Size()
+	return strconv.Itoa(ones)
+}
+
+func subnetHolds(subnet string, ip net.IP) bool {
+	_, ipNet, err := utilnet.ParseCIDRSloppy(subnet)
+	return err == nil && ipNet.Contains(ip)
+}
+
+// nodeLinkHolding returns the interface carrying the given address. Several holders is not a tie
+// to break: specs put a copy of a Node address on its loopback, whose MAC is the wrong answer.
+func (k *kube) nodeLinkHolding(instance, address string) (string, string, error) {
+	out, err := k.ExecK8NodeCommand(instance, []string{"ip", "-j", "addr", "show"})
+	if err != nil {
+		return "", "", err
+	}
+	var links []struct {
+		Name     string `json:"ifname"`
+		MAC      string `json:"address"`
+		AddrInfo []struct {
+			Local string `json:"local"`
+		} `json:"addr_info"`
+	}
+	if err := json.Unmarshal([]byte(out), &links); err != nil {
+		return "", "", fmt.Errorf("failed to read the interfaces of node %s from %q: %v", instance, out, err)
+	}
+
+	var holders []string
+	var name, mac string
+	want := net.ParseIP(address)
+	for _, link := range links {
+		for _, addr := range link.AddrInfo {
+			if net.ParseIP(addr.Local).Equal(want) {
+				holders = append(holders, link.Name)
+				name, mac = link.Name, link.MAC
+			}
+		}
+	}
+	if len(holders) == 0 {
+		return "", "", fmt.Errorf("no interface on node %s holds %s, which it publishes as the address of its uplink", instance, address)
+	}
+	if len(holders) > 1 {
+		return "", "", fmt.Errorf("interfaces %v on node %s all hold %s, so the one the specs mean cannot be told apart", holders, instance, address)
+	}
+	return name, mac, nil
+}
+
+func (k *kube) ExecK8NodeCommand(nodeName string, cmd []string) (string, error) {
+	shell, err := k.nodeShell(nodeName)
+	if err != nil {
+		return "", err
+	}
+	return e2ekubectl.RunKubectl(shell.Namespace,
+		append([]string{"exec", shell.Name, "--", "chroot", "/host"}, cmd...)...)
+}
+
+// nodeShell returns a running shell pod on nodeName, one per node for the whole run. It lives in
+// the OVN-K namespace because a privileged host-network pod is already admitted there.
+func (k *kube) nodeShell(nodeName string) (*corev1.Pod, error) {
+	client, err := framework.LoadClientset()
+	if err != nil {
+		return nil, err
+	}
+	if shell, ok := k.nodeShells[nodeName]; ok {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		current, err := client.CoreV1().Pods(shell.Namespace).Get(ctx, shell.Name, metav1.GetOptions{})
+		if err == nil && current.Status.Phase == corev1.PodRunning && current.DeletionTimestamp == nil {
+			return current, nil
+		}
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("get node shell on %s: %w", nodeName, err)
+		}
+		_ = client.CoreV1().Pods(shell.Namespace).Delete(ctx, shell.Name, metav1.DeleteOptions{})
+		delete(k.nodeShells, nodeName)
+	}
+	namespace := deploymentconfig.Get().OVNKubernetesNamespace()
+	image, err := ovnKubeNodeImage(client, namespace, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	shell, err := client.CoreV1().Pods(namespace).Create(ctx, nodeShellPod(nodeName, image), metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("create node shell on %s: %w", nodeName, err)
+	}
+	if err := e2epod.WaitForPodRunningInNamespace(ctx, client, shell); err != nil {
+		deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer deleteCancel()
+		_ = client.CoreV1().Pods(namespace).Delete(deleteCtx, shell.Name, metav1.DeleteOptions{})
+		return nil, fmt.Errorf("wait for node shell on %s: %w", nodeName, err)
+	}
+	k.nodeShells[nodeName] = shell
+	return shell, nil
+}
+
+func ovnKubeNodeImage(client clientset.Interface, namespace, nodeName string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pods, err := client.CoreV1().Pods(namespace).List(ctx,
+		metav1.ListOptions{LabelSelector: "app=ovnkube-node", FieldSelector: "spec.nodeName=" + nodeName})
+	if err != nil {
+		return "", fmt.Errorf("list ovnkube-node pods on %s: %w", nodeName, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no ovnkube-node pod on node %s to take a shell image from", nodeName)
+	}
+	return pods.Items[0].Spec.Containers[0].Image, nil
+}
+
+func nodeShellPod(nodeName, image string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "ovn-e2e-node-shell-"},
+		Spec: corev1.PodSpec{
+			NodeName:      nodeName,
+			HostNetwork:   true,
+			HostPID:       true,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Tolerations:   []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			Containers: []corev1.Container{{
+				Name:            "shell",
+				Image:           image,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"sleep", "infinity"},
+				SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(true)},
+				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "host", MountPath: "/host"}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name:         "host",
+				VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}},
+			}},
+		},
+	}
+}
+
+func (k *kube) ShutdownNode(string) error {
+	return skip("ShutdownNode", "the kube API does not power nodes on or off")
+}
+
+func (k *kube) StartNode(string) error {
+	return skip("StartNode", "the kube API does not power nodes on or off")
+}
+
+func (k *kube) ListNetworks() ([]string, error) {
+	return k.containerEngine().ListNetworks()
+}
+
+func (k *kube) GetNetwork(name string) (api.Network, error) {
+	return k.containerEngine().GetNetwork(name)
+}
+
+func (k *kube) GetExternalContainerNetworkInterface(external api.ExternalContainer, network api.Network) (api.NetworkInterface, error) {
+	return k.containerEngine().GetExternalContainerNetworkInterface(external, network)
+}
+
+func (k *kube) ExecExternalContainerCommand(external api.ExternalContainer, cmd []string) (string, error) {
+	return k.containerEngine().ExecExternalContainerCommand(external, cmd)
+}
+
+func (k *kube) GetExternalContainerLogs(external api.ExternalContainer) (string, error) {
+	return k.containerEngine().GetExternalContainerLogs(external)
+}
+
+func (k *kube) GetExternalContainerPort() uint16 {
+	return k.containerEngine().GetExternalContainerPort()
+}
+
+func (k *kube) ExternalContainerPrimaryInterfaceName() string {
+	return k.containerEngine().ExternalContainerPrimaryInterfaceName()
+}
+
+func (k *kube) NewTestContext() api.Context {
+	context := &testcontext.TestContext{}
+	ginkgo.DeferCleanup(context.CleanUp)
+	return &contextKube{TestContext: context, kube: k}
+}
+
+type contextKube struct {
+	*testcontext.TestContext
+	kube *kube
+}
+
+func (c *contextKube) containerEngine() *container.Engine {
+	if c.kube.engine == nil {
+		ginkgo.Skip(noContainerHost, 2)
+	}
+	return c.kube.engine.WithTestContext(c.TestContext)
+}
+
+func (c *contextKube) CreateNetwork(name string, subnets ...string) (api.Network, error) {
+	return c.containerEngine().CreateNetwork(name, subnets...)
+}
+
+func (c *contextKube) DeleteNetwork(network api.Network) error {
+	return c.containerEngine().DeleteNetwork(network)
+}
+
+func (c *contextKube) CreateExternalContainer(external api.ExternalContainer) (api.ExternalContainer, error) {
+	return c.containerEngine().CreateExternalContainer(external)
+}
+
+func (c *contextKube) DeleteExternalContainer(external api.ExternalContainer) error {
+	return c.containerEngine().DeleteExternalContainer(external)
+}
+
+// AttachNetwork is given a Node as often as an external container and the two cannot be told
+// apart by name, so it skips rather than working for some specs and failing for others.
+func (c *contextKube) AttachNetwork(api.Network, string) (api.NetworkInterface, error) {
+	return api.NetworkInterface{}, skip("AttachNetwork", whyNodeNotContainer)
+}
+
+func (c *contextKube) DetachNetwork(api.Network, string) error {
+	return skip("DetachNetwork", whyNodeNotContainer)
+}
+
+func (c *contextKube) SetupUnderlay(*framework.Framework, api.Underlay) error {
+	return skip("SetupUnderlay", "no spare host uplink is declared for this cluster")
+}

--- a/test/e2e/ipalloc/ipalloc.go
+++ b/test/e2e/ipalloc/ipalloc.go
@@ -30,7 +30,34 @@ func (n *ipAllocator) AllocateNextIP() (net.IP, error) {
 	n.count += 1
 	b := n.base.Bytes()
 	b = append(make([]byte, 16), b...)
-	return b[len(b)-16:], nil
+	next := net.IP(b[len(b)-16:])
+	// max is measured from the network address, not from the start IP, so it alone lets the walk leave the range.
+	if !n.net.Contains(next) {
+		return net.IP{}, fmt.Errorf("next address %s is outside %s", next, n.net)
+	}
+	if ipv4Broadcast(n.net, next) {
+		return net.IP{}, fmt.Errorf("next address %s is the broadcast address of %s", next, n.net)
+	}
+	return next, nil
+}
+
+func ipv4Broadcast(ipNet *net.IPNet, ip net.IP) bool {
+	v4, net4 := ip.To4(), ipNet.IP.To4()
+	if v4 == nil || net4 == nil {
+		return false
+	}
+	mask := ipNet.Mask
+	if len(mask) == net.IPv6len {
+		mask = mask[12:]
+	}
+	if len(mask) != net.IPv4len {
+		return false
+	}
+	last := make(net.IP, net.IPv4len)
+	for i := range last {
+		last[i] = net4[i] | ^mask[i]
+	}
+	return v4.Equal(last)
 }
 
 func getBaseInt(ip net.IP) *big.Int {

--- a/test/e2e/ipalloc/primaryipalloc.go
+++ b/test/e2e/ipalloc/primaryipalloc.go
@@ -5,12 +5,16 @@ package ipalloc
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/onsi/ginkgo/v2"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"net"
+	"os"
+	"strings"
 	"sync"
 )
 
@@ -22,27 +26,53 @@ type primaryIPAllocator struct {
 	nodeClient v1.NodeInterface
 }
 
-var pia *primaryIPAllocator
+// PrimaryIPPoolEnvVar names a CIDR, or a comma separated pair for dual stack, to allocate from
+// where no range can be derived from the Node subnets.
+const PrimaryIPPoolEnvVar = "OVN_TEST_PRIMARY_IP_POOL"
+
+// errNoRange marks the Node subnets yielding nothing to allocate from, which is a fact about how
+// the cluster is addressed. Every other error here is a fault in it and has to fail the run.
+var errNoRange = errors.New("no range")
+
+func IsNoRangeError(err error) bool {
+	return errors.Is(err, errNoRange)
+}
+
+// pia holds no range until initialised, so a run that never initialises it, as the DPU uplink
+// lane does not, skips those specs instead of dereferencing nothing.
+var pia = &primaryIPAllocator{mu: &sync.Mutex{}}
 
 // InitPrimaryIPAllocator must be called to init IP allocator(s). Callers must be synchronise.
 func InitPrimaryIPAllocator(nodeClient v1.NodeInterface) error {
 	var err error
-	pia, err = newPrimaryIPAllocator(nodeClient)
+	pia, err = newPrimaryIPAllocator(nodeClient, os.Getenv(PrimaryIPPoolEnvVar))
 	return err
 }
 
 func NewPrimaryIPv4() (net.IP, error) {
+	skipWithoutRange(pia.v4, "IPv4")
 	return pia.AllocateNextV4()
 }
 
 func NewPrimaryIPv6() (net.IP, error) {
+	skipWithoutRange(pia.v6, "IPv6")
 	return pia.AllocateNextV6()
 }
 
-// newPrimaryIPAllocator gets a Nodes primary interfaces network info, increments the 2 octet and checks if the IP is still
+func skipWithoutRange(allocator *ipAllocator, family string) {
+	if allocator == nil {
+		ginkgo.Skip(fmt.Sprintf("this run has no %s range to allocate from; give %s one to run this spec",
+			family, PrimaryIPPoolEnvVar), 2)
+	}
+}
+
+// newPrimaryIPAllocator gets the Nodes primary interface network info and picks a starting IP that stays
 // within the subnet of all the K8 nodes.
-func newPrimaryIPAllocator(nodeClient v1.NodeInterface) (*primaryIPAllocator, error) {
+func newPrimaryIPAllocator(nodeClient v1.NodeInterface, pool string) (*primaryIPAllocator, error) {
 	ipa := &primaryIPAllocator{mu: &sync.Mutex{}, nodeClient: nodeClient}
+	if pool != "" {
+		return ipa, ipa.setPool(pool)
+	}
 	nodes, err := nodeClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return ipa, fmt.Errorf("failed to get a list of node(s): %v", err)
@@ -50,54 +80,85 @@ func newPrimaryIPAllocator(nodeClient v1.NodeInterface) (*primaryIPAllocator, er
 	if len(nodes.Items) == 0 {
 		return ipa, fmt.Errorf("expected at least one node but found zero")
 	}
-	// FIXME: the approach taken here to find the first node IP+mask and then to increment the second last octet wont work in
-	// all scenarios (node with /24). We should generate an EgressIP compatible with a Node providers primary network and then take care its unique globally.
-
-	// The approach here is to grab initial starting IP from first node found, increment the second last octet.
-	// Approach taken here won't work for Nodes handed /24 subnets.
 	nodePrimaryIPs, err := util.ParseNodePrimaryIfAddr(&nodes.Items[0])
 	if err != nil {
 		return ipa, fmt.Errorf("failed to parse node primary interface address from Node object: %v", err)
 	}
+	var rangeErrs []error
 	if nodePrimaryIPs.V4.IP != nil {
-		// should be ok with /16 and /64 node primary provider subnets
-		// TODO; fixme; what about /24 subnet Nodes like GCP
-		nodePrimaryIPs.V4.IP[len(nodePrimaryIPs.V4.IP)-2]++
-		ipa.v4 = newIPAllocator(&net.IPNet{IP: nodePrimaryIPs.V4.IP, Mask: nodePrimaryIPs.V4.Net.Mask})
-	}
-	if nodePrimaryIPs.V6.IP != nil {
-		nodePrimaryIPs.V6.IP[len(nodePrimaryIPs.V6.IP)-2]++
-		ipa.v6 = newIPAllocator(&net.IPNet{IP: nodePrimaryIPs.V6.IP, Mask: nodePrimaryIPs.V6.Net.Mask})
-	}
-	// verify the new starting base IP is within all Nodes subnets
-	if nodePrimaryIPs.V4.IP != nil {
-		ipNets, err := getNodePrimaryProviderIPs(nodes.Items, false)
-		if err != nil {
-			return ipa, err
-		}
-		nextIP, err := ipa.v4.AllocateNextIP()
-		if err != nil {
-			return ipa, err
-		}
-		if !isIPWithinAllSubnets(ipNets, nextIP) {
-			return ipa, fmt.Errorf("IP %s is not within all Node subnets", nextIP)
+		if ipa.v4, err = deriveRange(nodes.Items, &nodePrimaryIPs.V4, false); err != nil {
+			if !IsNoRangeError(err) {
+				return ipa, err
+			}
+			rangeErrs = append(rangeErrs, err)
 		}
 	}
 	if nodePrimaryIPs.V6.IP != nil {
-		ipNets, err := getNodePrimaryProviderIPs(nodes.Items, true)
-		if err != nil {
-			return ipa, err
-		}
-		nextIP, err := ipa.v6.AllocateNextIP()
-		if err != nil {
-			return ipa, err
-		}
-		if !isIPWithinAllSubnets(ipNets, nextIP) {
-			return ipa, fmt.Errorf("IP %s is not within all Node subnets", nextIP)
+		if ipa.v6, err = deriveRange(nodes.Items, &nodePrimaryIPs.V6, true); err != nil {
+			if !IsNoRangeError(err) {
+				return ipa, err
+			}
+			rangeErrs = append(rangeErrs, err)
 		}
 	}
-
+	if ipa.v4 == nil && ipa.v6 == nil {
+		return ipa, errors.Join(rangeErrs...)
+	}
 	return ipa, nil
+}
+
+// deriveRange picks a range out of the Node subnets, and proves the choice by taking an address.
+// Bumping the second last octet clears the Node addresses where the subnet is wide enough for
+// the bump; where it is not, a /24, allocation starts at a Node IP and relies on allocateIP
+// stepping over the addresses the Nodes hold.
+func deriveRange(nodes []corev1.Node, primary *util.ParsedIFAddr, isIPv6 bool) (*ipAllocator, error) {
+	ipNets, err := getNodePrimaryProviderIPs(nodes, isIPv6)
+	if err != nil {
+		return nil, err
+	}
+	start := append(net.IP(nil), primary.IP...)
+	bumped := append(net.IP(nil), primary.IP...)
+	bumped[len(bumped)-2]++
+	if isIPWithinAllSubnets(ipNets, bumped) {
+		start = bumped
+	}
+	allocator := newIPAllocator(&net.IPNet{IP: start, Mask: primary.Net.Mask})
+	nextIP, err := allocator.AllocateNextIP()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errNoRange, err)
+	}
+	if !isIPWithinAllSubnets(ipNets, nextIP) {
+		return nil, fmt.Errorf("%w: IP %s is not within all Node subnets", errNoRange, nextIP)
+	}
+	return allocator, nil
+}
+
+// setPool allocates from the given CIDRs, which it deliberately does not check against the Node
+// subnets: a pool exists precisely because it lies outside them.
+func (pia *primaryIPAllocator) setPool(pool string) error {
+	for _, entry := range strings.Split(pool, ",") {
+		ip, ipNet, err := net.ParseCIDR(strings.TrimSpace(entry))
+		if err != nil {
+			return fmt.Errorf("failed to parse %s entry %q: %v", PrimaryIPPoolEnvVar, entry, err)
+		}
+		// allocateIP skips last-octet 0 and 1, and IPv4 broadcast, so narrower than this hands out none.
+		if ones, bits := ipNet.Mask.Size(); bits-ones < 2 {
+			return fmt.Errorf("%s entry %q is too small to allocate from", PrimaryIPPoolEnvVar, entry)
+		}
+		allocator := newIPAllocator(&net.IPNet{IP: ip, Mask: ipNet.Mask})
+		if ip.To4() != nil {
+			if pia.v4 != nil {
+				return fmt.Errorf("%s names IPv4 twice", PrimaryIPPoolEnvVar)
+			}
+			pia.v4 = allocator
+		} else {
+			if pia.v6 != nil {
+				return fmt.Errorf("%s names IPv6 twice", PrimaryIPPoolEnvVar)
+			}
+			pia.v6 = allocator
+		}
+	}
+	return nil
 }
 
 func getNodePrimaryProviderIPs(nodes []corev1.Node, isIPv6 bool) ([]*net.IPNet, error) {

--- a/test/e2e/ipalloc/primaryipalloc.go
+++ b/test/e2e/ipalloc/primaryipalloc.go
@@ -137,7 +137,7 @@ func deriveRange(nodes []corev1.Node, primary *util.ParsedIFAddr, isIPv6 bool) (
 // subnets: a pool exists precisely because it lies outside them.
 func (pia *primaryIPAllocator) setPool(pool string) error {
 	for _, entry := range strings.Split(pool, ",") {
-		ip, ipNet, err := net.ParseCIDR(strings.TrimSpace(entry))
+		_, ipNet, err := net.ParseCIDR(strings.TrimSpace(entry))
 		if err != nil {
 			return fmt.Errorf("failed to parse %s entry %q: %v", PrimaryIPPoolEnvVar, entry, err)
 		}
@@ -145,8 +145,8 @@ func (pia *primaryIPAllocator) setPool(pool string) error {
 		if ones, bits := ipNet.Mask.Size(); bits-ones < 2 {
 			return fmt.Errorf("%s entry %q is too small to allocate from", PrimaryIPPoolEnvVar, entry)
 		}
-		allocator := newIPAllocator(&net.IPNet{IP: ip, Mask: ipNet.Mask})
-		if ip.To4() != nil {
+		allocator := newIPAllocator(ipNet)
+		if ipNet.IP.To4() != nil {
 			if pia.v4 != nil {
 				return fmt.Errorf("%s names IPv4 twice", PrimaryIPPoolEnvVar)
 			}

--- a/test/e2e/ipalloc/primaryipalloc_test.go
+++ b/test/e2e/ipalloc/primaryipalloc_test.go
@@ -92,16 +92,27 @@ func TestIPAlloc(t *testing.T) {
 			expectedFromAllocateNext: []string{"192.168.2.3", "192.168.2.4"},
 		},
 		{
+			// The bump leaves the subnet here, so allocation starts at a Node IP and steps over the Nodes.
+			desc: "IPv4 /24",
+			existingPrimaryNodeIPs: []node{
+				{v4: network{ip: "192.168.104.1", mask: "24"}},
+				{v4: network{ip: "192.168.104.3", mask: "24"}},
+				{v4: network{ip: "192.168.104.4", mask: "24"}},
+				{v4: network{ip: "192.168.104.5", mask: "24"}},
+			},
+			expectedFromAllocateNext: []string{"192.168.104.6", "192.168.104.7"},
+		},
+		{
 			desc:                     "IPv6",
-			existingPrimaryNodeIPs:   []node{{v4: network{ip: "fc00:f853:ccd:e793::5", mask: "64"}}, {v4: network{ip: "fc00:f853:ccd:e793::6", mask: "64"}}},
-			expectedFromAllocateNext: []string{"fc00:f853:ccd:e793::8", "fc00:f853:ccd:e793::9"},
+			existingPrimaryNodeIPs:   []node{{v6: network{ip: "fc00:f853:ccd:e793::5", mask: "64"}}, {v6: network{ip: "fc00:f853:ccd:e793::6", mask: "64"}}},
+			expectedFromAllocateNext: []string{"fc00:f853:ccd:e793::107", "fc00:f853:ccd:e793::108"},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			cs := fake.NewSimpleClientset(getNodesWithIPs(tc.existingPrimaryNodeIPs))
-			pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes())
+			pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "")
 			if err != nil {
 				t.Error(err)
 				return
@@ -126,6 +137,130 @@ func TestIPAlloc(t *testing.T) {
 		})
 	}
 
+}
+
+var disjointRoutedNodes = []node{
+	{v4: network{ip: "10.1.253.3", mask: "31"}},
+	{v4: network{ip: "10.1.253.5", mask: "31"}},
+	{v4: network{ip: "10.1.1.1", mask: "31"}},
+}
+
+func TestRoutedNodesLeaveNothingToAllocate(t *testing.T) {
+	cs := fake.NewSimpleClientset(getNodesWithIPs(disjointRoutedNodes))
+	_, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "")
+	if !IsNoRangeError(err) {
+		t.Errorf("expected no range to be derivable from disjoint Node subnets, but found %v", err)
+	}
+}
+
+func TestUnreadableNodeIsAFault(t *testing.T) {
+	cs := fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{
+		getNodeObj("node0", map[string]string{}, map[string]string{})}})
+	_, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "")
+	if err == nil || IsNoRangeError(err) {
+		t.Errorf("expected an unannotated Node to fail the run, but found %v", err)
+	}
+}
+
+func TestPoolReplacesNodeSubnets(t *testing.T) {
+	cs := fake.NewSimpleClientset(getNodesWithIPs(disjointRoutedNodes))
+	pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "10.100.0.0/24, fd00:10:100::/64")
+	if err != nil {
+		t.Fatalf("failed to allocate from a pool: %v", err)
+	}
+	for _, tc := range []struct {
+		allocate allocNextFn
+		expected string
+	}{
+		{allocate: pipa.AllocateNextV4, expected: "10.100.0.2"},
+		{allocate: pipa.AllocateNextV6, expected: "fd00:10:100::2"},
+	} {
+		nextIP, err := tc.allocate()
+		if err != nil {
+			t.Fatalf("failed to allocate next address: %v", err)
+		}
+		if expectedIP := net.ParseIP(tc.expected); !nextIP.Equal(expectedIP) {
+			t.Errorf("expected IP %q, but found %q", expectedIP, nextIP)
+		}
+	}
+}
+
+func TestPoolIsRejected(t *testing.T) {
+	for _, pool := range []string{"10.100.0/24", "10.100.0.0/24,", "10.100.0.0/31", "10.100.0.0/24,10.101.0.0/24", "fd00:10:100::/64,fd00:10:101::/64"} {
+		t.Run(pool, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(getNodesWithIPs(disjointRoutedNodes))
+			_, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), pool)
+			if err == nil {
+				t.Errorf("expected pool %q to be rejected", pool)
+			}
+			if IsNoRangeError(err) {
+				t.Errorf("expected pool %q to fail the run, but it skips the specs: %v", pool, err)
+			}
+		})
+	}
+}
+
+func TestAllocationStaysInRange(t *testing.T) {
+	cs := fake.NewSimpleClientset(getNodesWithIPs(disjointRoutedNodes))
+	pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "10.100.0.0/25")
+	if err != nil {
+		t.Fatalf("failed to allocate from a pool: %v", err)
+	}
+	pool := &net.IPNet{IP: net.ParseIP("10.100.0.0"), Mask: net.CIDRMask(25, 32)}
+	var got int
+	for range 200 {
+		nextIP, err := pipa.AllocateNextV4()
+		if err != nil {
+			if got != 125 {
+				t.Errorf("allocated %d addresses from %s, want 125", got, pool)
+			}
+			return
+		}
+		got++
+		if !pool.Contains(nextIP) {
+			t.Fatalf("allocated %s from outside pool %s", nextIP, pool)
+		}
+	}
+	t.Errorf("expected allocation from %s to run out", pool)
+}
+
+func TestPoolDoesNotAllocateBroadcast(t *testing.T) {
+	cs := fake.NewSimpleClientset(getNodesWithIPs(disjointRoutedNodes))
+	pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "10.100.0.0/30")
+	if err != nil {
+		t.Fatalf("failed to allocate from a pool: %v", err)
+	}
+	got, err := pipa.AllocateNextV4()
+	if err != nil {
+		t.Fatalf("expected one address from 10.100.0.0/30: %v", err)
+	}
+	if !got.Equal(net.ParseIP("10.100.0.2")) {
+		t.Errorf("expected 10.100.0.2, got %s", got)
+	}
+	if _, err := pipa.AllocateNextV4(); err == nil {
+		t.Error("expected 10.100.0.0/30 to refuse its broadcast address")
+	}
+}
+
+func TestIPv6WhenIPv4HasNoRange(t *testing.T) {
+	cs := fake.NewSimpleClientset(getNodesWithIPs([]node{
+		{v4: network{ip: "10.1.253.3", mask: "31"}, v6: network{ip: "fc00:f853:ccd:e793::5", mask: "64"}},
+		{v4: network{ip: "10.1.253.5", mask: "31"}, v6: network{ip: "fc00:f853:ccd:e793::6", mask: "64"}},
+	}))
+	pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "")
+	if err != nil {
+		t.Fatalf("expected IPv6 to still initialise: %v", err)
+	}
+	if pipa.v4 != nil {
+		t.Error("expected no IPv4 range from disjoint /31s")
+	}
+	got, err := pipa.AllocateNextV6()
+	if err != nil {
+		t.Fatalf("failed to allocate IPv6: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected an IPv6 address")
+	}
 }
 
 func getNodesWithIPs(nodesSpec []node) runtime.Object {

--- a/test/e2e/ipalloc/primaryipalloc_test.go
+++ b/test/e2e/ipalloc/primaryipalloc_test.go
@@ -164,7 +164,7 @@ func TestUnreadableNodeIsAFault(t *testing.T) {
 
 func TestPoolReplacesNodeSubnets(t *testing.T) {
 	cs := fake.NewSimpleClientset(getNodesWithIPs(disjointRoutedNodes))
-	pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "10.100.0.0/24, fd00:10:100::/64")
+	pipa, err := newPrimaryIPAllocator(cs.CoreV1().Nodes(), "10.100.0.100/24, fd00:10:100::100/64")
 	if err != nil {
 		t.Fatalf("failed to allocate from a pool: %v", err)
 	}

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -38,8 +38,6 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 			customL2IPv4InfraCIDR        = "172.16.0.0/30"
 			customL2IPv6InfraCIDR        = "2014:100:200::/122"
 			nodeHostnameKey              = "kubernetes.io/hostname"
-			workerOneNodeName            = "ovn-worker"
-			workerTwoNodeName            = "ovn-worker2"
 			port                         = 9000
 			randomStringLength           = 5
 			nameSpaceYellowSuffix        = "yellow"
@@ -321,6 +319,14 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				allowServerPodConfig podConfiguration,
 				denyServerPodConfig podConfiguration,
 			) {
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), cs, 2)
+				framework.ExpectNoError(err, "failed to find two ready schedulable nodes for network policy tests")
+				if len(nodes.Items) < 2 {
+					ginkgo.Skip("requires at least 2 Nodes")
+				}
+				clientPodConfig.nodeSelector = map[string]string{nodeHostnameKey: nodes.Items[0].Name}
+				allowServerPodConfig.nodeSelector = map[string]string{nodeHostnameKey: nodes.Items[1].Name}
+				denyServerPodConfig.nodeSelector = map[string]string{nodeHostnameKey: nodes.Items[1].Name}
 
 				namespaceYellow := getNamespaceName(f, nameSpaceYellowSuffix)
 				namespaceBlue := getNamespaceName(f, namespaceBlueSuffix)
@@ -488,14 +494,12 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				"layer2",
 				*podConfig(
 					"client-pod",
-					withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
 				),
 				*podConfig(
 					"allow-server-pod",
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
-					withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
 					withLabels(allowServerPodLabel),
 				),
 				*podConfig(
@@ -503,7 +507,6 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
-					withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
 					withLabels(denyServerPodLabel),
 				),
 			),
@@ -512,14 +515,12 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				"layer3",
 				*podConfig(
 					"client-pod",
-					withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
 				),
 				*podConfig(
 					"allow-server-pod",
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
-					withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
 					withLabels(allowServerPodLabel),
 				),
 				*podConfig(
@@ -527,7 +528,6 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
-					withNodeSelector(map[string]string{nodeHostnameKey: workerTwoNodeName}),
 					withLabels(denyServerPodLabel),
 				),
 			))


### PR DESCRIPTION
## 📑 Description

Add a `kube` infrastructure provider that runs the existing Go e2e suite
against an already-running OVN-Kubernetes cluster. Kind remains the default.

Set `KUBECONFIG` and `OVN_TEST_INFRA_PROVIDER=kube` to select the provider. It
discovers deployment settings from the cluster, runs Node commands through
privileged shell Pods, and skips infrastructure operations it cannot safely
perform. Optional environment variables provide explicit address pools,
deployment settings, and an external container host for scopes that need one.

The provider does not create or destroy the cluster. Configuration, required
permissions, and remaining portability limits are documented in
`docs/developer-guide/kube-provider.md`.

## Release Notes

```release-note
Add a kube e2e provider for running tests against an existing OVN-Kubernetes cluster.
```

## Additional Information for reviewers

The provider implementation is contained in `test/e2e/infraprovider` and
`test/e2e/deploymentconfig`. Small suite-level changes select the provider,
support clusters without a shared Node address range, and remove hard-coded
Kind Node names from affected network-policy tests.

## Special notes for your reviewer

Codex materially assisted with the implementation, tests, documentation, and
commit messages. I reviewed the resulting changes and ran the validation listed
below.

## ✅ Checks

- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

```bash
cd test/e2e
go test ./infraprovider/providers/kube ./deploymentconfig/configs/kube ./ipalloc
go test -race ./infraprovider/providers/kube ./deploymentconfig/configs/kube ./ipalloc
OVN_TEST_INFRA_PROVIDER=kube KUBECONFIG=/tmp/nonexistent go test . -run '^$' -count=1
```

Against a disposable existing cluster:

```bash
cd test/e2e
export KUBECONFIG=/path/to/kubeconfig
export OVN_TEST_INFRA_PROVIDER=kube
go test -timeout=60m -v . \
  -ginkgo.v \
  -ginkgo.fail-on-empty \
  -ginkgo.focus='<focus>'
```
